### PR TITLE
ci: increase 1.21 E2E timeout from 20 to 40 min

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-121
     if: github.event_name == 'push' && github.ref_name == '1.21'
-    timeout-minutes: 20
+    timeout-minutes: 40
     services:
       wiremock:
         image: wiremock/wiremock:latest


### PR DESCRIPTION
The e2e-test-121 job runs 3 sequential HeadlessMC scenarios (skin-set-mojang, skin-clear, skin-persistence), each taking ~15 min under xvfb on the Forge 1.21 client. The 20-minute timeout was too tight for the full 3-scenario cycle.

Raised to 40 minutes to prevent spurious CI failures. If wall-clock time remains an issue, the scenarios can be split into parallel jobs in a follow-up.