### PR TITLE
test(e2e): 1.21 CI improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,14 @@ jobs:
             gradle-${{ runner.os }}-1.21-
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
+      - name: Verify test count meets minimum
+        run: |
+          COUNT=$(grep -r "@Test" src/test/java/ | wc -l)
+          echo "Test count: $COUNT"
+          if [ "$COUNT" -lt 150 ]; then
+            echo "ERROR: Test count dropped below 150 (got $COUNT)"
+            exit 1
+          fi
       - name: Build and test
         run: ./gradlew build test --no-daemon --stacktrace
       - name: Upload built jar
@@ -177,9 +185,9 @@ jobs:
             "https://github.com/headlesshq/headlessmc/releases/download/${{ env.HMC_VERSION }}/headlessmc-launcher-wrapper-${{ env.HMC_VERSION }}.jar"
       - name: Download HMCSpecifics
         run: |
-          curl -L -o "${{ env.MODS_DIR }}/hmc-specifics.jar" \
+          curl -fL -o "${{ env.MODS_DIR }}/hmc-specifics.jar" \
             "https://github.com/headlesshq/hmc-specifics/releases/download/2.4.0/hmc-specifics-1.21-2.4.0-lexforge-release.jar" \
-            || echo "WARNING: HMCSpecifics download failed, continuing"
+            || (echo "ERROR: HMCSpecifics download failed - E2E requires it"; exit 1)
       - name: Configure HeadlessMC (skin-set-mojang)
         run: |
           {
@@ -256,6 +264,32 @@ jobs:
             echo "SKIN FILE: still exists ❌"
             echo "CONTENT: $(head -c 200 $SKIN_FILE)"
           fi
+      - name: Configure HeadlessMC (skin-persistence)
+        run: |
+          {
+            echo "hmc.java.versions=$JAVA_HOME/bin/java"
+            echo "hmc.gamedir=${{ github.workspace }}/headlessmc-run"
+            echo "hmc.mcdir=$HOME/.minecraft"
+            echo "hmc.offline=true"
+            echo "hmc.offline.username=TestPlayer"
+            echo "hmc.rethrow.launch.exceptions=true"
+            echo "hmc.exit.on.failed.command=true"
+            echo "hmc.test.filename=${{ github.workspace }}/test-infrastructure/scenarios/skin-persistence.json"
+            echo "hmc.test.leave.after=true"
+            echo "hmc.assets.dummy=true"
+            echo "hmc.always.lwjgl.flag=true"
+          } > "${{ env.HMC_DIR }}/config.properties"
+      - name: Run E2E scenario - skin-persistence
+        run: |
+          cd "${{ env.HMC_DIR }}"
+          xvfb-run -a java -jar "headlessmc-launcher-wrapper-${{ env.HMC_VERSION }}.jar" \
+            --command "launch forge:1.21 -lwjgl -offline -specifics --jvm -Djava.awt.headless=true" \
+            --game-args "--server localhost --port 25565 --username TestPlayer" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-output-persistence.log"
+      - name: Assert GameProfile property via server log (persistence)
+        if: always()
+        run: |
+          chmod +x ${{ github.workspace }}/test-infrastructure/assert-skin-property.sh
+          bash ${{ github.workspace }}/test-infrastructure/assert-skin-property.sh ${{ env.SERVER_DIR }}/logs/latest.log TestPlayer
       - name: Verify WireMock requests
         if: always()
         run: |

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,11 @@ plugins {
     id 'maven-publish'
     id 'net.minecraftforge.gradle' version '[6.0.24,6.2)'
     id 'org.spongepowered.mixin' version '0.7.+'
+    id 'jacoco'
+}
+
+jacoco {
+    toolVersion = '0.8.11'
 }
 
 repositories {
@@ -154,6 +159,15 @@ test {
     testLogging {
         events "passed", "skipped", "failed"
         showStandardStreams = false
+    }
+    finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        html.required = true
     }
 }
 


### PR DESCRIPTION
## Changes
1. **Wire skin-persistence.json scenario** - Add configure + run E2E steps for persistence scenario
2. **Assert GameProfile property** - Call assert-skin-property.sh after persistence scenario
3. **HMCSpecifics download failure fatal** - Replace non-fatal warning with exit 1
4. **Test count regression guard** - Fail build if test count drops below 150
5. **JaCoCo coverage plugin** - Add JaCoCo 0.8.11 with XML + HTML reports