### PR TITLE
fix(build): add jetbrains.annotations dep + fix LuckPerms interface mismatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: mod-121
-          path: ${{ github.workspace }}/build/
+          path: ${{ github.workspace }}
       - name: Find mod JAR
         id: find-jar
         run: |
@@ -294,7 +294,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: mod-1122
-          path: ${{ github.workspace }}/build/
+          path: ${{ github.workspace }}
       - name: Find mod JAR
         id: find-jar
         run: |

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,9 @@ repositories {
 }
 
 dependencies {
+    // JetBrains annotations for @Nullable/@NotNull
+    provided 'org.jetbrains:annotations:24.0.0'
+
     // LuckPerms soft-dependency (compile-only)
     provided 'net.luckperms:api:5.5'
     provided 'me.clip:placeholderapi:2.12.3'

--- a/src/main/java/levosilimo/everlastingskins/permission/LuckPermsPermissionService.java
+++ b/src/main/java/levosilimo/everlastingskins/permission/LuckPermsPermissionService.java
@@ -1,6 +1,5 @@
 package levosilimo.everlastingskins.permission;
 
-import net.minecraft.entity.player.EntityPlayerMP;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -41,12 +40,12 @@ public class LuckPermsPermissionService implements IPermissionService {
     }
 
     @Override
-    public boolean hasPermission(EntityPlayerMP player, String permissionNode) {
+    public boolean hasPermission(PermissionContext context, String permissionNode) {
         if (luckPermsApi == null || userManager == null) {
             return false;
         }
         try {
-            UUID uuid = player.getUniqueID();
+            UUID uuid = context.uuid();
             Method isLoadedMethod = userManager.getClass().getMethod("isLoaded", UUID.class);
             Boolean isLoaded = (Boolean) isLoadedMethod.invoke(userManager, uuid);
             Object user = null;
@@ -59,7 +58,7 @@ public class LuckPermsPermissionService implements IPermissionService {
             }
             if (user == null) {
                 LOGGER.warn("LP user {} returned null from getUser, falling back to vanilla", uuid);
-                return vanillaFallback(player, permissionNode);
+                return vanillaFallback(context, permissionNode);
             }
 
             Method getCachedDataMethod = user.getClass().getMethod("getCachedData");
@@ -86,8 +85,8 @@ public class LuckPermsPermissionService implements IPermissionService {
         }
     }
 
-    private boolean vanillaFallback(EntityPlayerMP player, String permissionNode) {
-        return player.canUseCommand(2, "everlastingskins");
+    private boolean vanillaFallback(PermissionContext context, String permissionNode) {
+        return context.isOp();
     }
 
     @Override

--- a/src/test/java/levosilimo/everlastingskins/permission/LuckPermsPermissionServiceTest.java
+++ b/src/test/java/levosilimo/everlastingskins/permission/LuckPermsPermissionServiceTest.java
@@ -8,7 +8,6 @@ import net.luckperms.api.UserManager;
 import net.luckperms.api.cacheddata.CachedPermissionData;
 import net.luckperms.api.query.QueryOptions;
 import net.luckperms.api.util.Tristate;
-import net.minecraft.entity.player.EntityPlayerMP;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -24,11 +23,13 @@ import static org.mockito.Mockito.*;
 class LuckPermsPermissionServiceTest {
 
     private UUID uuid;
+    private PermissionContext ctx;
     private User fakeUser;
 
     @BeforeEach
     void setUp() {
         uuid = UUID.randomUUID();
+        ctx = PermissionContext.of(uuid, true);
         LuckPerms fakeLP = mock(LuckPerms.class);
         UserManager fakeUM = mock(UserManager.class);
         fakeUser = mock(User.class);
@@ -63,18 +64,14 @@ class LuckPermsPermissionServiceTest {
     @DisplayName("hasPermission returns true for granted node")
     void hasPermission_granted_returnsTrue() {
         LuckPermsPermissionService service = LuckPermsPermissionService.tryCreate();
-        EntityPlayerMP mockPlayer = mock(EntityPlayerMP.class);
-        when(mockPlayer.getUniqueID()).thenReturn(uuid);
-        assertTrue(service.hasPermission(mockPlayer, "everlastingskins.command.skin"));
+        assertTrue(service.hasPermission(ctx, "everlastingskins.command.skin"));
     }
 
     @Test
     @DisplayName("hasPermission returns false for denied node")
     void hasPermission_denied_returnsFalse() {
         LuckPermsPermissionService service = LuckPermsPermissionService.tryCreate();
-        EntityPlayerMP mockPlayer = mock(EntityPlayerMP.class);
-        when(mockPlayer.getUniqueID()).thenReturn(uuid);
-        assertFalse(service.hasPermission(mockPlayer, "other.node"));
+        assertFalse(service.hasPermission(ctx, "other.node"));
     }
 
     @Test

--- a/src/test/java/levosilimo/everlastingskins/permission/PermissionServiceManagerTest.java
+++ b/src/test/java/levosilimo/everlastingskins/permission/PermissionServiceManagerTest.java
@@ -1,15 +1,18 @@
 package levosilimo.everlastingskins.permission;
 
-import net.minecraft.entity.player.EntityPlayerMP;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.UUID;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 class PermissionServiceManagerTest {
+
+    private static final UUID TEST_UUID = UUID.randomUUID();
 
     @BeforeEach
     @AfterEach
@@ -58,9 +61,8 @@ class PermissionServiceManagerTest {
     @DisplayName("hasPermission before init falls back to Vanilla")
     void hasPermission_beforeInit_returnsFallback() {
         PermissionServiceManager.reset();
-        EntityPlayerMP mockPlayer = mock(EntityPlayerMP.class);
-        when(mockPlayer.canUseCommand(2, "everlastingskins")).thenReturn(true);
-        assertTrue(PermissionServiceManager.hasPermission(mockPlayer, "any.node"));
+        PermissionContext ctx = PermissionContext.of(TEST_UUID, true);
+        assertTrue(PermissionServiceManager.hasPermission(ctx, "any.node"));
     }
 
     @Test

--- a/src/test/java/levosilimo/everlastingskins/permission/VanillaPermissionServiceTest.java
+++ b/src/test/java/levosilimo/everlastingskins/permission/VanillaPermissionServiceTest.java
@@ -1,14 +1,15 @@
 package levosilimo.everlastingskins.permission;
 
-import net.minecraft.entity.player.EntityPlayerMP;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.UUID;
+
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
 class VanillaPermissionServiceTest {
 
+    private static final UUID TEST_UUID = UUID.randomUUID();
     private final VanillaPermissionService service = new VanillaPermissionService();
 
     @Test
@@ -26,30 +27,27 @@ class VanillaPermissionServiceTest {
     @Test
     @DisplayName("Service is an IPermissionService")
     void implementsInterface() {
-        assertInstanceOf(IPermissionService.class, service);
+        assertTrue(service instanceof IPermissionService);
     }
 
     @Test
     @DisplayName("OP player has permission")
     void hasPermission_opPlayer_returnsTrue() {
-        EntityPlayerMP mockPlayer = mock(EntityPlayerMP.class);
-        when(mockPlayer.canUseCommand(2, "everlastingskins")).thenReturn(true);
-        assertTrue(service.hasPermission(mockPlayer, "any.node"));
+        PermissionContext ctx = PermissionContext.of(TEST_UUID, true);
+        assertTrue(service.hasPermission(ctx, "any.node"));
     }
 
     @Test
     @DisplayName("Non-OP player lacks permission")
     void hasPermission_nonOpPlayer_returnsFalse() {
-        EntityPlayerMP mockPlayer = mock(EntityPlayerMP.class);
-        when(mockPlayer.canUseCommand(2, "everlastingskins")).thenReturn(false);
-        assertFalse(service.hasPermission(mockPlayer, "any.node"));
+        PermissionContext ctx = PermissionContext.of(TEST_UUID, false);
+        assertFalse(service.hasPermission(ctx, "any.node"));
     }
 
     @Test
     @DisplayName("OP level 1 is insufficient")
     void hasPermission_opLevel1_returnsFalse() {
-        EntityPlayerMP mockPlayer = mock(EntityPlayerMP.class);
-        when(mockPlayer.canUseCommand(2, "everlastingskins")).thenReturn(false);
-        assertFalse(service.hasPermission(mockPlayer, "any.node"));
+        PermissionContext ctx = PermissionContext.of(TEST_UUID, false);
+        assertFalse(service.hasPermission(ctx, "any.node"));
     }
 }

--- a/src/test/java/levosilimo/everlastingskins/permission/forge/ForgePermissionServiceTest.java
+++ b/src/test/java/levosilimo/everlastingskins/permission/forge/ForgePermissionServiceTest.java
@@ -1,53 +1,31 @@
 package levosilimo.everlastingskins.permission.forge;
 
-import net.minecraft.entity.player.EntityPlayerMP;
-import net.minecraftforge.server.permission.PermissionAPI;
+import levosilimo.everlastingskins.permission.PermissionContext;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
+
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
 
 class ForgePermissionServiceTest {
 
-    @Test
-    @DisplayName("hasPermission returns true when PermissionAPI grants it")
-    void hasPermission_granted_returnsTrue() {
-        try (MockedStatic<PermissionAPI> api = mockStatic(PermissionAPI.class)) {
-            EntityPlayerMP mockPlayer = mock(EntityPlayerMP.class);
-            api.when(() -> PermissionAPI.hasPermission(eq(mockPlayer), eq("everlastingskins.command.skin")))
-               .thenReturn(true);
-            ForgePermissionService service = new ForgePermissionService();
-            assertTrue(service.hasPermission(mockPlayer, "everlastingskins.command.skin"));
-        }
-    }
+    private static final UUID TEST_UUID = UUID.randomUUID();
 
     @Test
-    @DisplayName("hasPermission returns false when PermissionAPI denies and not .source")
-    void hasPermission_denied_returnsFalse() {
-        try (MockedStatic<PermissionAPI> api = mockStatic(PermissionAPI.class)) {
-            EntityPlayerMP mockPlayer = mock(EntityPlayerMP.class);
-            api.when(() -> PermissionAPI.hasPermission(any(EntityPlayerMP.class), anyString()))
-               .thenReturn(false);
-            ForgePermissionService service = new ForgePermissionService();
-            assertFalse(service.hasPermission(mockPlayer, "everlastingskins.command.skin"));
-        }
-    }
-
-    @Test
-    @DisplayName("hasPermission .skin.source always returns true even when API denies")
+    @DisplayName("hasPermission returns true for .source nodes")
     void hasPermission_sourceNode_returnsTrue() {
-        try (MockedStatic<PermissionAPI> api = mockStatic(PermissionAPI.class)) {
-            EntityPlayerMP mockPlayer = mock(EntityPlayerMP.class);
-            api.when(() -> PermissionAPI.hasPermission(any(EntityPlayerMP.class), anyString()))
-               .thenReturn(false);
-            ForgePermissionService service = new ForgePermissionService();
-            assertTrue(service.hasPermission(mockPlayer, "everlastingskins.command.skin.source"));
-        }
+        PermissionContext ctx = PermissionContext.of(TEST_UUID, false);
+        ForgePermissionService service = new ForgePermissionService();
+        assertTrue(service.hasPermission(ctx, "everlastingskins.command.skin.source"));
+    }
+
+    @Test
+    @DisplayName("hasPermission returns context.isOp() for non-source nodes")
+    void hasPermission_nonSource_usesContextIsOp() {
+        ForgePermissionService service = new ForgePermissionService();
+        assertTrue(service.hasPermission(PermissionContext.of(TEST_UUID, true), "everlastingskins.command.skin"));
+        assertFalse(service.hasPermission(PermissionContext.of(TEST_UUID, false), "everlastingskins.command.skin"));
     }
 
     @Test

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/SkinCommandPermissionTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/SkinCommandPermissionTest.java
@@ -1,15 +1,21 @@
 package levosilimo.everlastingskins.skinchanger;
 
+import levosilimo.everlastingskins.permission.PermissionContext;
+import levosilimo.everlastingskins.permission.PermissionServiceManager;
 import net.minecraft.command.CommandHandler;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.server.MinecraftServer;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.UUID;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 class SkinCommandPermissionTest {
+
+    private static final UUID TEST_UUID = UUID.randomUUID();
 
     @Test
     @DisplayName("register registers the skin command")
@@ -35,18 +41,14 @@ class SkinCommandPermissionTest {
     @Test
     @DisplayName("hasPermission delegates to PermissionServiceManager for op players")
     void permissionCheck_delegatesToManager() {
-        EntityPlayerMP mockPlayer = mock(EntityPlayerMP.class);
-        when(mockPlayer.canUseCommand(2, "everlastingskins")).thenReturn(true);
-        assertTrue(levosilimo.everlastingskins.permission.PermissionServiceManager
-            .hasPermission(mockPlayer, "everlastingskins.command.skin"));
+        PermissionContext ctx = PermissionContext.of(TEST_UUID, true);
+        assertTrue(PermissionServiceManager.hasPermission(ctx, "everlastingskins.command.skin"));
     }
 
     @Test
     @DisplayName("non-op player lacks permission")
     void nonOp_lacksPermission() {
-        EntityPlayerMP mockPlayer = mock(EntityPlayerMP.class);
-        when(mockPlayer.canUseCommand(2, "everlastingskins")).thenReturn(false);
-        assertFalse(levosilimo.everlastingskins.permission.PermissionServiceManager
-            .hasPermission(mockPlayer, "everlastingskins.command.skin"));
+        PermissionContext ctx = PermissionContext.of(TEST_UUID, false);
+        assertFalse(PermissionServiceManager.hasPermission(ctx, "everlastingskins.command.skin"));
     }
 }


### PR DESCRIPTION
Fixes 3 pre-existing build issues from merged rebase PRs:

1. Missing org.jetbrains:annotations:24.0.0 dependency (needed for @NotNull)
2. LuckPermsPermissionService had wrong hasPermission signature (EntityPlayerMP instead of PermissionContext) causing interface contract breakage
3. CI artifact download path mismatch (same as 1.21 #58)