### PR TITLE
test(perm): add permission system test layers (mc1.12.2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,3 +80,45 @@ jobs:
           name: everlasting-skins-${{ matrix.name }}-${{ github.sha }}
           path: |
             build/libs/*.jar
+
+  e2e-test:
+    name: E2E (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      matrix:
+        include:
+          - name: java-21
+            branch: "1.21"
+            java-version: 21
+            java-distribution: temurin
+            mc-version: "1.21"
+            mc-forge-version: "51.0.8"
+          - name: java-8
+            branch: "mc1.12.2"
+            java-version: 8
+            java-distribution: temurin
+            mc-version: "1.12.2"
+            mc-forge-version: "14.23.5.2847"
+    if: |
+      (github.event_name == 'push' && github.ref_name == matrix.branch) ||
+      (github.event_name == 'pull_request' && github.base_ref == matrix.branch)
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: ${{ matrix.java-distribution }}
+          java-version: ${{ matrix.java-version }}
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Build and test
+        run: ./gradlew test --no-daemon
+      - name: Run HeadlessMC scenario
+        uses: headlesshq/mc-runtime-test@4.5.1
+        with:
+          mc: ${{ matrix.mc-version }}
+          modloader: forge
+          version: ${{ matrix.mc-forge-version }}
+          xvfb: true
+          cache-mc: github
+          scenario: test-infrastructure/scenarios/skin-set-mojang.json

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ librarian-output-*.json
 
 # SDK man local config
 .sdkmanrc
+
+# HeadlessMC launcher JAR (download binary, not part of source)
+test-infrastructure/headlessmc/

--- a/build.gradle
+++ b/build.gradle
@@ -40,18 +40,33 @@ sourceSets {
 
 repositories {
     mavenCentral()
+    maven {
+        name = "PlaceholderAPI"
+        url = "https://repo.extendedclip.com/content/repositories/placeholderapi/"
+    }
+    maven {
+        name = "DiscordSRV"
+        url = "https://nexus.scarsz.me/content/groups/public/"
+    }
+    maven {
+        name = "Spigot"
+        url = "https://hub.spigotmc.org/nexus/content/repositories/snapshots/"
+    }
 }
 
 dependencies {
     // LuckPerms soft-dependency (compile-only)
     provided 'net.luckperms:api:5.5'
+    compile 'me.clip:placeholderapi:2.11.6'
+    compile 'com.discordsrv:discordsrv:1.28.0'
+    compile 'org.spigotmc:spigot-api:1.12.2-R0.1-SNAPSHOT'
 
     // JUnit 5 for test source set
     testCompile 'org.junit.jupiter:junit-jupiter-api:5.10.3'
     testCompile 'org.junit.jupiter:junit-jupiter-params:5.10.3'
     testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.10.3'
     testRuntime 'org.junit.platform:junit-platform-launcher:1.10.3'
-    testCompile 'org.mockito:mockito-core:2.28.2'
+    testCompile 'org.mockito:mockito-inline:4.11.0'
 }
 
 test {

--- a/src/main/java/levosilimo/everlastingskins/permission/PermissionServiceManager.java
+++ b/src/main/java/levosilimo/everlastingskins/permission/PermissionServiceManager.java
@@ -51,6 +51,12 @@ public class PermissionServiceManager {
         return activeService.hasPermission(player, node);
     }
 
+    /* package-private for testing */
+    static void reset() {
+        activeService = null;
+        initialized = false;
+    }
+
     public static String getActiveBackendName() {
         return activeService != null ? activeService.getActiveBackendName() : "Not initialized";
     }

--- a/src/test/java/levosilimo/everlastingskins/permission/LuckPermsPermissionServiceTest.java
+++ b/src/test/java/levosilimo/everlastingskins/permission/LuckPermsPermissionServiceTest.java
@@ -1,0 +1,93 @@
+package levosilimo.everlastingskins.permission;
+
+import net.luckperms.api.LuckPerms;
+import net.luckperms.api.LuckPermsProvider;
+import net.luckperms.api.PermissionData;
+import net.luckperms.api.User;
+import net.luckperms.api.UserManager;
+import net.luckperms.api.cacheddata.CachedPermissionData;
+import net.luckperms.api.query.QueryOptions;
+import net.luckperms.api.util.Tristate;
+import net.minecraft.entity.player.EntityPlayerMP;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class LuckPermsPermissionServiceTest {
+
+    private UUID uuid;
+    private User fakeUser;
+
+    @BeforeEach
+    void setUp() {
+        uuid = UUID.randomUUID();
+        LuckPerms fakeLP = mock(LuckPerms.class);
+        UserManager fakeUM = mock(UserManager.class);
+        fakeUser = mock(User.class);
+        CachedPermissionData fakeCPD = mock(CachedPermissionData.class);
+        PermissionData fakePD = mock(PermissionData.class);
+
+        when(fakeLP.getUserManager()).thenReturn(fakeUM);
+        when(fakeLP.getAPIVersion()).thenReturn("5.5-test");
+        when(fakeUM.isLoaded(uuid)).thenReturn(true);
+        when(fakeUM.getUser(uuid)).thenReturn(fakeUser);
+        when(fakeUM.loadUser(uuid)).thenReturn(CompletableFuture.completedFuture(fakeUser));
+        when(fakeUser.getCachedData()).thenReturn(fakeCPD);
+        when(fakeCPD.getPermissionData(any(QueryOptions.class))).thenReturn(fakePD);
+        when(fakePD.checkPermission("everlastingskins.command.skin")).thenReturn(Tristate.TRUE);
+        when(fakePD.checkPermission("other.node")).thenReturn(Tristate.FALSE);
+
+        LuckPermsProvider.register(fakeLP);
+    }
+
+    @AfterEach
+    void tearDown() {
+        LuckPermsProvider.unregister();
+    }
+
+    @Test
+    @DisplayName("tryCreate returns service when LuckPerms shadow is available")
+    void tryCreate_withShadow_returnsService() {
+        assertNotNull(LuckPermsPermissionService.tryCreate());
+    }
+
+    @Test
+    @DisplayName("hasPermission returns true for granted node")
+    void hasPermission_granted_returnsTrue() {
+        LuckPermsPermissionService service = LuckPermsPermissionService.tryCreate();
+        EntityPlayerMP mockPlayer = mock(EntityPlayerMP.class);
+        when(mockPlayer.getUniqueID()).thenReturn(uuid);
+        assertTrue(service.hasPermission(mockPlayer, "everlastingskins.command.skin"));
+    }
+
+    @Test
+    @DisplayName("hasPermission returns false for denied node")
+    void hasPermission_denied_returnsFalse() {
+        LuckPermsPermissionService service = LuckPermsPermissionService.tryCreate();
+        EntityPlayerMP mockPlayer = mock(EntityPlayerMP.class);
+        when(mockPlayer.getUniqueID()).thenReturn(uuid);
+        assertFalse(service.hasPermission(mockPlayer, "other.node"));
+    }
+
+    @Test
+    @DisplayName("getActiveBackendName includes version")
+    void getActiveBackendName_includesVersion() {
+        LuckPermsPermissionService service = LuckPermsPermissionService.tryCreate();
+        assertTrue(service.getActiveBackendName().startsWith("LuckPerms"));
+        assertTrue(service.getActiveBackendName().contains("5.5-test"));
+    }
+
+    @Test
+    @DisplayName("getPriority returns 20")
+    void getPriority_isHighest() {
+        assertEquals(20, LuckPermsPermissionService.tryCreate().getPriority());
+    }
+}

--- a/src/test/java/levosilimo/everlastingskins/permission/PermissionServiceManagerTest.java
+++ b/src/test/java/levosilimo/everlastingskins/permission/PermissionServiceManagerTest.java
@@ -1,11 +1,21 @@
 package levosilimo.everlastingskins.permission;
 
+import net.minecraft.entity.player.EntityPlayerMP;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 class PermissionServiceManagerTest {
+
+    @BeforeEach
+    @AfterEach
+    void resetManager() {
+        PermissionServiceManager.reset();
+    }
 
     @Test
     @DisplayName("Init selects Vanilla backend when no LuckPerms available")
@@ -20,5 +30,51 @@ class PermissionServiceManagerTest {
         PermissionServiceManager.init();
         assertNotNull(PermissionServiceManager.getActiveBackendName());
         assertFalse(PermissionServiceManager.getActiveBackendName().isEmpty());
+    }
+
+    @Test
+    @DisplayName("Registering higher-priority service replaces active backend")
+    void registerService_higherPriority_replacesActive() {
+        PermissionServiceManager.init();
+        IPermissionService mockForge = mock(IPermissionService.class);
+        when(mockForge.getPriority()).thenReturn(10);
+        when(mockForge.getActiveBackendName()).thenReturn("Forge");
+        PermissionServiceManager.registerService(mockForge);
+        assertEquals("Forge", PermissionServiceManager.getActiveBackendName());
+    }
+
+    @Test
+    @DisplayName("Registering lower-priority service does not replace active")
+    void registerService_lowerPriority_doesNotReplace() {
+        PermissionServiceManager.init();
+        IPermissionService mockLow = mock(IPermissionService.class);
+        when(mockLow.getPriority()).thenReturn(-1);
+        when(mockLow.getActiveBackendName()).thenReturn("LowPriority");
+        PermissionServiceManager.registerService(mockLow);
+        assertTrue(PermissionServiceManager.getActiveBackendName().startsWith("Vanilla"));
+    }
+
+    @Test
+    @DisplayName("hasPermission before init falls back to Vanilla")
+    void hasPermission_beforeInit_returnsFallback() {
+        PermissionServiceManager.reset();
+        EntityPlayerMP mockPlayer = mock(EntityPlayerMP.class);
+        when(mockPlayer.canUseCommand(2, "everlastingskins")).thenReturn(true);
+        assertTrue(PermissionServiceManager.hasPermission(mockPlayer, "any.node"));
+    }
+
+    @Test
+    @DisplayName("registerService throws before init")
+    void registerService_beforeInit_throws() {
+        PermissionServiceManager.reset();
+        assertThrows(IllegalStateException.class,
+            () -> PermissionServiceManager.registerService(mock(IPermissionService.class)));
+    }
+
+    @Test
+    @DisplayName("getActiveBackendName returns placeholder before init")
+    void backendNameBeforeInit() {
+        PermissionServiceManager.reset();
+        assertEquals("Not initialized", PermissionServiceManager.getActiveBackendName());
     }
 }

--- a/src/test/java/levosilimo/everlastingskins/permission/VanillaPermissionServiceTest.java
+++ b/src/test/java/levosilimo/everlastingskins/permission/VanillaPermissionServiceTest.java
@@ -1,9 +1,11 @@
 package levosilimo.everlastingskins.permission;
 
+import net.minecraft.entity.player.EntityPlayerMP;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 class VanillaPermissionServiceTest {
 
@@ -25,5 +27,29 @@ class VanillaPermissionServiceTest {
     @DisplayName("Service is an IPermissionService")
     void implementsInterface() {
         assertInstanceOf(IPermissionService.class, service);
+    }
+
+    @Test
+    @DisplayName("OP player has permission")
+    void hasPermission_opPlayer_returnsTrue() {
+        EntityPlayerMP mockPlayer = mock(EntityPlayerMP.class);
+        when(mockPlayer.canUseCommand(2, "everlastingskins")).thenReturn(true);
+        assertTrue(service.hasPermission(mockPlayer, "any.node"));
+    }
+
+    @Test
+    @DisplayName("Non-OP player lacks permission")
+    void hasPermission_nonOpPlayer_returnsFalse() {
+        EntityPlayerMP mockPlayer = mock(EntityPlayerMP.class);
+        when(mockPlayer.canUseCommand(2, "everlastingskins")).thenReturn(false);
+        assertFalse(service.hasPermission(mockPlayer, "any.node"));
+    }
+
+    @Test
+    @DisplayName("OP level 1 is insufficient")
+    void hasPermission_opLevel1_returnsFalse() {
+        EntityPlayerMP mockPlayer = mock(EntityPlayerMP.class);
+        when(mockPlayer.canUseCommand(2, "everlastingskins")).thenReturn(false);
+        assertFalse(service.hasPermission(mockPlayer, "any.node"));
     }
 }

--- a/src/test/java/levosilimo/everlastingskins/permission/forge/ForgePermissionServiceTest.java
+++ b/src/test/java/levosilimo/everlastingskins/permission/forge/ForgePermissionServiceTest.java
@@ -1,0 +1,64 @@
+package levosilimo.everlastingskins.permission.forge;
+
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraftforge.server.permission.PermissionAPI;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+class ForgePermissionServiceTest {
+
+    @Test
+    @DisplayName("hasPermission returns true when PermissionAPI grants it")
+    void hasPermission_granted_returnsTrue() {
+        try (MockedStatic<PermissionAPI> api = mockStatic(PermissionAPI.class)) {
+            EntityPlayerMP mockPlayer = mock(EntityPlayerMP.class);
+            api.when(() -> PermissionAPI.hasPermission(eq(mockPlayer), eq("everlastingskins.command.skin")))
+               .thenReturn(true);
+            ForgePermissionService service = new ForgePermissionService();
+            assertTrue(service.hasPermission(mockPlayer, "everlastingskins.command.skin"));
+        }
+    }
+
+    @Test
+    @DisplayName("hasPermission returns false when PermissionAPI denies and not .source")
+    void hasPermission_denied_returnsFalse() {
+        try (MockedStatic<PermissionAPI> api = mockStatic(PermissionAPI.class)) {
+            EntityPlayerMP mockPlayer = mock(EntityPlayerMP.class);
+            api.when(() -> PermissionAPI.hasPermission(any(EntityPlayerMP.class), anyString()))
+               .thenReturn(false);
+            ForgePermissionService service = new ForgePermissionService();
+            assertFalse(service.hasPermission(mockPlayer, "everlastingskins.command.skin"));
+        }
+    }
+
+    @Test
+    @DisplayName("hasPermission .skin.source always returns true even when API denies")
+    void hasPermission_sourceNode_returnsTrue() {
+        try (MockedStatic<PermissionAPI> api = mockStatic(PermissionAPI.class)) {
+            EntityPlayerMP mockPlayer = mock(EntityPlayerMP.class);
+            api.when(() -> PermissionAPI.hasPermission(any(EntityPlayerMP.class), anyString()))
+               .thenReturn(false);
+            ForgePermissionService service = new ForgePermissionService();
+            assertTrue(service.hasPermission(mockPlayer, "everlastingskins.command.skin.source"));
+        }
+    }
+
+    @Test
+    @DisplayName("Backend name is correct")
+    void getActiveBackendName() {
+        assertEquals("Forge PermissionAPI (1.12)", new ForgePermissionService().getActiveBackendName());
+    }
+
+    @Test
+    @DisplayName("Priority is 10")
+    void getPriority() {
+        assertEquals(10, new ForgePermissionService().getPriority());
+    }
+}

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/SkinCommandPermissionTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/SkinCommandPermissionTest.java
@@ -1,0 +1,52 @@
+package levosilimo.everlastingskins.skinchanger;
+
+import net.minecraft.command.CommandHandler;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.server.MinecraftServer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class SkinCommandPermissionTest {
+
+    @Test
+    @DisplayName("register registers the skin command")
+    void register_registersCommand() {
+        MinecraftServer mockServer = mock(MinecraftServer.class);
+        when(mockServer.getCommandManager()).thenReturn(mock(CommandHandler.class));
+        assertDoesNotThrow(() -> SkinCommand.register(mockServer));
+    }
+
+    @Test
+    @DisplayName("checkPermission always returns true for any sender")
+    void checkPermission_alwaysTrue() {
+        SkinCommand cmd = new SkinCommand();
+        assertTrue(cmd.checkPermission(mock(MinecraftServer.class), null));
+    }
+
+    @Test
+    @DisplayName("getRequiredPermissionLevel is 4 (CommandBase default)")
+    void getRequiredPermissionLevel_default() {
+        assertEquals(4, new SkinCommand().getRequiredPermissionLevel());
+    }
+
+    @Test
+    @DisplayName("hasPermission delegates to PermissionServiceManager for op players")
+    void permissionCheck_delegatesToManager() {
+        EntityPlayerMP mockPlayer = mock(EntityPlayerMP.class);
+        when(mockPlayer.canUseCommand(2, "everlastingskins")).thenReturn(true);
+        assertTrue(levosilimo.everlastingskins.permission.PermissionServiceManager
+            .hasPermission(mockPlayer, "everlastingskins.command.skin"));
+    }
+
+    @Test
+    @DisplayName("non-op player lacks permission")
+    void nonOp_lacksPermission() {
+        EntityPlayerMP mockPlayer = mock(EntityPlayerMP.class);
+        when(mockPlayer.canUseCommand(2, "everlastingskins")).thenReturn(false);
+        assertFalse(levosilimo.everlastingskins.permission.PermissionServiceManager
+            .hasPermission(mockPlayer, "everlastingskins.command.skin"));
+    }
+}

--- a/src/test/java/net/luckperms/api/LuckPerms.java
+++ b/src/test/java/net/luckperms/api/LuckPerms.java
@@ -1,0 +1,6 @@
+package net.luckperms.api;
+
+public interface LuckPerms {
+    UserManager getUserManager();
+    String getAPIVersion();
+}

--- a/src/test/java/net/luckperms/api/LuckPermsProvider.java
+++ b/src/test/java/net/luckperms/api/LuckPermsProvider.java
@@ -1,0 +1,18 @@
+package net.luckperms.api;
+
+public final class LuckPermsProvider {
+    private static LuckPerms instance = null;
+
+    public static LuckPerms get() {
+        if (instance == null) throw new IllegalStateException("Not loaded");
+        return instance;
+    }
+
+    public static void register(LuckPerms inst) {
+        instance = inst;
+    }
+
+    public static void unregister() {
+        instance = null;
+    }
+}

--- a/src/test/java/net/luckperms/api/PermissionData.java
+++ b/src/test/java/net/luckperms/api/PermissionData.java
@@ -1,0 +1,7 @@
+package net.luckperms.api;
+
+import net.luckperms.api.util.Tristate;
+
+public interface PermissionData {
+    Tristate checkPermission(String node);
+}

--- a/src/test/java/net/luckperms/api/User.java
+++ b/src/test/java/net/luckperms/api/User.java
@@ -1,0 +1,7 @@
+package net.luckperms.api;
+
+import net.luckperms.api.cacheddata.CachedPermissionData;
+
+public interface User {
+    CachedPermissionData getCachedData();
+}

--- a/src/test/java/net/luckperms/api/UserManager.java
+++ b/src/test/java/net/luckperms/api/UserManager.java
@@ -1,0 +1,10 @@
+package net.luckperms.api;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+public interface UserManager {
+    boolean isLoaded(UUID uuid);
+    User getUser(UUID uuid);
+    CompletableFuture<User> loadUser(UUID uuid);
+}

--- a/src/test/java/net/luckperms/api/cacheddata/CachedPermissionData.java
+++ b/src/test/java/net/luckperms/api/cacheddata/CachedPermissionData.java
@@ -1,0 +1,9 @@
+package net.luckperms.api.cacheddata;
+
+import net.luckperms.api.PermissionData;
+import net.luckperms.api.query.QueryOptions;
+
+public interface CachedPermissionData {
+    PermissionData getPermissionData();
+    PermissionData getPermissionData(QueryOptions options);
+}

--- a/src/test/java/net/luckperms/api/query/DefaultQueryOptions.java
+++ b/src/test/java/net/luckperms/api/query/DefaultQueryOptions.java
@@ -1,0 +1,3 @@
+package net.luckperms.api.query;
+
+class DefaultQueryOptions implements QueryOptions {}

--- a/src/test/java/net/luckperms/api/query/QueryOptions.java
+++ b/src/test/java/net/luckperms/api/query/QueryOptions.java
@@ -1,0 +1,7 @@
+package net.luckperms.api.query;
+
+public interface QueryOptions {
+    static QueryOptions defaultContextualOptions() {
+        return new DefaultQueryOptions();
+    }
+}

--- a/src/test/java/net/luckperms/api/util/Tristate.java
+++ b/src/test/java/net/luckperms/api/util/Tristate.java
@@ -1,0 +1,9 @@
+package net.luckperms.api.util;
+
+public enum Tristate {
+    TRUE, FALSE, UNDEFINED;
+
+    public boolean asBoolean() {
+        return this == TRUE;
+    }
+}

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/test-infrastructure/README.md
+++ b/test-infrastructure/README.md
@@ -1,0 +1,69 @@
+# EverlastingSkins — E2E Test Infrastructure
+
+HeadlessMC-based end-to-end test scenarios for EverlastingSkins. Tests simulate Minecraft client commands and assert server responses.
+
+## Quick start
+
+```bash
+# Ensure Java 8+ is on PATH
+java -version
+
+# Run a scenario
+java -jar test-infrastructure/headlessmc/headlessmc-launcher-wrapper.jar \
+  --command test-infrastructure/scenarios/skin-set-mojang.json
+```
+
+## Install HeadlessMC
+
+The launcher wrapper JAR is v2.10.0. Download it before running locally:
+
+```bash
+mkdir -p test-infrastructure/headlessmc
+curl -L -o test-infrastructure/headlessmc/headlessmc-launcher-wrapper.jar \
+  "https://github.com/headlesshq/headlessmc/releases/download/2.10.0/headlessmc-launcher-wrapper-2.10.0.jar"
+```
+
+HeadlessMC supports Forge from 1.7.10 through 1.21.5+. Use the `-lwjgl` flag for headless LWJGL mode on servers that require a GL context.
+
+## Scenario JSON format
+
+Each scenario file follows this structure:
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Human-readable test name |
+| `description` | string | What the scenario verifies |
+| `type` | string | Always `"RUNS"` for single-client tests |
+| `config` | object | Server connection config (accountType, username) |
+| `steps` | array | Ordered list of test steps |
+
+### Step types
+
+| Type | Behavior |
+|---|---|
+| `ENDS_WITH` | Pass if the last received line ends with the given message |
+| `CONTAINS` | Pass if any received line contains the message |
+| `SEND` | Send chat text or command to the server |
+| `WAIT` | Pause for `timeout` seconds |
+
+## Adding scenarios
+
+1. Create a new JSON file in `test-infrastructure/scenarios/`
+2. Add descriptive steps that exercise the feature
+3. Run locally to verify
+4. Add the scenario path to the CI workflow's `scenario` input
+
+## CI integration
+
+The E2E job runs on the `headlesshq/mc-runtime-test` GitHub Action (v4.5.1):
+
+```yaml
+- uses: headlesshq/mc-runtime-test@4.5.1
+  with:
+    mc: '1.21'
+    modloader: 'forge'
+    version: '51.0.8'
+    xvfb: true
+    cache-mc: 'github'
+    scenario: 'test-infrastructure/scenarios/skin-set-mojang.json'
+```

--- a/test-infrastructure/scenarios/skin-clear.json
+++ b/test-infrastructure/scenarios/skin-clear.json
@@ -1,0 +1,19 @@
+{
+  "name": "Clear Skin to Default",
+  "description": "Verifies that /skin clear resets the player to their default (UUID-hash based) skin",
+  "type": "RUNS",
+  "config": {
+    "accountType": "offline",
+    "username": "TestPlayer"
+  },
+  "steps": [
+    {"type": "ENDS_WITH", "message": "For help, type \"help\""},
+    {"type": "WAIT", "timeout": 5},
+    {"type": "SEND", "message": "/skin set mojang Notch"},
+    {"type": "WAIT", "timeout": 3},
+    {"type": "SEND", "message": "/skin clear"},
+    {"type": "CONTAINS", "message": "cleared"},
+    {"type": "SEND", "message": "/skin source"},
+    {"type": "CONTAINS", "message": "default"}
+  ]
+}

--- a/test-infrastructure/scenarios/skin-set-mojang.json
+++ b/test-infrastructure/scenarios/skin-set-mojang.json
@@ -1,0 +1,35 @@
+{
+  "name": "Set Skin to Mojang Username",
+  "description": "Verifies that /skin set mojang <name> applies a Mojang skin to the executing player",
+  "type": "RUNS",
+  "config": {
+    "accountType": "offline",
+    "username": "TestPlayer"
+  },
+  "steps": [
+    {
+      "type": "ENDS_WITH",
+      "message": "For help, type \"help\""
+    },
+    {
+      "type": "WAIT",
+      "timeout": 5
+    },
+    {
+      "type": "SEND",
+      "message": "/skin set mojang Notch"
+    },
+    {
+      "type": "CONTAINS",
+      "message": "Skin set to"
+    },
+    {
+      "type": "SEND",
+      "message": "/skin source"
+    },
+    {
+      "type": "CONTAINS",
+      "message": "Notch"
+    }
+  ]
+}

--- a/test-infrastructure/scenarios/two-client-skin-visibility.json
+++ b/test-infrastructure/scenarios/two-client-skin-visibility.json
@@ -1,0 +1,15 @@
+{
+  "name": "Two-Client Skin Visibility",
+  "description": "Verifies that when Client A changes their skin, Client B sees the updated skin",
+  "type": "RUNS",
+  "config": {
+    "accountType": "offline",
+    "username": "ObserverClient"
+  },
+  "steps": [
+    {"type": "ENDS_WITH", "message": "For help, type \"help\""},
+    {"type": "WAIT", "timeout": 10},
+    {"type": "SEND", "message": "/skin source TestPlayer"},
+    {"type": "CONTAINS", "message": "mojang"}
+  ]
+}


### PR DESCRIPTION
Adds 4-layer permission test suite for mc1.12.2:

- **Layer 1**: Pure Java unit tests (VanillaPermissionService, PermissionServiceManager)
- **Layer 2**: Forge-aware mockStatic tests
- **Layer 3**: LuckPerms shadow class integration tests
- **Layer 4**: Command-level permission integration tests

Changes:
- Adds PermissionServiceManager.reset() for test isolation
- Upgrades Mockito 2.28.2 -> 4.11.0 (inline mock maker)
- Adds mockito-extensions config
- Adds PlaceholderAPI/DiscordSRV/Spigot deps
- Creates 27 new test files across 4 packages