### PR TITLE
test(scenarios): fix message strings to match actual mod output

### DIFF
--- a/test-infrastructure/scenarios/two-client-skin-visibility.json
+++ b/test-infrastructure/scenarios/two-client-skin-visibility.json
@@ -10,6 +10,6 @@
     {"type": "ENDS_WITH", "message": "For help, type \"help\""},
     {"type": "WAIT", "timeout": 15},
     {"type": "SEND", "message": "/skin source TestPlayer"},
-    {"type": "SUCCESS", "message": "Source check sent"}
+    {"type": "CONTAINS", "message": "Notch"}
   ]
 }


### PR DESCRIPTION
## Summary

Fixes the scenario message strings to match what the mod actually sends to players.

### Changes

**test-infrastructure/scenarios/two-client-skin-visibility.json (1.21):**
- Changed `SUCCESS 'Source check sent'` → `CONTAINS 'Notch'`
  - The mod does not send 'Source check sent'; `/skin source TestPlayer` returns the stored source string ('Notch') when TestPlayer's skin was set via `/skin set mojang Notch`.

### Verification
- All scenario files pass `python3 -m json.tool` validation
- Messages verified against actual mod source (`SkinCommand.java` + `I18nUtils.java`)