### PR TITLE
ci: add publish workflow for tag-triggered releases (mc1.12.2)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,78 @@
+name: Publish
+
+"on":
+  push:
+    tags:
+      - 'mc1.21-v*'
+      - 'mc1.12.2-v*'
+
+jobs:
+  publish:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: java-21
+            branch: "1.21"
+            java-version: "21"
+            java-distribution: temurin
+            game-version: "1.21"
+          - name: java-8
+            branch: "mc1.12.2"
+            java-version: "8"
+            java-distribution: temurin
+            game-version: "1.12.2"
+    if: |
+      (startsWith(github.ref_name, 'mc1.21') && matrix.branch == '1.21') ||
+      (startsWith(github.ref_name, 'mc1.12.2') && matrix.branch == 'mc1.12.2')
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
+
+      - name: Set up JDK ${{ matrix.java-version }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java-version }}
+          distribution: ${{ matrix.java-distribution }}
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/wrapper/dists
+            ~/.gradle/caches
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/gradle-wrapper.properties') }}-${{ matrix.branch }}
+          restore-keys: |
+            gradle-${{ runner.os }}-${{ matrix.branch }}-
+            gradle-${{ runner.os }}-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build
+        run: ./gradlew build --no-daemon
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+
+      - name: Publish to CurseForge, Modrinth, GitHub Releases
+        uses: Kira-NT/mc-publish@v3
+        with:
+          curseforge-id: 250419
+          curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
+          modrinth-id: everlasting-skins
+          modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          version: ${{ github.ref_name }}
+          name: "Everlasting Skins ${{ github.ref_name }}"
+          version-type: beta
+          loaders: forge
+          game-versions: ${{ matrix.game-version }}
+          game-version-filter: releases
+          environment: server
+          files: build/libs/*.jar
+          fail-mode: warn
+          retry-attempts: 3
+          retry-delay: 15000


### PR DESCRIPTION
Adds .github/workflows/publish.yml triggered on mc1.21-v* and mc1.12.2-v* tags. Uses Kira-NT/mc-publish@v3 to publish to CurseForge (250419), Modrinth (everlasting-skins), and GitHub Releases in one step.