### PR TITLE
fix(ci): search workspace root for jar artifact in download step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,10 +105,10 @@ jobs:
       - name: Find mod JAR
         id: find-jar
         run: |
-          JAR=$(ls ${{ github.workspace }}/build/libs/*.jar 2>/dev/null | head -1)
+          JAR=$(ls ${{ github.workspace }}/build/libs/*.jar 2>/dev/null || ls ${{ github.workspace }}/*.jar 2>/dev/null | head -1)
           if [ -z "$JAR" ]; then
-            echo "ERROR: No mod JAR found in build/libs/"
-            ls -la ${{ github.workspace }}/build/libs/ || true
+            echo "ERROR: No mod JAR found"
+            find ${{ github.workspace }} -maxdepth 3 -name "*.jar" -type f 2>/dev/null || true
             exit 1
           fi
           echo "jar_path=$JAR" >> $GITHUB_OUTPUT
@@ -298,10 +298,10 @@ jobs:
       - name: Find mod JAR
         id: find-jar
         run: |
-          JAR=$(ls ${{ github.workspace }}/build/libs/*.jar 2>/dev/null | head -1)
+          JAR=$(ls ${{ github.workspace }}/build/libs/*.jar 2>/dev/null || ls ${{ github.workspace }}/*.jar 2>/dev/null | head -1)
           if [ -z "$JAR" ]; then
-            echo "ERROR: No mod JAR found in build/libs/"
-            ls -la ${{ github.workspace }}/build/libs/ || true
+            echo "ERROR: No mod JAR found"
+            find ${{ github.workspace }} -maxdepth 3 -name "*.jar" -type f 2>/dev/null || true
             exit 1
           fi
           echo "jar_path=$JAR" >> $GITHUB_OUTPUT


### PR DESCRIPTION
actions/upload-artifact@v4 strips directory prefixes from glob patterns. Updated find-jar step to search workspace root (where v4 downloads) with fallback to find.