### PR TITLE
fix(ci): switch to raw HeadlessMC launcher, disable -specifics auto-download

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,11 +180,11 @@ jobs:
             fi
             sleep 5
           done
-      - name: Download HeadlessMC launcher wrapper
+      - name: Download HeadlessMC launcher (raw, not wrapper)
         run: |
           mkdir -p "${{ env.HMC_DIR }}"
-          curl -L -o "${{ env.HMC_DIR }}/headlessmc-launcher-wrapper-${{ env.HMC_VERSION }}.jar" \
-            "https://github.com/headlesshq/headlessmc/releases/download/${{ env.HMC_VERSION }}/headlessmc-launcher-wrapper-${{ env.HMC_VERSION }}.jar"
+          curl -L -o "${{ env.HMC_DIR }}/headlessmc-launcher-${{ env.HMC_VERSION }}.jar" \
+            "https://github.com/headlesshq/headlessmc/releases/download/${{ env.HMC_VERSION }}/headlessmc-launcher-${{ env.HMC_VERSION }}.jar"
       - name: Download HMCSpecifics
         run: |
           curl -fL -o "${{ env.MODS_DIR }}/hmc-specifics.jar" \
@@ -217,13 +217,13 @@ jobs:
       - name: Pre-install Forge 51.0.24 for HeadlessMC client
         run: |
           cd "${{ env.HMC_DIR }}"
-          java -jar "headlessmc-launcher-wrapper-${{ env.HMC_VERSION }}.jar" \
+          java -jar "headlessmc-launcher-${{ env.HMC_VERSION }}.jar" \
             --command "forge 1.21 --uid 51.0.24" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-forge-install.log"
       - name: Run E2E scenario - skin-set-mojang
         run: |
           cd "${{ env.HMC_DIR }}"
-          xvfb-run -a java -jar "headlessmc-launcher-wrapper-${{ env.HMC_VERSION }}.jar" \
-            --command "launch forge:1.21 -lwjgl -offline -specifics --uid 51.0.24 --jvm -Djava.awt.headless=true" \
+          xvfb-run -a java -jar "headlessmc-launcher-${{ env.HMC_VERSION }}.jar" \
+            --command "launch forge:1.21 -lwjgl -offline --uid 51.0.24 --jvm -Djava.awt.headless=true" \
             --game-args "--server localhost --port 25565 --username TestPlayer" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-output-set.log"
       - name: Assert GameProfile property via server log
         if: always()
@@ -263,8 +263,8 @@ jobs:
       - name: Run E2E scenario - skin-clear
         run: |
           cd "${{ env.HMC_DIR }}"
-          xvfb-run -a java -jar "headlessmc-launcher-wrapper-${{ env.HMC_VERSION }}.jar" \
-            --command "launch forge:1.21 -lwjgl -offline -specifics --uid 51.0.24 --jvm -Djava.awt.headless=true" \
+          xvfb-run -a java -jar "headlessmc-launcher-${{ env.HMC_VERSION }}.jar" \
+            --command "launch forge:1.21 -lwjgl -offline --uid 51.0.24 --jvm -Djava.awt.headless=true" \
             --game-args "--server localhost --port 25565 --username TestPlayer" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-output-clear.log"
       - name: Verify skin file cleared (after clear)
         if: always()
@@ -298,8 +298,8 @@ jobs:
       - name: Run E2E scenario - skin-persistence
         run: |
           cd "${{ env.HMC_DIR }}"
-          xvfb-run -a java -jar "headlessmc-launcher-wrapper-${{ env.HMC_VERSION }}.jar" \
-            --command "launch forge:1.21 -lwjgl -offline -specifics --uid 51.0.24 --jvm -Djava.awt.headless=true" \
+          xvfb-run -a java -jar "headlessmc-launcher-${{ env.HMC_VERSION }}.jar" \
+            --command "launch forge:1.21 -lwjgl -offline --uid 51.0.24 --jvm -Djava.awt.headless=true" \
             --game-args "--server localhost --port 25565 --username TestPlayer" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-output-persistence.log"
       - name: Assert GameProfile property via server log (persistence)
         if: always()


### PR DESCRIPTION
## Problem

The 1.21 E2E tests fail because the HeadlessMC launcher-wrapper's `-specifics` flag triggers `autoDownloadSpecifics()` in ProcessFactory, which:
1. Fetches the latest GitHub release tag via `/repos/headlesshq/hmc-specifics/releases/latest` → returns `26.1.2-latest`
2. Constructs a download URL: `hmc-specifics-1.21-26.1.2-latest-lexforge-release.jar`
3. This file does **not exist** in the 26.1.2-latest release (naming scheme changed) → 404 → IOException → E2E crash

mc1.12.2 is green (different HMCSpecifics asset pattern, and download failure is non-fatal with `|| echo WARNING`).

## Fix

- Switch from `headlessmc-launcher-wrapper-2.10.0.jar` to `headlessmc-launcher-2.10.0.jar` (raw launcher)
- Remove `-specifics` from all 3 launch commands
- Keep the manual HMCSpecifics download from `1.21-latest` release — Forge loads it from `mods/`

The raw launcher supports all the same `--command`, `--game-args`, `--uid` flags since these are handled by the launcher module, not the wrapper. The wrapper's only additional feature is a transforming classloader for plugins, which we don't use.

## Changes

```diff
- headlessmc-launcher-wrapper-2.10.0.jar
+ headlessmc-launcher-2.10.0.jar
- -specifics (removed from all 3 launch commands)
```

## Verification

- [ ] E2E passes on 1.21 push