### PR TITLE
test(e2e): add disconnect-reconnect persistence scenario

### DIFF
--- a/test-infrastructure/scenarios/skin-persistence.json
+++ b/test-infrastructure/scenarios/skin-persistence.json
@@ -1,0 +1,21 @@
+{
+  "name": "Disconnect-Reconnect Persistence",
+  "description": "Sets a skin, disconnects, reconnects, and verifies the skin is still applied",
+  "type": "RUNS",
+  "config": {"accountType": "offline", "username": "TestPlayer"},
+  "steps": [
+    {"type": "ENDS_WITH", "message": "For help, type \"help\""},
+    {"type": "WAIT", "timeout": 10},
+    {"type": "SEND", "message": "/skin set mojang Notch"},
+    {"type": "WAIT", "timeout": 5},
+    {"type": "CONTAINS", "message": "applied."},
+    {"type": "SEND", "message": "disconnect"},
+    {"type": "WAIT", "timeout": 5},
+    {"type": "SEND", "message": "connect localhost 25565"},
+    {"type": "WAIT", "timeout": 15},
+    {"type": "CONTAINS", "message": "For help"},
+    {"type": "SEND", "message": "/skin source"},
+    {"type": "WAIT", "timeout": 3},
+    {"type": "CONTAINS", "message": "Notch"}
+  ]
+}


### PR DESCRIPTION
Creates skin-persistence.json scenario that:
1. Sets a skin via /skin set mojang Notch
2. Disconnects via disconnect command
3. Reconnects via connect command
4. Verifies skin persists via /skin source

Part of E2E persistence testing infrastructure.