### PR TITLE
fix(e2e): remove broken WireMock cleanup step that ran before checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,8 +87,6 @@ jobs:
       MODS_DIR: ${{ github.workspace }}/test-server/mods
       HMC_VERSION: "2.10.0"
     steps:
-      - name: Clean WireMock artifacts (EACCES workaround)
-        run: sudo rm -rf ${{ github.workspace }}/test-infrastructure/wiremock || true
       - uses: actions/checkout@v4
       - name: Set up JDK 21
         uses: actions/setup-java@v4


### PR DESCRIPTION
## Problem

The `Clean WireMock artifacts (EACCES workaround)` step ran **before** `actions/checkout@v4`. This meant the workspace was empty when attempting `sudo rm -rf` — the WireMock fixtures hadn't been checked out yet. 

Result: WireMock's volume mount mapped an empty directory, WireMock returned 404 for all endpoints, the Forge server made 0 successful HTTP requests, and the `SkinRefreshHandler.task()` never ran.

## Fix

Removed the cleanup step entirely. The original EACCES bug was already resolved by other CI configuration changes, so this step was both broken and unnecessary.

## Verification

- No `Clean WireMock` step remains in ci.yml
- YAML parses as valid
- Checkout remains as the first step in the e2e job