### PR TITLE
feat(integration): wire DiscordSrvHook call site (mc1.12.2)

### DIFF
--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinCommand.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinCommand.java
@@ -7,6 +7,7 @@ import levosilimo.everlastingskins.enums.SkinVariant;
 import levosilimo.everlastingskins.permission.PermissionContext;
 import levosilimo.everlastingskins.permission.PermissionServiceManager;
 import levosilimo.everlastingskins.skinchanger.responses.mojang.MojangSkinDataResult;
+import levosilimo.everlastingskins.integration.discordsrv.DiscordSrvHook;
 import levosilimo.everlastingskins.util.CustomSkinProperty;
 import levosilimo.everlastingskins.util.EverlastingHelpers;
 import net.minecraft.command.CommandBase;
@@ -306,6 +307,13 @@ public class SkinCommand extends CommandBase {
             }
             for (EntityPlayerMP p : targets) {
                 SkinRestorer.getServer().addScheduledTask(() -> task(p));
+            }
+            for (EntityPlayerMP p : targets) {
+                try {
+                    DiscordSrvHook.announceSkinChange(p, customSource);
+                } catch (Exception e) {
+                    EverlastingSkins.logger.warn("Failed to announce skin change to DiscordSRV", e);
+                }
             }
         });
     }


### PR DESCRIPTION
Backport-of: f4de0123254ca10ec4237cf8db65cea0d7a9aaab\n\nAdds DiscordSrvHook.announceSkinChange() call to SkinCommand.applySkinChange() success branch so skin changes are announced to the configured Discord channel.\n\n- Import DiscordSrvHook in SkinCommand.java\n- Call announceSkinChange(p, customSource) after skin refresh task dispatch\n- Wrapped in try/catch; DiscordSrvHook already has internal reflective guards\n\nBuild: ./gradlew compileJava ✓\nTests: ./gradlew test ✓