### PR TITLE
fix(e2e): address all 5 E2E blockers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,15 +77,18 @@ jobs:
           - ${{ github.workspace }}/test-infrastructure/wiremock/fixtures/mappings:/home/wiremock/mappings
         options: >-
           --health-cmd "curl -sf http://localhost:8080/__admin/health || exit 1"
-          --health-interval 2s
-          --health-timeout 5s
-          --health-retries 30
+          --health-interval 5s
+          --health-timeout 10s
+          --health-retries 12
+          --health-start-period 15s
     env:
       HMC_DIR: ${{ github.workspace }}/HeadlessMC
       SERVER_DIR: ${{ github.workspace }}/test-server
       MODS_DIR: ${{ github.workspace }}/test-server/mods
       HMC_VERSION: "2.10.0"
     steps:
+      - name: Clean WireMock artifacts (EACCES workaround)
+        run: sudo rm -rf ${{ github.workspace }}/test-infrastructure/wiremock || true
       - uses: actions/checkout@v4
       - name: Set up JDK 21
         uses: actions/setup-java@v4
@@ -146,12 +149,12 @@ jobs:
           fi
           java -Xmx1G -Xms512M \
             -Deverlastingskins.allowHttp=true \
-            -Deverlastingskins.endpoints.uuid.eclipse="http://localhost:8080/uuid/eclipse/%playerName%" \
-            -Deverlastingskins.endpoints.uuid.mojang="http://localhost:8080/uuid/mojang/%playerName%" \
-            -Deverlastingskins.endpoints.uuid.minetools="http://localhost:8080/uuid/minetools/%playerName%" \
-            -Deverlastingskins.endpoints.profile.eclipse="http://localhost:8080/profile/eclipse/%uuid%" \
-            -Deverlastingskins.endpoints.profile.mojang="http://localhost:8080/profile/mojang/%uuid%" \
-            -Deverlastingskins.endpoints.profile.minetools="http://localhost:8080/profile/minetools/%uuid%" \
+            -Deverlastingskins.endpoint.uuid.eclipse="http://localhost:8080/uuid/eclipse/%playerName%" \
+            -Deverlastingskins.endpoint.uuid.mojang="http://localhost:8080/uuid/mojang/%playerName%" \
+            -Deverlastingskins.endpoint.uuid.minetools="http://localhost:8080/uuid/minetools/%playerName%" \
+            -Deverlastingskins.endpoint.profile.eclipse="http://localhost:8080/profile/eclipse/%uuid%" \
+            -Deverlastingskins.endpoint.profile.mojang="http://localhost:8080/profile/mojang/%uuid%" \
+            -Deverlastingskins.endpoint.profile.minetools="http://localhost:8080/profile/minetools/%uuid%" \
             -jar "$SERVER_JAR" nogui > "${{ env.SERVER_DIR }}/logs/server-stdout.log" 2>&1 &
           SERVER_PID=$!
           echo "server_pid=$SERVER_PID" >> $GITHUB_OUTPUT
@@ -172,8 +175,8 @@ jobs:
       - name: Download HeadlessMC launcher
         run: |
           mkdir -p "${{ env.HMC_DIR }}"
-          curl -L -o "${{ env.HMC_DIR }}/headlessmc-launcher-${{ env.HMC_VERSION }}.jar" \
-            "https://github.com/headlesshq/headlessmc/releases/download/${{ env.HMC_VERSION }}/headlessmc-launcher-${{ env.HMC_VERSION }}.jar"
+          curl -L -o "${{ env.HMC_DIR }}/headlessmc-launcher-wrapper-${{ env.HMC_VERSION }}.jar" \
+            "https://github.com/headlesshq/headlessmc/releases/download/${{ env.HMC_VERSION }}/headlessmc-launcher-wrapper-${{ env.HMC_VERSION }}.jar"
       - name: Download HMCSpecifics
         run: |
           curl -L -o "${{ env.MODS_DIR }}/hmc-specifics.jar" \
