### PR TITLE
fix(exp-2): HTTP layer correctness — ProfileLookup, MineSkin lock + API key (batch 2)

### DIFF
--- a/src/main/java/levosilimo/everlastingskins/skinchanger/MineSkinApiHttpImpl.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/MineSkinApiHttpImpl.java
@@ -18,6 +18,7 @@
 package levosilimo.everlastingskins.skinchanger;
 
 import com.google.gson.Gson;
+import levosilimo.everlastingskins.Config;
 import levosilimo.everlastingskins.enums.SkinVariant;
 import levosilimo.everlastingskins.skinchanger.requests.mineskin.MineSkinUrlRequest;
 import levosilimo.everlastingskins.skinchanger.responses.HttpResponse;
@@ -53,11 +54,11 @@ public class MineSkinApiHttpImpl implements MineSkinAPI {
     private final String apiKey;
 
     public MineSkinApiHttpImpl() {
-        this(new HttpsUrlConnectionHttpClient(), "");
+        this(new HttpsUrlConnectionHttpClient(), Config.MINESKIN_API_KEY);
     }
 
     public MineSkinApiHttpImpl(HttpClient httpClient) {
-        this(httpClient, "");
+        this(httpClient, Config.MINESKIN_API_KEY);
     }
 
     public MineSkinApiHttpImpl(HttpClient httpClient, String apiKey) {
@@ -71,23 +72,25 @@ public class MineSkinApiHttpImpl implements MineSkinAPI {
         imageUrl = SRHelpers.sanitizeImageURL(imageUrl);
         int retryAttempts = 0;
         do {
+            Optional<MineSkinResponse> optional;
             lock.lock();
             try {
-                Optional<MineSkinResponse> optional = genSkinInternal(imageUrl, skinVariant);
-
-                if (optional == null) {
-                    return null;
-                }
-
-                if (optional.isPresent()) {
-                    return optional.get();
-                }
+                optional = genSkinInternal(imageUrl, skinVariant);
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             } catch (IOException e) {
                 logger.debug("[ERROR] MineSkin Failed! IOException (connection/disk): (" + imageUrl + ")", e);
+                optional = null;
             } finally {
                 lock.unlock();
+            }
+
+            if (optional == null) {
+                return null;
+            }
+
+            if (optional.isPresent()) {
+                return optional.get();
             }
         } while (++retryAttempts < MAX_RETRIES);
         return null;

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/MojangAPI.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/MojangAPI.java
@@ -2,7 +2,6 @@ package levosilimo.everlastingskins.skinchanger;
 
 import levosilimo.everlastingskins.skinchanger.responses.mojang.MojangSkinDataResult;
 import levosilimo.everlastingskins.util.CustomSkinProperty;
-import net.minecraft.util.Tuple;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -36,8 +35,8 @@ public interface MojangAPI {
      * Fetch profile properties (skin texture) for a player identified by a
      * username/UUID pair.
      *
-     * @param usernameUUIDPair tuple of (username, optional UUID)
+     * @param lookup resolved username and UUID (never partial)
      * @return the skin property if found, or empty on error
      */
-    Optional<CustomSkinProperty> getProfile(Tuple<String, Optional<UUID>> usernameUUIDPair);
+    Optional<CustomSkinProperty> getProfile(ProfileLookup lookup);
 }

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/MojangApiHttpImpl.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/MojangApiHttpImpl.java
@@ -14,7 +14,6 @@ import levosilimo.everlastingskins.util.HttpClient;
 import levosilimo.everlastingskins.util.HttpsUrlConnectionHttpClient;
 import levosilimo.everlastingskins.util.SRHelpers;
 import levosilimo.everlastingskins.util.UUIDUtils;
-import net.minecraft.util.Tuple;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -56,7 +55,7 @@ public class MojangApiHttpImpl implements MojangAPI {
             return Optional.empty();
         }
 
-        return getProfile(new Tuple<>(nameOrUniqueId, uuidResult)).map(propertyResponse ->
+        return getProfile(new ProfileLookup(nameOrUniqueId, uuidResult.get())).map(propertyResponse ->
                 new MojangSkinDataResult(uuidResult.get(), propertyResponse));
     }
 
@@ -149,13 +148,13 @@ public class MojangApiHttpImpl implements MojangAPI {
     }
 
     @Override
-    public Optional<CustomSkinProperty> getProfile(Tuple<String, Optional<UUID>> usernameUUIDPair) {
+    public Optional<CustomSkinProperty> getProfile(ProfileLookup lookup) {
         Optional<CustomSkinProperty> customSkinProperty = Optional.empty();
 
         List<Supplier<Optional<CustomSkinProperty>>> profileSources = Arrays.asList(
-                () -> getProfileEclipse(usernameUUIDPair),
-                () -> getProfileMojang(usernameUUIDPair),
-                () -> getProfileMineTools(usernameUUIDPair)
+                () -> getProfileEclipse(lookup),
+                () -> getProfileMojang(lookup),
+                () -> getProfileMineTools(lookup)
         );
 
         for (Supplier<Optional<CustomSkinProperty>> source : profileSources) {
@@ -168,8 +167,8 @@ public class MojangApiHttpImpl implements MojangAPI {
         return customSkinProperty;
     }
 
-    public Optional<CustomSkinProperty> getProfileEclipse(Tuple<String, Optional<UUID>> usernameUUIDPair) {
-        HttpResult result = readURL(URI.create(endpoints.profileEclipse().replace("%uuid%", usernameUUIDPair.getSecond().get().toString())));
+    public Optional<CustomSkinProperty> getProfileEclipse(ProfileLookup lookup) {
+        HttpResult result = readURL(URI.create(endpoints.profileEclipse().replace("%uuid%", lookup.getUuid().toString())));
         if (!result.isSuccess()) {
             return Optional.empty();
         }
@@ -183,11 +182,11 @@ public class MojangApiHttpImpl implements MojangAPI {
             return Optional.empty();
         }
 
-        return Optional.of(new CustomSkinProperty(response.skinProperty().value(), response.skinProperty().signature(), usernameUUIDPair.getFirst()));
+        return Optional.of(new CustomSkinProperty(response.skinProperty().value(), response.skinProperty().signature(), lookup.getUsername()));
     }
 
-    public Optional<CustomSkinProperty> getProfileMojang(Tuple<String, Optional<UUID>> usernameUUIDPair) {
-        HttpResult result = readURL(URI.create(endpoints.profileMojang().replace("%uuid%", UUIDUtils.convertToNoDashes(usernameUUIDPair.getSecond().get()))));
+    public Optional<CustomSkinProperty> getProfileMojang(ProfileLookup lookup) {
+        HttpResult result = readURL(URI.create(endpoints.profileMojang().replace("%uuid%", UUIDUtils.convertToNoDashes(lookup.getUuid()))));
         if (!result.isSuccess()) {
             return Optional.empty();
         }
@@ -205,11 +204,11 @@ public class MojangApiHttpImpl implements MojangAPI {
             return Optional.empty();
         }
 
-        return Optional.of(new CustomSkinProperty(property.value(), property.signature(), usernameUUIDPair.getFirst()));
+        return Optional.of(new CustomSkinProperty(property.value(), property.signature(), lookup.getUsername()));
     }
 
-    protected Optional<CustomSkinProperty> getProfileMineTools(Tuple<String, Optional<UUID>> usernameUUIDPair) {
-        HttpResult result = readURL(URI.create(endpoints.profileMineTools().replace("%uuid%", UUIDUtils.convertToNoDashes(usernameUUIDPair.getSecond().get()))), 10_000);
+    protected Optional<CustomSkinProperty> getProfileMineTools(ProfileLookup lookup) {
+        HttpResult result = readURL(URI.create(endpoints.profileMineTools().replace("%uuid%", UUIDUtils.convertToNoDashes(lookup.getUuid()))), 10_000);
         if (!result.isSuccess()) {
             return Optional.empty();
         }
@@ -229,7 +228,7 @@ public class MojangApiHttpImpl implements MojangAPI {
             return Optional.empty();
         }
 
-        return Optional.of(new CustomSkinProperty(property.value(), property.signature(), usernameUUIDPair.getFirst()));
+        return Optional.of(new CustomSkinProperty(property.value(), property.signature(), lookup.getUsername()));
     }
 
     private HttpResult readURL(URI uri) {

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/ProfileLookup.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/ProfileLookup.java
@@ -1,0 +1,42 @@
+package levosilimo.everlastingskins.skinchanger;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Resolved username + UUID pair for profile lookups.
+ * Replaces {@code Tuple<String, Optional<UUID>>} which leaked the Minecraft
+ * type and forced unsafe {@code Optional.get()} calls.
+ * <p>
+ * Java 8-compatible value class (record is Java 14+).
+ */
+public final class ProfileLookup {
+    private final String username;
+    private final UUID uuid;
+
+    public ProfileLookup(String username, UUID uuid) {
+        this.username = Objects.requireNonNull(username, "username must not be null");
+        this.uuid = Objects.requireNonNull(uuid, "uuid must not be null");
+    }
+
+    public String getUsername() { return username; }
+    public UUID getUuid() { return uuid; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ProfileLookup)) return false;
+        ProfileLookup that = (ProfileLookup) o;
+        return username.equals(that.username) && uuid.equals(that.uuid);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(username, uuid);
+    }
+
+    @Override
+    public String toString() {
+        return "ProfileLookup{username='" + username + "', uuid=" + uuid + "}";
+    }
+}

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/MojangApiHttpImplTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/MojangApiHttpImplTest.java
@@ -3,7 +3,6 @@ package levosilimo.everlastingskins.skinchanger;
 import levosilimo.everlastingskins.FakeHttpClient;
 import levosilimo.everlastingskins.skinchanger.responses.mojang.MojangSkinDataResult;
 import levosilimo.everlastingskins.util.CustomSkinProperty;
-import net.minecraft.util.Tuple;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -113,11 +112,11 @@ class MojangApiHttpImplTest {
     @DisplayName("Profile fallback order")
     class ProfileFallback {
 
-        private Tuple<String, Optional<UUID>> pair;
+        private ProfileLookup lookup;
 
         @BeforeEach
         void init() {
-            pair = new Tuple<String, Optional<UUID>>(PLAYER_NAME, Optional.<UUID>of(PLAYER_UUID));
+            lookup = new ProfileLookup(PLAYER_NAME, PLAYER_UUID);
         }
 
         @Test
@@ -125,7 +124,7 @@ class MojangApiHttpImplTest {
         void eclipseFirst() {
             httpClient.addResponse(eclipseProfileUri, 200, profileEclipseBody("value1", "sig1"));
 
-            Optional<CustomSkinProperty> result = api.getProfile(pair);
+            Optional<CustomSkinProperty> result = api.getProfile(lookup);
 
             assertTrue(result.isPresent());
             assertEquals("value1", result.get().getOriginalProperty().getValue());
@@ -137,7 +136,7 @@ class MojangApiHttpImplTest {
             httpClient.addResponse(eclipseProfileUri, 404, "");
             httpClient.addResponse(mojangProfileUri, 200, profileMojangBody("value2", "sig2"));
 
-            Optional<CustomSkinProperty> result = api.getProfile(pair);
+            Optional<CustomSkinProperty> result = api.getProfile(lookup);
 
             assertTrue(result.isPresent());
             assertEquals("value2", result.get().getOriginalProperty().getValue());
@@ -150,7 +149,7 @@ class MojangApiHttpImplTest {
             httpClient.addResponse(mojangProfileUri, 404, "");
             httpClient.addResponse(mineToolsProfileUri, 200, profileMineToolsBody("value3", "sig3"));
 
-            Optional<CustomSkinProperty> result = api.getProfile(pair);
+            Optional<CustomSkinProperty> result = api.getProfile(lookup);
 
             assertTrue(result.isPresent());
             assertEquals("value3", result.get().getOriginalProperty().getValue());
@@ -162,7 +161,7 @@ class MojangApiHttpImplTest {
             httpClient.addResponse(eclipseProfileUri, 404, "");
             httpClient.addResponse(mojangProfileUri, 404, "");
 
-            Optional<CustomSkinProperty> result = api.getProfile(pair);
+            Optional<CustomSkinProperty> result = api.getProfile(lookup);
             assertFalse(result.isPresent());
         }
     }
@@ -254,11 +253,11 @@ class MojangApiHttpImplTest {
     @DisplayName("HTTP outcomes per profile provider")
     class ProfileHttpOutcomes {
 
-        private Tuple<String, Optional<UUID>> pair;
+        private ProfileLookup lookup;
 
         @BeforeEach
         void init() {
-            pair = new Tuple<String, Optional<UUID>>(PLAYER_NAME, Optional.<UUID>of(PLAYER_UUID));
+            lookup = new ProfileLookup(PLAYER_NAME, PLAYER_UUID);
         }
 
         @Test
@@ -267,7 +266,7 @@ class MojangApiHttpImplTest {
             httpClient.addResponse(eclipseProfileUri, 204, "");
             httpClient.addResponse(mojangProfileUri, 200, profileMojangBody("v", "s"));
 
-            Optional<CustomSkinProperty> result = api.getProfile(pair);
+            Optional<CustomSkinProperty> result = api.getProfile(lookup);
             assertTrue(result.isPresent());
         }
 
@@ -277,7 +276,7 @@ class MojangApiHttpImplTest {
             httpClient.addResponse(eclipseProfileUri, 404, "");
             httpClient.addResponse(mojangProfileUri, 204, "");
 
-            Optional<CustomSkinProperty> result = api.getProfile(pair);
+            Optional<CustomSkinProperty> result = api.getProfile(lookup);
             assertFalse(result.isPresent());
         }
 
@@ -287,7 +286,7 @@ class MojangApiHttpImplTest {
             httpClient.addResponse(eclipseProfileUri, 404, "");
             httpClient.addResponse(mojangProfileUri, 200, "{\"id\":\"abc\",\"name\":\"x\"}");
 
-            Optional<CustomSkinProperty> result = api.getProfile(pair);
+            Optional<CustomSkinProperty> result = api.getProfile(lookup);
             assertFalse(result.isPresent());
         }
 
@@ -298,7 +297,7 @@ class MojangApiHttpImplTest {
             httpClient.addResponse(mojangProfileUri, 200,
                     "{\"id\":\"x\",\"name\":\"x\",\"properties\":[{\"name\":\"textures\",\"value\":\"\",\"signature\":\"\"}]}");
 
-            Optional<CustomSkinProperty> result = api.getProfile(pair);
+            Optional<CustomSkinProperty> result = api.getProfile(lookup);
             assertFalse(result.isPresent());
         }
 
@@ -309,7 +308,7 @@ class MojangApiHttpImplTest {
             httpClient.addResponse(mojangProfileUri, 404, "");
             httpClient.addResponse(mineToolsProfileUri, 200, "{\"raw\":{\"id\":\"x\",\"name\":\"x\",\"status\":\"ERR\",\"properties\":[]}}");
 
-            Optional<CustomSkinProperty> result = api.getProfile(pair);
+            Optional<CustomSkinProperty> result = api.getProfile(lookup);
             assertFalse(result.isPresent());
         }
 
@@ -319,7 +318,7 @@ class MojangApiHttpImplTest {
             httpClient.addResponse(eclipseProfileUri, 404, "");
             httpClient.addResponse(mojangProfileUri, 429, "");
 
-            Optional<CustomSkinProperty> result = api.getProfile(pair);
+            Optional<CustomSkinProperty> result = api.getProfile(lookup);
             assertFalse(result.isPresent());
         }
 
@@ -329,7 +328,7 @@ class MojangApiHttpImplTest {
             httpClient.addTimeout(eclipseProfileUri);
             httpClient.addResponse(mojangProfileUri, 200, profileMojangBody("v", "sig"));
 
-            Optional<CustomSkinProperty> result = api.getProfile(pair);
+            Optional<CustomSkinProperty> result = api.getProfile(lookup);
             assertTrue(result.isPresent());
         }
     }

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/SkinCommandTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/SkinCommandTest.java
@@ -3,7 +3,6 @@ package levosilimo.everlastingskins.skinchanger;
 import levosilimo.everlastingskins.skinchanger.SkinCommand.MojangRestoreResult;
 import levosilimo.everlastingskins.skinchanger.responses.mojang.MojangSkinDataResult;
 import levosilimo.everlastingskins.util.CustomSkinProperty;
-import net.minecraft.util.Tuple;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -42,7 +41,7 @@ class SkinCommandTest {
         }
 
         @Override
-        public Optional<CustomSkinProperty> getProfile(Tuple<String, Optional<UUID>> usernameUUIDPair) {
+        public Optional<CustomSkinProperty> getProfile(ProfileLookup lookup) {
             return Optional.empty();
         }
     }


### PR DESCRIPTION
## Summary

Batch 2 of exp-2 audit fixes — HTTP layer correctness (mc1.12.2 port).

### Changes

Same as the 1.21 PR with one additional fix:

- **ProfileLookup class** (Java 8 value class replacing )
- **MineSkinApiHttpImpl lock** moved inside retry loop
- **MineSkinApiHttpImpl API key** — default constructors now read  instead of hardcoded  (HIGH severity fix)
- Test updates for ProfileLookup

### Verification
- aislop scan --staged: 100/100
- ./gradlew compileJava: SUCCESS
- ./gradlew test: ALL tests pass