### PR TITLE
fix(ci): WireMock health check uses curl on /__admin/health

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
         volumes:
           - ${{ github.workspace }}/test-infrastructure/wiremock/fixtures/mappings:/home/wiremock/mappings
         options: >-
-          --health-cmd "wget --spider http://localhost:8080/__admin || exit 1"
+          --health-cmd "curl -sf http://localhost:8080/__admin/health || exit 1"
           --health-interval 5s
           --health-timeout 10s
           --health-retries 12
@@ -267,7 +267,7 @@ jobs:
         volumes:
           - ${{ github.workspace }}/test-infrastructure/wiremock/fixtures/mappings:/home/wiremock/mappings
         options: >-
-          --health-cmd "wget --spider http://localhost:8080/__admin || exit 1"
+          --health-cmd "curl -sf http://localhost:8080/__admin/health || exit 1"
           --health-interval 5s
           --health-timeout 10s
           --health-retries 12

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,11 +75,12 @@ jobs:
           - 8080:8080
         volumes:
           - ${{ github.workspace }}/test-infrastructure/wiremock/fixtures/mappings:/home/wiremock/mappings
-        health:
-          test: ["CMD", "wget", "--spider", "http://localhost:8080/__admin"]
-          interval: 2s
-          timeout: 5s
-          retries: 30
+        options: >-
+          --health-cmd "wget --spider http://localhost:8080/__admin || exit 1"
+          --health-interval 5s
+          --health-timeout 10s
+          --health-retries 12
+          --health-start-period 15s
     env:
       HMC_DIR: ${{ github.workspace }}/HeadlessMC
       SERVER_DIR: ${{ github.workspace }}/test-server
@@ -265,11 +266,12 @@ jobs:
           - 8080:8080
         volumes:
           - ${{ github.workspace }}/test-infrastructure/wiremock/fixtures/mappings:/home/wiremock/mappings
-        health:
-          test: ["CMD", "wget", "--spider", "http://localhost:8080/__admin"]
-          interval: 2s
-          timeout: 5s
-          retries: 30
+        options: >-
+          --health-cmd "wget --spider http://localhost:8080/__admin || exit 1"
+          --health-interval 5s
+          --health-timeout 10s
+          --health-retries 12
+          --health-start-period 15s
     env:
       HMC_DIR: ${{ github.workspace }}/HeadlessMC
       SERVER_DIR: ${{ github.workspace }}/test-server


### PR DESCRIPTION
fixes E2E failing at Initialize containers — wget --spider returns exit 8 on /__admin redirect; curl -sf on /__admin/health returns 0 on HTTP 200