@@ -197,7 +200,7 @@ jobs:
       - name: Run E2E scenario via xvfb
         run: |
           cd "${{ env.HMC_DIR }}"
-          xvfb-run -a java -jar "headlessmc-launcher-${{ env.HMC_VERSION }}.jar" \
+          xvfb-run -a java -jar "headlessmc-launcher-wrapper-${{ env.HMC_VERSION }}.jar" \
             --command "launch forge:1.21 -lwjgl -offline -specifics --jvm -Djava.awt.headless=true" \
             --game-args "--server localhost --port 25565 --username TestPlayer" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-output.log"
       - name: Kill server
@@ -267,15 +270,18 @@ jobs:
           - ${{ github.workspace }}/test-infrastructure/wiremock/fixtures/mappings:/home/wiremock/mappings
         options: >-
           --health-cmd "curl -sf http://localhost:8080/__admin/health || exit 1"
-          --health-interval 2s
-          --health-timeout 5s
-          --health-retries 30
+          --health-interval 5s
+          --health-timeout 10s
+          --health-retries 12
+          --health-start-period 15s
     env:
       HMC_DIR: ${{ github.workspace }}/HeadlessMC
       SERVER_DIR: ${{ github.workspace }}/test-server
       MODS_DIR: ${{ github.workspace }}/test-server/mods
       HMC_VERSION: "2.10.0"
     steps:
+      - name: Clean WireMock artifacts (EACCES workaround)
+        run: sudo rm -rf ${{ github.workspace }}/test-infrastructure/wiremock || true
       - uses: actions/checkout@v4
       - name: Set up JDK 8
         uses: actions/setup-java@v4
@@ -336,12 +342,12 @@ jobs:
           fi
           java -Xmx1G -Xms512M \
             -Deverlastingskins.allowHttp=true \
-            -Deverlastingskins.endpoints.uuid.eclipse="http://localhost:8080/uuid/eclipse/%playerName%" \
-            -Deverlastingskins.endpoints.uuid.mojang="http://localhost:8080/uuid/mojang/%playerName%" \
-            -Deverlastingskins.endpoints.uuid.minetools="http://localhost:8080/uuid/minetools/%playerName%" \
-            -Deverlastingskins.endpoints.profile.eclipse="http://localhost:8080/profile/eclipse/%uuid%" \
-            -Deverlastingskins.endpoints.profile.mojang="http://localhost:8080/profile/mojang/%uuid%" \
-            -Deverlastingskins.endpoints.profile.minetools="http://localhost:8080/profile/minetools/%uuid%" \
+            -Deverlastingskins.endpoint.uuid.eclipse="http://localhost:8080/uuid/eclipse/%playerName%" \
+            -Deverlastingskins.endpoint.uuid.mojang="http://localhost:8080/uuid/mojang/%playerName%" \
+            -Deverlastingskins.endpoint.uuid.minetools="http://localhost:8080/uuid/minetools/%playerName%" \
+            -Deverlastingskins.endpoint.profile.eclipse="http://localhost:8080/profile/eclipse/%uuid%" \
+            -Deverlastingskins.endpoint.profile.mojang="http://localhost:8080/profile/mojang/%uuid%" \
+            -Deverlastingskins.endpoint.profile.minetools="http://localhost:8080/profile/minetools/%uuid%" \
             -jar "$SERVER_JAR" nogui > "${{ env.SERVER_DIR }}/logs/server-stdout.log" 2>&1 &
           SERVER_PID=$!
           echo "server_pid=$SERVER_PID" >> $GITHUB_OUTPUT
@@ -362,8 +368,8 @@ jobs:
       - name: Download HeadlessMC launcher
         run: |
           mkdir -p "${{ env.HMC_DIR }}"
