### PR TITLE
fix: call PermissionServiceManager.init() before registerNodes() in constructor

### DIFF
--- a/src/main/java/levosilimo/everlastingskins/EverlastingSkins.java
+++ b/src/main/java/levosilimo/everlastingskins/EverlastingSkins.java
@@ -31,6 +31,7 @@ public class EverlastingSkins {
     public static final List<String> languages = Lists.newArrayList();
 
     public EverlastingSkins() {
+        PermissionServiceManager.init();
         ForgePermissionService.registerNodes();
         MinecraftForge.EVENT_BUS.addListener(ForgePermissionService::onPermissionGather);
         ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, Config.COMMON_CONFIG);


### PR DESCRIPTION
## Bug

BUG-1: `EverlastingSkins()` constructor calls `ForgePermissionService.registerNodes()` which internally calls `registerService()` — but `registerService()` throws `IllegalStateException("init() must be called first")` because `PermissionServiceManager.init()` has not been called yet.

`init()` was only called later in `onServerAboutToStart` (lifecycle event), which is too late — the constructor runs during mod construction, before any server lifecycle events fire.

## Fix

Added `PermissionServiceManager.init();` as the first statement in the `EverlastingSkins()` constructor, before `ForgePermissionService.registerNodes()`.

## Verification

- `./gradlew compileJava` — BUILD SUCCESSFUL
- `./gradlew test` — 109/109 tests passed
- `aislop scan --staged` — clean run (0 issues)