### PR TITLE
fix(e2e): add SUCCESS step to scenarios (mc1.12.2)

### DIFF
--- a/test-infrastructure/scenarios/skin-clear.json
+++ b/test-infrastructure/scenarios/skin-clear.json
@@ -14,6 +14,7 @@
     {"type": "SEND", "message": "/skin clear"},
     {"type": "CONTAINS", "message": "cleared"},
     {"type": "SEND", "message": "/skin source"},
-    {"type": "CONTAINS", "message": "default"}
+    {"type": "CONTAINS", "message": "default"},
+    {"type": "SUCCESS"}
   ]
 }

--- a/test-infrastructure/scenarios/skin-persistence.json
+++ b/test-infrastructure/scenarios/skin-persistence.json
@@ -16,6 +16,7 @@
     {"type": "CONTAINS", "message": "For help"},
     {"type": "SEND", "message": "/skin source"},
     {"type": "WAIT", "timeout": 3},
-    {"type": "CONTAINS", "message": "Notch"}
+    {"type": "CONTAINS", "message": "Notch"},
+    {"type": "SUCCESS"}
   ]
 }

--- a/test-infrastructure/scenarios/skin-set-mojang.json
+++ b/test-infrastructure/scenarios/skin-set-mojang.json
@@ -30,6 +30,9 @@
     {
       "type": "CONTAINS",
       "message": "Notch"
+    },
+    {
+      "type": "SUCCESS"
     }
   ]
 }

--- a/test-infrastructure/scenarios/two-client-skin-visibility.json
+++ b/test-infrastructure/scenarios/two-client-skin-visibility.json
@@ -10,6 +10,7 @@
     {"type": "ENDS_WITH", "message": "For help, type \"help\""},
     {"type": "WAIT", "timeout": 10},
     {"type": "SEND", "message": "/skin source TestPlayer"},
-    {"type": "CONTAINS", "message": "mojang"}
+    {"type": "CONTAINS", "message": "mojang"},
+    {"type": "SUCCESS"}
   ]
 }


### PR DESCRIPTION
Backport of the scenario SUCCESS step fix from 1.21.

## Problem

Same as 1.21: without HMCSpecifics, the test framework's implicit `WAIT_FOR_END` hangs indefinitely because the Minecraft client doesn't auto-exit after scenario commands complete.

## Fix

Add explicit `{"type": "SUCCESS"}` step to all 4 scenarios so the framework signals completion and terminates cleanly.