### PR TITLE
fix(e2e): fix scenarios + server configs + local run script + docs

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,69 @@
+# Testing Architecture
+
+EverlastingSkins uses a three-tier testing pyramid:
+
+## Tier 1: Pure Java unit tests (JUnit 5)
+- 130+ tests on 1.21 branch
+- 150+ tests on mc1.12.2 branch
+- Coverage: provider fallback, HTTP outcomes, persistence atomicity, corruption handling, cache behavior, permission system, command dispatch, integration hooks
+- Run: `./gradlew test`
+
+## Tier 2: Forge server integration (manual smoke test)
+- Real Forge server startup
+- `/skin` command execution
+- Lifecycle event observation
+- Run: `./gradlew runServer --no-daemon`
+
+## Tier 3: End-to-end tests (HeadlessMC + HMCSpecifics)
+
+### Architecture
+
+The E2E test suite uses HeadlessMC 2.10.0 + HMC-Specifics to drive a real Minecraft client against a real Forge server. Tests run in CI on every push to `1.21` and `mc1.12.2` branches.
+
+Components:
+- `test-infrastructure/scenarios/*.json` — HeadlessMC JSON test definitions (EndsWith, Contains, Send, Wait step types)
+- `test-infrastructure/server/` — server.properties + eula.txt templates
+- `test-infrastructure/run-e2e.sh` — local execution script
+- `.github/workflows/ci.yml` — CI orchestration
+
+### Scenarios
+
+- `skin-set-mojang.json` — sets skin to Mojang username "Notch", verifies success
+- `skin-clear.json` — sets skin, then clears it, verifies cleared state
+- `two-client-skin-visibility.json` — observer client verifies another player's skin
+
+### Local execution
+
+Prerequisites: Java 21 (for 1.21) or Java 8+ (for 1.12.2), network access to Forge Maven
+
+```bash
+# Run E2E for 1.21 with default scenario
+./test-infrastructure/run-e2e.sh 1.21
+
+# Run E2E for 1.12.2 with skin-clear scenario
+./test-infrastructure/run-e2e.sh mc1.12.2 skin-clear
+
+# Run with observer scenario (after setting skin as TestPlayer)
+./test-infrastructure/run-e2e.sh 1.21 two-client-skin-visibility
+```
+
+### CI execution
+
+The CI workflow `.github/workflows/ci.yml` orchestrates:
+1. **lint-yaml** — yamllint over all YAML files
+2. **build** matrix — Gradle build + test on Java 21 (1.21) and Java 8 (mc1.12.2)
+3. **e2e-test** matrix — HeadlessMC scenario execution against a Forge server
+
+### Troubleshooting
+
+**Server fails to start**: Check `eula.txt` exists and contains `eula=true`. Check `server.properties` has `enforce-secure-profile=false`.
+
+**Mojang API rate limiting**: CI runners share IP space with rate-limited sources. If skin fetch fails, use `--offline` mode or stub the Mojang API.
+
+**HeadlessMC crashes**: Delete `~/.minecraft` and `$PROJECT_DIR/headlessmc-run` to clear caches.
+
+**Two-client scenario fails**: HeadlessMC currently runs single client per invocation. Two-client testing requires coordinated invocations.
+
+## Skipping E2E for local commits
+
+E2E runs only on pushes to `1.21` and `mc1.12.2` branches. Feature branches don't trigger E2E.

--- a/test-infrastructure/README.md
+++ b/test-infrastructure/README.md
@@ -9,21 +9,29 @@ HeadlessMC-based end-to-end test scenarios for EverlastingSkins. Tests simulate 
 java -version
 
 # Run a scenario
-java -jar test-infrastructure/headlessmc/headlessmc-launcher-wrapper.jar \
+java -jar headlessmc/headlessmc-launcher-wrapper.jar \
   --command test-infrastructure/scenarios/skin-set-mojang.json
 ```
 
 ## Install HeadlessMC
 
-The launcher wrapper JAR is v2.10.0. Download it before running locally:
+The launcher wrapper JAR is bundled at `headlessmc/headlessmc-launcher-wrapper.jar` (v2.10.0).
+
+To download the latest version:
 
 ```bash
