### PR TITLE
fix(build): SLF4J NoSuchMethodError via classpath ordering

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -148,6 +148,12 @@ dependencies {
     compileOnly 'net.luckperms:api:5.5'
     compileOnly 'me.clip:placeholderapi:2.12.3'
     compileOnly 'com.discordsrv:discordsrv:1.30.5'
+
+    // slf4j-api MUST appear before discordsrv in the classpath order.
+    // discordsrv bundles unrelocated SLF4J 1.x classes (org/slf4j/LoggerFactory)
+    // that lack the getProvider() method required by SLF4J 2.x. The declaration
+    // order within testImplementation determines classpath ordering.
+    testImplementation 'org.slf4j:slf4j-api:2.0.9'
     testImplementation 'com.discordsrv:discordsrv:1.30.5'
     testImplementation 'io.papermc.paper:paper-api:1.20.4-R0.1-SNAPSHOT'
     compileOnly 'org.spigotmc:spigot-api:1.20.4-R0.1-SNAPSHOT'
@@ -157,11 +163,20 @@ dependencies {
     testImplementation 'org.spigotmc:spigot-api:1.20.4-R0.1-SNAPSHOT'
     testImplementation 'org.mockito:mockito-core:5.12.0'
     testImplementation 'org.mockito:mockito-junit-jupiter:5.12.0'
+
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.3'
 }
 
 configurations.testRuntimeClasspath {
     exclude group: 'org.slf4j', module: 'slf4j-simple'
+}
+
+configurations.all {
+    resolutionStrategy.eachDependency { details ->
+        if (details.requested.group == 'org.slf4j') {
+            details.useVersion '2.0.9'
+        }
+    }
 }
 
 test {


### PR DESCRIPTION
## Problem

SkinCommandPermissionTest fails with `NoSuchMethodError: LoggerFactory.getProvider()` due to SLF4J classpath conflict.

## Root Cause

`discordsrv-1.30.5.jar` bundles **unrelocated** SLF4J 1.x classes at the standard `org/slf4j/` namespace (including `LoggerFactory`, `StaticLoggerBinder`, etc.). When this JAR appears **before** `slf4j-api-2.0.9.jar` on the test runtime classpath, the JVM loads `LoggerFactory` from the 1.x bundled copy — which lacks the `getProvider()` method added in SLF4J 2.x. The chain is:

`MarkerFactory.<clinit>` → calls `LoggerFactory.getProvider()` (2.x API) → `NoSuchMethodError` (loaded 1.x class) → `ExceptionInInitializerError` → Minecraft's `LogUtils` / `Commands` fail to initialize → `SkinCommand` tests fail.

## Fix

1. **Classpath ordering**: Declare `testImplementation 'org.slf4j:slf4j-api:2.0.9'` **before** `testImplementation 'com.discordsrv:discordsrv:1.30.5'` in the `dependencies {}` block. Gradle's classpath order respects declaration order within the same configuration, so the 2.0.9 JAR is now found first.

2. **Version constraint** (belt): `configurations.all { resolutionStrategy.eachDependency \{ ... useVersion '2.0.9' } }` forces all SLF4J versions.

3. **Binding exclusion** (suspenders): Retain the existing `configurations.testRuntimeClasspath { exclude group: 'org.slf4j', module: 'slf4j-simple' }`.

## Verification

- `SkinCommandPermissionTest`: 5/5 passing (was 2/5 passing)
- Full test suite: all tests pass
- `./gradlew test --no-daemon`: BUILD SUCCESSFUL