### PR TITLE
test(integration): add DiscordSrvHook test for DSRV-2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,7 @@ dependencies {
     testCompile 'org.spigotmc:spigot-api:1.12.2-R0.1-SNAPSHOT'
     testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.10.3'
     testRuntime 'org.junit.platform:junit-platform-launcher:1.10.3'
+    testCompile 'com.discordsrv:discordsrv:1.30.5'
     testCompile 'org.mockito:mockito-core:2.28.2'
 }
 

--- a/src/test/java/levosilimo/everlastingskins/integration/discordsrv/DiscordSrvHookTest.java
+++ b/src/test/java/levosilimo/everlastingskins/integration/discordsrv/DiscordSrvHookTest.java
@@ -1,0 +1,39 @@
+package levosilimo.everlastingskins.integration.discordsrv;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/**
+ * Unit tests for {@link DiscordSrvHook}.
+ * <p>
+ * Covers lib-39 scenario DSRV-2 (null plugin) which is testable without
+ * mocking — {@code DiscordSRV.getPlugin()} returns {@code null} naturally
+ * when Bukkit is not running.
+ * <p>
+ * DSRV-3 through DSRV-5 require Mockito static mocking of DiscordSRV, which
+ * is unavailable here because:
+ * <ol>
+ *   <li>DiscordSRV's constant pool references PaperMC types not available
+ *       on the mc1.12.2 classpath — ByteBuddy retransformation fails.</li>
+ *   <li>Mockito 2.x (the version compatible with Java 8 / ForgeGradle 2.3)
+ *       does not support {@code mockStatic}.</li>
+ * </ol>
+ * These scenarios rely on the same reflection chain and are covered by the
+ * 1.21 target where PaperMC API is available.
+ * <p>
+ * {@code doReturn} cannot bypass the type mismatch for {@code getJda()} return
+ * type because the relocated JDA type is not imported and returning {@code null}
+ * is the only value that satisfies both the compiler and Mockito's type check.
+ */
+class DiscordSrvHookTest {
+
+    @Test
+    @DisplayName("null DiscordSRV plugin instance is handled gracefully (DSRV-2)")
+    void announceSkinChange_handlesNullPluginInstance() {
+        // DiscordSRV.getPlugin() returns null when Bukkit is not running.
+        // No mocking required — the reflection chain hits null, logs, and returns.
+        assertDoesNotThrow(() -> DiscordSrvHook.announceSkinChange(null, "TestSource"));
+    }
+}


### PR DESCRIPTION
Adds unit test for DiscordSrvHook DSRV-2 (null plugin graceful handling).

DSRV-3 through DSRV-5 are not testable on mc1.12.2 because:
1. DiscordSRV references PaperMC types not available for 1.12.2
2. Mockito 2.x (Java 8-compatible) lacks mockStatic support

These scenarios are covered by the 1.21 target.