### PR TITLE
ci(publish): add permissions: contents:write for GITHUB_TOKEN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,8 @@
 name: Publish
 
+permissions:
+  contents: write
+
 on:
   push:
     tags:


### PR DESCRIPTION
Adds `permissions: contents: write` to the publish workflow so GITHUB_TOKEN can create GitHub Releases.

Fixes the 403 error: `Resource not accessible by integration` when calling `POST /releases`.