### PR TITLE
fix(e2e): pin Forge installer to 14.23.5.2847 for HeadlessMC forgecli compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,12 +325,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.SERVER_DIR }}/forge-installer.jar
-          key: forge-1.12.2-14.23.5.2860-installer
+          key: forge-1.12.2-14.23.5.2847-installer
       - name: Download Forge installer
         if: steps.cache-forge.outputs.cache-hit != 'true'
         run: |
           curl -L -o "${{ env.SERVER_DIR }}/forge-installer.jar" \
-            "https://maven.minecraftforge.net/net/minecraftforge/forge/1.12.2-14.23.5.2860/forge-1.12.2-14.23.5.2860-installer.jar"
+            "https://maven.minecraftforge.net/net/minecraftforge/forge/1.12.2-14.23.5.2847/forge-1.12.2-14.23.5.2847-installer.jar"
       - name: Install Forge server
         run: |
           cd "${{ env.SERVER_DIR }}"

--- a/test-infrastructure/run-e2e.sh
+++ b/test-infrastructure/run-e2e.sh
@@ -14,7 +14,7 @@ HMC_DIR_NAME="HeadlessMC"
 # Determine branch directory
 if [ "$BRANCH" = "mc1.12.2" ]; then
     BRANCH_DIR="mc1.12.2"
-    FORGE_VERSION="14.23.5.2860"
+    FORGE_VERSION="14.23.5.2847"
     MC_VERSION="1.12.2"
 else
     BRANCH_DIR="1.21"


### PR DESCRIPTION
## Problem

ForgeCLI 1.2.0 (embedded in HeadlessMC 2.10.0) extends Forge's `actions.ClientInstall`
and calls `super.run(File, Predicate, File)` which doesn't exist in Forge
14.23.5.2860. This causes a `java.lang.NoSuchMethodError` at class loading time
(uncatchable because it's a linkage error), crashing forge-cli.jar and blocking
ALL E2E tests on mc1.12.2.

The new GameProfile assertion step (#80) surfaces this previously-silent crash.

## Root cause

Forge 2855+ migrated `ClientInstall.run(File, Predicate)` to
`ClientInstall.run(File, File)`, breaking ForgeCLI's wrapper that
calls `super.run(File, Predicate, File)`.

## Fix

Pin Forge installer from 14.23.5.2860 → 14.23.5.2847. This is the latest
version with the old pre-1.13 installer API. ForgeCLI's pre-1.13 install
path uses `net.minecraftforge.installer.ClientInstall` via reflection
(Guava Predicate API), bypassing the broken 3-arg call entirely. The
post-1.13 install path (which has the 3-arg issue) is never reached.

## Files changed

- `.github/workflows/ci.yml`: forge cache key + installer URL
- `test-infrastructure/run-e2e.sh`: FORGE_VERSION constant

## Verification

- Forge 14.23.5.2847 installer confirmed on Maven (HTTP 200)
- Pre-1.13 ClientInstall class confirmed present in 2847 installer jar
- ServerInstall.headless field confirmed present (required by ForgeCLI)