### PR TITLE
ci(e2e): HeadlessMC orchestration — direct server+client, no mc-runtime-test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,27 @@ env:
   GRADLE_OPTS: -Dorg.gradle.daemon=false
 
 jobs:
+  lint-yaml:
+    name: YAML Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+      - name: Run yamllint
+        uses: frenck/action-yamllint@v1
+        with:
+          config_file: .yamllint.yml
+          strict: true
+
   build:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
+    needs: lint-yaml
     strategy:
+      fail-fast: false
       matrix:
         include:
           - name: java-21
@@ -24,23 +41,14 @@ jobs:
             branch: "mc1.12.2"
             java-version: 8
             java-distribution: temurin
-    # Run only the matrix entry whose branch matches the triggering push/PR target.
-    # Matrix context is available in job-level if.
-    if: |
-      (github.event_name == 'push' && github.ref_name == matrix.branch) ||
-      (github.event_name == 'pull_request' && github.base_ref == matrix.branch)
-
+    if: ${{ (github.event_name == 'push' && github.ref_name == matrix.branch) || (github.event_name == 'pull_request' && github.base_ref == matrix.branch) }}
     steps:
       - uses: actions/checkout@v4
-
       - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java-version }}
           distribution: ${{ matrix.java-distribution }}
-
-      # Cache Gradle wrapper distributions and ForgeGradle/Maven dependencies.
-      # The modules-2 directory caches heavy ForgeGradle dependency downloads.
       - name: Cache Gradle wrapper and caches
         uses: actions/cache@v4
         with:
@@ -50,19 +58,11 @@ jobs:
           key: gradle-${{ runner.os }}-${{ hashFiles('**/gradle-wrapper.properties') }}
           restore-keys: |
             gradle-${{ runner.os }}-
-
       - name: Grant execute permission for gradlew
-        # gradlew may be non-executable on Linux due to CRLF line endings in the repo
         run: chmod +x gradlew
-
-      # 1.12.2 builds may encounter HTTP 400 on Mojang asset downloads.
-      # ForgeGradle can tolerate these with a continue-on-failure flag if available.
-      # The --no-daemon flag ensures clean JVM exit on self-hosted runners.
       - name: Build and test
-        run: ./gradlew test --no-daemon
-
-      - name: Run aislop scanner (informational)
-        # Does not block — the pre-commit hook enforces local enforcement.
+        run: ./gradlew test --no-daemon --stacktrace
+      - name: Run aislop scanner
         continue-on-error: true
         run: |
           if command -v bunx &> /dev/null; then
@@ -72,20 +72,19 @@ jobs:
           else
             echo "aislop skipped: neither bunx nor npx on PATH"
           fi
-
       - name: Upload built jar
-        if: success()
         uses: actions/upload-artifact@v4
         with:
           name: everlasting-skins-${{ matrix.name }}-${{ github.sha }}
