### PR TITLE
fix(ci): correct artifact download path in E2E jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: mod-121
-          path: ${{ github.workspace }}/build/
+          path: ${{ github.workspace }}
       - name: Find mod JAR
         id: find-jar
         run: |
@@ -292,7 +292,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: mod-1122
-          path: ${{ github.workspace }}/build/
+          path: ${{ github.workspace }}
       - name: Find mod JAR
         id: find-jar
         run: |


### PR DESCRIPTION
The download path used ${{ github.workspace }}/build/ but artifacts store files under build/libs/. Download path and find-jar lookup path were misaligned by one directory level.