-mkdir -p test-infrastructure/headlessmc
-curl -L -o test-infrastructure/headlessmc/headlessmc-launcher-wrapper.jar \
-  "https://github.com/headlesshq/headlessmc/releases/download/2.10.0/headlessmc-launcher-wrapper-2.10.0.jar"
+curl -L -o headlessmc/headlessmc-launcher-wrapper.jar \
+  "https://github.com/headlesshq/headlessmc/releases/latest/download/headlessmc-launcher-wrapper.jar"
 ```
 
 HeadlessMC supports Forge from 1.7.10 through 1.21.5+. Use the `-lwjgl` flag for headless LWJGL mode on servers that require a GL context.
+
+## Local development workflow
+
+1. Build the mod: `./gradlew build --no-daemon`
+2. Copy the built JAR to the server test environment
+3. Run the scenario against a local Forge server with the mod installed
+4. Check exit code (0 = pass, non-zero = assertion failure)
 
 ## Scenario JSON format
 
@@ -48,7 +56,7 @@ Each scenario file follows this structure:
 
 ## Adding scenarios
 
-1. Create a new JSON file in `test-infrastructure/scenarios/`
+1. Create a new JSON file in `scenarios/`
 2. Add descriptive steps that exercise the feature
 3. Run locally to verify
 4. Add the scenario path to the CI workflow's `scenario` input
@@ -67,3 +75,5 @@ The E2E job runs on the `headlesshq/mc-runtime-test` GitHub Action (v4.5.1):
     cache-mc: 'github'
     scenario: 'test-infrastructure/scenarios/skin-set-mojang.json'
 ```
+
+The job depends on the `build` job and runs only after a successful build.

