### PR TITLE
chore(release): promote v2.0.0 from beta to release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,8 @@
 name: Publish
 
+permissions:
+  contents: write
+
 on:
   push:
     tags:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,7 +55,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           version: ${{ github.ref_name }}
           name: "Everlasting Skins ${{ github.ref_name }}"
-          version-type: beta
+          version-type: release
           loaders: forge
           game-versions: "1.21"
           game-version-filter: releases
@@ -110,7 +110,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           version: ${{ github.ref_name }}
           name: "Everlasting Skins ${{ github.ref_name }}"
-          version-type: beta
+          version-type: release
           loaders: forge
           game-versions: "1.12.2"
           game-version-filter: releases

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Publish to CurseForge, Modrinth, GitHub Releases
         uses: Kira-NT/mc-publish@v3
         with:
-          curseforge-id: 250419
+          curseforge-id: 538149
           curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
           modrinth-id: everlasting-skins
           modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
@@ -103,7 +103,7 @@ jobs:
       - name: Publish to CurseForge, Modrinth, GitHub Releases
         uses: Kira-NT/mc-publish@v3
         with:
-          curseforge-id: 250419
+          curseforge-id: 538149
           curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
           modrinth-id: everlasting-skins
           modrinth-token: ${{ secrets.MODRINTH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Server-side Minecraft Forge mod for persistent custom skins. Players change thei
 ## 📦 Installation
 
 1. Install [Forge for Minecraft 1.21](https://files.minecraftforge.net/net/minecraftforge/forge/index_1.21.html).
-2. Download `EverlastingSkins-1.21-2.0.0-beta.1.jar` from the [Releases page](https://github.com/Levosilimo/Everlasting-Skins/releases).
+2. Download `EverlastingSkins-1.21-2.0.0.jar` from the [Releases page](https://github.com/Levosilimo/Everlasting-Skins/releases).
 3. Place the JAR in your server's `mods/` folder.
 4. Restart the server.
 
@@ -70,7 +70,7 @@ cd Everlasting-Skins
 ./gradlew build
 ```
 
-Output: `build/libs/EverlastingSkins-1.21-2.0.0-beta.1.jar`
+Output: `build/libs/EverlastingSkins-1.21-2.0.0.jar`
 
 ## ❓ FAQ
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ loader_version_range=[31,)
 
 # Curse properties
 curse_versions=1.21
-curse_project=250419
+curse_project=538149
 
 # Mixins
 mixin_id=everlastingskins

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ group=levosilimo.everlastingskins
 
 # Mod Properties
 mod_id=everlastingskins
-mod_version=2.0.0-beta.1
+mod_version=2.0.0
 mod_name=EverlastingSkins
 mod_vendor=Levosilimo
 mod_license=MIT

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -19,7 +19,7 @@ modId = "everlastingskins" #mandatory
 # The version number of the mod - there's a few well known ${} variables useable here or just hardcode it
 # ${file.jarVersion} will substitute the value of the Implementation-Version as read from the mod's JAR file metadata
 # see the associated build.gradle script for how to populate this completely automatically during a build
-version = "2.0.0-beta.1" #mandatory
+version = "2.0.0" #mandatory
 # A display name for the mod
 displayName = "Everlasting Skins" #mandatory
 # A URL to query for updates for this mod. See the JSON update specification <here>


### PR DESCRIPTION
Promote v2.0.0 from beta to release:
- Update mod_version in gradle.properties
- Update version in mods.toml
- Update JAR references in README.md
- Change version-type from beta to release in publish workflow