### PR TITLE
test(scenarios): fix message strings to match actual mod output

### DIFF
--- a/test-infrastructure/scenarios/skin-set-mojang.json
+++ b/test-infrastructure/scenarios/skin-set-mojang.json
@@ -11,7 +11,7 @@
     {"type": "WAIT", "timeout": 10},
     {"type": "SEND", "message": "/skin set mojang Notch"},
     {"type": "WAIT", "timeout": 5},
-    {"type": "CONTAINS", "message": "applied."},
+    {"type": "CONTAINS", "message": "applied"},
     {"type": "SEND", "message": "/skin source"},
     {"type": "CONTAINS", "message": "Notch"}
   ]

--- a/test-infrastructure/scenarios/two-client-skin-visibility.json
+++ b/test-infrastructure/scenarios/two-client-skin-visibility.json
@@ -10,6 +10,6 @@
     {"type": "ENDS_WITH", "message": "For help, type \"help\""},
     {"type": "WAIT", "timeout": 15},
     {"type": "SEND", "message": "/skin source TestPlayer"},
-    {"type": "CONTAINS", "message": "mojang"}
+    {"type": "CONTAINS", "message": "Notch"}
   ]
 }


### PR DESCRIPTION
## Summary

Fixes the scenario message strings to match what the mod actually sends to players.

### Changes

**test-infrastructure/scenarios/skin-set-mojang.json (mc1.12.2):**
- Changed `CONTAINS 'applied.'` → `CONTAINS 'applied'`
  - mc1.12.2 sends 'Skin applied' (no trailing period), unlike 1.21 which sends 'Skin has been applied.'

**test-infrastructure/scenarios/two-client-skin-visibility.json (mc1.12.2):**
- Changed `CONTAINS 'mojang'` → `CONTAINS 'Notch'`
  - The stored source for `/skin set mojang Notch` is the Mojang username ('Notch'), not the literal string 'mojang'

### Verification
- All scenario files pass `python3 -m json.tool` validation
- Messages verified against actual mod source (`SkinCommand.java`)