### PR TITLE
chore(release): promote v2.0.0 from beta to release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,8 @@
 name: Publish
 
+permissions:
+  contents: write
+
 on:
   push:
     tags:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,7 +55,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           version: ${{ github.ref_name }}
           name: "Everlasting Skins ${{ github.ref_name }}"
-          version-type: beta
+          version-type: release
           loaders: forge
           game-versions: "1.21"
           game-version-filter: releases
@@ -110,7 +110,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           version: ${{ github.ref_name }}
           name: "Everlasting Skins ${{ github.ref_name }}"
-          version-type: beta
+          version-type: release
           loaders: forge
           game-versions: "1.12.2"
           game-version-filter: releases

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Publish to CurseForge, Modrinth, GitHub Releases
         uses: Kira-NT/mc-publish@v3
         with:
-          curseforge-id: 250419
+          curseforge-id: 538149
           curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
           modrinth-id: everlasting-skins
           modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
@@ -103,7 +103,7 @@ jobs:
       - name: Publish to CurseForge, Modrinth, GitHub Releases
         uses: Kira-NT/mc-publish@v3
         with:
-          curseforge-id: 250419
+          curseforge-id: 538149
           curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
           modrinth-id: everlasting-skins
           modrinth-token: ${{ secrets.MODRINTH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Server-side Minecraft Forge mod for persistent custom skins. Players change thei
 ## 📦 Installation
 
 1. Install [Forge for Minecraft 1.12.2](https://files.minecraftforge.net/net/minecraftforge/forge/index_1.12.2.html).
-2. Download `everlastingskins-1.12.2-2.0.0-beta.1.jar` from the [Releases page](https://github.com/Levosilimo/Everlasting-Skins/releases).
+2. Download `everlastingskins-1.12.2-2.0.0.jar` from the [Releases page](https://github.com/Levosilimo/Everlasting-Skins/releases).
 3. Place the JAR in your server's `mods/` folder.
 4. Restart the server.
 
@@ -70,7 +70,7 @@ cd Everlasting-Skins
 ./gradlew build
 ```
 
-Output: `build/libs/everlastingskins-1.12.2-2.0.0-beta.1.jar`
+Output: `build/libs/everlastingskins-1.12.2-2.0.0.jar`
 
 ## ❓ FAQ
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
 
 apply plugin: 'net.minecraftforge.gradle.forge'
 
-version = '2.0.0-beta.1'
+version = '2.0.0'
 group = 'levosilimo.everlastingskins'
 archivesBaseName = 'everlastingskins-1.12.2'
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx3G
 group=levosilimo.everlastingskins
 
 mod_id=everlastingskins
-mod_version=2.0.0-beta.1
+mod_version=2.0.0
 mod_name=EverlastingSkins
 mod_vendor=Levosilimo
 mod_license=MIT


### PR DESCRIPTION
Promote v2.0.0 from beta to release:
- Update mod_version in gradle.properties
- Update version in build.gradle
- Update JAR references in README.md
- Change version-type from beta to release in publish workflow