### PR TITLE
fix(ci): WireMock health check uses curl on /__admin/health

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
         volumes:
           - ${{ github.workspace }}/test-infrastructure/wiremock/fixtures/mappings:/home/wiremock/mappings
         options: >-
-          --health-cmd "wget --spider http://localhost:8080/__admin || exit 1"
+          --health-cmd "curl -sf http://localhost:8080/__admin/health || exit 1"
           --health-interval 2s
           --health-timeout 5s
           --health-retries 30
@@ -266,7 +266,7 @@ jobs:
         volumes:
           - ${{ github.workspace }}/test-infrastructure/wiremock/fixtures/mappings:/home/wiremock/mappings
         options: >-
-          --health-cmd "wget --spider http://localhost:8080/__admin || exit 1"
+          --health-cmd "curl -sf http://localhost:8080/__admin/health || exit 1"
           --health-interval 2s
           --health-timeout 5s
           --health-retries 30


### PR DESCRIPTION
fixes E2E failing at Initialize containers — wget --spider returns exit 8 on /__admin redirect; curl -sf on /__admin/health returns 0 on HTTP 200