### PR TITLE
fix: compilation fixes (static I18nUtils, non-final apiKey)

### DIFF
--- a/src/main/java/levosilimo/everlastingskins/skinchanger/MineSkinApiHttpImpl.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/MineSkinApiHttpImpl.java
@@ -51,7 +51,7 @@ public class MineSkinApiHttpImpl implements MineSkinAPI {
     private final Gson gson = new Gson();
     private final Logger logger = LogManager.getLogger();
     private final HttpClient httpClient;
-    private final String apiKey;
+    private String apiKey;
 
     public MineSkinApiHttpImpl() {
         this(new HttpsUrlConnectionHttpClient());

--- a/src/main/java/levosilimo/everlastingskins/util/I18nUtils.java
+++ b/src/main/java/levosilimo/everlastingskins/util/I18nUtils.java
@@ -81,7 +81,7 @@ public final class I18nUtils {
         }
     }
 
-    private void loadProperties(Path localizationsDir) {
+    private static void loadProperties(Path localizationsDir) {
         Properties properties = new Properties();
 
         try (Stream<Path> files = Files.walk(localizationsDir)) {
@@ -105,6 +105,7 @@ public final class I18nUtils {
     }
 
     private static void createLocalizationFiles(Path localizationsDir) {
+        if (localizationsDir == null) return;
         try {
             for (Map.Entry<String, Map<String, String>> entry : localizedStrings.entrySet()) {
                 String locale = entry.getKey();


### PR DESCRIPTION
Fixes two compilation errors: loadProperties must be static, apiKey must be mutable for lazy init