### PR TITLE
chore(scan): fix 2 aislop warnings on 1.21 branch

### DIFF
--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinCommand.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinCommand.java
@@ -12,25 +12,18 @@ import levosilimo.everlastingskins.enums.SkinVariant;
 import levosilimo.everlastingskins.permission.PermissionServiceManager;
 import levosilimo.everlastingskins.skinchanger.responses.mojang.MojangSkinDataResult;
 import levosilimo.everlastingskins.util.CustomSkinProperty;
-import levosilimo.everlastingskins.util.I18nUtils;
 import levosilimo.everlastingskins.util.SRHelpers;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.commands.arguments.EntityArgument;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.network.protocol.game.*;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.server.players.PlayerList;
-import net.minecraft.world.entity.Entity;
-import net.minecraft.world.level.storage.LevelData;
 import net.minecraftforge.server.command.EnumArgument;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.*;
@@ -39,8 +32,6 @@ public class SkinCommand {
 
     private static final ScheduledExecutorService skinCommandExecutor = Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors() * 2);
     private static final String FEEDBACK_PREFIX = "§6[EverlastingSkins]§f";
-
-    private static I18nUtils i18nUtils;
 
     private static MineSkinAPI mineSkinAPIInstance;
     private static MojangAPI mojangAPIInstance;
@@ -72,11 +63,6 @@ public class SkinCommand {
             boolean withCape,
             @Nullable String customSource
     ) {}
-
-    private static String getLocalizedString(String key) {
-        if(i18nUtils == null) i18nUtils = new I18nUtils();
-        return i18nUtils.getLocalizedString(key, Config.LANGUAGE.get());
-    }
 
     public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
         LiteralArgumentBuilder<CommandSourceStack> skinCommand = Commands.literal("skin")
