### PR TITLE
docs: sync AGENTS.md + TESTING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,8 +18,8 @@
 ## Build facts and traps
 
 - Current configuration targets Minecraft `1.21`, Forge `51.0.8`, Java 21, Gradle 8.8, ForgeGradle 6, official mappings, and Mixin `0.8.5` annotation processing.
-- Build with the repository wrapper. The current `gradlew` is non-executable and has CRLF line endings, so `./gradlew` and `bash gradlew` fail on Linux. Fix the wrapper before documenting a canonical build command or adding CI.
-- There is no test source set or CI workflow yet. Do not claim tests pass. A successful Gradle build is currently the narrowest available verification.
+- Build with the repository wrapper. The current `gradlew` is LF-encoded and executable. Build with `./gradlew build`.
+- CI runs on every push to `1.21` and `mc1.12.2` branches: lint (yamllint) + build + unit tests (JUnit 5) + E2E (HeadlessMC + HMCSpecifics + Forge + WireMock).
 - `gradle.properties` contains stale metadata (`minecraft_version_range`, `curse_versions`, placeholder description, broad loader/Forge ranges). Treat executable dependency coordinates in `build.gradle` as authoritative until metadata is reconciled.
 - The local Qartez index currently points at another workspace. If Qartez returns paths such as `neodeal/` or `ik_llama.cpp`, stop and re-index this repository rather than trusting impact or dependency results.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -3,8 +3,8 @@
 EverlastingSkins uses a three-tier testing pyramid:
 
 ## Tier 1: Pure Java unit tests (JUnit 5)
-- 130+ tests on 1.21 branch
-- 150+ tests on mc1.12.2 branch
+- 151 tests on 1.21 branch
+- 137 tests on mc1.12.2 branch
 - Coverage: provider fallback, HTTP outcomes, persistence atomicity, corruption handling, cache behavior, permission system, command dispatch, integration hooks
 - Run: `./gradlew test`
 


### PR DESCRIPTION
Update stale claims in AGENTS.md (CRLF, missing CI) and fix test counts in TESTING.md to reflect actual counts (151 on 1.21, 137 on mc1.12.2).