### PR TITLE
fix(ci): 1.21 EACCES workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,8 @@ jobs:
       MODS_DIR: ${{ github.workspace }}/test-server/mods
       HMC_VERSION: "2.10.0"
     steps:
+      - name: Clean WireMock artifacts (EACCES workaround)
+        run: sudo rm -rf ${{ github.workspace }}/test-infrastructure/wiremock || true
       - uses: actions/checkout@v4
       - name: Set up JDK 21
         uses: actions/setup-java@v4


### PR DESCRIPTION
Adds the same WireMock artifacts cleanup step that mc1.12.2 already has. WireMock Docker service runs as root, leaving root-owned files under test-infrastructure/wiremock, which causes actions/checkout@v4 to fail with EACCES.\n\nThis is a one-line copy of the existing fix from mc1.12.2's e2e-test-1122 job (PR #91 missed 1.21).