### PR TITLE
fix(e2e): --quickPlayMultiplayer for 1.21 + 5-min fail-fast timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-121
     if: github.event_name == 'push' && github.ref_name == '1.21'
-    timeout-minutes: 8
+    timeout-minutes: 15
     services:
       wiremock:
         image: wiremock/wiremock:latest
@@ -254,7 +254,7 @@ jobs:
           cd "${{ env.HMC_DIR }}"
           xvfb-run -a java -jar "headlessmc-launcher-${{ env.HMC_VERSION }}.jar" \
             --command "launch forge:1.21 -lwjgl -offline --uid 51.0.24 --jvm -Djava.awt.headless=true" \
-            --game-args "--server localhost --port 25565 --username TestPlayer" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-output-set.log"
+            --game-args "--quickPlayMultiplayer 127.0.0.1:25565 --username TestPlayer" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-output-set.log"
       - name: Assert GameProfile property via server log
         if: always()
         run: |
@@ -295,7 +295,7 @@ jobs:
           cd "${{ env.HMC_DIR }}"
           xvfb-run -a java -jar "headlessmc-launcher-${{ env.HMC_VERSION }}.jar" \
             --command "launch forge:1.21 -lwjgl -offline --uid 51.0.24 --jvm -Djava.awt.headless=true" \
-            --game-args "--server localhost --port 25565 --username TestPlayer" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-output-clear.log"
+            --game-args "--quickPlayMultiplayer 127.0.0.1:25565 --username TestPlayer" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-output-clear.log"
       - name: Verify skin file cleared (after clear)
         if: always()
         run: |
@@ -330,7 +330,7 @@ jobs:
           cd "${{ env.HMC_DIR }}"
           xvfb-run -a java -jar "headlessmc-launcher-${{ env.HMC_VERSION }}.jar" \
             --command "launch forge:1.21 -lwjgl -offline --uid 51.0.24 --jvm -Djava.awt.headless=true" \
-            --game-args "--server localhost --port 25565 --username TestPlayer" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-output-persistence.log"
+            --game-args "--quickPlayMultiplayer 127.0.0.1:25565 --username TestPlayer" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-output-persistence.log"
       - name: Assert GameProfile property via server log (persistence)
         if: always()
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-121
     if: github.event_name == 'push' && github.ref_name == '1.21'
-    timeout-minutes: 40
+    timeout-minutes: 8
     services:
       wiremock:
         image: wiremock/wiremock:latest

--- a/test-infrastructure/run-e2e.sh
+++ b/test-infrastructure/run-e2e.sh
@@ -135,13 +135,29 @@ hmc.always.lwjgl.flag=true
 CONFIG
 
 # 6. Run test
-echo "[6/6] Running E2E test scenario: $SCENARIO..."
+if [ "$BRANCH" = "1.21" ]; then
+    SERVER_ARGS="--quickPlayMultiplayer \"127.0.0.1:25565\" --username TestPlayer"
+else
+    SERVER_ARGS="--server localhost --port 25565 --username TestPlayer"
+fi
+
+echo "  Server args: $SERVER_ARGS"
+echo "[6/6] Running E2E test scenario: $SCENARIO (5-min fail-fast timeout)..."
 cd "$PROJECT_DIR"
-java -jar "$HMC_DIR/headlessmc-launcher-wrapper.jar" \
+timeout 300 java -jar "$HMC_DIR/headlessmc-launcher-wrapper.jar" \
     --command launch forge:$MC_VERSION \
-    --game-args "--server localhost --port 25565 --username TestPlayer"
+    --game-args "$SERVER_ARGS"
 
 EXIT_CODE=$?
+
+if [ $EXIT_CODE -eq 124 ]; then
+    echo "=== E2E TEST TIMED OUT (no progress in 5 min) ==="
+    echo "Last 100 lines of server log:"
+    tail -100 "$SERVER_DIR/logs/latest.log" 2>/dev/null || true
+    kill "$SERVER_PID" 2>/dev/null || true
+    wait "$SERVER_PID" 2>/dev/null || true
+    exit 124
+fi
 
 kill "$SERVER_PID" 2>/dev/null || true
 wait "$SERVER_PID" 2>/dev/null || true

--- a/test-infrastructure/run-e2e.sh
+++ b/test-infrastructure/run-e2e.sh
@@ -136,7 +136,7 @@ CONFIG
 
 # 6. Run test
 if [ "$BRANCH" = "1.21" ]; then
-    SERVER_ARGS="--quickPlayMultiplayer \"127.0.0.1:25565\" --username TestPlayer"
+    SERVER_ARGS="--quickPlayMultiplayer 127.0.0.1:25565 --username TestPlayer"
 else
     SERVER_ARGS="--server localhost --port 25565 --username TestPlayer"
 fi
@@ -144,11 +144,10 @@ fi
 echo "  Server args: $SERVER_ARGS"
 echo "[6/6] Running E2E test scenario: $SCENARIO (5-min fail-fast timeout)..."
 cd "$PROJECT_DIR"
-timeout 300 java -jar "$HMC_DIR/headlessmc-launcher-wrapper.jar" \
+EXIT_CODE=0
+timeout --kill-after=10 300 java -jar "$HMC_DIR/headlessmc-launcher-wrapper.jar" \
     --command launch forge:$MC_VERSION \
-    --game-args "$SERVER_ARGS"
-
-EXIT_CODE=$?
+    --game-args "$SERVER_ARGS" || EXIT_CODE=$?
 
 if [ $EXIT_CODE -eq 124 ]; then
     echo "=== E2E TEST TIMED OUT (no progress in 5 min) ==="


### PR DESCRIPTION
1.21 removed --server/--port in 23w14a, use --quickPlayMultiplayer instead. Wrap HeadlessMC in timeout 300 for fail-fast.