### PR TITLE
fix(skin-storage): match 1.21 getSkin() behavior — no file delete on null load

### DIFF
--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinStorage.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinStorage.java
@@ -54,7 +54,9 @@ public class SkinStorage {
         if (skinProperty != null) return skinProperty;
 
         skinProperty = loadSkin(uuid);
-        skinProperty = setSkin(uuid, skinProperty);
+        if (skinProperty != null) {
+            skinMap.put(uuid, skinProperty);
+        }
         return skinProperty;
     }
     @Nullable


### PR DESCRIPTION
## Rank 8 (exp-2)
Aligns mc1.12.2 `SkinStorage.getSkin()` with the 1.21 reference implementation to avoid the unintended file-deletion side effect when `loadSkin` returns null.

**Change**: `SkinStorage.getSkin()`: replace `setSkin(uuid, skinProperty)` with null-guarded `skinMap.put`
- No more `removeSkin()` → file deletion on cache miss
- Pre-commit hook: 100/100 aislop
- All tests pass including SkinStorageTest