### PR TITLE
fix(ci): 1.21 client Forge version mismatch - clear cache + pre-install 51.0.24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,8 +188,17 @@ jobs:
       - name: Download HMCSpecifics
         run: |
           curl -fL -o "${{ env.MODS_DIR }}/hmc-specifics.jar" \
-            "https://github.com/headlesshq/hmc-specifics/releases/download/2.4.0/hmc-specifics-1.21-2.4.0-lexforge-release.jar" \
+            "https://github.com/headlesshq/hmc-specifics/releases/download/1.21-latest/hmc-specifics-1.21-forge-latest.jar" \
             || (echo "ERROR: HMCSpecifics download failed - E2E requires it"; exit 1)
+      - name: Clear HeadlessMC forge cache
+        run: |
+          echo "Clearing HeadlessMC forge version cache to force re-download of Forge 51.0.24..."
+          rm -rf "$HOME/.minecraft/versions/1.21-forge-"* 2>/dev/null || true
+          rm -rf "$HOME/.minecraft/versions/forge-1.21-"* 2>/dev/null || true
+          rm -rf "$HOME/.minecraft/libraries/net/minecraftforge/forge/1.21-"* 2>/dev/null || true
+          rm -rf "${{ github.workspace }}/headlessmc-run/versions/1.21-forge-"* 2>/dev/null || true
+          rm -rf "${{ github.workspace }}/headlessmc-run/versions/forge-1.21-"* 2>/dev/null || true
+          echo "Done clearing cache"
       - name: Configure HeadlessMC (skin-set-mojang)
         run: |
           {
@@ -205,6 +214,11 @@ jobs:
             echo "hmc.assets.dummy=true"
             echo "hmc.always.lwjgl.flag=true"
           } > "${{ env.HMC_DIR }}/config.properties"
+      - name: Pre-install Forge 51.0.24 for HeadlessMC client
+        run: |
+          cd "${{ env.HMC_DIR }}"
+          java -jar "headlessmc-launcher-wrapper-${{ env.HMC_VERSION }}.jar" \
+            --command "forge 1.21 --uid 51.0.24" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-forge-install.log"
       - name: Run E2E scenario - skin-set-mojang
         run: |
           cd "${{ env.HMC_DIR }}"


### PR DESCRIPTION
## Problem
PR #101 added `--uid 51.0.24` to all HeadlessMC launch commands, but the client still launches Forge 51.0.33 from HeadlessMC's internal version cache. HMCSpecifics 2.4.0 crashes on 51.0.33 with `java.lang.NoSuchMethodError: TerminalBuilder.jni(boolean)`.

## Fix (3 layers, ordered by preference)

### Layer 1: Cache clearing
Clears HeadlessMC's forge version cache before the first launch so that cached 51.0.33 version metadata doesn't override the `--uid 51.0.24` pinning.

### Layer 2: Pre-install forge version
Runs `forge 1.21 --uid 51.0.24` command directly to explicitly install Forge 51.0.24 in HeadlessMC's version list before the first E2E launch. This bypasses any argument-forwarding issues between the launch and forge commands.

### Layer 3: Updated HMCSpecifics
Updated HMCSpecifics from 2.4.0 to `1.21-latest` (tagged 2026-04-13, 6 days after 2.4.0) which may have fixes for Forge 51.0.33 compatibility if the first two layers aren't sufficient.

## Testing
- E2E CI on this branch will verify the client connects with Forge 51.0.24
- Server-side already pinned to 51.0.24 (#101) - no changes needed