### PR TITLE
test(e2e): add GameProfile property assertion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,11 @@ jobs:
           xvfb-run -a java -jar "headlessmc-launcher-wrapper-${{ env.HMC_VERSION }}.jar" \
             --command "launch forge:1.21 -lwjgl -offline -specifics --jvm -Djava.awt.headless=true" \
             --game-args "--server localhost --port 25565 --username TestPlayer" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-output-set.log"
+      - name: Assert GameProfile property via server log
+        if: always()
+        run: |
+          chmod +x ${{ github.workspace }}/test-infrastructure/assert-skin-property.sh
+          bash ${{ github.workspace }}/test-infrastructure/assert-skin-property.sh ${{ env.SERVER_DIR }}/logs/latest.log TestPlayer
       - name: Verify skin file exists (after set)
         if: always()
         run: |

--- a/test-infrastructure/assert-skin-property.sh
+++ b/test-infrastructure/assert-skin-property.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Asserts the server-side GameProfile property was set by base64-decoding the
+# SKIN_REFRESH log line emitted by SkinRefreshHandler.task().
+#
+# Usage: assert-skin-property.sh <server-log-file> <expected-source>
+# Expected exit code: 0 if property is valid, 1 otherwise
+
+set -uo pipefail
+
+LOG_FILE="${1:-logs/latest.log}"
+EXPECTED_SOURCE="${2:-Notch}"
+
+if [ ! -f "$LOG_FILE" ]; then
+  echo "ERROR: log file not found: $LOG_FILE"
+  exit 1
+fi
+
+# Find the SKIN_REFRESH line and extract the base64 property value
+# Format: SKIN_REFRESH: profile=<name>, property=Property[name=textures,value=<base64>,signature=<base64>]
+SKIN_LINE=$(grep "SKIN_REFRESH" "$LOG_FILE" | tail -1)
+
+if [ -z "$SKIN_LINE" ]; then
+  echo "FAIL: no SKIN_REFRESH line in log"
+  exit 1
+fi
+
+# Extract the base64 value (the long base64 string after "value=")
+BASE64_VALUE=$(echo "$SKIN_LINE" | grep -oP 'value=\K[A-Za-z0-9+/=]+' | head -1)
+
+if [ -z "$BASE64_VALUE" ]; then
+  echo "FAIL: could not extract base64 value from SKIN_REFRESH line"
+  echo "Line was: $SKIN_LINE"
+  exit 1
+fi
+
+# Decode the base64 value
+DECODED=$(echo "$BASE64_VALUE" | base64 -d 2>/dev/null)
+
+if [ -z "$DECODED" ]; then
+  echo "FAIL: base64 decode failed"
+  exit 1
+fi
+
+# Check that decoded JSON has textures.SKIN.url
+if echo "$DECODED" | grep -q "textures.*SKIN.*url"; then
+  echo "PASS: GameProfile property contains textures.SKIN.url"
+  echo "Decoded JSON: $DECODED"
+  exit 0
+else
+  echo "FAIL: decoded JSON does not contain textures.SKIN.url"
+  echo "Decoded JSON: $DECODED"
+  exit 1
+fi


### PR DESCRIPTION
Adds a shell script that asserts the server-side GameProfile property was set by base64-decoding the SKIN_REFRESH log line from SkinRefreshHandler.task(), and wires it into the E2E workflow after the skin-set-mojang scenario.\n\nCloses lib-35 #2 recommendation for server-log-based assertion.