### PR TITLE
fix(e2e): add SUCCESS step to scenarios to prevent client hang

### DIFF
--- a/test-infrastructure/scenarios/skin-clear.json
+++ b/test-infrastructure/scenarios/skin-clear.json
@@ -14,6 +14,7 @@
     {"type": "SEND", "message": "/skin clear"},
     {"type": "CONTAINS", "message": "cleared"},
     {"type": "SEND", "message": "/skin source"},
-    {"type": "CONTAINS", "message": "TestPlayer"}
+    {"type": "CONTAINS", "message": "TestPlayer"},
+    {"type": "SUCCESS"}
   ]
 }

--- a/test-infrastructure/scenarios/skin-persistence.json
+++ b/test-infrastructure/scenarios/skin-persistence.json
@@ -16,6 +16,7 @@
     {"type": "CONTAINS", "message": "For help"},
     {"type": "SEND", "message": "/skin source"},
     {"type": "WAIT", "timeout": 3},
-    {"type": "CONTAINS", "message": "Notch"}
+    {"type": "CONTAINS", "message": "Notch"},
+    {"type": "SUCCESS"}
   ]
 }

--- a/test-infrastructure/scenarios/skin-set-mojang.json
+++ b/test-infrastructure/scenarios/skin-set-mojang.json
@@ -13,6 +13,7 @@
     {"type": "WAIT", "timeout": 5},
     {"type": "CONTAINS", "message": "applied."},
     {"type": "SEND", "message": "/skin source"},
-    {"type": "CONTAINS", "message": "Notch"}
+    {"type": "CONTAINS", "message": "Notch"},
+    {"type": "SUCCESS"}
   ]
 }

--- a/test-infrastructure/scenarios/two-client-skin-visibility.json
+++ b/test-infrastructure/scenarios/two-client-skin-visibility.json
@@ -10,6 +10,7 @@
     {"type": "ENDS_WITH", "message": "For help, type \"help\""},
     {"type": "WAIT", "timeout": 15},
     {"type": "SEND", "message": "/skin source TestPlayer"},
-    {"type": "CONTAINS", "message": "Notch"}
+    {"type": "CONTAINS", "message": "Notch"},
+    {"type": "SUCCESS"}
   ]
 }


### PR DESCRIPTION
## Problem

Without the `-specifics` flag (HMCSpecifics), the raw HeadlessMC launcher's test framework hangs indefinitely because:

1. The Minecraft client process never auto-exits after commands complete
2. The test framework's implicit `WAIT_FOR_END` step calls `process.waitFor()`, blocking until the process dies
3. The CI job eventually times out after 18-20 minutes

## Fix

Add an explicit `{"type": "SUCCESS"}` step as the last step in every scenario. This triggers the test framework's `END_SUCCESS` result, which signals successful completion and allows the framework to cleanly terminate the client process instead of waiting for it to exit on its own.

## Verification

- `python3 -m json.tool` validates all 4 scenario files ✅
- aislop scan passed cleanly ✅

## Changes

- `skin-set-mojang.json`: added SUCCESS step
- `skin-clear.json`: added SUCCESS step
- `skin-persistence.json`: added SUCCESS step
- `two-client-skin-visibility.json`: added SUCCESS step