### PR TITLE
fix(ci): search workspace root for jar artifact in download step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: mod-121
-          path: ${{ github.workspace }}/build/
+          path: ${{ github.workspace }}
       - name: Find mod JAR
         id: find-jar
         run: |
@@ -290,7 +290,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: mod-1122
-          path: ${{ github.workspace }}/build/
+          path: ${{ github.workspace }}
       - name: Find mod JAR
         id: find-jar
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,10 +103,10 @@ jobs:
       - name: Find mod JAR
         id: find-jar
         run: |
-          JAR=$(ls ${{ github.workspace }}/build/libs/*.jar 2>/dev/null | head -1)
+          JAR=$(ls ${{ github.workspace }}/build/libs/*.jar 2>/dev/null || ls ${{ github.workspace }}/*.jar 2>/dev/null | head -1)
           if [ -z "$JAR" ]; then
-            echo "ERROR: No mod JAR found in build/libs/"
-            ls -la ${{ github.workspace }}/build/libs/ || true
+            echo "ERROR: No mod JAR found"
+            find ${{ github.workspace }} -maxdepth 3 -name "*.jar" -type f 2>/dev/null || true
             exit 1
           fi
           echo "jar_path=$JAR" >> $GITHUB_OUTPUT
@@ -294,10 +294,10 @@ jobs:
       - name: Find mod JAR
         id: find-jar
         run: |
-          JAR=$(ls ${{ github.workspace }}/build/libs/*.jar 2>/dev/null | head -1)
+          JAR=$(ls ${{ github.workspace }}/build/libs/*.jar 2>/dev/null || ls ${{ github.workspace }}/*.jar 2>/dev/null | head -1)
           if [ -z "$JAR" ]; then
-            echo "ERROR: No mod JAR found in build/libs/"
-            ls -la ${{ github.workspace }}/build/libs/ || true
+            echo "ERROR: No mod JAR found"
+            find ${{ github.workspace }} -maxdepth 3 -name "*.jar" -type f 2>/dev/null || true
             exit 1
           fi
           echo "jar_path=$JAR" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
         volumes:
           - ${{ github.workspace }}/test-infrastructure/wiremock/fixtures/mappings:/home/wiremock/mappings
         options: >-
-          --health-cmd "wget --spider http://localhost:8080/__admin || exit 1"
+          --health-cmd "curl -sf http://localhost:8080/__admin/health || exit 1"
           --health-interval 5s
           --health-timeout 10s
           --health-retries 12
@@ -267,7 +267,7 @@ jobs:
         volumes:
           - ${{ github.workspace }}/test-infrastructure/wiremock/fixtures/mappings:/home/wiremock/mappings
         options: >-
-          --health-cmd "wget --spider http://localhost:8080/__admin || exit 1"
+          --health-cmd "curl -sf http://localhost:8080/__admin/health || exit 1"
           --health-interval 5s
           --health-timeout 10s
           --health-retries 12

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,11 +75,12 @@ jobs:
           - 8080:8080
         volumes:
           - ${{ github.workspace }}/test-infrastructure/wiremock/fixtures/mappings:/home/wiremock/mappings
-        health:
-          test: ["CMD", "wget", "--spider", "http://localhost:8080/__admin"]
-          interval: 2s
-          timeout: 5s
-          retries: 30
+        options: >-
+          --health-cmd "wget --spider http://localhost:8080/__admin || exit 1"
+          --health-interval 5s
+          --health-timeout 10s
+          --health-retries 12
+          --health-start-period 15s
     env:
       HMC_DIR: ${{ github.workspace }}/HeadlessMC
       SERVER_DIR: ${{ github.workspace }}/test-server
@@ -265,11 +266,12 @@ jobs:
           - 8080:8080
         volumes:
           - ${{ github.workspace }}/test-infrastructure/wiremock/fixtures/mappings:/home/wiremock/mappings
-        health:
-          test: ["CMD", "wget", "--spider", "http://localhost:8080/__admin"]
-          interval: 2s
-          timeout: 5s
-          retries: 30
+        options: >-
+          --health-cmd "wget --spider http://localhost:8080/__admin || exit 1"
+          --health-interval 5s
+          --health-timeout 10s
+          --health-retries 12
+          --health-start-period 15s
     env:
       HMC_DIR: ${{ github.workspace }}/HeadlessMC
       SERVER_DIR: ${{ github.workspace }}/test-server


### PR DESCRIPTION
actions/upload-artifact@v4 strips directory prefixes from glob patterns, so build/libs/*.jar is stored at artifact root (not under build/libs/). The find-jar step now checks both locations and has a debug fallback.