### PR TITLE
test(e2e): mc1.12.2 CI parity — skin-persistence, fatal HMCSpecifics, test count guard, JaCoCo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,6 +253,14 @@ jobs:
           name: mod-1122
           path: build/libs/*.jar
           if-no-files-found: error
+      - name: Verify test count meets minimum
+        run: |
+          COUNT=$(grep -r "@Test" src/test/java/ | wc -l)
+          echo "Test count: $COUNT"
+          if [ "$COUNT" -lt 110 ]; then
+            echo "ERROR: Test count dropped below 110 (got $COUNT)"
+            exit 1
+          fi
 
   # ── E2E test on mc1.12.2 ──────────────────────────────────────
   e2e-test-1122:
@@ -374,7 +382,7 @@ jobs:
         run: |
           curl -L -o "${{ env.MODS_DIR }}/hmc-specifics.jar" \
             "https://github.com/headlesshq/hmc-specifics/releases/download/2.4.0/hmc-specifics-1.12.2-2.4.0-lexforge-release.jar" \
-            || echo "WARNING: HMCSpecifics download failed, continuing"
+            || { echo "FATAL: HMCSpecifics download failed"; exit 1; }
       - name: Configure HeadlessMC (skin-set-mojang)
         run: |
           {
@@ -451,6 +459,27 @@ jobs:
             echo "SKIN FILE: still exists ❌"
             echo "CONTENT: $(head -c 200 $SKIN_FILE)"
           fi
+      - name: Configure HeadlessMC (skin-persistence)
+        run: |
+          {
+            echo "hmc.java.versions=$JAVA_HOME/bin/java"
+            echo "hmc.gamedir=${{ github.workspace }}/headlessmc-run"
+            echo "hmc.mcdir=$HOME/.minecraft"
+            echo "hmc.offline=true"
+            echo "hmc.offline.username=TestPlayer"
+            echo "hmc.rethrow.launch.exceptions=true"
+            echo "hmc.exit.on.failed.command=true"
+            echo "hmc.test.filename=${{ github.workspace }}/test-infrastructure/scenarios/skin-persistence.json"
+            echo "hmc.test.leave.after=true"
+            echo "hmc.assets.dummy=true"
+            echo "hmc.always.lwjgl.flag=true"
+          } > "${{ env.HMC_DIR }}/config.properties"
+      - name: Run E2E scenario - skin-persistence
+        run: |
+          cd "${{ env.HMC_DIR }}"
+          xvfb-run -a java -jar "headlessmc-launcher-wrapper-${{ env.HMC_VERSION }}.jar" \
+            --command "launch forge:1.12.2 -lwjgl -offline -specifics --jvm -Djava.awt.headless=true" \
+            --game-args "--server localhost --port 25565 --username TestPlayer" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-output-persistence.log"
       - name: Verify WireMock requests
         if: always()
         run: |

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,11 @@ buildscript {
 
 plugins {
     id 'java'
+    id 'jacoco'
+}
+
+jacoco {
+    toolVersion = '0.8.11'
 }
 
 apply plugin: 'net.minecraftforge.gradle.forge'
@@ -82,6 +87,15 @@ test {
     // Prevent test task from failing if no tests are found (clean build)
     testLogging {
         events "passed", "skipped", "failed"
+    }
+    finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.enabled = true
+        html.enabled = true
     }
 }
 


### PR DESCRIPTION
Adds the remaining 4 parity improvements to mc1.12.2 CI:

1. **skin-persistence scenario** — configure + run skin-persistence scenario after skin-clear
2. **HMCSpecifics download failure fatal** — `|| exit 1` instead of `|| echo WARNING`
3. **Test count regression guard** — fail CI if `@Test` count drops below 110 (current: 137)
4. **JaCoCo coverage plugin** — generates XML + HTML reports after test run