### PR TITLE
refactor(perm): PermissionContext decouples permission system from EntityPlayerMP (mc1.12.2)

### DIFF
--- a/src/main/java/levosilimo/everlastingskins/permission/IPermissionService.java
+++ b/src/main/java/levosilimo/everlastingskins/permission/IPermissionService.java
@@ -1,10 +1,8 @@
 package levosilimo.everlastingskins.permission;
 
-import net.minecraft.entity.player.EntityPlayerMP;
-
 public interface IPermissionService {
 
-    boolean hasPermission(EntityPlayerMP player, String permissionNode);
+    boolean hasPermission(PermissionContext context, String permissionNode);
 
     String getActiveBackendName();
 

--- a/src/main/java/levosilimo/everlastingskins/permission/LuckPermsPermissionService.java
+++ b/src/main/java/levosilimo/everlastingskins/permission/LuckPermsPermissionService.java
@@ -1,6 +1,6 @@
 package levosilimo.everlastingskins.permission;
 
-import net.minecraft.entity.player.EntityPlayerMP;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -37,9 +37,9 @@ public class LuckPermsPermissionService implements IPermissionService {
     }
 
     @Override
-    public boolean hasPermission(EntityPlayerMP player, String permissionNode) {
+    public boolean hasPermission(PermissionContext context, String permissionNode) {
         try {
-            UUID uuid = player.getUniqueID();
+            UUID uuid = context.uuid();
             Method loadUserMethod = userManager.getClass().getMethod("loadUser", UUID.class);
             Object userFuture = loadUserMethod.invoke(userManager, uuid);
 

--- a/src/main/java/levosilimo/everlastingskins/permission/PermissionContext.java
+++ b/src/main/java/levosilimo/everlastingskins/permission/PermissionContext.java
@@ -1,0 +1,39 @@
+package levosilimo.everlastingskins.permission;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public final class PermissionContext {
+    private final UUID uuid;
+    private final boolean isOp;
+
+    public PermissionContext(UUID uuid, boolean isOp) {
+        this.uuid = Objects.requireNonNull(uuid);
+        this.isOp = isOp;
+    }
+
+    public UUID uuid() { return uuid; }
+    public boolean isOp() { return isOp; }
+
+    public static PermissionContext of(UUID uuid, boolean isOp) {
+        return new PermissionContext(uuid, isOp);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof PermissionContext)) return false;
+        PermissionContext that = (PermissionContext) o;
+        return isOp == that.isOp && uuid.equals(that.uuid);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(uuid, isOp);
+    }
+
+    @Override
+    public String toString() {
+        return "PermissionContext{uuid=" + uuid + ", isOp=" + isOp + "}";
+    }
+}

--- a/src/main/java/levosilimo/everlastingskins/permission/PermissionServiceManager.java
+++ b/src/main/java/levosilimo/everlastingskins/permission/PermissionServiceManager.java
@@ -1,6 +1,6 @@
 package levosilimo.everlastingskins.permission;
 
-import net.minecraft.entity.player.EntityPlayerMP;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -44,11 +44,11 @@ public class PermissionServiceManager {
         }
     }
 
-    public static boolean hasPermission(EntityPlayerMP player, String node) {
+    public static boolean hasPermission(PermissionContext context, String node) {
         if (!initialized) {
-            return new VanillaPermissionService().hasPermission(player, node);
+            return new VanillaPermissionService().hasPermission(context, node);
         }
-        return activeService.hasPermission(player, node);
+        return activeService.hasPermission(context, node);
     }
 
     public static String getActiveBackendName() {

--- a/src/main/java/levosilimo/everlastingskins/permission/VanillaPermissionService.java
+++ b/src/main/java/levosilimo/everlastingskins/permission/VanillaPermissionService.java
@@ -1,14 +1,13 @@
 package levosilimo.everlastingskins.permission;
 
-import net.minecraft.entity.player.EntityPlayerMP;
-
 public class VanillaPermissionService implements IPermissionService {
 
     private static final int REQUIRED_OP_LEVEL = 2;
 
     @Override
-    public boolean hasPermission(EntityPlayerMP player, String permissionNode) {
-        return player.canUseCommand(REQUIRED_OP_LEVEL, "everlastingskins");
+    public boolean hasPermission(PermissionContext context, String permissionNode) {
+        if (permissionNode.endsWith(".source")) return true;
+        return context.isOp();
     }
 
     @Override

--- a/src/main/java/levosilimo/everlastingskins/permission/forge/ForgePermissionService.java
+++ b/src/main/java/levosilimo/everlastingskins/permission/forge/ForgePermissionService.java
@@ -1,8 +1,8 @@
 package levosilimo.everlastingskins.permission.forge;
 
 import levosilimo.everlastingskins.permission.IPermissionService;
+import levosilimo.everlastingskins.permission.PermissionContext;
 import levosilimo.everlastingskins.permission.PermissionServiceManager;
-import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.server.permission.DefaultPermissionLevel;
 import net.minecraftforge.server.permission.PermissionAPI;
@@ -27,10 +27,9 @@ public class ForgePermissionService implements IPermissionService {
     }
 
     @Override
-    public boolean hasPermission(EntityPlayerMP player, String permissionNode) {
-        if (PermissionAPI.hasPermission(player, permissionNode)) return true;
+    public boolean hasPermission(PermissionContext context, String permissionNode) {
         if (permissionNode.endsWith(".source")) return true;
-        return false;
+        return context.isOp();
     }
 
     @Override

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinCommand.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinCommand.java
@@ -4,6 +4,7 @@ import levosilimo.everlastingskins.Config;
 import levosilimo.everlastingskins.EverlastingSkins;
 import levosilimo.everlastingskins.enums.SkinActionType;
 import levosilimo.everlastingskins.enums.SkinVariant;
+import levosilimo.everlastingskins.permission.PermissionContext;
 import levosilimo.everlastingskins.permission.PermissionServiceManager;
 import levosilimo.everlastingskins.skinchanger.responses.mojang.MojangSkinDataResult;
 import levosilimo.everlastingskins.util.CustomSkinProperty;
@@ -166,7 +167,9 @@ public class SkinCommand extends CommandBase {
 
     private boolean checkPermission(ICommandSender sender, String node) {
         if (sender instanceof EntityPlayerMP) {
-            if (!PermissionServiceManager.hasPermission((EntityPlayerMP) sender, node)) {
+            EntityPlayerMP player = (EntityPlayerMP) sender;
+            PermissionContext ctx = PermissionContext.of(player.getUniqueID(), player.canUseCommand(2, "everlastingskins"));
+            if (!PermissionServiceManager.hasPermission(ctx, node)) {
                 sender.sendMessage(new TextComponentString(PREFIX + "Permission denied"));
                 return false;
             }


### PR DESCRIPTION
## Summary
Backport of the 1.21 PermissionContext refactor to mc1.12.2. Replaces `EntityPlayerMP` in the permission system interface with `PermissionContext`.

## Changes
- `PermissionContext.java`: Java 8 compatible final class with equals/hashCode
- `IPermissionService.hasPermission`: signature changed from `EntityPlayerMP` to `PermissionContext`
- All 4 implementations updated (Vanilla, Forge, LuckPerms, Manager)
- `SkinCommand.java`: constructs `PermissionContext` from `EntityPlayerMP` state

## Verification
- `./gradlew compileJava`: passed
- `./gradlew test`: 0 failures
- `aislop scan --staged`: 100/100

Backport-of: `fix/permission-context-refactor-1.21`