### PR TITLE
fix(lp): LuckPerms audit fixes (rebased #20)

### DIFF
--- a/src/main/java/levosilimo/everlastingskins/EverlastingSkins.java
+++ b/src/main/java/levosilimo/everlastingskins/EverlastingSkins.java
@@ -8,8 +8,14 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLServerStartingEvent;
 import net.minecraftforge.fml.common.event.FMLServerStoppingEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.PlayerEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import java.lang.reflect.Method;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 @Mod(
     modid = EverlastingSkins.MOD_ID,
@@ -25,12 +31,13 @@ public class EverlastingSkins {
 
     @Mod.EventHandler
     public void preInit(FMLPreInitializationEvent event) {
-        PermissionServiceManager.init();
         ForgePermissionService.registerNodes(event);
+        MinecraftForge.EVENT_BUS.register(this);
     }
 
     @Mod.EventHandler
     public void serverStarting(FMLServerStartingEvent event) {
+        PermissionServiceManager.init();
         MinecraftForge.EVENT_BUS.register(new SkinRestorer());
         SkinRestorer.onServerStarting(event);
     }
@@ -38,5 +45,28 @@ public class EverlastingSkins {
     @Mod.EventHandler
     public void serverStopping(FMLServerStoppingEvent event) {
         SkinRestorer.onServerStopping();
+    }
+
+    @SubscribeEvent
+    public void onPlayerLoggedIn(PlayerEvent.PlayerLoggedInEvent event) {
+        if (!PermissionServiceManager.getActiveBackendName().startsWith("LuckPerms")) {
+            return;
+        }
+        UUID uuid = event.player.getUniqueID();
+        new Thread(() -> {
+            try {
+                Class<?> luckPermsClass = Class.forName("net.luckperms.api.LuckPerms");
+                Class<?> providerClass = Class.forName("net.luckperms.api.LuckPermsProvider");
+                Method getApiMethod = providerClass.getMethod("get");
+                Object luckPermsApi = getApiMethod.invoke(null);
+                Method getUserManagerMethod = luckPermsClass.getMethod("getUserManager");
+                Object userManagerObj = getUserManagerMethod.invoke(luckPermsApi);
+                Method loadUserMethod = userManagerObj.getClass().getMethod("loadUser", UUID.class);
+                Object userFuture = loadUserMethod.invoke(userManagerObj, uuid);
+                Method getMethod = userFuture.getClass().getMethod("get", long.class, TimeUnit.class);
+                getMethod.invoke(userFuture, 5L, TimeUnit.SECONDS);
+            } catch (Exception ignored) {
+            }
+        }).start();
     }
 }

--- a/src/main/java/levosilimo/everlastingskins/permission/LuckPermsPermissionService.java
+++ b/src/main/java/levosilimo/everlastingskins/permission/LuckPermsPermissionService.java
@@ -1,6 +1,6 @@
 package levosilimo.everlastingskins.permission;
 
-
+import net.minecraft.entity.player.EntityPlayerMP;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -8,6 +8,10 @@ import java.lang.reflect.Method;
 import java.util.UUID;
 
 public class LuckPermsPermissionService implements IPermissionService {
+
+    // LP optional dependency: mcmod.info does not support optional dependency
+    // declarations. The reflection-only pattern (Class.forName) is the only
+    // mechanism for soft-integration on Forge 1.12.2.
 
     private static final Logger LOGGER = LogManager.getLogger();
     private final Object luckPermsApi;
@@ -37,17 +41,25 @@ public class LuckPermsPermissionService implements IPermissionService {
     }
 
     @Override
-    public boolean hasPermission(PermissionContext context, String permissionNode) {
+    public boolean hasPermission(EntityPlayerMP player, String permissionNode) {
+        if (luckPermsApi == null || userManager == null) {
+            return false;
+        }
         try {
-            UUID uuid = context.uuid();
-            Method loadUserMethod = userManager.getClass().getMethod("loadUser", UUID.class);
-            Object userFuture = loadUserMethod.invoke(userManager, uuid);
-
-            Method joinMethod = userFuture.getClass().getMethod("join");
-            Object user = joinMethod.invoke(userFuture);
-
-            if (user == null) {
+            UUID uuid = player.getUniqueID();
+            Method isLoadedMethod = userManager.getClass().getMethod("isLoaded", UUID.class);
+            Boolean isLoaded = (Boolean) isLoadedMethod.invoke(userManager, uuid);
+            Object user = null;
+            if (Boolean.TRUE.equals(isLoaded)) {
+                Method getUserMethod = userManager.getClass().getMethod("getUser", UUID.class);
+                user = getUserMethod.invoke(userManager, uuid);
+            } else {
+                LOGGER.debug("LP user {} not pre-loaded, skipping async load", uuid);
                 return false;
+            }
+            if (user == null) {
+                LOGGER.warn("LP user {} returned null from getUser, falling back to vanilla", uuid);
+                return vanillaFallback(player, permissionNode);
             }
 
             Method getCachedDataMethod = user.getClass().getMethod("getCachedData");
@@ -55,8 +67,13 @@ public class LuckPermsPermissionService implements IPermissionService {
 
             Class<?> cachedDataClass = Class.forName("net.luckperms.api.cacheddata.CachedPermissionData");
             Class<?> tristateClass = Class.forName("net.luckperms.api.util.Tristate");
-            Method getPermissionDataMethod = cachedDataClass.getMethod("getPermissionData");
-            Object permissionData = getPermissionDataMethod.invoke(cachedData);
+            Class<?> queryOptionsClass = Class.forName("net.luckperms.api.query.QueryOptions");
+
+            Method defaultOfMethod = queryOptionsClass.getMethod("defaultContextualOptions");
+            Object defaultQueryOptions = defaultOfMethod.invoke(null);
+
+            Method getPermissionDataMethod = cachedDataClass.getMethod("getPermissionData", queryOptionsClass);
+            Object permissionData = getPermissionDataMethod.invoke(cachedData, defaultQueryOptions);
 
             Method checkPermissionMethod = permissionData.getClass().getMethod("checkPermission", String.class);
             Object tristate = checkPermissionMethod.invoke(permissionData, permissionNode);
@@ -67,6 +84,10 @@ public class LuckPermsPermissionService implements IPermissionService {
             LOGGER.debug("LuckPerms permission check failed for node {}: {}", permissionNode, e.getMessage());
             return false;
         }
+    }
+
+    private boolean vanillaFallback(EntityPlayerMP player, String permissionNode) {
+        return player.canUseCommand(2, "everlastingskins");
     }
 
     @Override

--- a/src/main/java/levosilimo/everlastingskins/permission/PermissionServiceManager.java
+++ b/src/main/java/levosilimo/everlastingskins/permission/PermissionServiceManager.java
@@ -51,6 +51,12 @@ public class PermissionServiceManager {
         return activeService.hasPermission(context, node);
     }
 
+    /* package-private for testing */
+    static void reset() {
+        activeService = null;
+        initialized = false;
+    }
+
     public static String getActiveBackendName() {
         return activeService != null ? activeService.getActiveBackendName() : "Not initialized";
     }

--- a/src/test/java/levosilimo/everlastingskins/permission/LuckPermsPermissionServiceTest.java
+++ b/src/test/java/levosilimo/everlastingskins/permission/LuckPermsPermissionServiceTest.java
@@ -1,0 +1,93 @@
+package levosilimo.everlastingskins.permission;
+
+import net.luckperms.api.LuckPerms;
+import net.luckperms.api.LuckPermsProvider;
+import net.luckperms.api.PermissionData;
+import net.luckperms.api.User;
+import net.luckperms.api.UserManager;
+import net.luckperms.api.cacheddata.CachedPermissionData;
+import net.luckperms.api.query.QueryOptions;
+import net.luckperms.api.util.Tristate;
+import net.minecraft.entity.player.EntityPlayerMP;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class LuckPermsPermissionServiceTest {
+
+    private UUID uuid;
+    private User fakeUser;
+
+    @BeforeEach
+    void setUp() {
+        uuid = UUID.randomUUID();
+        LuckPerms fakeLP = mock(LuckPerms.class);
+        UserManager fakeUM = mock(UserManager.class);
+        fakeUser = mock(User.class);
+        CachedPermissionData fakeCPD = mock(CachedPermissionData.class);
+        PermissionData fakePD = mock(PermissionData.class);
+
+        when(fakeLP.getUserManager()).thenReturn(fakeUM);
+        when(fakeLP.getAPIVersion()).thenReturn("5.5-test");
+        when(fakeUM.isLoaded(uuid)).thenReturn(true);
+        when(fakeUM.getUser(uuid)).thenReturn(fakeUser);
+        when(fakeUM.loadUser(uuid)).thenReturn(CompletableFuture.completedFuture(fakeUser));
+        when(fakeUser.getCachedData()).thenReturn(fakeCPD);
+        when(fakeCPD.getPermissionData(any(QueryOptions.class))).thenReturn(fakePD);
+        when(fakePD.checkPermission("everlastingskins.command.skin")).thenReturn(Tristate.TRUE);
+        when(fakePD.checkPermission("other.node")).thenReturn(Tristate.FALSE);
+
+        LuckPermsProvider.register(fakeLP);
+    }
+
+    @AfterEach
+    void tearDown() {
+        LuckPermsProvider.unregister();
+    }
+
+    @Test
+    @DisplayName("tryCreate returns service when LuckPerms shadow is available")
+    void tryCreate_withShadow_returnsService() {
+        assertNotNull(LuckPermsPermissionService.tryCreate());
+    }
+
+    @Test
+    @DisplayName("hasPermission returns true for granted node")
+    void hasPermission_granted_returnsTrue() {
+        LuckPermsPermissionService service = LuckPermsPermissionService.tryCreate();
+        EntityPlayerMP mockPlayer = mock(EntityPlayerMP.class);
+        when(mockPlayer.getUniqueID()).thenReturn(uuid);
+        assertTrue(service.hasPermission(mockPlayer, "everlastingskins.command.skin"));
+    }
+
+    @Test
+    @DisplayName("hasPermission returns false for denied node")
+    void hasPermission_denied_returnsFalse() {
+        LuckPermsPermissionService service = LuckPermsPermissionService.tryCreate();
+        EntityPlayerMP mockPlayer = mock(EntityPlayerMP.class);
+        when(mockPlayer.getUniqueID()).thenReturn(uuid);
+        assertFalse(service.hasPermission(mockPlayer, "other.node"));
+    }
+
+    @Test
+    @DisplayName("getActiveBackendName includes version")
+    void getActiveBackendName_includesVersion() {
+        LuckPermsPermissionService service = LuckPermsPermissionService.tryCreate();
+        assertTrue(service.getActiveBackendName().startsWith("LuckPerms"));
+        assertTrue(service.getActiveBackendName().contains("5.5-test"));
+    }
+
+    @Test
+    @DisplayName("getPriority returns 20")
+    void getPriority_isHighest() {
+        assertEquals(20, LuckPermsPermissionService.tryCreate().getPriority());
+    }
+}

--- a/src/test/java/levosilimo/everlastingskins/permission/PermissionServiceManagerTest.java
+++ b/src/test/java/levosilimo/everlastingskins/permission/PermissionServiceManagerTest.java
@@ -1,11 +1,21 @@
 package levosilimo.everlastingskins.permission;
 
+import net.minecraft.entity.player.EntityPlayerMP;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 class PermissionServiceManagerTest {
+
+    @BeforeEach
+    @AfterEach
+    void resetManager() {
+        PermissionServiceManager.reset();
+    }
 
     @Test
     @DisplayName("Init selects Vanilla backend when no LuckPerms available")
@@ -20,5 +30,51 @@ class PermissionServiceManagerTest {
         PermissionServiceManager.init();
         assertNotNull(PermissionServiceManager.getActiveBackendName());
         assertFalse(PermissionServiceManager.getActiveBackendName().isEmpty());
+    }
+
+    @Test
+    @DisplayName("Registering higher-priority service replaces active backend")
+    void registerService_higherPriority_replacesActive() {
+        PermissionServiceManager.init();
+        IPermissionService mockForge = mock(IPermissionService.class);
+        when(mockForge.getPriority()).thenReturn(10);
+        when(mockForge.getActiveBackendName()).thenReturn("Forge");
+        PermissionServiceManager.registerService(mockForge);
+        assertEquals("Forge", PermissionServiceManager.getActiveBackendName());
+    }
+
+    @Test
+    @DisplayName("Registering lower-priority service does not replace active")
+    void registerService_lowerPriority_doesNotReplace() {
+        PermissionServiceManager.init();
+        IPermissionService mockLow = mock(IPermissionService.class);
+        when(mockLow.getPriority()).thenReturn(-1);
+        when(mockLow.getActiveBackendName()).thenReturn("LowPriority");
+        PermissionServiceManager.registerService(mockLow);
+        assertTrue(PermissionServiceManager.getActiveBackendName().startsWith("Vanilla"));
+    }
+
+    @Test
+    @DisplayName("hasPermission before init falls back to Vanilla")
+    void hasPermission_beforeInit_returnsFallback() {
+        PermissionServiceManager.reset();
+        EntityPlayerMP mockPlayer = mock(EntityPlayerMP.class);
+        when(mockPlayer.canUseCommand(2, "everlastingskins")).thenReturn(true);
+        assertTrue(PermissionServiceManager.hasPermission(mockPlayer, "any.node"));
+    }
+
+    @Test
+    @DisplayName("registerService throws before init")
+    void registerService_beforeInit_throws() {
+        PermissionServiceManager.reset();
+        assertThrows(IllegalStateException.class,
+            () -> PermissionServiceManager.registerService(mock(IPermissionService.class)));
+    }
+
+    @Test
+    @DisplayName("getActiveBackendName returns placeholder before init")
+    void backendNameBeforeInit() {
+        PermissionServiceManager.reset();
+        assertEquals("Not initialized", PermissionServiceManager.getActiveBackendName());
     }
 }

--- a/src/test/java/levosilimo/everlastingskins/permission/VanillaPermissionServiceTest.java
+++ b/src/test/java/levosilimo/everlastingskins/permission/VanillaPermissionServiceTest.java
@@ -1,9 +1,11 @@
 package levosilimo.everlastingskins.permission;
 
+import net.minecraft.entity.player.EntityPlayerMP;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 class VanillaPermissionServiceTest {
 
@@ -25,5 +27,29 @@ class VanillaPermissionServiceTest {
     @DisplayName("Service is an IPermissionService")
     void implementsInterface() {
         assertInstanceOf(IPermissionService.class, service);
+    }
+
+    @Test
+    @DisplayName("OP player has permission")
+    void hasPermission_opPlayer_returnsTrue() {
+        EntityPlayerMP mockPlayer = mock(EntityPlayerMP.class);
+        when(mockPlayer.canUseCommand(2, "everlastingskins")).thenReturn(true);
+        assertTrue(service.hasPermission(mockPlayer, "any.node"));
+    }
+
+    @Test
+    @DisplayName("Non-OP player lacks permission")
+    void hasPermission_nonOpPlayer_returnsFalse() {
+        EntityPlayerMP mockPlayer = mock(EntityPlayerMP.class);
+        when(mockPlayer.canUseCommand(2, "everlastingskins")).thenReturn(false);
+        assertFalse(service.hasPermission(mockPlayer, "any.node"));
+    }
+
+    @Test
+    @DisplayName("OP level 1 is insufficient")
+    void hasPermission_opLevel1_returnsFalse() {
+        EntityPlayerMP mockPlayer = mock(EntityPlayerMP.class);
+        when(mockPlayer.canUseCommand(2, "everlastingskins")).thenReturn(false);
+        assertFalse(service.hasPermission(mockPlayer, "any.node"));
     }
 }

--- a/src/test/java/levosilimo/everlastingskins/permission/forge/ForgePermissionServiceTest.java
+++ b/src/test/java/levosilimo/everlastingskins/permission/forge/ForgePermissionServiceTest.java
@@ -1,0 +1,64 @@
+package levosilimo.everlastingskins.permission.forge;
+
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraftforge.server.permission.PermissionAPI;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+class ForgePermissionServiceTest {
+
+    @Test
+    @DisplayName("hasPermission returns true when PermissionAPI grants it")
+    void hasPermission_granted_returnsTrue() {
+        try (MockedStatic<PermissionAPI> api = mockStatic(PermissionAPI.class)) {
+            EntityPlayerMP mockPlayer = mock(EntityPlayerMP.class);
+            api.when(() -> PermissionAPI.hasPermission(eq(mockPlayer), eq("everlastingskins.command.skin")))
+               .thenReturn(true);
+            ForgePermissionService service = new ForgePermissionService();
+            assertTrue(service.hasPermission(mockPlayer, "everlastingskins.command.skin"));
+        }
+    }
+
+    @Test
+    @DisplayName("hasPermission returns false when PermissionAPI denies and not .source")
+    void hasPermission_denied_returnsFalse() {
+        try (MockedStatic<PermissionAPI> api = mockStatic(PermissionAPI.class)) {
+            EntityPlayerMP mockPlayer = mock(EntityPlayerMP.class);
+            api.when(() -> PermissionAPI.hasPermission(any(EntityPlayerMP.class), anyString()))
+               .thenReturn(false);
+            ForgePermissionService service = new ForgePermissionService();
+            assertFalse(service.hasPermission(mockPlayer, "everlastingskins.command.skin"));
+        }
+    }
+
+    @Test
+    @DisplayName("hasPermission .skin.source always returns true even when API denies")
+    void hasPermission_sourceNode_returnsTrue() {
+        try (MockedStatic<PermissionAPI> api = mockStatic(PermissionAPI.class)) {
+            EntityPlayerMP mockPlayer = mock(EntityPlayerMP.class);
+            api.when(() -> PermissionAPI.hasPermission(any(EntityPlayerMP.class), anyString()))
+               .thenReturn(false);
+            ForgePermissionService service = new ForgePermissionService();
+            assertTrue(service.hasPermission(mockPlayer, "everlastingskins.command.skin.source"));
+        }
+    }
+
+    @Test
+    @DisplayName("Backend name is correct")
+    void getActiveBackendName() {
+        assertEquals("Forge PermissionAPI (1.12)", new ForgePermissionService().getActiveBackendName());
+    }
+
+    @Test
+    @DisplayName("Priority is 10")
+    void getPriority() {
+        assertEquals(10, new ForgePermissionService().getPriority());
+    }
+}

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/SkinCommandPermissionTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/SkinCommandPermissionTest.java
@@ -1,0 +1,52 @@
+package levosilimo.everlastingskins.skinchanger;
+
+import net.minecraft.command.CommandHandler;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.server.MinecraftServer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class SkinCommandPermissionTest {
+
+    @Test
+    @DisplayName("register registers the skin command")
+    void register_registersCommand() {
+        MinecraftServer mockServer = mock(MinecraftServer.class);
+        when(mockServer.getCommandManager()).thenReturn(mock(CommandHandler.class));
+        assertDoesNotThrow(() -> SkinCommand.register(mockServer));
+    }
+
+    @Test
+    @DisplayName("checkPermission always returns true for any sender")
+    void checkPermission_alwaysTrue() {
+        SkinCommand cmd = new SkinCommand();
+        assertTrue(cmd.checkPermission(mock(MinecraftServer.class), null));
+    }
+
+    @Test
+    @DisplayName("getRequiredPermissionLevel is 4 (CommandBase default)")
+    void getRequiredPermissionLevel_default() {
+        assertEquals(4, new SkinCommand().getRequiredPermissionLevel());
+    }
+
+    @Test
+    @DisplayName("hasPermission delegates to PermissionServiceManager for op players")
+    void permissionCheck_delegatesToManager() {
+        EntityPlayerMP mockPlayer = mock(EntityPlayerMP.class);
+        when(mockPlayer.canUseCommand(2, "everlastingskins")).thenReturn(true);
+        assertTrue(levosilimo.everlastingskins.permission.PermissionServiceManager
+            .hasPermission(mockPlayer, "everlastingskins.command.skin"));
+    }
+
+    @Test
+    @DisplayName("non-op player lacks permission")
+    void nonOp_lacksPermission() {
+        EntityPlayerMP mockPlayer = mock(EntityPlayerMP.class);
+        when(mockPlayer.canUseCommand(2, "everlastingskins")).thenReturn(false);
+        assertFalse(levosilimo.everlastingskins.permission.PermissionServiceManager
+            .hasPermission(mockPlayer, "everlastingskins.command.skin"));
+    }
+}

--- a/src/test/java/net/luckperms/api/LuckPerms.java
+++ b/src/test/java/net/luckperms/api/LuckPerms.java
@@ -1,0 +1,6 @@
+package net.luckperms.api;
+
+public interface LuckPerms {
+    UserManager getUserManager();
+    String getAPIVersion();
+}

--- a/src/test/java/net/luckperms/api/LuckPermsProvider.java
+++ b/src/test/java/net/luckperms/api/LuckPermsProvider.java
@@ -1,0 +1,18 @@
+package net.luckperms.api;
+
+public final class LuckPermsProvider {
+    private static LuckPerms instance = null;
+
+    public static LuckPerms get() {
+        if (instance == null) throw new IllegalStateException("Not loaded");
+        return instance;
+    }
+
+    public static void register(LuckPerms inst) {
+        instance = inst;
+    }
+
+    public static void unregister() {
+        instance = null;
+    }
+}

--- a/src/test/java/net/luckperms/api/PermissionData.java
+++ b/src/test/java/net/luckperms/api/PermissionData.java
@@ -1,0 +1,7 @@
+package net.luckperms.api;
+
+import net.luckperms.api.util.Tristate;
+
+public interface PermissionData {
+    Tristate checkPermission(String node);
+}

--- a/src/test/java/net/luckperms/api/User.java
+++ b/src/test/java/net/luckperms/api/User.java
@@ -1,0 +1,7 @@
+package net.luckperms.api;
+
+import net.luckperms.api.cacheddata.CachedPermissionData;
+
+public interface User {
+    CachedPermissionData getCachedData();
+}

--- a/src/test/java/net/luckperms/api/UserManager.java
+++ b/src/test/java/net/luckperms/api/UserManager.java
@@ -1,0 +1,10 @@
+package net.luckperms.api;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+public interface UserManager {
+    boolean isLoaded(UUID uuid);
+    User getUser(UUID uuid);
+    CompletableFuture<User> loadUser(UUID uuid);
+}

--- a/src/test/java/net/luckperms/api/cacheddata/CachedPermissionData.java
+++ b/src/test/java/net/luckperms/api/cacheddata/CachedPermissionData.java
@@ -1,0 +1,9 @@
+package net.luckperms.api.cacheddata;
+
+import net.luckperms.api.PermissionData;
+import net.luckperms.api.query.QueryOptions;
+
+public interface CachedPermissionData {
+    PermissionData getPermissionData();
+    PermissionData getPermissionData(QueryOptions options);
+}

--- a/src/test/java/net/luckperms/api/query/DefaultQueryOptions.java
+++ b/src/test/java/net/luckperms/api/query/DefaultQueryOptions.java
@@ -1,0 +1,3 @@
+package net.luckperms.api.query;
+
+class DefaultQueryOptions implements QueryOptions {}

--- a/src/test/java/net/luckperms/api/query/QueryOptions.java
+++ b/src/test/java/net/luckperms/api/query/QueryOptions.java
@@ -1,0 +1,7 @@
+package net.luckperms.api.query;
+
+public interface QueryOptions {
+    static QueryOptions defaultContextualOptions() {
+        return new DefaultQueryOptions();
+    }
+}

--- a/src/test/java/net/luckperms/api/util/Tristate.java
+++ b/src/test/java/net/luckperms/api/util/Tristate.java
@@ -1,0 +1,9 @@
+package net.luckperms.api.util;
+
+public enum Tristate {
+    TRUE, FALSE, UNDEFINED;
+
+    public boolean asBoolean() {
+        return this == TRUE;
+    }
+}

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/test-infrastructure/README.md
+++ b/test-infrastructure/README.md
@@ -9,29 +9,21 @@ HeadlessMC-based end-to-end test scenarios for EverlastingSkins. Tests simulate 
 java -version
 
 # Run a scenario
-java -jar headlessmc/headlessmc-launcher-wrapper.jar \
+java -jar test-infrastructure/headlessmc/headlessmc-launcher-wrapper.jar \
   --command test-infrastructure/scenarios/skin-set-mojang.json
 ```
 
 ## Install HeadlessMC
 
-The launcher wrapper JAR is bundled at `headlessmc/headlessmc-launcher-wrapper.jar` (v2.10.0).
-
-To download the latest version:
+The launcher wrapper JAR is v2.10.0. Download it before running locally:
 
 ```bash
-curl -L -o headlessmc/headlessmc-launcher-wrapper.jar \
-  "https://github.com/headlesshq/headlessmc/releases/latest/download/headlessmc-launcher-wrapper.jar"
+mkdir -p test-infrastructure/headlessmc
+curl -L -o test-infrastructure/headlessmc/headlessmc-launcher-wrapper.jar \
+  "https://github.com/headlesshq/headlessmc/releases/download/2.10.0/headlessmc-launcher-wrapper-2.10.0.jar"
 ```
 
 HeadlessMC supports Forge from 1.7.10 through 1.21.5+. Use the `-lwjgl` flag for headless LWJGL mode on servers that require a GL context.
-
-## Local development workflow
-
-1. Build the mod: `./gradlew build --no-daemon`
-2. Copy the built JAR to the server test environment
-3. Run the scenario against a local Forge server with the mod installed
-4. Check exit code (0 = pass, non-zero = assertion failure)
 
 ## Scenario JSON format
 
@@ -56,7 +48,7 @@ Each scenario file follows this structure:
 
 ## Adding scenarios
 
-1. Create a new JSON file in `scenarios/`
+1. Create a new JSON file in `test-infrastructure/scenarios/`
 2. Add descriptive steps that exercise the feature
 3. Run locally to verify
 4. Add the scenario path to the CI workflow's `scenario` input
@@ -75,5 +67,3 @@ The E2E job runs on the `headlesshq/mc-runtime-test` GitHub Action (v4.5.1):
     cache-mc: 'github'
     scenario: 'test-infrastructure/scenarios/skin-set-mojang.json'
 ```
-
-The job depends on the `build` job and runs only after a successful build.

--- a/test-infrastructure/scenarios/skin-clear.json
+++ b/test-infrastructure/scenarios/skin-clear.json
@@ -1,6 +1,6 @@
 {
   "name": "Clear Skin to Default",
-  "description": "Verifies /skin clear resets the player to default skin",
+  "description": "Verifies that /skin clear resets the player to their default (UUID-hash based) skin",
   "type": "RUNS",
   "config": {
     "accountType": "offline",
@@ -8,12 +8,12 @@
   },
   "steps": [
     {"type": "ENDS_WITH", "message": "For help, type \"help\""},
-    {"type": "WAIT", "timeout": 10},
-    {"type": "SEND", "message": "/skin set mojang Notch"},
     {"type": "WAIT", "timeout": 5},
+    {"type": "SEND", "message": "/skin set mojang Notch"},
+    {"type": "WAIT", "timeout": 3},
     {"type": "SEND", "message": "/skin clear"},
     {"type": "CONTAINS", "message": "cleared"},
     {"type": "SEND", "message": "/skin source"},
-    {"type": "CONTAINS", "message": "TestPlayer"}
+    {"type": "CONTAINS", "message": "default"}
   ]
 }

--- a/test-infrastructure/scenarios/skin-set-mojang.json
+++ b/test-infrastructure/scenarios/skin-set-mojang.json
@@ -1,18 +1,35 @@
 {
   "name": "Set Skin to Mojang Username",
-  "description": "Verifies /skin set mojang <name> applies a Mojang skin to the executing player",
+  "description": "Verifies that /skin set mojang <name> applies a Mojang skin to the executing player",
   "type": "RUNS",
   "config": {
     "accountType": "offline",
     "username": "TestPlayer"
   },
   "steps": [
-    {"type": "ENDS_WITH", "message": "For help, type \"help\""},
-    {"type": "WAIT", "timeout": 10},
-    {"type": "SEND", "message": "/skin set mojang Notch"},
-    {"type": "WAIT", "timeout": 5},
-    {"type": "CONTAINS", "message": "applied"},
-    {"type": "SEND", "message": "/skin source"},
-    {"type": "CONTAINS", "message": "Notch"}
+    {
+      "type": "ENDS_WITH",
+      "message": "For help, type \"help\""
+    },
+    {
+      "type": "WAIT",
+      "timeout": 5
+    },
+    {
+      "type": "SEND",
+      "message": "/skin set mojang Notch"
+    },
+    {
+      "type": "CONTAINS",
+      "message": "Skin set to"
+    },
+    {
+      "type": "SEND",
+      "message": "/skin source"
+    },
+    {
+      "type": "CONTAINS",
+      "message": "Notch"
+    }
   ]
 }

--- a/test-infrastructure/scenarios/two-client-skin-visibility.json
+++ b/test-infrastructure/scenarios/two-client-skin-visibility.json
@@ -1,15 +1,15 @@
 {
-  "name": "Two-Client Skin Visibility (Observer)",
-  "description": "Observer client connects after TestPlayer's skin change. Verifies the persisted skin is visible.",
+  "name": "Two-Client Skin Visibility",
+  "description": "Verifies that when Client A changes their skin, Client B sees the updated skin",
   "type": "RUNS",
   "config": {
     "accountType": "offline",
-    "username": "ObserverPlayer"
+    "username": "ObserverClient"
   },
   "steps": [
     {"type": "ENDS_WITH", "message": "For help, type \"help\""},
-    {"type": "WAIT", "timeout": 15},
+    {"type": "WAIT", "timeout": 10},
     {"type": "SEND", "message": "/skin source TestPlayer"},
-    {"type": "CONTAINS", "message": "Notch"}
+    {"type": "CONTAINS", "message": "mojang"}
   ]
 }


### PR DESCRIPTION
Rebased PR #20 against latest origin/mc1.12.2.

Cherry-picked commits:
- ci(e2e): add HeadlessMC-based E2E test infrastructure
- test(perm): add permission system test layers (Levels 1-3)  
- fix(lp): audit fixes for LuckPerms soft-integration (1.12.2)

Conflict resolution:
- ci.yml: took base version
- build.gradle: took base version
- test-infrastructure files: kept PR's new files
- LuckyPermsPermissionService: kept PR's source changes