### PR TITLE
feat(perm): add IPermissionService abstraction with vanilla, Forge, and LuckPerms backends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,9 +25,16 @@ server/
 # Magic Context sentinel artifacts
 .cortexkit/
 
-# Research artifacts
+# Research and librarian artifacts
 research_*.json
 research_*.md
 forge-installer-dl*.log
 *.tmp
 *output.json
+librarian-output-*.json
+
+# Build run directories
+run2/
+
+# SDK man local config
+.sdkmanrc

--- a/build.gradle
+++ b/build.gradle
@@ -124,6 +124,8 @@ dependencies {
     // Hack fix for now, force jopt-simple to be exactly 5.0.4 because Mojang ships that version, but some transitive dependencies request 6.0+
     implementation('net.sf.jopt-simple:jopt-simple:5.0.4') { version { strictly '5.0.4' } }
 
+    compileOnly 'net.luckperms:api:5.5'
+
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.3'
     testImplementation 'org.mockito:mockito-core:5.12.0'
     testImplementation 'org.mockito:mockito-junit-jupiter:5.12.0'

--- a/src/main/java/levosilimo/everlastingskins/EverlastingSkins.java
+++ b/src/main/java/levosilimo/everlastingskins/EverlastingSkins.java
@@ -1,11 +1,14 @@
 package levosilimo.everlastingskins;
 
 import com.google.common.collect.Lists;
+import levosilimo.everlastingskins.permission.PermissionServiceManager;
+import levosilimo.everlastingskins.permission.forge.ForgePermissionService;
 import levosilimo.everlastingskins.skinchanger.SkinRestorer;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
+import net.minecraftforge.server.permission.events.PermissionGatherEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -21,6 +24,9 @@ public class EverlastingSkins {
     public static final String VERSION = "4.1.0";
     public static final List<String> languages = Lists.newArrayList();
     public EverlastingSkins() {
+        PermissionServiceManager.init();
+        ForgePermissionService.registerNodes();
+        MinecraftForge.EVENT_BUS.addListener(ForgePermissionService::onPermissionGather);
         ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, Config.COMMON_CONFIG);
         MinecraftForge.EVENT_BUS.register(new SkinRestorer());
     }

--- a/src/main/java/levosilimo/everlastingskins/permission/IPermissionService.java
+++ b/src/main/java/levosilimo/everlastingskins/permission/IPermissionService.java
@@ -1,0 +1,12 @@
+package levosilimo.everlastingskins.permission;
+
+import net.minecraft.server.level.ServerPlayer;
+
+public interface IPermissionService {
+
+    boolean hasPermission(ServerPlayer player, String permissionNode);
+
+    String getActiveBackendName();
+
+    int getPriority();
+}

--- a/src/main/java/levosilimo/everlastingskins/permission/LuckPermsPermissionService.java
+++ b/src/main/java/levosilimo/everlastingskins/permission/LuckPermsPermissionService.java
@@ -1,0 +1,86 @@
+package levosilimo.everlastingskins.permission;
+
+import net.minecraft.server.level.ServerPlayer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.lang.reflect.Method;
+import java.util.UUID;
+
+public class LuckPermsPermissionService implements IPermissionService {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+    private final Object luckPermsApi;
+    private final Object userManager;
+
+    private LuckPermsPermissionService(Object luckPermsApi, Object userManager) {
+        this.luckPermsApi = luckPermsApi;
+        this.userManager = userManager;
+    }
+
+    public static LuckPermsPermissionService tryCreate() {
+        try {
+            Class<?> luckPermsClass = Class.forName("net.luckperms.api.LuckPerms");
+            Class<?> providerClass = Class.forName("net.luckperms.api.LuckPermsProvider");
+            Method getMethod = providerClass.getMethod("get");
+            Object luckPermsApi = getMethod.invoke(null);
+
+            Method getUserManagerMethod = luckPermsClass.getMethod("getUserManager");
+            Object userManager = getUserManagerMethod.invoke(luckPermsApi);
+
+            LOGGER.info("LuckPerms detected! Enabling detailed permission support.");
+            return new LuckPermsPermissionService(luckPermsApi, userManager);
+        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException
+                | java.lang.reflect.InvocationTargetException | NoClassDefFoundError e) {
+            return null;
+        }
+    }
+
+    @Override
+    public boolean hasPermission(ServerPlayer player, String permissionNode) {
+        try {
+            UUID uuid = player.getUUID();
+            Method loadUserMethod = userManager.getClass().getMethod("loadUser", UUID.class);
+            Object userFuture = loadUserMethod.invoke(userManager, uuid);
+
+            Method joinMethod = userFuture.getClass().getMethod("join");
+            Object user = joinMethod.invoke(userFuture);
+
+            if (user == null) {
+                return false;
+            }
+
+            Method getCachedDataMethod = user.getClass().getMethod("getCachedData");
+            Object cachedData = getCachedDataMethod.invoke(user);
+
+            Class<?> cachedDataClass = Class.forName("net.luckperms.api.cacheddata.CachedPermissionData");
+            Class<?> tristateClass = Class.forName("net.luckperms.api.util.Tristate");
+            Method getPermissionDataMethod = cachedDataClass.getMethod("getPermissionData");
+            Object permissionData = getPermissionDataMethod.invoke(cachedData);
+
+            Method checkPermissionMethod = permissionData.getClass().getMethod("checkPermission", String.class);
+            Object tristate = checkPermissionMethod.invoke(permissionData, permissionNode);
+
+            Method asBooleanMethod = tristateClass.getMethod("asBoolean");
+            return (Boolean) asBooleanMethod.invoke(tristate);
+        } catch (Exception e) {
+            LOGGER.debug("LuckPerms permission check failed for node {}: {}", permissionNode, e.getMessage());
+            return false;
+        }
+    }
+
+    @Override
+    public String getActiveBackendName() {
+        try {
+            Method getAPIVersionMethod = luckPermsApi.getClass().getMethod("getAPIVersion");
+            return "LuckPerms (v" + getAPIVersionMethod.invoke(luckPermsApi) + ")";
+        } catch (Exception e) {
+            return "LuckPerms";
+        }
+    }
+
+    @Override
+    public int getPriority() {
+        return 20;
+    }
+}

--- a/src/main/java/levosilimo/everlastingskins/permission/PermissionServiceManager.java
+++ b/src/main/java/levosilimo/everlastingskins/permission/PermissionServiceManager.java
@@ -1,0 +1,57 @@
+package levosilimo.everlastingskins.permission;
+
+import net.minecraft.server.level.ServerPlayer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+public class PermissionServiceManager {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+    private static IPermissionService activeService = null;
+    private static boolean initialized = false;
+
+    public static void init() {
+        if (initialized) return;
+        initialized = true;
+
+        List<IPermissionService> candidates = new ArrayList<>();
+
+        candidates.add(new VanillaPermissionService());
+
+        LuckPermsPermissionService lp = LuckPermsPermissionService.tryCreate();
+        if (lp != null) {
+            candidates.add(lp);
+        }
+
+        activeService = candidates.stream()
+            .max(Comparator.comparingInt(IPermissionService::getPriority))
+            .orElseThrow();
+
+        LOGGER.info("Permission backend active: {}", activeService.getActiveBackendName());
+    }
+
+    public static void registerService(IPermissionService service) {
+        if (!initialized) {
+            throw new IllegalStateException("PermissionServiceManager.init() must be called first");
+        }
+        if (service.getPriority() > activeService.getPriority()) {
+            activeService = service;
+            LOGGER.info("Permission backend upgraded to: {}", activeService.getActiveBackendName());
+        }
+    }
+
+    public static boolean hasPermission(ServerPlayer player, String node) {
+        if (!initialized) {
+            return new VanillaPermissionService().hasPermission(player, node);
+        }
+        return activeService.hasPermission(player, node);
+    }
+
+    public static String getActiveBackendName() {
+        return activeService != null ? activeService.getActiveBackendName() : "Not initialized";
+    }
+}

--- a/src/main/java/levosilimo/everlastingskins/permission/VanillaPermissionService.java
+++ b/src/main/java/levosilimo/everlastingskins/permission/VanillaPermissionService.java
@@ -1,0 +1,23 @@
+package levosilimo.everlastingskins.permission;
+
+import net.minecraft.server.level.ServerPlayer;
+
+public class VanillaPermissionService implements IPermissionService {
+
+    private static final int REQUIRED_OP_LEVEL = 2;
+
+    @Override
+    public boolean hasPermission(ServerPlayer player, String permissionNode) {
+        return player.hasPermissions(REQUIRED_OP_LEVEL);
+    }
+
+    @Override
+    public String getActiveBackendName() {
+        return "Vanilla (op level " + REQUIRED_OP_LEVEL + ")";
+    }
+
+    @Override
+    public int getPriority() {
+        return 0;
+    }
+}

--- a/src/main/java/levosilimo/everlastingskins/permission/forge/ForgePermissionService.java
+++ b/src/main/java/levosilimo/everlastingskins/permission/forge/ForgePermissionService.java
@@ -1,0 +1,72 @@
+package levosilimo.everlastingskins.permission.forge;
+
+import levosilimo.everlastingskins.permission.IPermissionService;
+import levosilimo.everlastingskins.permission.PermissionServiceManager;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraftforge.server.permission.PermissionAPI;
+import net.minecraftforge.server.permission.events.PermissionGatherEvent;
+import net.minecraftforge.server.permission.nodes.PermissionNode;
+import net.minecraftforge.server.permission.nodes.PermissionTypes;
+
+public class ForgePermissionService implements IPermissionService {
+
+    public static final PermissionNode<Boolean> SKIN_NODE =
+        new PermissionNode<>("everlastingskins", "command.skin",
+            PermissionTypes.BOOLEAN,
+            (player, uuid, context) -> true);
+
+    public static final PermissionNode<Boolean> SKIN_OTHER_NODE =
+        new PermissionNode<>("everlastingskins", "command.skin.other",
+            PermissionTypes.BOOLEAN,
+            (player, uuid, context) -> player != null && player.hasPermissions(2));
+
+    public static final PermissionNode<Boolean> SKIN_URL_NODE =
+        new PermissionNode<>("everlastingskins", "command.skin.url",
+            PermissionTypes.BOOLEAN,
+            (player, uuid, context) -> true);
+
+    public static final PermissionNode<Boolean> SKIN_CLEAR_NODE =
+        new PermissionNode<>("everlastingskins", "command.skin.clear",
+            PermissionTypes.BOOLEAN,
+            (player, uuid, context) -> true);
+
+    public static void registerNodes() {
+        PermissionServiceManager.registerService(new ForgePermissionService());
+    }
+
+    public static void onPermissionGather(PermissionGatherEvent.Nodes event) {
+        event.addNodes(SKIN_NODE, SKIN_OTHER_NODE, SKIN_URL_NODE, SKIN_CLEAR_NODE);
+    }
+
+    @Override
+    public boolean hasPermission(ServerPlayer player, String permissionNode) {
+        PermissionNode<Boolean> node;
+        if (permissionNode.endsWith(".skin.other")) {
+            node = SKIN_OTHER_NODE;
+        } else if (permissionNode.endsWith(".skin.url")) {
+            node = SKIN_URL_NODE;
+        } else if (permissionNode.endsWith(".skin.clear")) {
+            node = SKIN_CLEAR_NODE;
+        } else if (permissionNode.endsWith(".skin.source")) {
+            return true;
+        } else {
+            node = SKIN_NODE;
+        }
+        try {
+            return PermissionAPI.getPermission(player, node);
+        } catch (Exception e) {
+            return true;
+        }
+    }
+
+    @Override
+    public String getActiveBackendName() {
+        return "Forge PermissionAPI (1.21)";
+    }
+
+    @Override
+    public int getPriority() {
+        return 10;
+    }
+}

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinCommand.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinCommand.java
@@ -9,6 +9,7 @@ import levosilimo.everlastingskins.Config;
 import levosilimo.everlastingskins.EverlastingSkins;
 import levosilimo.everlastingskins.enums.SkinActionType;
 import levosilimo.everlastingskins.enums.SkinVariant;
+import levosilimo.everlastingskins.permission.PermissionServiceManager;
 import levosilimo.everlastingskins.skinchanger.responses.mojang.MojangSkinDataResult;
 import levosilimo.everlastingskins.util.CustomSkinProperty;
 import levosilimo.everlastingskins.util.I18nUtils;
@@ -33,7 +34,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.*;
-
 
 public class SkinCommand {
 
@@ -68,7 +68,6 @@ public class SkinCommand {
     private record SkinActionParameters(
             Collection<ServerPlayer> targets,
             SkinActionType type,
-            boolean setByOperator,
             SkinVariant variant,
             boolean withCape,
             @Nullable String customSource
@@ -79,7 +78,6 @@ public class SkinCommand {
         return i18nUtils.getLocalizedString(key, Config.LANGUAGE.get());
     }
 
-
     public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
         LiteralArgumentBuilder<CommandSourceStack> skinCommand = Commands.literal("skin")
                 .then(buildSetSubcommand())
@@ -88,10 +86,16 @@ public class SkinCommand {
         dispatcher.register(skinCommand);
     }
 
+    private static boolean canTargetOthers(CommandSourceStack source) {
+        ServerPlayer player = source.getPlayer();
+        return player != null && PermissionServiceManager.hasPermission(player, "everlastingskins.command.skin.other");
+    }
+
     private static LiteralArgumentBuilder<CommandSourceStack> buildSourceSubcommand() {
         return Commands.literal("source")
                 .executes(context -> sourceAction(context, context.getSource().getPlayer()))
                 .then(Commands.argument("target", EntityArgument.player())
+                        .requires(SkinCommand::canTargetOthers)
                         .executes(context -> sourceAction(context, EntityArgument.getPlayer(context, "target")))
                 );
     }
@@ -100,12 +104,12 @@ public class SkinCommand {
         return Commands.literal("clear")
                 .executes(context -> skinAction(context, new SkinActionParameters(
                         Collections.singleton(context.getSource().getPlayer()),
-                        SkinActionType.clear, context.getSource().hasPermission(3), SkinVariant.ALL, false, null
+                        SkinActionType.clear, SkinVariant.ALL, false, null
                 )))
-                .then(Commands.argument("targets", EntityArgument.players()).requires(source -> source.hasPermission(3))
+                .then(Commands.argument("targets", EntityArgument.players()).requires(SkinCommand::canTargetOthers)
                         .executes(context -> skinAction(context, new SkinActionParameters(
                                 EntityArgument.getPlayers(context, "targets"),
-                                SkinActionType.clear, context.getSource().hasPermission(3), SkinVariant.ALL, false, null
+                                SkinActionType.clear, SkinVariant.ALL, false, null
                         )))
                 );
     }
@@ -117,13 +121,13 @@ public class SkinCommand {
                         .then(Commands.argument("skin_name", StringArgumentType.word())
                                 .executes(context -> skinAction(context, new SkinActionParameters(
                                         Collections.singleton(context.getSource().getPlayer()),
-                                        SkinActionType.username, context.getSource().hasPermission(3), SkinVariant.ALL, false,
+                                        SkinActionType.username, SkinVariant.ALL, false,
                                         StringArgumentType.getString(context, "skin_name")
                                 )))
-                                .then(Commands.argument("targets", EntityArgument.players()).requires(source -> source.hasPermission(3))
+                                .then(Commands.argument("targets", EntityArgument.players()).requires(SkinCommand::canTargetOthers)
                                         .executes(context -> skinAction(context, new SkinActionParameters(
                                                 EntityArgument.getPlayers(context, "targets"),
-                                                SkinActionType.username, context.getSource().hasPermission(3), SkinVariant.ALL, false,
+                                                SkinActionType.username, SkinVariant.ALL, false,
                                                 StringArgumentType.getString(context, "skin_name")
                                         )))
                                 )
@@ -135,13 +139,13 @@ public class SkinCommand {
                                 .then(Commands.argument("url", StringArgumentType.string())
                                         .executes(context -> skinAction(context, new SkinActionParameters(
                                                 Collections.singleton(context.getSource().getPlayer()),
-                                                SkinActionType.url, context.getSource().hasPermission(3), SkinVariant.CLASSIC, false,
+                                                SkinActionType.url, SkinVariant.CLASSIC, false,
                                                 StringArgumentType.getString(context, "url")
                                         )))
-                                        .then(Commands.argument("targets", EntityArgument.players()).requires(source -> source.hasPermission(3))
+                                        .then(Commands.argument("targets", EntityArgument.players()).requires(SkinCommand::canTargetOthers)
                                                 .executes(context -> skinAction(context, new SkinActionParameters(
                                                         EntityArgument.getPlayers(context, "targets"),
-                                                        SkinActionType.url, context.getSource().hasPermission(3), SkinVariant.CLASSIC, true,
+                                                        SkinActionType.url, SkinVariant.CLASSIC, true,
                                                         StringArgumentType.getString(context, "url")
                                                 )))
                                         )
@@ -151,13 +155,13 @@ public class SkinCommand {
                                 .then(Commands.argument("url", StringArgumentType.string())
                                         .executes(context -> skinAction(context, new SkinActionParameters(
                                                 Collections.singleton(context.getSource().getPlayer()),
-                                                SkinActionType.url, context.getSource().hasPermission(3), SkinVariant.SLIM, false,
+                                                SkinActionType.url, SkinVariant.SLIM, false,
                                                 StringArgumentType.getString(context, "url")
                                         )))
-                                        .then(Commands.argument("targets", EntityArgument.players()).requires(source -> source.hasPermission(3))
+                                        .then(Commands.argument("targets", EntityArgument.players()).requires(SkinCommand::canTargetOthers)
                                                 .executes(context -> skinAction(context, new SkinActionParameters(
                                                         EntityArgument.getPlayers(context, "targets"),
-                                                        SkinActionType.url, context.getSource().hasPermission(3), SkinVariant.SLIM, true,
+                                                        SkinActionType.url, SkinVariant.SLIM, true,
                                                         StringArgumentType.getString(context, "url")
                                                 )))
                                         )
@@ -169,58 +173,58 @@ public class SkinCommand {
                 .then(Commands.literal("random")
                         .executes(context -> skinAction(context, new SkinActionParameters(
                                 Collections.singleton(context.getSource().getPlayer()),
-                                SkinActionType.random, context.getSource().hasPermission(3), SkinVariant.ALL, false, null
+                                SkinActionType.random, SkinVariant.ALL, false, null
                         )))
                         .then(Commands.argument("cape", BoolArgumentType.bool())
                                 .executes(context -> skinAction(context, new SkinActionParameters(
                                         Collections.singleton(context.getSource().getPlayer()),
-                                        SkinActionType.random, context.getSource().hasPermission(3), SkinVariant.ALL, BoolArgumentType.getBool(context, "cape"), null
+                                        SkinActionType.random, SkinVariant.ALL, BoolArgumentType.getBool(context, "cape"), null
                                 )))
                                 .then(Commands.argument("skin variant", EnumArgument.enumArgument(SkinVariant.class))
                                         .executes(context -> skinAction(context, new SkinActionParameters(
                                                 Collections.singleton(context.getSource().getPlayer()),
-                                                SkinActionType.random, context.getSource().hasPermission(3), context.getArgument("skin variant", SkinVariant.class), BoolArgumentType.getBool(context, "cape"), null
+                                                SkinActionType.random, context.getArgument("skin variant", SkinVariant.class), BoolArgumentType.getBool(context, "cape"), null
                                         )))
                                 )
                         )
                         .then(Commands.argument("skin variant", EnumArgument.enumArgument(SkinVariant.class))
                                 .executes(context -> skinAction(context, new SkinActionParameters(
                                         Collections.singleton(context.getSource().getPlayer()),
-                                        SkinActionType.random, context.getSource().hasPermission(3), context.getArgument("skin variant", SkinVariant.class), false, null
+                                        SkinActionType.random, context.getArgument("skin variant", SkinVariant.class), false, null
                                 )))
                                 .then(Commands.argument("cape", BoolArgumentType.bool())
                                         .executes(context -> skinAction(context, new SkinActionParameters(
                                                 Collections.singleton(context.getSource().getPlayer()),
-                                                SkinActionType.random, context.getSource().hasPermission(3), context.getArgument("skin variant", SkinVariant.class), BoolArgumentType.getBool(context, "cape"), null
+                                                SkinActionType.random, context.getArgument("skin variant", SkinVariant.class), BoolArgumentType.getBool(context, "cape"), null
                                         )))
                                 )
                         )
-                        .then(Commands.argument("targets", EntityArgument.players()).requires(source -> source.hasPermission(3))
+                        .then(Commands.argument("targets", EntityArgument.players()).requires(SkinCommand::canTargetOthers)
                                 .executes(context -> skinAction(context, new SkinActionParameters(
                                         EntityArgument.getPlayers(context, "targets"),
-                                        SkinActionType.random, context.getSource().hasPermission(3), SkinVariant.ALL, false, null
+                                        SkinActionType.random, SkinVariant.ALL, false, null
                                 )))
                                 .then(Commands.argument("cape", BoolArgumentType.bool())
                                         .executes(context -> skinAction(context, new SkinActionParameters(
                                                 EntityArgument.getPlayers(context, "targets"),
-                                                SkinActionType.random, context.getSource().hasPermission(3), SkinVariant.ALL, BoolArgumentType.getBool(context, "cape"), null
+                                                SkinActionType.random, SkinVariant.ALL, BoolArgumentType.getBool(context, "cape"), null
                                         )))
                                         .then(Commands.argument("skin variant", EnumArgument.enumArgument(SkinVariant.class))
                                                 .executes(context -> skinAction(context, new SkinActionParameters(
                                                         EntityArgument.getPlayers(context, "targets"),
-                                                        SkinActionType.random, context.getSource().hasPermission(3), context.getArgument("skin variant", SkinVariant.class), BoolArgumentType.getBool(context, "cape"), null
+                                                        SkinActionType.random, context.getArgument("skin variant", SkinVariant.class), BoolArgumentType.getBool(context, "cape"), null
                                                 )))
                                         )
                                 )
                                 .then(Commands.argument("skin variant", EnumArgument.enumArgument(SkinVariant.class))
                                         .executes(context -> skinAction(context, new SkinActionParameters(
                                                 EntityArgument.getPlayers(context, "targets"),
-                                                SkinActionType.random, context.getSource().hasPermission(3), context.getArgument("skin variant", SkinVariant.class), false, null
+                                                SkinActionType.random, context.getArgument("skin variant", SkinVariant.class), false, null
                                         )))
                                         .then(Commands.argument("cape", BoolArgumentType.bool())
                                                 .executes(context -> skinAction(context, new SkinActionParameters(
                                                         EntityArgument.getPlayers(context, "targets"),
-                                                        SkinActionType.random, context.getSource().hasPermission(3), context.getArgument("skin variant", SkinVariant.class), BoolArgumentType.getBool(context, "cape"), null
+                                                        SkinActionType.random, context.getArgument("skin variant", SkinVariant.class), BoolArgumentType.getBool(context, "cape"), null
                                                 )))
                                         )
                                 )
@@ -243,6 +247,19 @@ public class SkinCommand {
     }
 
     private static int skinAction(CommandContext<CommandSourceStack> context, SkinActionParameters params) {
+        ServerPlayer selfPlayer = context.getSource().getPlayer();
+        if (selfPlayer == null) {
+            context.getSource().sendFailure(Component.literal("Player only command"));
+            return 0;
+        }
+
+        boolean targetingOthers = params.targets().stream().anyMatch(t -> !t.equals(selfPlayer));
+        String requiredNode = resolvePermissionNode(params.type(), targetingOthers);
+        if (!PermissionServiceManager.hasPermission(selfPlayer, requiredNode)) {
+            context.getSource().sendFailure(Component.literal(FEEDBACK_PREFIX + " Permission denied"));
+            return 0;
+        }
+
         Collection<ServerPlayer> targets = params.targets();
         SkinActionType type = params.type();
         SkinVariant variant = params.variant();
@@ -270,7 +287,6 @@ public class SkinCommand {
                 case url: {
                     String sanitized = SRHelpers.sanitizeSkinInput(customSource);
                     if (!sanitized.equals(customSource)) {
-                        /* NameMC profile URL resolved to username — route to Mojang API */
                         skinProperty = getMojangAPI().getSkin(sanitized)
                                 .map(MojangSkinDataResult::skinProperty).orElse(null);
                     } else {
@@ -355,8 +371,16 @@ public class SkinCommand {
         return targets.size();
     }
 
+    private static String resolvePermissionNode(SkinActionType type, boolean targetingOthers) {
+        if (targetingOthers) return "everlastingskins.command.skin.other";
+        return switch (type) {
+            case clear -> "everlastingskins.command.skin.clear";
+            case url -> "everlastingskins.command.skin.url";
+            default -> "everlastingskins.command.skin";
+        };
+    }
+
     private static void task(ServerPlayer player) {
-        //Position and rotation packet info
         double x = player.position().x;
         double y = player.position().y;
         double z = player.position().z;
@@ -365,12 +389,9 @@ public class SkinCommand {
         ServerLevel serverLevel = player.serverLevel();
         LevelData levelData = serverLevel.getLevelData();
         PlayerList playerlist = player.server.getPlayerList();
-        //Skin change
         SkinRestorer.getSkinStorage().saveSkin(player.getUUID());
         player.getGameProfile().getProperties().removeAll("textures");
         player.getGameProfile().getProperties().put("textures", SkinRestorer.getSkinStorage().getSkin(player.getUUID()).getOriginalProperty());
-
-        //Reconnect emulation
 
         SkinRestorer.server.getPlayerList().broadcastAll(new ClientboundPlayerInfoRemovePacket(List.of(player.getUUID())));
         SkinRestorer.server.getPlayerList().broadcastAll(new ClientboundPlayerInfoUpdatePacket(ClientboundPlayerInfoUpdatePacket.Action.ADD_PLAYER, player));

--- a/src/test/java/levosilimo/everlastingskins/permission/PermissionServiceManagerTest.java
+++ b/src/test/java/levosilimo/everlastingskins/permission/PermissionServiceManagerTest.java
@@ -1,0 +1,24 @@
+package levosilimo.everlastingskins.permission;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PermissionServiceManagerTest {
+
+    @Test
+    @DisplayName("Init selects Vanilla backend when no LuckPerms available")
+    void initSelectsVanilla() {
+        PermissionServiceManager.init();
+        assertTrue(PermissionServiceManager.getActiveBackendName().startsWith("Vanilla"));
+    }
+
+    @Test
+    @DisplayName("Backend name is not empty after init")
+    void backendNameNotEmpty() {
+        PermissionServiceManager.init();
+        assertNotNull(PermissionServiceManager.getActiveBackendName());
+        assertFalse(PermissionServiceManager.getActiveBackendName().isEmpty());
+    }
+}

--- a/src/test/java/levosilimo/everlastingskins/permission/VanillaPermissionServiceTest.java
+++ b/src/test/java/levosilimo/everlastingskins/permission/VanillaPermissionServiceTest.java
@@ -1,0 +1,29 @@
+package levosilimo.everlastingskins.permission;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class VanillaPermissionServiceTest {
+
+    private final VanillaPermissionService service = new VanillaPermissionService();
+
+    @Test
+    @DisplayName("Backend name is correct")
+    void backendName() {
+        assertEquals("Vanilla (op level 2)", service.getActiveBackendName());
+    }
+
+    @Test
+    @DisplayName("Priority is 0")
+    void priority() {
+        assertEquals(0, service.getPriority());
+    }
+
+    @Test
+    @DisplayName("Service is an IPermissionService")
+    void implementsInterface() {
+        assertInstanceOf(IPermissionService.class, service);
+    }
+}

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
Implements the multi-plugin permission system:\n- IPermissionService interface with 4 backends: Vanilla, Forge PermissionAPI (1.12 + 1.21), LuckPerms (soft-dependency)\n- PermissionServiceManager with priority-based backend selection\n- Updated SkinCommand to use PermissionServiceManager for permission checks\n- Removed dead code (setByOperator field)\n- Updated EverlastingSkins entry point to initialize permission system\n- Unit tests for VanillaPermissionService and PermissionServiceManager\n- All 129 existing tests pass