--- a/test-infrastructure/run-e2e.sh
+++ b/test-infrastructure/run-e2e.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# EverlastingSkins - Local E2E Test Runner
+# Usage: ./run-e2e.sh [branch] [scenario]
+#   branch:   1.21 (default) or mc1.12.2
+#   scenario: skin-set-mojang (default), skin-clear, two-client-skin-visibility
+
+set -euo pipefail
+
+BRANCH="${1:-1.21}"
+SCENARIO="${2:-skin-set-mojang}"
+HMC_VERSION="2.10.0"
+HMC_DIR_NAME="HeadlessMC"
+
+# Determine branch directory
+if [ "$BRANCH" = "mc1.12.2" ]; then
+    BRANCH_DIR="mc1.12.2"
+    FORGE_VERSION="14.23.5.2847"
+    MC_VERSION="1.12.2"
+else
+    BRANCH_DIR="1.21"
+    FORGE_VERSION="51.0.8"
+    MC_VERSION="1.21"
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+SCENARIO_FILE="$SCRIPT_DIR/scenarios/${SCENARIO}.json"
+
+if [ ! -f "$SCENARIO_FILE" ]; then
+    echo "ERROR: Scenario file not found: $SCENARIO_FILE"
+    echo "Available scenarios:"
+    ls "$SCRIPT_DIR/scenarios/"*.json 2>/dev/null || echo "  (none)"
+    exit 1
+fi
+
+echo "=== EverlastingSkins E2E Test ==="
+echo "Branch:    $BRANCH (MC $MC_VERSION, Forge $FORGE_VERSION)"
+echo "Scenario:  $SCENARIO_FILE"
+echo
+
+# 1. Build the mod
+echo "[1/6] Building mod..."
+cd "$PROJECT_DIR/$BRANCH_DIR"
+if [ ! -x gradlew ]; then
+    chmod +x gradlew
+fi
+./gradlew build --no-daemon
+
+# 2. Prepare server directory
+echo "[2/6] Setting up test server..."
+SERVER_DIR="$(mktemp -d)"
+trap 'rm -rf "$SERVER_DIR"; echo "Cleaned up temp directory"' EXIT
+
+mkdir -p "$SERVER_DIR/mods"
+mkdir -p "$SERVER_DIR/logs"
+
+JAR_FILE=$(ls build/libs/*.jar 2>/dev/null | head -1)
+if [ -z "$JAR_FILE" ]; then
+    echo "ERROR: No mod JAR found in build/libs/"
+    exit 1
+fi
+cp "$JAR_FILE" "$SERVER_DIR/mods/"
+echo "  Copied mod: $(basename "$JAR_FILE")"
+
+cp "$SCRIPT_DIR/server/server.properties" "$SERVER_DIR/"
+cp "$SCRIPT_DIR/server/eula.txt" "$SERVER_DIR/"
+
+# 3. Download Forge server if not cached
+echo "[3/6] Installing Forge server..."
+FORGE_INSTALLER="forge-$MC_VERSION-$FORGE_VERSION-installer.jar"
+if [ ! -f "$HOME/.cache/everlastingskins/$FORGE_INSTALLER" ]; then
+    mkdir -p "$HOME/.cache/everlastingskins"
+    FORGE_URL="https://maven.minecraftforge.net/net/minecraftforge/forge/$MC_VERSION-$FORGE_VERSION/forge-$MC_VERSION-$FORGE_VERSION-installer.jar"
+    echo "  Downloading $FORGE_URL..."
+    curl -L -o "$HOME/.cache/everlastingskins/$FORGE_INSTALLER" "$FORGE_URL"
+fi
+java -jar "$HOME/.cache/everlastingskins/$FORGE_INSTALLER" --installServer "$SERVER_DIR"
+
+# 4. Start server
+echo "[4/6] Starting Forge server..."
+cd "$SERVER_DIR"
+SERVER_JAR=$(ls forge-*-universal.jar forge-*-server.jar 2>/dev/null | head -1 || true)
+if [ -z "$SERVER_JAR" ]; then
+    SERVER_JAR="$(ls minecraft_server*.jar 2>/dev/null | head -1)"
+fi
+if [ -z "$SERVER_JAR" ]; then
+    echo "ERROR: No server JAR found in $SERVER_DIR"
+    ls -la "$SERVER_DIR"
+    exit 1
+fi
+java -Xmx1G -Xms512M -jar "$SERVER_JAR" nogui &
+SERVER_PID=$!
+echo "  Server PID: $SERVER_PID"
+
+echo "  Waiting for server to start..."
+for i in $(seq 1 60); do
+    if grep -q 'For help, type "help"' "$SERVER_DIR/logs/latest.log" 2>/dev/null; then
+        echo "  Server ready after ${i}s"
+        break
+    fi
+    if [ $i -eq 60 ]; then
+        echo "ERROR: Server did not start within 5 minutes"
+        cat "$SERVER_DIR/logs/latest.log" 2>/dev/null || true
+        kill "$SERVER_PID" 2>/dev/null || true
+        exit 1
+    fi
+    sleep 5
+done
+
+# 5. Download HeadlessMC if needed
+echo "[5/6] Setting up HeadlessMC..."
+HMC_DIR="$SCRIPT_DIR/headlessmc"
+mkdir -p "$HMC_DIR"
+if [ ! -f "$HMC_DIR/headlessmc-launcher-wrapper.jar" ]; then
+    echo "  Downloading HeadlessMC $HMC_VERSION..."
+    curl -L -o "$HMC_DIR/headlessmc-launcher-wrapper.jar" \
+        "https://github.com/headlesshq/headlessmc/releases/download/$HMC_VERSION/headlessmc-launcher-wrapper-$HMC_VERSION.jar"
+fi
+
+# Configure HeadlessMC for test
+HMC_CONFIG_DIR="$PROJECT_DIR/$HMC_DIR_NAME"
+mkdir -p "$HMC_CONFIG_DIR"
+cat > "$HMC_CONFIG_DIR/config.properties" << CONFIG
+hmc.java.versions=$JAVA_HOME/bin/java
+hmc.gamedir=$PROJECT_DIR/headlessmc-run
+hmc.mcdir=$HOME/.minecraft
+hmc.offline=true
+hmc.offline.username=TestPlayer
+hmc.rethrow.launch.exceptions=true
+hmc.exit.on.failed.command=true
+hmc.test.filename=$SCENARIO_FILE
+hmc.test.leave.after=true
+hmc.assets.dummy=true
+hmc.always.lwjgl.flag=true
+CONFIG
+
+# 6. Run test
+echo "[6/6] Running E2E test scenario: $SCENARIO..."
+cd "$PROJECT_DIR"
+java -jar "$HMC_DIR/headlessmc-launcher-wrapper.jar" \
+    --command launch forge:$MC_VERSION \
+    --game-args "--server localhost --port 25565 --username TestPlayer"
+
+EXIT_CODE=$?
+
+kill "$SERVER_PID" 2>/dev/null || true
+wait "$SERVER_PID" 2>/dev/null || true
+
+echo
+if [ $EXIT_CODE -eq 0 ]; then
+    echo "=== E2E TEST PASSED ==="
+else
+    echo "=== E2E TEST FAILED (exit code: $EXIT_CODE) ==="
+    echo "Server logs: $SERVER_DIR/logs/latest.log"
+fi
+exit $EXIT_CODE

--- a/test-infrastructure/scenarios/skin-clear.json
+++ b/test-infrastructure/scenarios/skin-clear.json
@@ -1,6 +1,6 @@
 {
   "name": "Clear Skin to Default",
-  "description": "Verifies that /skin clear resets the player to their default (UUID-hash based) skin",
+  "description": "Verifies /skin clear resets the player to default skin",
   "type": "RUNS",
   "config": {
     "accountType": "offline",
@@ -8,12 +8,12 @@
   },
   "steps": [
     {"type": "ENDS_WITH", "message": "For help, type \"help\""},
-    {"type": "WAIT", "timeout": 5},
+    {"type": "WAIT", "timeout": 10},
     {"type": "SEND", "message": "/skin set mojang Notch"},
-    {"type": "WAIT", "timeout": 3},
+    {"type": "WAIT", "timeout": 5},
     {"type": "SEND", "message": "/skin clear"},
     {"type": "CONTAINS", "message": "cleared"},
     {"type": "SEND", "message": "/skin source"},
-    {"type": "CONTAINS", "message": "default"}
+    {"type": "CONTAINS", "message": "TestPlayer"}
   ]
 }

--- a/test-infrastructure/scenarios/skin-set-mojang.json
+++ b/test-infrastructure/scenarios/skin-set-mojang.json
@@ -1,35 +1,18 @@
 {
   "name": "Set Skin to Mojang Username",
-  "description": "Verifies that /skin set mojang <name> applies a Mojang skin to the executing player",
+  "description": "Verifies /skin set mojang <name> applies a Mojang skin to the executing player",
   "type": "RUNS",
   "config": {
     "accountType": "offline",
     "username": "TestPlayer"
   },
   "steps": [
-    {
-      "type": "ENDS_WITH",
-      "message": "For help, type \"help\""
-    },
-    {
-      "type": "WAIT",
-      "timeout": 5
-    },
-    {
-      "type": "SEND",
-      "message": "/skin set mojang Notch"
-    },
-    {
-      "type": "CONTAINS",
-      "message": "Skin set to"
-    },
-    {
-      "type": "SEND",
-      "message": "/skin source"
-    },
-    {
-      "type": "CONTAINS",
-      "message": "Notch"
-    }
+    {"type": "ENDS_WITH", "message": "For help, type \"help\""},
+    {"type": "WAIT", "timeout": 10},
+    {"type": "SEND", "message": "/skin set mojang Notch"},
+    {"type": "WAIT", "timeout": 5},
+    {"type": "CONTAINS", "message": "applied."},
+    {"type": "SEND", "message": "/skin source"},
+    {"type": "CONTAINS", "message": "Notch"}
   ]
 }

--- a/test-infrastructure/scenarios/two-client-skin-visibility.json
+++ b/test-infrastructure/scenarios/two-client-skin-visibility.json
@@ -1,14 +1,14 @@
 {
-  "name": "Two-Client Skin Visibility",
-  "description": "Verifies that when Client A changes their skin, Client B sees the updated skin",
+  "name": "Two-Client Skin Visibility (Observer)",
+  "description": "Observer client connects after TestPlayer's skin change. Verifies the persisted skin is visible.",
   "type": "RUNS",
   "config": {
     "accountType": "offline",
-    "username": "ObserverClient"
+    "username": "ObserverPlayer"
   },
   "steps": [
     {"type": "ENDS_WITH", "message": "For help, type \"help\""},
-    {"type": "WAIT", "timeout": 10},
+    {"type": "WAIT", "timeout": 15},
     {"type": "SEND", "message": "/skin source TestPlayer"},
     {"type": "CONTAINS", "message": "mojang"}
   ]

--- a/test-infrastructure/server/eula.txt
+++ b/test-infrastructure/server/eula.txt
@@ -1,0 +1,1 @@
+eula=true

--- a/test-infrastructure/server/server.properties
+++ b/test-infrastructure/server/server.properties
@@ -1,0 +1,12 @@
+online-mode=false
+enforce-secure-profile=false
+server-port=25565
+motd=EverlastingSkins Test Server
+gamemode=survival
+difficulty=easy
+pvp=false
+spawn-animals=false
+spawn-monsters=false
+enable-command-block=true
+max-players=5
+view-distance=4


### PR DESCRIPTION
## Summary

Implements Phase 6 release E2E changes from lib-15's Phases A, C, H, I:

### Phase A: Fix JSON scenario messages
- `skin-set-mojang.json`: Changed CONTAINS check from 'Skin set to' to 'applied.' (matches actual mod output from localized 'fulfilled' key)
- `skin-clear.json`: Changed CONTAINS check from 'default' to 'TestPlayer' (hasDefaultSkin returns player name after clear)
- `two-client-skin-visibility.json`: Updated to observer pattern - single client connects AFTER TestPlayer's skin change

### Phase C: Server config templates
- `test-infrastructure/server/server.properties`: offline-mode, command blocks enabled, E2E-optimized settings
- `test-infrastructure/server/eula.txt`: eula=true

### Phase H: Local run script
- `test-infrastructure/run-e2e.sh`: Builds mod, downloads Forge + HeadlessMC, starts server, runs scenario

### Phase I: Documentation
- `TESTING.md`: Three-tier testing pyramid (unit, integration, E2E) with architecture, scenarios, execution guide, troubleshooting

## Verification
- All 3 JSON files pass python3 -m json.tool validation
- run-e2e.sh passes bash -n syntax check
- Pre-commit hook (aislop) passed cleanly
- Files synced to both 1.21 and mc1.12.2 worktrees