-          curl -L -o "${{ env.HMC_DIR }}/headlessmc-launcher-${{ env.HMC_VERSION }}.jar" \
-            "https://github.com/headlesshq/headlessmc/releases/download/${{ env.HMC_VERSION }}/headlessmc-launcher-${{ env.HMC_VERSION }}.jar"
+          curl -L -o "${{ env.HMC_DIR }}/headlessmc-launcher-wrapper-${{ env.HMC_VERSION }}.jar" \
+            "https://github.com/headlesshq/headlessmc/releases/download/${{ env.HMC_VERSION }}/headlessmc-launcher-wrapper-${{ env.HMC_VERSION }}.jar"
       - name: Download HMCSpecifics
         run: |
           curl -L -o "${{ env.MODS_DIR }}/hmc-specifics.jar" \
@@ -387,7 +393,7 @@ jobs:
       - name: Run E2E scenario via xvfb
         run: |
           cd "${{ env.HMC_DIR }}"
-          xvfb-run -a java -jar "headlessmc-launcher-${{ env.HMC_VERSION }}.jar" \
+          xvfb-run -a java -jar "headlessmc-launcher-wrapper-${{ env.HMC_VERSION }}.jar" \
             --command "launch forge:1.12.2 -lwjgl -offline -specifics --jvm -Djava.awt.headless=true" \
             --game-args "--server localhost --port 25565 --username TestPlayer" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-output.log"
       - name: Kill server

--- a/src/main/java/levosilimo/everlastingskins/util/EndpointsConfig.java
+++ b/src/main/java/levosilimo/everlastingskins/util/EndpointsConfig.java
@@ -30,6 +30,13 @@ public class EndpointsConfig {
     }
 
     public static String getString(String key) {
+        // System property override (for E2E tests with WireMock)
+        // Example: -Deverlastingskins.endpoint.uuid.eclipse=http://localhost:8080/...
+        String sysProp = System.getProperty("everlastingskins." + key);
+        if (sysProp != null && !sysProp.isEmpty()) {
+            return sysProp;
+        }
+        // Existing resource-based lookup
         String value = props.getProperty(key);
         if (value == null) {
             throw new IllegalArgumentException("Missing endpoint property: " + key);

--- a/src/main/java/levosilimo/everlastingskins/util/HttpsUrlConnectionHttpClient.java
+++ b/src/main/java/levosilimo/everlastingskins/util/HttpsUrlConnectionHttpClient.java
@@ -26,7 +26,8 @@ public class HttpsUrlConnectionHttpClient implements HttpClient {
         URL url = uri.toURL();
 
         // Ensure we're never sending a request to a non-HTTPS URL.
-        if (!url.getProtocol().equals("https")) {
+        // Allow HTTP when the system property everlastingskins.allowHttp is true (E2E tests with WireMock).
+        if (!url.getProtocol().equals("https") && !Boolean.getBoolean("everlastingskins.allowHttp")) {
             throw new IOException("Only HTTPS is supported.");
         }
 


### PR DESCRIPTION
## Fixes

1. **CRITICAL: EACCES at checkout** — Added `sudo rm -rf` cleanup step for WireMock volume mounts before checkout in both E2E jobs
2. **CRITICAL: allowHttp not applied** — `HttpsUrlConnectionHttpClient` now checks `Boolean.getBoolean("everlastingskins.allowHttp")` before rejecting non-HTTPS URLs
3. **CRITICAL: EndpointsConfig ignores system properties** — Added system property override (`everlastingskins.<key>`) before resource-based property lookup in `EndpointsConfig.getString()`
4. **MEDIUM: Missing --health-start-period** — Synced mc1.12.2 WireMock health params to use 5s interval, 10s timeout, 12 retries, 15s start period (matching 1.21)
5. **MEDIUM: headlessmc-launcher wrapper** — Switched from `headlessmc-launcher` to `headlessmc-launcher-wrapper` for `--command`/`--game-args` CLI support

Also fixed system property key naming from plural `endpoints` to singular `endpoint` to match `endpoints.properties` resource keys.