### PR TITLE
fix(ci): replace health: key with options: for WireMock service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,11 +75,12 @@ jobs:
           - 8080:8080
         volumes:
           - ${{ github.workspace }}/test-infrastructure/wiremock/fixtures/mappings:/home/wiremock/mappings
-        health:
-          test: ["CMD", "wget", "--spider", "http://localhost:8080/__admin"]
-          interval: 2s
-          timeout: 5s
-          retries: 30
+        options: >-
+          --health-cmd "wget --spider http://localhost:8080/__admin || exit 1"
+          --health-interval 5s
+          --health-timeout 10s
+          --health-retries 12
+          --health-start-period 15s
     env:
       HMC_DIR: ${{ github.workspace }}/HeadlessMC
       SERVER_DIR: ${{ github.workspace }}/test-server
@@ -265,11 +266,12 @@ jobs:
           - 8080:8080
         volumes:
           - ${{ github.workspace }}/test-infrastructure/wiremock/fixtures/mappings:/home/wiremock/mappings
-        health:
-          test: ["CMD", "wget", "--spider", "http://localhost:8080/__admin"]
-          interval: 2s
-          timeout: 5s
-          retries: 30
+        options: >-
+          --health-cmd "wget --spider http://localhost:8080/__admin || exit 1"
+          --health-interval 5s
+          --health-timeout 10s
+          --health-retries 12
+          --health-start-period 15s
     env:
       HMC_DIR: ${{ github.workspace }}/HeadlessMC
       SERVER_DIR: ${{ github.workspace }}/test-server


### PR DESCRIPTION
## Summary

The ci.yml on 1.21 uses the Docker Compose-style `health:` key under `services:`, which is invalid in GitHub Actions workflows. This caused the entire workflow to fail to parse (zero jobs executed).

## Fix

Replace `health:` with `options: >-` using Docker `--health-cmd` flags, matching the syntax already proven on mc1.12.2 (PR #49). Also add `--health-start-period 15s` to give WireMock time to initialize.

## Verification

- [ ] CI runs on this PR branch
- [ ] YAML Lint passes
- [ ] Build (1.21) passes
- [ ] E2E (1.21) passes