### PR TITLE
fix(test): resolve SLF4J NoSuchMethodError in SkinCommandPermissionTest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -149,6 +149,10 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.3'
 }
 
+configurations.testRuntimeClasspath {
+    exclude group: 'org.slf4j', module: 'slf4j-simple'
+}
+
 test {
     useJUnitPlatform()
     testLogging {


### PR DESCRIPTION
## Problem

SkinCommandPermissionTest intermittently fails with a SLF4J `NoSuchMethodError` during test execution. This is caused by a classpath conflict between two SLF4J bindings bundled by Forge:

- `slf4j-simple:1.7.30` (SLF4J 1.x simple binding) — compiled against SLF4J API 1.x
- `log4j-slf4j2-impl:2.22.1` (SLF4J 2.x bridge to Log4j) — compiled against SLF4J API 2.x

When SLF4J loads `slf4j-simple:1.7.30` as the binding (classpath-order dependent), it calls internal methods from the 1.x API against the `slf4j-api:2.0.9` jar, causing `NoSuchMethodError`.

## Fix

Excluded `slf4j-simple` from `testRuntimeClasspath` in `build.gradle`. The Forge-provided `log4j-slf4j2-impl:2.22.1` is the proper SLF4J 2.x binding and remains in place.

## Verification

- `SkinCommandPermissionTest` (5 tests) — all pass
- Full test suite (all test classes) — all pass