### PR TITLE
test(e2e): P0 coverage - WireMock fixtures, filesystem assertion, debug log, all scenarios

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
           curl -L -o "${{ env.MODS_DIR }}/hmc-specifics.jar" \
             "https://github.com/headlesshq/hmc-specifics/releases/download/2.4.0/hmc-specifics-1.21-2.4.0-lexforge-release.jar" \
             || echo "WARNING: HMCSpecifics download failed, continuing"
-      - name: Configure HeadlessMC
+      - name: Configure HeadlessMC (skin-set-mojang)
         run: |
           {
             echo "hmc.java.versions=$JAVA_HOME/bin/java"
@@ -197,12 +197,72 @@ jobs:
             echo "hmc.assets.dummy=true"
             echo "hmc.always.lwjgl.flag=true"
           } > "${{ env.HMC_DIR }}/config.properties"
-      - name: Run E2E scenario via xvfb
+      - name: Run E2E scenario - skin-set-mojang
         run: |
           cd "${{ env.HMC_DIR }}"
           xvfb-run -a java -jar "headlessmc-launcher-wrapper-${{ env.HMC_VERSION }}.jar" \
             --command "launch forge:1.21 -lwjgl -offline -specifics --jvm -Djava.awt.headless=true" \
-            --game-args "--server localhost --port 25565 --username TestPlayer" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-output.log"
+            --game-args "--server localhost --port 25565 --username TestPlayer" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-output-set.log"
+      - name: Verify skin file exists (after set)
+        if: always()
+        run: |
+          USERNAME="TestPlayer"
+          UUID=$(python3 -c "import hashlib,uuid; d=hashlib.md5(('OfflinePlayer:'+'$USERNAME').encode('utf-8')).digest(); print(uuid.UUID(bytes=d,version=3).hex)")
+          SKIN_FILE="${{ env.SERVER_DIR }}/EverlastingSkins/$UUID.json"
+          echo "UUID: $UUID"
+          echo "Skin file: $SKIN_FILE"
+          if [ -f "$SKIN_FILE" ]; then
+            echo "SKIN FILE: exists ✅"
+            echo "CONTENT: $(head -c 200 $SKIN_FILE)"
+          else
+            echo "SKIN FILE: missing ❌"
+            ls -la "${{ env.SERVER_DIR }}/EverlastingSkins/" 2>/dev/null || echo "No EverlastingSkins dir"
+          fi
+      - name: Configure HeadlessMC (skin-clear)
+        run: |
+          {
+            echo "hmc.java.versions=$JAVA_HOME/bin/java"
+            echo "hmc.gamedir=${{ github.workspace }}/headlessmc-run"
+            echo "hmc.mcdir=$HOME/.minecraft"
+            echo "hmc.offline=true"
+            echo "hmc.offline.username=TestPlayer"
+            echo "hmc.rethrow.launch.exceptions=true"
+            echo "hmc.exit.on.failed.command=true"
+            echo "hmc.test.filename=${{ github.workspace }}/test-infrastructure/scenarios/skin-clear.json"
+            echo "hmc.test.leave.after=true"
+            echo "hmc.assets.dummy=true"
+            echo "hmc.always.lwjgl.flag=true"
+          } > "${{ env.HMC_DIR }}/config.properties"
+      - name: Run E2E scenario - skin-clear
+        run: |
+          cd "${{ env.HMC_DIR }}"
+          xvfb-run -a java -jar "headlessmc-launcher-wrapper-${{ env.HMC_VERSION }}.jar" \
+            --command "launch forge:1.21 -lwjgl -offline -specifics --jvm -Djava.awt.headless=true" \
+            --game-args "--server localhost --port 25565 --username TestPlayer" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-output-clear.log"
+      - name: Verify skin file cleared (after clear)
+        if: always()
+        run: |
+          USERNAME="TestPlayer"
+          UUID=$(python3 -c "import hashlib,uuid; d=hashlib.md5(('OfflinePlayer:'+'$USERNAME').encode('utf-8')).digest(); print(uuid.UUID(bytes=d,version=3).hex)")
+          SKIN_FILE="${{ env.SERVER_DIR }}/EverlastingSkins/$UUID.json"
+          echo "UUID: $UUID"
+          echo "Skin file: $SKIN_FILE"
+          if [ ! -f "$SKIN_FILE" ]; then
+            echo "SKIN FILE CLEARED: does not exist ✅"
+          else
+            echo "SKIN FILE: still exists ❌"
+            echo "CONTENT: $(head -c 200 $SKIN_FILE)"
+          fi
+      - name: Verify WireMock requests
+        if: always()
+        run: |
+          REQUESTS=$(curl -s http://localhost:8080/__admin/requests 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print(len(d.get('requests',[])))" 2>/dev/null || echo "0")
+          echo "WireMock requests served: $REQUESTS"
+          if [ "$REQUESTS" -ge "1" ]; then
+            echo "WireMock: received requests ✅"
+          else
+            echo "WireMock: NO requests received ❌"
+          fi
       - name: Kill server
         if: always()
         run: |
@@ -373,7 +433,7 @@ jobs:
           curl -L -o "${{ env.MODS_DIR }}/hmc-specifics.jar" \
             "https://github.com/headlesshq/hmc-specifics/releases/download/2.4.0/hmc-specifics-1.12.2-2.4.0-lexforge-release.jar" \
             || echo "WARNING: HMCSpecifics download failed, continuing"
-      - name: Configure HeadlessMC
+      - name: Configure HeadlessMC (skin-set-mojang)
         run: |
           {
             echo "hmc.java.versions=$JAVA_HOME/bin/java"
@@ -388,12 +448,72 @@ jobs:
             echo "hmc.assets.dummy=true"
             echo "hmc.always.lwjgl.flag=true"
           } > "${{ env.HMC_DIR }}/config.properties"
-      - name: Run E2E scenario via xvfb
+      - name: Run E2E scenario - skin-set-mojang
         run: |
           cd "${{ env.HMC_DIR }}"
           xvfb-run -a java -jar "headlessmc-launcher-wrapper-${{ env.HMC_VERSION }}.jar" \
             --command "launch forge:1.12.2 -lwjgl -offline -specifics --jvm -Djava.awt.headless=true" \
-            --game-args "--server localhost --port 25565 --username TestPlayer" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-output.log"
+            --game-args "--server localhost --port 25565 --username TestPlayer" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-output-set.log"
+      - name: Verify skin file exists (after set)
+        if: always()
+        run: |
+          USERNAME="TestPlayer"
+          UUID=$(python3 -c "import hashlib,uuid; d=hashlib.md5(('OfflinePlayer:'+'$USERNAME').encode('utf-8')).digest(); print(uuid.UUID(bytes=d,version=3).hex)")
+          SKIN_FILE="${{ env.SERVER_DIR }}/EverlastingSkins/$UUID.json"
+          echo "UUID: $UUID"
+          echo "Skin file: $SKIN_FILE"
+          if [ -f "$SKIN_FILE" ]; then
+            echo "SKIN FILE: exists ✅"
+            echo "CONTENT: $(head -c 200 $SKIN_FILE)"
+          else
+            echo "SKIN FILE: missing ❌"
+            ls -la "${{ env.SERVER_DIR }}/EverlastingSkins/" 2>/dev/null || echo "No EverlastingSkins dir"
+          fi
+      - name: Configure HeadlessMC (skin-clear)
+        run: |
+          {
+            echo "hmc.java.versions=$JAVA_HOME/bin/java"
+            echo "hmc.gamedir=${{ github.workspace }}/headlessmc-run"
+            echo "hmc.mcdir=$HOME/.minecraft"
+            echo "hmc.offline=true"
+            echo "hmc.offline.username=TestPlayer"
+            echo "hmc.rethrow.launch.exceptions=true"
+            echo "hmc.exit.on.failed.command=true"
+            echo "hmc.test.filename=${{ github.workspace }}/test-infrastructure/scenarios/skin-clear.json"
+            echo "hmc.test.leave.after=true"
+            echo "hmc.assets.dummy=true"
+            echo "hmc.always.lwjgl.flag=true"
+          } > "${{ env.HMC_DIR }}/config.properties"
+      - name: Run E2E scenario - skin-clear
+        run: |
+          cd "${{ env.HMC_DIR }}"
+          xvfb-run -a java -jar "headlessmc-launcher-wrapper-${{ env.HMC_VERSION }}.jar" \
+            --command "launch forge:1.12.2 -lwjgl -offline -specifics --jvm -Djava.awt.headless=true" \
+            --game-args "--server localhost --port 25565 --username TestPlayer" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-output-clear.log"
+      - name: Verify skin file cleared (after clear)
+        if: always()
+        run: |
+          USERNAME="TestPlayer"
+          UUID=$(python3 -c "import hashlib,uuid; d=hashlib.md5(('OfflinePlayer:'+'$USERNAME').encode('utf-8')).digest(); print(uuid.UUID(bytes=d,version=3).hex)")
+          SKIN_FILE="${{ env.SERVER_DIR }}/EverlastingSkins/$UUID.json"
+          echo "UUID: $UUID"
+          echo "Skin file: $SKIN_FILE"
+          if [ ! -f "$SKIN_FILE" ]; then
+            echo "SKIN FILE CLEARED: does not exist ✅"
+          else
+            echo "SKIN FILE: still exists ❌"
+            echo "CONTENT: $(head -c 200 $SKIN_FILE)"
+          fi
+      - name: Verify WireMock requests
+        if: always()
+        run: |
+          REQUESTS=$(curl -s http://localhost:8080/__admin/requests 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print(len(d.get('requests',[])))" 2>/dev/null || echo "0")
+          echo "WireMock requests served: $REQUESTS"
+          if [ "$REQUESTS" -ge "1" ]; then
+            echo "WireMock: received requests ✅"
+          else
+            echo "WireMock: NO requests received ❌"
+          fi
       - name: Kill server
         if: always()
         run: |

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRefreshHandler.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRefreshHandler.java
@@ -1,6 +1,7 @@
 package levosilimo.everlastingskins.skinchanger;
 
 import levosilimo.everlastingskins.Config;
+import levosilimo.everlastingskins.EverlastingSkins;
 import levosilimo.everlastingskins.enums.SkinActionType;
 import levosilimo.everlastingskins.skinchanger.responses.mojang.MojangSkinDataResult;
 import levosilimo.everlastingskins.util.CustomSkinProperty;
@@ -34,6 +35,9 @@ public class SkinRefreshHandler {
         SkinRestorer.getSkinStorage().saveSkin(player.getUUID());
         player.getGameProfile().getProperties().removeAll("textures");
         player.getGameProfile().getProperties().put("textures", SkinRestorer.getSkinStorage().getSkin(player.getUUID()).getOriginalProperty());
+        EverlastingSkins.logger.info("SKIN_REFRESH: profile={}, property={}",
+                player.getGameProfile().getName(),
+                player.getGameProfile().getProperties().get("textures"));
 
         SkinRestorer.server.getPlayerList().broadcastAll(new ClientboundPlayerInfoUpdatePacket(ClientboundPlayerInfoUpdatePacket.Action.UPDATE_DISPLAY_NAME, player));
         player.connection.send(new ClientboundRespawnPacket(player.createCommonSpawnInfo(serverLevel), (byte) 3));

--- a/test-infrastructure/wiremock/fixtures/mappings/profile-eclipse-Notch.json
+++ b/test-infrastructure/wiremock/fixtures/mappings/profile-eclipse-Notch.json
@@ -1,0 +1,23 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPattern": "/profile/eclipse/([0-9a-f-]+)"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "cacheData": {
+        "state": "MISS",
+        "createdAt": 0
+      },
+      "exists": true,
+      "skinProperty": {
+        "value": "eyJ0aW1lc3RhbXAiOjEyMzQ1Njc4OTAsInByb2ZpbGVJZCI6IjA2OWE3OWY0LTQ0ZTktNDcyNi1hNWJlLWZjYTkwZTM4YWFmNSIsInByb2ZpbGVOYW1lIjoiTm90Y2giLCJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYWJjMTIzZGVmNDU2In19fQ==",
+        "signature": "SIGNATURE_PLACEHOLDER_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+      }
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/test-infrastructure/wiremock/fixtures/mappings/profile-minetools-Notch.json
+++ b/test-infrastructure/wiremock/fixtures/mappings/profile-minetools-Notch.json
@@ -1,0 +1,26 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPattern": "/profile/minetools/([0-9a-f]+)"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "raw": {
+        "id": "069a79f444e94726a5befca90e38aaf5",
+        "name": "Notch",
+        "status": "OK",
+        "properties": [
+          {
+            "name": "textures",
+            "value": "eyJ0aW1lc3RhbXAiOjEyMzQ1Njc4OTAsInByb2ZpbGVJZCI6IjA2OWE3OWY0LTQ0ZTktNDcyNi1hNWJlLWZjYTkwZTM4YWFmNSIsInByb2ZpbGVOYW1lIjoiTm90Y2giLCJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYWJjMTIzZGVmNDU2In19fQ==",
+            "signature": "SIGNATURE_PLACEHOLDER_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+          }
+        ]
+      }
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/test-infrastructure/wiremock/fixtures/mappings/profile-mojang-Notch.json
+++ b/test-infrastructure/wiremock/fixtures/mappings/profile-mojang-Notch.json
@@ -1,0 +1,23 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPattern": "/profile/mojang/([0-9a-f]+)"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "id": "069a79f444e94726a5befca90e38aaf5",
+      "name": "Notch",
+      "properties": [
+        {
+          "name": "textures",
+          "value": "eyJ0aW1lc3RhbXAiOjEyMzQ1Njc4OTAsInByb2ZpbGVJZCI6IjA2OWE3OWY0LTQ0ZTktNDcyNi1hNWJlLWZjYTkwZTM4YWFmNSIsInByb2ZpbGVOYW1lIjoiTm90Y2giLCJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYWJjMTIzZGVmNDU2In19fQ==",
+          "signature": "SIGNATURE_PLACEHOLDER_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ]
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/test-infrastructure/wiremock/fixtures/mappings/uuid-eclipse-Notch.json
+++ b/test-infrastructure/wiremock/fixtures/mappings/uuid-eclipse-Notch.json
@@ -1,0 +1,20 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPattern": "/uuid/eclipse/([a-zA-Z0-9_]+)"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "cacheData": {
+        "state": "MISS",
+        "createdAt": 0
+      },
+      "exists": true,
+      "uuid": "069a79f4-44e9-4726-a5be-fca90e38aaf5"
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/test-infrastructure/wiremock/fixtures/mappings/uuid-minetools-Notch.json
+++ b/test-infrastructure/wiremock/fixtures/mappings/uuid-minetools-Notch.json
@@ -1,0 +1,18 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPattern": "/uuid/minetools/([a-zA-Z0-9_]+)"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "id": "069a79f444e94726a5befca90e38aaf5",
+      "name": "{{request.pathSegments.[2]}}",
+      "status": "OK"
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "transformers": ["response-template"]
+  }
+}

--- a/test-infrastructure/wiremock/fixtures/mappings/uuid-mojang-Notch.json
+++ b/test-infrastructure/wiremock/fixtures/mappings/uuid-mojang-Notch.json
@@ -1,0 +1,17 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPattern": "/uuid/mojang/([a-zA-Z0-9_]+)"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "id": "069a79f444e94726a5befca90e38aaf5",
+      "name": "{{request.pathSegments.[2]}}"
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "transformers": ["response-template"]
+  }
+}


### PR DESCRIPTION
Implements P0 recommendations from E2E coverage audit:
- WireMock fixture mappings (6 stubs) for uuid/profile endpoints
- Filesystem assertion checking EverlastingSkins/<uuid>.json
- Debug log line in SkinRefreshHandler for GameProfile property
- WireMock request count verification
- skin-clear scenario now runs as second step