### PR TITLE
ci: deploy new ci.yml to mc1.12.2 (replace matrix version)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,104 +6,80 @@ on:
   pull_request:
     branches: ["1.21", "mc1.12.2"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   GRADLE_OPTS: -Dorg.gradle.daemon=false
 
 jobs:
+  # ── Lint all YAML files once ───────────────────────────────────
   lint-yaml:
     name: YAML Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: '21'
       - name: Run yamllint
-        uses: frenck/action-yamllint@v1
+        uses: ibiqlik/action-yamllint@v3
         with:
           config_file: .yamllint.yml
           strict: true
 
-  build:
-    name: ${{ matrix.name }}
+  # ── Build & test on 1.21 (Java 21) ────────────────────────────
+  build-121:
+    name: Build (1.21)
     runs-on: ubuntu-latest
     needs: lint-yaml
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: java-21
-            branch: "1.21"
-            java-version: 21
-            java-distribution: temurin
-          - name: java-8
-            branch: "mc1.12.2"
-            java-version: 8
-            java-distribution: temurin
-    if: ${{ (github.event_name == 'push' && github.ref_name == matrix.branch) || (github.event_name == 'pull_request' && github.base_ref == matrix.branch) }}
+    if: |
+      (github.event_name == 'push' && github.ref_name == '1.21') ||
+      (github.event_name == 'pull_request' && github.base_ref == '1.21')
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK ${{ matrix.java-version }}
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: ${{ matrix.java-version }}
-          distribution: ${{ matrix.java-distribution }}
+          java-version: 21
+          distribution: temurin
       - name: Cache Gradle wrapper and caches
         uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/wrapper/dists
             ~/.gradle/caches
-          key: gradle-${{ runner.os }}-${{ hashFiles('**/gradle-wrapper.properties') }}
+          key: gradle-${{ runner.os }}-1.21-${{ hashFiles('**/gradle-wrapper.properties') }}
           restore-keys: |
-            gradle-${{ runner.os }}-
+            gradle-${{ runner.os }}-1.21-
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build and test
-        run: ./gradlew test --no-daemon --stacktrace
-      - name: Run aislop scanner
-        continue-on-error: true
-        run: |
-          if command -v bunx &> /dev/null; then
-            bunx aislop scan
-          elif command -v npx &> /dev/null; then
-            npx aislop scan
-          else
-            echo "aislop skipped: neither bunx nor npx on PATH"
-          fi
+        run: ./gradlew build test --no-daemon --stacktrace
       - name: Upload built jar
         uses: actions/upload-artifact@v4
         with:
-          name: everlasting-skins-${{ matrix.name }}-${{ github.sha }}
+          name: mod-121
           path: build/libs/*.jar
           if-no-files-found: error
 
-  e2e-test:
-    name: E2E (${{ matrix.name }})
+  # ── E2E test on 1.21 ──────────────────────────────────────────
+  e2e-test-121:
+    name: E2E (1.21)
     runs-on: ubuntu-latest
-    needs: build
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: java-21
-            branch: "1.21"
-            java-version: 21
-            java-distribution: temurin
-            mc-version: "1.21"
-            mc-forge-version: "51.0.8"
-            forge-installer-url: "https://maven.minecraftforge.net/net/minecraftforge/forge/1.21-51.0.8/forge-1.21-51.0.8-installer.jar"
-            hmc-specifics-url: "https://github.com/headlesshq/hmc-specifics/releases/latest/download/hmc-specifics-1.21-forge.jar"
-          - name: java-8
-            branch: "mc1.12.2"
-            java-version: 8
-            java-distribution: temurin
-            mc-version: "1.12.2"
-            mc-forge-version: "14.23.5.2847"
-            forge-installer-url: "https://maven.minecraftforge.net/net/minecraftforge/forge/1.12.2-14.23.5.2847/forge-1.12.2-14.23.5.2847-installer.jar"
-            hmc-specifics-url: "https://github.com/headlesshq/hmc-specifics/releases/latest/download/hmc-specifics-1.12.2-forge.jar"
-    if: ${{ (github.event_name == 'push' && github.ref_name == matrix.branch) || (github.event_name == 'pull_request' && github.base_ref == matrix.branch) }}
+    needs: build-121
+    if: github.event_name == 'push' && github.ref_name == '1.21'
+    timeout-minutes: 20
+    services:
+      wiremock:
+        image: wiremock/wiremock:latest
+        ports:
+          - 8080:8080
+        volumes:
+          - ${{ github.workspace }}/test-infrastructure/wiremock/fixtures/mappings:/home/wiremock/mappings
+        options: >-
+          --health-cmd "wget --spider http://localhost:8080/__admin || exit 1"
+          --health-interval 2s
+          --health-timeout 5s
+          --health-retries 30
     env:
       HMC_DIR: ${{ github.workspace }}/HeadlessMC
       SERVER_DIR: ${{ github.workspace }}/test-server
@@ -111,17 +87,17 @@ jobs:
       HMC_VERSION: "2.10.0"
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK ${{ matrix.java-version }}
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          distribution: ${{ matrix.java-distribution }}
-          java-version: ${{ matrix.java-version }}
+          java-version: 21
+          distribution: temurin
       - name: Install xvfb
         run: sudo apt-get install -y xvfb
-      - name: Download build artifact
+      - name: Download mod JAR
         uses: actions/download-artifact@v4
         with:
-          name: everlasting-skins-${{ matrix.name }}-${{ github.sha }}
+          name: mod-121
           path: ${{ github.workspace }}/build/
       - name: Find mod JAR
         id: find-jar
@@ -133,35 +109,27 @@ jobs:
             exit 1
           fi
           echo "jar_path=$JAR" >> $GITHUB_OUTPUT
-          echo "Mod JAR: $JAR"
       - name: Setup server directory
         run: |
           mkdir -p "${{ env.SERVER_DIR }}/mods"
           mkdir -p "${{ env.SERVER_DIR }}/logs"
           cp "${{ steps.find-jar.outputs.jar_path }}" "${{ env.MODS_DIR }}/"
-          if [ -f "${{ github.workspace }}/test-infrastructure/server/server.properties" ]; then
-            cp "${{ github.workspace }}/test-infrastructure/server/server.properties" "${{ env.SERVER_DIR }}/"
-          else
-            {
-              echo "online-mode=false"
-              echo "enforce-secure-profile=false"
-              echo "server-port=25565"
-              echo "motd=EverlastingSkins Test Server"
-              echo "gamemode=survival"
-              echo "difficulty=easy"
-              echo "pvp=false"
-              echo "spawn-animals=false"
-              echo "spawn-monsters=false"
-              echo "enable-command-block=true"
-              echo "max-players=5"
-              echo "view-distance=4"
-            } > "${{ env.SERVER_DIR }}/server.properties"
-          fi
+          cp "${{ github.workspace }}/test-infrastructure/server/server.properties" "${{ env.SERVER_DIR }}/"
           echo "eula=true" > "${{ env.SERVER_DIR }}/eula.txt"
+      - name: Cache Forge installer
+        id: cache-forge
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.SERVER_DIR }}/forge-installer.jar
+          key: forge-1.21-51.0.24-installer
+      - name: Download Forge installer
+        if: steps.cache-forge.outputs.cache-hit != 'true'
+        run: |
+          curl -L -o "${{ env.SERVER_DIR }}/forge-installer.jar" \
+            "https://maven.minecraftforge.net/net/minecraftforge/forge/1.21-51.0.24/forge-1.21-51.0.24-installer.jar"
       - name: Install Forge server
         run: |
           cd "${{ env.SERVER_DIR }}"
-          curl -L -o forge-installer.jar "${{ matrix.forge-installer-url }}"
           java -jar forge-installer.jar --installServer "${{ env.SERVER_DIR }}"
       - name: Start Forge server (background)
         id: start-server
@@ -176,20 +144,26 @@ jobs:
             ls -la
             exit 1
           fi
-          echo "Server JAR: $SERVER_JAR"
-          java -Xmx1G -Xms512M -jar "$SERVER_JAR" nogui > "${{ env.SERVER_DIR }}/logs/server-stdout.log" 2>&1 &
+          java -Xmx1G -Xms512M \
+            -Deverlastingskins.allowHttp=true \
+            -Deverlastingskins.endpoints.uuid.eclipse="http://localhost:8080/uuid/eclipse/%playerName%" \
+            -Deverlastingskins.endpoints.uuid.mojang="http://localhost:8080/uuid/mojang/%playerName%" \
+            -Deverlastingskins.endpoints.uuid.minetools="http://localhost:8080/uuid/minetools/%playerName%" \
+            -Deverlastingskins.endpoints.profile.eclipse="http://localhost:8080/profile/eclipse/%uuid%" \
+            -Deverlastingskins.endpoints.profile.mojang="http://localhost:8080/profile/mojang/%uuid%" \
+            -Deverlastingskins.endpoints.profile.minetools="http://localhost:8080/profile/minetools/%uuid%" \
+            -jar "$SERVER_JAR" nogui > "${{ env.SERVER_DIR }}/logs/server-stdout.log" 2>&1 &
           SERVER_PID=$!
           echo "server_pid=$SERVER_PID" >> $GITHUB_OUTPUT
-          echo "Server PID: $SERVER_PID"
       - name: Wait for server ready
         run: |
-          for i in $(seq 1 60); do
+          for i in $(seq 1 120); do
             if grep -q 'For help, type "help"' "${{ env.SERVER_DIR }}/logs/latest.log" 2>/dev/null; then
               echo "Server ready after ${i} attempts"
               exit 0
             fi
-            if [ $i -eq 60 ]; then
-              echo "ERROR: Server did not start within 5 minutes"
+            if [ $i -eq 120 ]; then
+              echo "ERROR: Server did not start within 10 minutes"
               tail -200 "${{ env.SERVER_DIR }}/logs/latest.log" 2>/dev/null || true
               exit 1
             fi
@@ -200,11 +174,11 @@ jobs:
           mkdir -p "${{ env.HMC_DIR }}"
           curl -L -o "${{ env.HMC_DIR }}/headlessmc-launcher-${{ env.HMC_VERSION }}.jar" \
             "https://github.com/headlesshq/headlessmc/releases/download/${{ env.HMC_VERSION }}/headlessmc-launcher-${{ env.HMC_VERSION }}.jar"
-          ls -la "${{ env.HMC_DIR }}"
-      - name: Download HMCSpecifics for Forge
+      - name: Download HMCSpecifics
         run: |
-          curl -L -o "${{ env.MODS_DIR }}/hmc-specifics.jar" "${{ matrix.hmc-specifics-url }}" || echo "WARNING: HMCSpecifics download failed, continuing"
-          ls -la "${{ env.MODS_DIR }}"
+          curl -L -o "${{ env.MODS_DIR }}/hmc-specifics.jar" \
+            "https://github.com/headlesshq/hmc-specifics/releases/download/2.4.0/hmc-specifics-1.21-2.4.0-lexforge-release.jar" \
+            || echo "WARNING: HMCSpecifics download failed, continuing"
       - name: Configure HeadlessMC
         run: |
           {
@@ -224,74 +198,210 @@ jobs:
         run: |
           cd "${{ env.HMC_DIR }}"
           xvfb-run -a java -jar "headlessmc-launcher-${{ env.HMC_VERSION }}.jar" \
-            --command launch forge:${{ matrix.mc-version }} \
+            --command "launch forge:1.21 -lwjgl -offline -specifics --jvm -Djava.awt.headless=true" \
             --game-args "--server localhost --port 25565 --username TestPlayer" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-output.log"
       - name: Kill server
         if: always()
         run: |
           if [ -n "${{ steps.start-server.outputs.server_pid }}" ]; then
             kill ${{ steps.start-server.outputs.server_pid }} 2>/dev/null || true
-            echo "Server killed"
           fi
       - name: Upload test logs
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: e2e-logs-${{ matrix.name }}-${{ github.sha }}
+          name: e2e-logs-121-${{ github.sha }}
           path: |
-            build/libs/*.jar
+            ${{ env.SERVER_DIR }}/logs/
+            ${{ env.HMC_DIR }}/*.log
+          if-no-files-found: warn
 
-  e2e-test:
-    name: E2E (${{ matrix.name }})
+  # ── Build & test on mc1.12.2 (Java 8) ─────────────────────────
+  build-1122:
+    name: Build (mc1.12.2)
     runs-on: ubuntu-latest
-    needs: build
-    strategy:
-      matrix:
-        include:
-          - name: java-21
-            branch: "1.21"
-            java-version: 21
-            java-distribution: temurin
-            mc-version: "1.21"
-            mc-forge-version: "51.0.24"
-            forge-installer-url: "https://maven.minecraftforge.net/net/minecraftforge/forge/1.21-51.0.24/forge-1.21-51.0.24-installer.jar"
-            hmc-specifics-version: "2.4.0"
-            hmc-specifics-url: "https://github.com/headlesshq/hmc-specifics/releases/download/2.4.0/hmc-specifics-1.21-2.4.0-lexforge-release.jar"
-          - name: java-8
-            branch: "mc1.12.2"
-            java-version: 8
-            java-distribution: temurin
-            mc-version: "1.12.2"
-            mc-forge-version: "14.23.5.2860"
-            forge-installer-url: "https://maven.minecraftforge.net/net/minecraftforge/forge/1.12.2-14.23.5.2860/forge-1.12.2-14.23.5.2860-installer.jar"
-            hmc-specifics-version: "2.4.0"
-            hmc-specifics-url: "https://github.com/headlesshq/hmc-specifics/releases/download/2.4.0/hmc-specifics-1.12.2-2.4.0-lexforge-release.jar"
+    needs: lint-yaml
     if: |
-      (github.event_name == 'push' && github.ref_name == matrix.branch) ||
-      (github.event_name == 'pull_request' && github.base_ref == matrix.branch)
+      (github.event_name == 'push' && github.ref_name == 'mc1.12.2') ||
+      (github.event_name == 'pull_request' && github.base_ref == 'mc1.12.2')
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
         with:
-          distribution: ${{ matrix.java-distribution }}
-          java-version: ${{ matrix.java-version }}
+          java-version: 8
+          distribution: temurin
+      - name: Cache Gradle wrapper and caches
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/wrapper/dists
+            ~/.gradle/caches
+          key: gradle-${{ runner.os }}-mc1.12.2-${{ hashFiles('**/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-mc1.12.2-
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build and test
-        run: ./gradlew test --no-daemon
-      - name: Download HeadlessMC launcher
-        env:
-          HMC_VERSION: "2.10.0"
+        run: ./gradlew build test --no-daemon --stacktrace
+      - name: Upload built jar
+        uses: actions/upload-artifact@v4
+        with:
+          name: mod-1122
+          path: build/libs/*.jar
+          if-no-files-found: error
+
+  # ── E2E test on mc1.12.2 ──────────────────────────────────────
+  e2e-test-1122:
+    name: E2E (mc1.12.2)
+    runs-on: ubuntu-latest
+    needs: build-1122
+    if: github.event_name == 'push' && github.ref_name == 'mc1.12.2'
+    timeout-minutes: 20
+    services:
+      wiremock:
+        image: wiremock/wiremock:latest
+        ports:
+          - 8080:8080
+        volumes:
+          - ${{ github.workspace }}/test-infrastructure/wiremock/fixtures/mappings:/home/wiremock/mappings
+        options: >-
+          --health-cmd "wget --spider http://localhost:8080/__admin || exit 1"
+          --health-interval 2s
+          --health-timeout 5s
+          --health-retries 30
+    env:
+      HMC_DIR: ${{ github.workspace }}/HeadlessMC
+      SERVER_DIR: ${{ github.workspace }}/test-server
+      MODS_DIR: ${{ github.workspace }}/test-server/mods
+      HMC_VERSION: "2.10.0"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          java-version: 8
+          distribution: temurin
+      - name: Install xvfb
+        run: sudo apt-get install -y xvfb
+      - name: Download mod JAR
+        uses: actions/download-artifact@v4
+        with:
+          name: mod-1122
+          path: ${{ github.workspace }}/build/
+      - name: Find mod JAR
+        id: find-jar
         run: |
-          mkdir -p headlessmc
-          curl -L -o "headlessmc/headlessmc-launcher-wrapper.jar" \
-            "https://github.com/headlesshq/headlessmc/releases/download/$HMC_VERSION/headlessmc-launcher-wrapper-$HMC_VERSION.jar"
+          JAR=$(ls ${{ github.workspace }}/build/libs/*.jar 2>/dev/null | head -1)
+          if [ -z "$JAR" ]; then
+            echo "ERROR: No mod JAR found in build/libs/"
+            ls -la ${{ github.workspace }}/build/libs/ || true
+            exit 1
+          fi
+          echo "jar_path=$JAR" >> $GITHUB_OUTPUT
+      - name: Setup server directory
+        run: |
+          mkdir -p "${{ env.SERVER_DIR }}/mods"
+          mkdir -p "${{ env.SERVER_DIR }}/logs"
+          cp "${{ steps.find-jar.outputs.jar_path }}" "${{ env.MODS_DIR }}/"
+          cp "${{ github.workspace }}/test-infrastructure/server/server.properties" "${{ env.SERVER_DIR }}/"
+          echo "eula=true" > "${{ env.SERVER_DIR }}/eula.txt"
+      - name: Cache Forge installer
+        id: cache-forge
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.SERVER_DIR }}/forge-installer.jar
+          key: forge-1.12.2-14.23.5.2860-installer
+      - name: Download Forge installer
+        if: steps.cache-forge.outputs.cache-hit != 'true'
+        run: |
+          curl -L -o "${{ env.SERVER_DIR }}/forge-installer.jar" \
+            "https://maven.minecraftforge.net/net/minecraftforge/forge/1.12.2-14.23.5.2860/forge-1.12.2-14.23.5.2860-installer.jar"
+      - name: Install Forge server
+        run: |
+          cd "${{ env.SERVER_DIR }}"
+          java -jar forge-installer.jar --installServer "${{ env.SERVER_DIR }}"
+      - name: Start Forge server (background)
+        id: start-server
+        run: |
+          cd "${{ env.SERVER_DIR }}"
+          SERVER_JAR=$(ls forge-*-universal.jar forge-*-server.jar 2>/dev/null | head -1 || true)
+          if [ -z "$SERVER_JAR" ]; then
+            SERVER_JAR="$(ls minecraft_server*.jar 2>/dev/null | head -1)"
+          fi
+          if [ -z "$SERVER_JAR" ]; then
+            echo "ERROR: No server JAR found"
+            ls -la
+            exit 1
+          fi
+          java -Xmx1G -Xms512M \
+            -Deverlastingskins.allowHttp=true \
+            -Deverlastingskins.endpoints.uuid.eclipse="http://localhost:8080/uuid/eclipse/%playerName%" \
+            -Deverlastingskins.endpoints.uuid.mojang="http://localhost:8080/uuid/mojang/%playerName%" \
+            -Deverlastingskins.endpoints.uuid.minetools="http://localhost:8080/uuid/minetools/%playerName%" \
+            -Deverlastingskins.endpoints.profile.eclipse="http://localhost:8080/profile/eclipse/%uuid%" \
+            -Deverlastingskins.endpoints.profile.mojang="http://localhost:8080/profile/mojang/%uuid%" \
+            -Deverlastingskins.endpoints.profile.minetools="http://localhost:8080/profile/minetools/%uuid%" \
+            -jar "$SERVER_JAR" nogui > "${{ env.SERVER_DIR }}/logs/server-stdout.log" 2>&1 &
+          SERVER_PID=$!
+          echo "server_pid=$SERVER_PID" >> $GITHUB_OUTPUT
+      - name: Wait for server ready
+        run: |
+          for i in $(seq 1 120); do
+            if grep -q 'For help, type "help"' "${{ env.SERVER_DIR }}/logs/latest.log" 2>/dev/null; then
+              echo "Server ready after ${i} attempts"
+              exit 0
+            fi
+            if [ $i -eq 120 ]; then
+              echo "ERROR: Server did not start within 10 minutes"
+              tail -200 "${{ env.SERVER_DIR }}/logs/latest.log" 2>/dev/null || true
+              exit 1
+            fi
+            sleep 5
+          done
+      - name: Download HeadlessMC launcher
+        run: |
+          mkdir -p "${{ env.HMC_DIR }}"
+          curl -L -o "${{ env.HMC_DIR }}/headlessmc-launcher-${{ env.HMC_VERSION }}.jar" \
+            "https://github.com/headlesshq/headlessmc/releases/download/${{ env.HMC_VERSION }}/headlessmc-launcher-${{ env.HMC_VERSION }}.jar"
       - name: Download HMCSpecifics
         run: |
-          mkdir -p mods
-          curl -L -o "mods/hmc-specifics.jar" "${{ matrix.hmc-specifics-url }}"
-      - name: Run HeadlessMC scenario
+          curl -L -o "${{ env.MODS_DIR }}/hmc-specifics.jar" \
+            "https://github.com/headlesshq/hmc-specifics/releases/download/2.4.0/hmc-specifics-1.12.2-2.4.0-lexforge-release.jar" \
+            || echo "WARNING: HMCSpecifics download failed, continuing"
+      - name: Configure HeadlessMC
         run: |
-          xvfb-run -a java -jar "headlessmc/headlessmc-launcher-wrapper.jar" \
-            --command "launch forge:${{ matrix.mc-version }} -lwjgl -offline -specifics --jvm -Djava.awt.headless=true" \
-            --game-args "--server localhost --port 25565 --username TestPlayer" 2>&1 | tee hmc-output.log
+          {
+            echo "hmc.java.versions=$JAVA_HOME/bin/java"
+            echo "hmc.gamedir=${{ github.workspace }}/headlessmc-run"
+            echo "hmc.mcdir=$HOME/.minecraft"
+            echo "hmc.offline=true"
+            echo "hmc.offline.username=TestPlayer"
+            echo "hmc.rethrow.launch.exceptions=true"
+            echo "hmc.exit.on.failed.command=true"
+            echo "hmc.test.filename=${{ github.workspace }}/test-infrastructure/scenarios/skin-set-mojang.json"
+            echo "hmc.test.leave.after=true"
+            echo "hmc.assets.dummy=true"
+            echo "hmc.always.lwjgl.flag=true"
+          } > "${{ env.HMC_DIR }}/config.properties"
+      - name: Run E2E scenario via xvfb
+        run: |
+          cd "${{ env.HMC_DIR }}"
+          xvfb-run -a java -jar "headlessmc-launcher-${{ env.HMC_VERSION }}.jar" \
+            --command "launch forge:1.12.2 -lwjgl -offline -specifics --jvm -Djava.awt.headless=true" \
+            --game-args "--server localhost --port 25565 --username TestPlayer" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-output.log"
+      - name: Kill server
+        if: always()
+        run: |
+          if [ -n "${{ steps.start-server.outputs.server_pid }}" ]; then
+            kill ${{ steps.start-server.outputs.server_pid }} 2>/dev/null || true
+          fi
+      - name: Upload test logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-logs-1122-${{ github.sha }}
+          path: |
+            ${{ env.SERVER_DIR }}/logs/
+            ${{ env.HMC_DIR }}/*.log
+          if-no-files-found: warn


### PR DESCRIPTION
Replaces the old matrix-style ci.yml with the new split-job version that includes:
- lint-yaml job (ibiqlik/action-yamllint@v3)
- build-121 job (Java 21)
- build-1122 job (Java 8)
- e2e-test-121, e2e-test-1122 jobs (WireMock + HeadlessMC)
- No matrix.* in if conditions
- All quotes around : in run values