-          path: |
-            build/libs/*.jar
+          path: build/libs/*.jar
+          if-no-files-found: error
 
   e2e-test:
     name: E2E (${{ matrix.name }})
     runs-on: ubuntu-latest
     needs: build
     strategy:
+      fail-fast: false
       matrix:
         include:
           - name: java-21
@@ -94,31 +93,152 @@ jobs:
             java-distribution: temurin
             mc-version: "1.21"
             mc-forge-version: "51.0.8"
+            forge-installer-url: "https://maven.minecraftforge.net/net/minecraftforge/forge/1.21-51.0.8/forge-1.21-51.0.8-installer.jar"
+            hmc-specifics-url: "https://github.com/headlesshq/hmc-specifics/releases/latest/download/hmc-specifics-1.21-forge.jar"
           - name: java-8
             branch: "mc1.12.2"
             java-version: 8
             java-distribution: temurin
             mc-version: "1.12.2"
             mc-forge-version: "14.23.5.2847"
-    if: |
-      (github.event_name == 'push' && github.ref_name == matrix.branch) ||
-      (github.event_name == 'pull_request' && github.base_ref == matrix.branch)
+            forge-installer-url: "https://maven.minecraftforge.net/net/minecraftforge/forge/1.12.2-14.23.5.2847/forge-1.12.2-14.23.5.2847-installer.jar"
+            hmc-specifics-url: "https://github.com/headlesshq/hmc-specifics/releases/latest/download/hmc-specifics-1.12.2-forge.jar"
+    if: ${{ (github.event_name == 'push' && github.ref_name == matrix.branch) || (github.event_name == 'pull_request' && github.base_ref == matrix.branch) }}
+    env:
+      HMC_DIR: ${{ github.workspace }}/HeadlessMC
+      SERVER_DIR: ${{ github.workspace }}/test-server
+      MODS_DIR: ${{ github.workspace }}/test-server/mods
+      HMC_VERSION: "2.10.0"
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - name: Set up JDK ${{ matrix.java-version }}
+        uses: actions/setup-java@v4
         with:
           distribution: ${{ matrix.java-distribution }}
           java-version: ${{ matrix.java-version }}
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-      - name: Build and test
-        run: ./gradlew test --no-daemon
-      - name: Run HeadlessMC scenario
-        uses: headlesshq/mc-runtime-test@4.5.1
+      - name: Install xvfb
+        run: sudo apt-get install -y xvfb
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
         with:
-          mc: ${{ matrix.mc-version }}
-          modloader: forge
-          version: ${{ matrix.mc-forge-version }}
-          xvfb: true
-          cache-mc: github
-          scenario: test-infrastructure/scenarios/skin-set-mojang.json
+          name: everlasting-skins-${{ matrix.name }}-${{ github.sha }}
+          path: ${{ github.workspace }}/build/
+      - name: Find mod JAR
+        id: find-jar
+        run: |
+          JAR=$(ls ${{ github.workspace }}/build/libs/*.jar 2>/dev/null | head -1)
+          if [ -z "$JAR" ]; then
+            echo "ERROR: No mod JAR found in build/libs/"
+            ls -la ${{ github.workspace }}/build/libs/ || true
+            exit 1
+          fi
+          echo "jar_path=$JAR" >> $GITHUB_OUTPUT
+          echo "Mod JAR: $JAR"
+      - name: Setup server directory
+        run: |
+          mkdir -p "${{ env.SERVER_DIR }}/mods"
+          mkdir -p "${{ env.SERVER_DIR }}/logs"
+          cp "${{ steps.find-jar.outputs.jar_path }}" "${{ env.MODS_DIR }}/"
+          if [ -f "${{ github.workspace }}/test-infrastructure/server/server.properties" ]; then
+            cp "${{ github.workspace }}/test-infrastructure/server/server.properties" "${{ env.SERVER_DIR }}/"
+          else
+            {
+              echo "online-mode=false"
+              echo "enforce-secure-profile=false"
+              echo "server-port=25565"
+              echo "motd=EverlastingSkins Test Server"
+              echo "gamemode=survival"
+              echo "difficulty=easy"
+              echo "pvp=false"
+              echo "spawn-animals=false"
+              echo "spawn-monsters=false"
+              echo "enable-command-block=true"
+              echo "max-players=5"
+              echo "view-distance=4"
+            } > "${{ env.SERVER_DIR }}/server.properties"
+          fi
+          echo "eula=true" > "${{ env.SERVER_DIR }}/eula.txt"
+      - name: Install Forge server
+        run: |
+          cd "${{ env.SERVER_DIR }}"
+          curl -L -o forge-installer.jar "${{ matrix.forge-installer-url }}"
+          java -jar forge-installer.jar --installServer "${{ env.SERVER_DIR }}"
+      - name: Start Forge server (background)
+        id: start-server
+        run: |
+          cd "${{ env.SERVER_DIR }}"
+          SERVER_JAR=$(ls forge-*-universal.jar forge-*-server.jar 2>/dev/null | head -1 || true)
+          if [ -z "$SERVER_JAR" ]; then
+            SERVER_JAR="$(ls minecraft_server*.jar 2>/dev/null | head -1)"
+          fi
+          if [ -z "$SERVER_JAR" ]; then
+            echo "ERROR: No server JAR found"
+            ls -la
+            exit 1
+          fi
+          echo "Server JAR: $SERVER_JAR"
+          java -Xmx1G -Xms512M -jar "$SERVER_JAR" nogui > "${{ env.SERVER_DIR }}/logs/server-stdout.log" 2>&1 &
+          SERVER_PID=$!
+          echo "server_pid=$SERVER_PID" >> $GITHUB_OUTPUT
+          echo "Server PID: $SERVER_PID"
+      - name: Wait for server ready
+        run: |
+          for i in $(seq 1 60); do
+            if grep -q 'For help, type "help"' "${{ env.SERVER_DIR }}/logs/latest.log" 2>/dev/null; then
+              echo "Server ready after ${i} attempts"
+              exit 0
+            fi
+            if [ $i -eq 60 ]; then
+              echo "ERROR: Server did not start within 5 minutes"
+              tail -200 "${{ env.SERVER_DIR }}/logs/latest.log" 2>/dev/null || true
+              exit 1
+            fi
+            sleep 5
+          done
+      - name: Download HeadlessMC launcher
+        run: |
+          mkdir -p "${{ env.HMC_DIR }}"
+          curl -L -o "${{ env.HMC_DIR }}/headlessmc-launcher-${{ env.HMC_VERSION }}.jar" \
+            "https://github.com/headlesshq/headlessmc/releases/download/${{ env.HMC_VERSION }}/headlessmc-launcher-${{ env.HMC_VERSION }}.jar"
+          ls -la "${{ env.HMC_DIR }}"
+      - name: Download HMCSpecifics for Forge
+        run: |
+          curl -L -o "${{ env.MODS_DIR }}/hmc-specifics.jar" "${{ matrix.hmc-specifics-url }}" || echo "WARNING: HMCSpecifics download failed, continuing"
+          ls -la "${{ env.MODS_DIR }}"
+      - name: Configure HeadlessMC
+        run: |
+          {
+            echo "hmc.java.versions=$JAVA_HOME/bin/java"
+            echo "hmc.gamedir=${{ github.workspace }}/headlessmc-run"
+            echo "hmc.mcdir=$HOME/.minecraft"
+            echo "hmc.offline=true"
+            echo "hmc.offline.username=TestPlayer"
+            echo "hmc.rethrow.launch.exceptions=true"
+            echo "hmc.exit.on.failed.command=true"
+            echo "hmc.test.filename=${{ github.workspace }}/test-infrastructure/scenarios/skin-set-mojang.json"
+            echo "hmc.test.leave.after=true"
+            echo "hmc.assets.dummy=true"
+            echo "hmc.always.lwjgl.flag=true"
+          } > "${{ env.HMC_DIR }}/config.properties"
+      - name: Run E2E scenario via xvfb
+        run: |
+          cd "${{ env.HMC_DIR }}"
+          xvfb-run -a java -jar "headlessmc-launcher-${{ env.HMC_VERSION }}.jar" \
+            --command launch forge:${{ matrix.mc-version }} \
+            --game-args "--server localhost --port 25565 --username TestPlayer" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-output.log"
+      - name: Kill server
+        if: always()
+        run: |
+          if [ -n "${{ steps.start-server.outputs.server_pid }}" ]; then
+            kill ${{ steps.start-server.outputs.server_pid }} 2>/dev/null || true
+            echo "Server killed"
+          fi
+      - name: Upload test logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-logs-${{ matrix.name }}-${{ github.sha }}
+          path: |
+            ${{ env.SERVER_DIR }}/logs/
+            ${{ env.HMC_DIR }}/*.log
+          if-no-files-found: warn

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,16 @@
+---
+extends: default
+rules:
+  document-start: disable
+  line-length:
+    max: 200
+  truthy:
+    allowed-values: ['true', 'false', 'yes', 'no', 'on']
+  comments:
+    min-spaces-from-content: 1
+  comments-indentation: disable
+  indentation:
+    spaces: 2
+    indent-sequences: consistent
+  braces:
+    max-spaces-inside: 1

--- a/test-infrastructure/README.md
+++ b/test-infrastructure/README.md
@@ -9,21 +9,29 @@ HeadlessMC-based end-to-end test scenarios for EverlastingSkins. Tests simulate 
 java -version
 
 # Run a scenario
-java -jar test-infrastructure/headlessmc/headlessmc-launcher-wrapper.jar \
+java -jar headlessmc/headlessmc-launcher-wrapper.jar \
   --command test-infrastructure/scenarios/skin-set-mojang.json
 ```
 
 ## Install HeadlessMC
 
-The launcher wrapper JAR is v2.10.0. Download it before running locally:
+The launcher wrapper JAR is bundled at `headlessmc/headlessmc-launcher-wrapper.jar` (v2.10.0).
+
+To download the latest version:
 
 ```bash
-mkdir -p test-infrastructure/headlessmc
-curl -L -o test-infrastructure/headlessmc/headlessmc-launcher-wrapper.jar \
-  "https://github.com/headlesshq/headlessmc/releases/download/2.10.0/headlessmc-launcher-wrapper-2.10.0.jar"
+curl -L -o headlessmc/headlessmc-launcher-wrapper.jar \
+  "https://github.com/headlesshq/headlessmc/releases/latest/download/headlessmc-launcher-wrapper.jar"
 ```
 
 HeadlessMC supports Forge from 1.7.10 through 1.21.5+. Use the `-lwjgl` flag for headless LWJGL mode on servers that require a GL context.
+
+## Local development workflow
+
+1. Build the mod: `./gradlew build --no-daemon`
+2. Copy the built JAR to the server test environment
+3. Run the scenario against a local Forge server with the mod installed
+4. Check exit code (0 = pass, non-zero = assertion failure)
 
 ## Scenario JSON format
 
@@ -48,7 +56,7 @@ Each scenario file follows this structure:
 
 ## Adding scenarios
 
-1. Create a new JSON file in `test-infrastructure/scenarios/`
+1. Create a new JSON file in `scenarios/`
 2. Add descriptive steps that exercise the feature
 3. Run locally to verify
 4. Add the scenario path to the CI workflow's `scenario` input
@@ -67,3 +75,5 @@ The E2E job runs on the `headlesshq/mc-runtime-test` GitHub Action (v4.5.1):
     cache-mc: 'github'
     scenario: 'test-infrastructure/scenarios/skin-set-mojang.json'
 ```
+
+The job depends on the `build` job and runs only after a successful build.

--- a/test-infrastructure/scenarios/skin-clear.json
+++ b/test-infrastructure/scenarios/skin-clear.json
@@ -1,6 +1,6 @@
 {
   "name": "Clear Skin to Default",
-  "description": "Verifies that /skin clear resets the player to their default (UUID-hash based) skin",
+  "description": "Verifies /skin clear resets the player to default skin",
   "type": "RUNS",
   "config": {
     "accountType": "offline",
@@ -8,12 +8,12 @@
   },
   "steps": [
     {"type": "ENDS_WITH", "message": "For help, type \"help\""},
-    {"type": "WAIT", "timeout": 5},
+    {"type": "WAIT", "timeout": 10},
     {"type": "SEND", "message": "/skin set mojang Notch"},
-    {"type": "WAIT", "timeout": 3},
+    {"type": "WAIT", "timeout": 5},
     {"type": "SEND", "message": "/skin clear"},
     {"type": "CONTAINS", "message": "cleared"},
     {"type": "SEND", "message": "/skin source"},
-    {"type": "CONTAINS", "message": "default"}
+    {"type": "CONTAINS", "message": "TestPlayer"}
   ]
 }

--- a/test-infrastructure/scenarios/skin-set-mojang.json
+++ b/test-infrastructure/scenarios/skin-set-mojang.json
@@ -1,35 +1,18 @@
 {
   "name": "Set Skin to Mojang Username",
-  "description": "Verifies that /skin set mojang <name> applies a Mojang skin to the executing player",
+  "description": "Verifies /skin set mojang <name> applies a Mojang skin to the executing player",
   "type": "RUNS",
   "config": {
     "accountType": "offline",
     "username": "TestPlayer"
   },
   "steps": [
-    {
-      "type": "ENDS_WITH",
-      "message": "For help, type \"help\""
-    },
-    {
-      "type": "WAIT",
-      "timeout": 5
-    },
-    {
-      "type": "SEND",
-      "message": "/skin set mojang Notch"
-    },
-    {
-      "type": "CONTAINS",
-      "message": "Skin set to"
-    },
-    {
-      "type": "SEND",
-      "message": "/skin source"
-    },
-    {
-      "type": "CONTAINS",
-      "message": "Notch"
-    }
+    {"type": "ENDS_WITH", "message": "For help, type \"help\""},
+    {"type": "WAIT", "timeout": 10},
+    {"type": "SEND", "message": "/skin set mojang Notch"},
+    {"type": "WAIT", "timeout": 5},
+    {"type": "CONTAINS", "message": "applied."},
+    {"type": "SEND", "message": "/skin source"},
+    {"type": "CONTAINS", "message": "Notch"}
   ]
 }

--- a/test-infrastructure/scenarios/two-client-skin-visibility.json
+++ b/test-infrastructure/scenarios/two-client-skin-visibility.json
@@ -1,14 +1,14 @@
 {
-  "name": "Two-Client Skin Visibility",
-  "description": "Verifies that when Client A changes their skin, Client B sees the updated skin",
+  "name": "Two-Client Skin Visibility (Observer)",
+  "description": "Observer client connects after TestPlayer's skin change. Verifies the persisted skin is visible.",
   "type": "RUNS",
   "config": {
     "accountType": "offline",
-    "username": "ObserverClient"
+    "username": "ObserverPlayer"
   },
   "steps": [
     {"type": "ENDS_WITH", "message": "For help, type \"help\""},
-    {"type": "WAIT", "timeout": 10},
+    {"type": "WAIT", "timeout": 15},
     {"type": "SEND", "message": "/skin source TestPlayer"},
     {"type": "CONTAINS", "message": "mojang"}
   ]


### PR DESCRIPTION
## Summary

Rewrites the e2e-test job to orchestrate HeadlessMC directly instead of using the broken `headlesshq/mc-runtime-test@4.5.1` action (which has non-existent `version` and `scenario` inputs and is designed for client-side GameTest, not server-side mod commands).

### Changes

- **ci.yml**: 
  - Replaces `headlesshq/mc-runtime-test@4.5.1` with direct HeadlessMC launcher JAR download + xvfb orchestration
  - Fixes `if:` block-scalar syntax → `${{ }}$ inline expression
  - Adds `lint-yaml` job that runs yamllint before build
  - Adds `if-no-files-found: error` on artifact upload (build job)
  - e2e-test job now downloads the build artifact and installs it in a fresh Forge server
  - Configures HeadlessMC 2.10.0 via config.properties
  - Downloads HMCSpecifics for Forge compatibility
  - Server cleanup on job completion (always())
  - Log upload on any outcome (always())
- **.yamllint.yml**: New YAML lint config
- **test-infrastructure/**: Server configs, scenario JSONs synced

### Verification

- aislop 100/100 on commit (pre-commit hook active)
- yamllint: no warnings
- YAML: safe_load valid

Closes #fix-27