@@ -268,19 +254,34 @@ public class SkinCommand {
 
         targets.forEach(player -> {
                 if(Config.TOGGLE.get()) {
-                    if(player == context.getSource().getEntity()) context.getSource().sendSuccess(() -> Component.literal(FEEDBACK_PREFIX + " " + getLocalizedString("change")), false);
-                    else player.sendSystemMessage(Component.literal(FEEDBACK_PREFIX + " " + getLocalizedString("change")));
+                    if(player == context.getSource().getEntity()) context.getSource().sendSuccess(() -> Component.literal(FEEDBACK_PREFIX + " " + SkinRefreshHandler.getLocalizedString("change")), false);
+                    else player.sendSystemMessage(Component.literal(FEEDBACK_PREFIX + " " + SkinRefreshHandler.getLocalizedString("change")));
                 }
         });
 
-        CompletableFuture<CustomSkinProperty> skinPropertyCompletableFuture = CompletableFuture.supplyAsync(() -> {
+        CompletableFuture<CustomSkinProperty> skinPropertyCompletableFuture = fetchSkinProperty(type, variant, withCape, customSource, targets);
+        skinPropertyCompletableFuture.whenComplete((skinProperty, throwable) ->
+                handleSkinCompletion(skinProperty, throwable, targets, context, type, customSource));
+
+        skinCommandExecutor.schedule(() -> {
+            if(skinPropertyCompletableFuture.completeExceptionally(new TimeoutException("Skin fetch timeout occurred"))) {
+                EverlastingSkins.logger.error(SkinRefreshHandler.getLocalizedString("timeout"));
+                for(ServerPlayer player: targets) player.sendSystemMessage(Component.literal(FEEDBACK_PREFIX + " " + SkinRefreshHandler.getLocalizedString("timeout")));
+            }
+        }, 10000, TimeUnit.MILLISECONDS);
+
+        return targets.size();
+    }
+
+    private static CompletableFuture<CustomSkinProperty> fetchSkinProperty(SkinActionType type, SkinVariant variant, boolean withCape, String customSource, Collection<ServerPlayer> targets) {
+        return CompletableFuture.supplyAsync(() -> {
             CustomSkinProperty skinProperty = null;
             switch (type) {
                 case clear: {
                     ServerPlayer first = targets.stream().findFirst().get();
                     String storedSrc = SkinRestorer.getSkinStorage().getSource(first.getUUID());
                     String pName = first.getGameProfile().getName();
-                    MojangRestoreResult restore = tryRestoreFromMojang(getMojangAPI(), storedSrc, pName);
+                    SkinRefreshHandler.MojangRestoreResult restore = SkinRefreshHandler.tryRestoreFromMojang(getMojangAPI(), storedSrc, pName);
                     skinProperty = restore != null ? restore.skin : null;
                     break;
                 }
@@ -316,59 +317,54 @@ public class SkinCommand {
                     break;
             }
             return skinProperty;
-        }, skinCommandExecutor).whenComplete((skinProperty, throwable) -> {
-            if (throwable != null) {
-                EverlastingSkins.logger.error("Skin process error occurred");
-                for (ServerPlayer player : targets) player.sendSystemMessage(Component.literal(FEEDBACK_PREFIX + " " + getLocalizedString("error")));
-                return;
-            }
-            boolean isClear = type == SkinActionType.clear;
-            if (skinProperty == null && !isClear) {
-                String reason = deriveReason(type, customSource);
-                EverlastingSkins.logger.warn("Skin provider returned no result: {}", reason);
-                for (ServerPlayer player : targets) player.sendSystemMessage(Component.literal(FEEDBACK_PREFIX + " " + reason));
-                return;
-            }
-            if (isClear && skinProperty == null) {
-                EverlastingSkins.logger.info("Skin cleared for player(s) — no Mojang profile found");
-                for (ServerPlayer player : targets) {
-                    SkinRestorer.getSkinStorage().setSkin(player.getUUID(), null);
-                    if (Config.TOGGLE.get()) {
-                        player.sendSystemMessage(Component.literal(FEEDBACK_PREFIX + " Skin cleared (no Mojang profile found)"));
-                    }
-                }
-                for (ServerPlayer player : targets) {
-                    SkinRestorer.server.execute(() -> task(player));
-                }
-                return;
-            }
-            boolean isRestore = isClear && skinProperty != null;
+        }, skinCommandExecutor);
+    }
+
+    private static void handleSkinCompletion(CustomSkinProperty skinProperty, Throwable throwable,
+                                             Collection<ServerPlayer> targets, CommandContext<CommandSourceStack> context,
+                                             SkinActionType type, String customSource) {
+        if (throwable != null) {
+            EverlastingSkins.logger.error("Skin process error occurred");
+            for (ServerPlayer player : targets) player.sendSystemMessage(Component.literal(FEEDBACK_PREFIX + " " + SkinRefreshHandler.getLocalizedString("error")));
+            return;
+        }
+        boolean isClear = type == SkinActionType.clear;
+        if (skinProperty == null && !isClear) {
+            String reason = SkinRefreshHandler.deriveReason(type, customSource);
+            EverlastingSkins.logger.warn("Skin provider returned no result: {}", reason);
+            for (ServerPlayer player : targets) player.sendSystemMessage(Component.literal(FEEDBACK_PREFIX + " " + reason));
+            return;
+        }
+        if (isClear && skinProperty == null) {
+            EverlastingSkins.logger.info("Skin cleared for player(s) — no Mojang profile found");
             for (ServerPlayer player : targets) {
-                SkinRestorer.getSkinStorage().setSkin(player.getUUID(), skinProperty);
+                SkinRestorer.getSkinStorage().setSkin(player.getUUID(), null);
                 if (Config.TOGGLE.get()) {
-                    String msg = isRestore
-                        ? "Skin restored from " + skinProperty.getSource()
-                        : getLocalizedString("fulfilled");
-                    if (player == context.getSource().getEntity()) {
-                        context.getSource().sendSuccess(() -> Component.literal(FEEDBACK_PREFIX + " " + msg), false);
-                    } else {
-                        player.sendSystemMessage(Component.literal(FEEDBACK_PREFIX + " " + msg));
-                    }
+                    player.sendSystemMessage(Component.literal(FEEDBACK_PREFIX + " Skin cleared (no Mojang profile found)"));
                 }
             }
             for (ServerPlayer player : targets) {
-                SkinRestorer.server.execute(() -> task(player));
+                SkinRestorer.server.execute(() -> SkinRefreshHandler.task(player));
             }
-        });
-
-        skinCommandExecutor.schedule(() -> {
-            if(skinPropertyCompletableFuture.completeExceptionally(new TimeoutException("Skin fetch timeout occurred"))) {
-                EverlastingSkins.logger.error(getLocalizedString("timeout"));
-                for(ServerPlayer player: targets) player.sendSystemMessage(Component.literal(FEEDBACK_PREFIX + " " + getLocalizedString("timeout")));
+            return;
+        }
+        boolean isRestore = isClear && skinProperty != null;
+        for (ServerPlayer player : targets) {
+            SkinRestorer.getSkinStorage().setSkin(player.getUUID(), skinProperty);
+            if (Config.TOGGLE.get()) {
+                String msg = isRestore
+                    ? "Skin restored from " + skinProperty.getSource()
+                    : SkinRefreshHandler.getLocalizedString("fulfilled");
+                if (player == context.getSource().getEntity()) {
+                    context.getSource().sendSuccess(() -> Component.literal(FEEDBACK_PREFIX + " " + msg), false);
+                } else {
+                    player.sendSystemMessage(Component.literal(FEEDBACK_PREFIX + " " + msg));
+                }
             }
-        }, 10000, TimeUnit.MILLISECONDS);
-
-        return targets.size();
+        }
+        for (ServerPlayer player : targets) {
+            SkinRestorer.server.execute(() -> SkinRefreshHandler.task(player));
+        }
     }
 
     private static String resolvePermissionNode(SkinActionType type, boolean targetingOthers) {
@@ -380,78 +376,4 @@ public class SkinCommand {
         };
     }
 
-    private static void task(ServerPlayer player) {
-        double x = player.position().x;
-        double y = player.position().y;
-        double z = player.position().z;
-        float yaw = player.getYRot();
-        float pitch = player.getXRot();
-        ServerLevel serverLevel = player.serverLevel();
-        LevelData levelData = serverLevel.getLevelData();
-        PlayerList playerlist = player.server.getPlayerList();
-        SkinRestorer.getSkinStorage().saveSkin(player.getUUID());
-        player.getGameProfile().getProperties().removeAll("textures");
-        player.getGameProfile().getProperties().put("textures", SkinRestorer.getSkinStorage().getSkin(player.getUUID()).getOriginalProperty());
-
-        SkinRestorer.server.getPlayerList().broadcastAll(new ClientboundPlayerInfoRemovePacket(List.of(player.getUUID())));
-        SkinRestorer.server.getPlayerList().broadcastAll(new ClientboundPlayerInfoUpdatePacket(ClientboundPlayerInfoUpdatePacket.Action.ADD_PLAYER, player));
-        player.connection.send(new ClientboundRespawnPacket(player.createCommonSpawnInfo(serverLevel), (byte)3));
-        player.absMoveTo(x,y,z,yaw,pitch);
-        player.connection.send(new ClientboundPlayerPositionPacket(x,y,z,yaw,pitch,Collections.emptySet(), 0));
-        playerlist.sendLevelInfo(player, serverLevel);
-        playerlist.sendPlayerPermissionLevel(player);
-        playerlist.sendAllPlayerInfo(player);
-        playerlist.sendActivePlayerEffects(player);
-        player.connection.send(new ClientboundPlayerAbilitiesPacket(player.getAbilities()));
-        player.connection.send(new ClientboundChangeDifficultyPacket(levelData.getDifficulty(), levelData.isDifficultyLocked()));
-        SkinRestorer.server.getPlayerList().sendPlayerPermissionLevel(player);
-
-        serverLevel.getChunkSource().chunkMap.removeEntity(player);
-        serverLevel.getChunkSource().chunkMap.addEntity(player);
-    }
-
-    @Nullable
-    static MojangRestoreResult tryRestoreFromMojang(MojangAPI mojangAPI, @Nullable String storedSource, String playerName) {
-        String licensedUsername = (storedSource != null && !storedSource.trim().isEmpty())
-            ? storedSource : playerName;
-        CustomSkinProperty skin = mojangAPI.getSkin(licensedUsername)
-            .map(MojangSkinDataResult::skinProperty)
-            .filter(s -> !s.isEmpty())
-            .orElse(null);
-        if (skin == null) return null;
-        return new MojangRestoreResult(skin, licensedUsername);
-    }
-
-    static class MojangRestoreResult {
-        final CustomSkinProperty skin;
-        final String licensedUsername;
-
-        MojangRestoreResult(CustomSkinProperty skin, String licensedUsername) {
-            this.skin = skin;
-            this.licensedUsername = licensedUsername;
-        }
-    }
-
-    private static String deriveReason(SkinActionType type, @Nullable String customSource) {
-        switch (type) {
-            case username:
-                return customSource != null
-                    ? "No skin found for \"" + customSource + "\""
-                    : "No skin found";
-            case url: {
-                if (customSource != null) {
-                    String sanitized = SRHelpers.sanitizeSkinInput(customSource);
-                    if (!sanitized.equals(customSource)) {
-                        return "No skin found for \"" + sanitized + "\"";
-                    }
-                }
-                return "MineSkin rejected the URL";
-            }
-            case random:
-            case NEW:
-                return "No random username available";
-            default:
-                return "Provider returned no result";
-        }
-    }
 }

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRefreshHandler.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRefreshHandler.java
@@ -1,0 +1,103 @@
+package levosilimo.everlastingskins.skinchanger;
+
+import levosilimo.everlastingskins.Config;
+import levosilimo.everlastingskins.enums.SkinActionType;
+import levosilimo.everlastingskins.skinchanger.responses.mojang.MojangSkinDataResult;
+import levosilimo.everlastingskins.util.CustomSkinProperty;
+import levosilimo.everlastingskins.util.I18nUtils;
+import levosilimo.everlastingskins.util.SRHelpers;
+import net.minecraft.network.protocol.game.*;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.players.PlayerList;
+import net.minecraft.world.level.storage.LevelData;
+
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+public class SkinRefreshHandler {
+
+    private static I18nUtils i18nUtils;
+
+    static String getLocalizedString(String key) {
+        if (i18nUtils == null) i18nUtils = new I18nUtils();
+        return i18nUtils.getLocalizedString(key, Config.LANGUAGE.get());
+    }
+
+    static void task(ServerPlayer player) {
+        double x = player.position().x;
+        double y = player.position().y;
+        double z = player.position().z;
+        float yaw = player.getYRot();
+        float pitch = player.getXRot();
+        ServerLevel serverLevel = player.serverLevel();
+        LevelData levelData = serverLevel.getLevelData();
+        PlayerList playerlist = player.server.getPlayerList();
+        SkinRestorer.getSkinStorage().saveSkin(player.getUUID());
+        player.getGameProfile().getProperties().removeAll("textures");
+        player.getGameProfile().getProperties().put("textures", SkinRestorer.getSkinStorage().getSkin(player.getUUID()).getOriginalProperty());
+
+        SkinRestorer.server.getPlayerList().broadcastAll(new ClientboundPlayerInfoRemovePacket(List.of(player.getUUID())));
+        SkinRestorer.server.getPlayerList().broadcastAll(new ClientboundPlayerInfoUpdatePacket(ClientboundPlayerInfoUpdatePacket.Action.ADD_PLAYER, player));
+        player.connection.send(new ClientboundRespawnPacket(player.createCommonSpawnInfo(serverLevel), (byte) 3));
+        player.absMoveTo(x, y, z, yaw, pitch);
+        player.connection.send(new ClientboundPlayerPositionPacket(x, y, z, yaw, pitch, Collections.emptySet(), 0));
+        playerlist.sendLevelInfo(player, serverLevel);
+        playerlist.sendPlayerPermissionLevel(player);
+        playerlist.sendAllPlayerInfo(player);
+        playerlist.sendActivePlayerEffects(player);
+        player.connection.send(new ClientboundPlayerAbilitiesPacket(player.getAbilities()));
+        player.connection.send(new ClientboundChangeDifficultyPacket(levelData.getDifficulty(), levelData.isDifficultyLocked()));
+        SkinRestorer.server.getPlayerList().sendPlayerPermissionLevel(player);
+
+        serverLevel.getChunkSource().chunkMap.removeEntity(player);
+        serverLevel.getChunkSource().chunkMap.addEntity(player);
+    }
+
+    @Nullable
+    static MojangRestoreResult tryRestoreFromMojang(MojangAPI mojangAPI, @Nullable String storedSource, String playerName) {
+        String licensedUsername = (storedSource != null && !storedSource.trim().isEmpty())
+                ? storedSource : playerName;
+        CustomSkinProperty skin = mojangAPI.getSkin(licensedUsername)
+                .map(MojangSkinDataResult::skinProperty)
+                .filter(s -> !s.isEmpty())
+                .orElse(null);
+        if (skin == null) return null;
+        return new MojangRestoreResult(skin, licensedUsername);
+    }
+
+    static class MojangRestoreResult {
+        final CustomSkinProperty skin;
+        final String licensedUsername;
+
+        MojangRestoreResult(CustomSkinProperty skin, String licensedUsername) {
+            this.skin = skin;
+            this.licensedUsername = licensedUsername;
+        }
+    }
+
+    static String deriveReason(SkinActionType type, @Nullable String customSource) {
+        switch (type) {
+            case username:
+                return customSource != null
+                        ? "No skin found for \"" + customSource + "\""
+                        : "No skin found";
+            case url: {
+                if (customSource != null) {
+                    String sanitized = SRHelpers.sanitizeSkinInput(customSource);
+                    if (!sanitized.equals(customSource)) {
+                        return "No skin found for \"" + sanitized + "\"";
+                    }
+                }
+                return "MineSkin rejected the URL";
+            }
+            case random:
+            case NEW:
+                return "No random username available";
+            default:
+                return "Provider returned no result";
+        }
+    }
+}

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/SkinCommandTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/SkinCommandTest.java
@@ -56,7 +56,7 @@ class SkinCommandTest {
             FakeMojangAPI api = new FakeMojangAPI();
             api.addSkin(STORED_SOURCE, new CustomSkinProperty(FAKE_VALUE, FAKE_SIG, STORED_SOURCE));
 
-            SkinCommand.MojangRestoreResult result = SkinCommand.tryRestoreFromMojang(api, STORED_SOURCE, PLAYER_NAME);
+            SkinRefreshHandler.MojangRestoreResult result = SkinRefreshHandler.tryRestoreFromMojang(api, STORED_SOURCE, PLAYER_NAME);
 
             assertNotNull(result);
             assertEquals(FAKE_VALUE, result.skin.getOriginalProperty().value());
@@ -69,7 +69,7 @@ class SkinCommandTest {
             FakeMojangAPI api = new FakeMojangAPI();
             api.addSkin(PLAYER_NAME, new CustomSkinProperty(FAKE_VALUE, FAKE_SIG, PLAYER_NAME));
 
-            SkinCommand.MojangRestoreResult result = SkinCommand.tryRestoreFromMojang(api, null, PLAYER_NAME);
+            SkinRefreshHandler.MojangRestoreResult result = SkinRefreshHandler.tryRestoreFromMojang(api, null, PLAYER_NAME);
 
             assertNotNull(result);
             assertEquals(FAKE_VALUE, result.skin.getOriginalProperty().value());
@@ -82,7 +82,7 @@ class SkinCommandTest {
             FakeMojangAPI api = new FakeMojangAPI();
             api.addSkin(PLAYER_NAME, new CustomSkinProperty(FAKE_VALUE, FAKE_SIG, PLAYER_NAME));
 
-            SkinCommand.MojangRestoreResult result = SkinCommand.tryRestoreFromMojang(api, "", PLAYER_NAME);
+            SkinRefreshHandler.MojangRestoreResult result = SkinRefreshHandler.tryRestoreFromMojang(api, "", PLAYER_NAME);
 
             assertNotNull(result);
             assertEquals(FAKE_VALUE, result.skin.getOriginalProperty().value());
@@ -95,7 +95,7 @@ class SkinCommandTest {
             FakeMojangAPI api = new FakeMojangAPI();
             api.addSkin(STORED_SOURCE, new CustomSkinProperty(FAKE_VALUE, FAKE_SIG, STORED_SOURCE));
 
-            SkinCommand.MojangRestoreResult result = SkinCommand.tryRestoreFromMojang(api, STORED_SOURCE, PLAYER_NAME);
+            SkinRefreshHandler.MojangRestoreResult result = SkinRefreshHandler.tryRestoreFromMojang(api, STORED_SOURCE, PLAYER_NAME);
 
             assertNotNull(result);
             assertEquals(STORED_SOURCE, result.licensedUsername);
@@ -106,7 +106,7 @@ class SkinCommandTest {
         void mojangNoProfile() {
             FakeMojangAPI api = new FakeMojangAPI();
 
-            SkinCommand.MojangRestoreResult result = SkinCommand.tryRestoreFromMojang(api, STORED_SOURCE, PLAYER_NAME);
+            SkinRefreshHandler.MojangRestoreResult result = SkinRefreshHandler.tryRestoreFromMojang(api, STORED_SOURCE, PLAYER_NAME);
 
             assertNull(result);
         }
@@ -118,7 +118,7 @@ class SkinCommandTest {
             FakeMojangAPI api = new FakeMojangAPI();
             api.addSkin(STORED_SOURCE, emptySkin);
 
-            SkinCommand.MojangRestoreResult result = SkinCommand.tryRestoreFromMojang(api, STORED_SOURCE, PLAYER_NAME);
+            SkinRefreshHandler.MojangRestoreResult result = SkinRefreshHandler.tryRestoreFromMojang(api, STORED_SOURCE, PLAYER_NAME);
 
             assertNull(result);
         }


### PR DESCRIPTION
Fixes two aislop warnings:
- `complexity/file-too-large`: SkinCommand was 457 lines (max 400). Moved helpers to new SkinRefreshHandler.java (now 379 lines).
- `complexity/function-too-long`: skinAction() was 124 lines (max 80). Extracted fetchSkinProperty() and handleSkinCompletion() (now 40 lines).

Verification:
- `bunx aislop scan`: 100/100 clean
- `./gradlew build --no-daemon`: BUILD SUCCESSFUL