### PR TITLE
fix: add missing @Nullable import in MojangApiHttpImpl

### DIFF
--- a/src/main/java/levosilimo/everlastingskins/skinchanger/MojangApiHttpImpl.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/MojangApiHttpImpl.java
@@ -17,6 +17,7 @@ import levosilimo.everlastingskins.util.SRHelpers;
 import levosilimo.everlastingskins.util.UUIDUtils;
 import org.apache.logging.log4j.Logger;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.net.URI;
 import java.util.*;


### PR DESCRIPTION
Fixes compilation error: add javax.annotation.Nullable import needed by findTextureProperty method