### PR TITLE
fix(e2e): pin 1.21 HeadlessMC forge version to 51.0.24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
         run: |
           cd "${{ env.HMC_DIR }}"
           xvfb-run -a java -jar "headlessmc-launcher-wrapper-${{ env.HMC_VERSION }}.jar" \
-            --command "launch forge:1.21 -lwjgl -offline -specifics --jvm -Djava.awt.headless=true" \
+            --command "launch forge:1.21 -lwjgl -offline -specifics --uid 51.0.24 --jvm -Djava.awt.headless=true" \
             --game-args "--server localhost --port 25565 --username TestPlayer" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-output-set.log"
       - name: Assert GameProfile property via server log
         if: always()
@@ -250,7 +250,7 @@ jobs:
         run: |
           cd "${{ env.HMC_DIR }}"
           xvfb-run -a java -jar "headlessmc-launcher-wrapper-${{ env.HMC_VERSION }}.jar" \
-            --command "launch forge:1.21 -lwjgl -offline -specifics --jvm -Djava.awt.headless=true" \
+            --command "launch forge:1.21 -lwjgl -offline -specifics --uid 51.0.24 --jvm -Djava.awt.headless=true" \
             --game-args "--server localhost --port 25565 --username TestPlayer" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-output-clear.log"
       - name: Verify skin file cleared (after clear)
         if: always()
@@ -285,7 +285,7 @@ jobs:
         run: |
           cd "${{ env.HMC_DIR }}"
           xvfb-run -a java -jar "headlessmc-launcher-wrapper-${{ env.HMC_VERSION }}.jar" \
-            --command "launch forge:1.21 -lwjgl -offline -specifics --jvm -Djava.awt.headless=true" \
+            --command "launch forge:1.21 -lwjgl -offline -specifics --uid 51.0.24 --jvm -Djava.awt.headless=true" \
             --game-args "--server localhost --port 25565 --username TestPlayer" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-output-persistence.log"
       - name: Assert GameProfile property via server log (persistence)
         if: always()

--- a/test-infrastructure/run-e2e.sh
+++ b/test-infrastructure/run-e2e.sh
@@ -18,7 +18,7 @@ if [ "$BRANCH" = "mc1.12.2" ]; then
     MC_VERSION="1.12.2"
 else
     BRANCH_DIR="1.21"
-    FORGE_VERSION="51.0.8"
+    FORGE_VERSION="51.0.24"
     MC_VERSION="1.21"
 fi
 


### PR DESCRIPTION
## Problem

HeadlessMC 2.10.0 forgecli extends Forge's ClientInstall and calls
super.run(File, Predicate, File) which doesn't exist in Forge 51.x.
All 1.21 E2E steps fail with a client crash.

## Root cause

Forge 1.21 (51.x) migrated ClientInstall.run(File, Predicate, File) to
run(File, File). The forgecli has a fallback that catches the
NoSuchMethodError and uses reflection, but the latest Forge version
(51.0.33) that HeadlessMC resolves by default has a runtime
incompatibility with HMCSpecifics 2.4.0's JLineCommandLineReader.

Additionally, the server was pinned to 51.0.24 but HeadlessMC
resolved to 51.0.33 independently, creating a version mismatch.

## Changes

- `.github/workflows/ci.yml`: add `--uid 51.0.24` to all three HeadlessMC
  launch commands to use the same Forge version as the server
- `test-infrastructure/run-e2e.sh`: update FORGE_VERSION from 51.0.8 to
  51.0.24 for consistency

## Verification

- Forge 51.0.24 installer confirmed on Maven (HTTP 200)
- YAML parses cleanly
- ForgeCLI 2.10.0 tested successfully with 51.0.24 (fallback handles
  NoSuchMethodError, installation completes)