### PR TITLE
fix(e2e): move --game-args inside --command string

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,9 +252,9 @@ jobs:
       - name: Run E2E scenario - skin-set-mojang
         run: |
           cd "${{ env.HMC_DIR }}"
+          CMD="launch forge:1.21 -lwjgl -offline --uid 51.0.24 --game-args \"--quickPlayMultiplayer 127.0.0.1:25565 --username TestPlayer\" --jvm -Djava.awt.headless=true"
           xvfb-run -a java -jar "headlessmc-launcher-${{ env.HMC_VERSION }}.jar" \
-            --command "launch forge:1.21 -lwjgl -offline --uid 51.0.24 --jvm -Djava.awt.headless=true" \
-            --game-args "--quickPlayMultiplayer 127.0.0.1:25565 --username TestPlayer" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-output-set.log"
+            --command "$CMD" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-output-set.log"
       - name: Assert GameProfile property via server log
         if: always()
         run: |
@@ -293,9 +293,9 @@ jobs:
       - name: Run E2E scenario - skin-clear
         run: |
           cd "${{ env.HMC_DIR }}"
+          CMD="launch forge:1.21 -lwjgl -offline --uid 51.0.24 --game-args \"--quickPlayMultiplayer 127.0.0.1:25565 --username TestPlayer\" --jvm -Djava.awt.headless=true"
           xvfb-run -a java -jar "headlessmc-launcher-${{ env.HMC_VERSION }}.jar" \
-            --command "launch forge:1.21 -lwjgl -offline --uid 51.0.24 --jvm -Djava.awt.headless=true" \
-            --game-args "--quickPlayMultiplayer 127.0.0.1:25565 --username TestPlayer" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-output-clear.log"
+            --command "$CMD" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-output-clear.log"
       - name: Verify skin file cleared (after clear)
         if: always()
         run: |
@@ -328,9 +328,9 @@ jobs:
       - name: Run E2E scenario - skin-persistence
         run: |
           cd "${{ env.HMC_DIR }}"
+          CMD="launch forge:1.21 -lwjgl -offline --uid 51.0.24 --game-args \"--quickPlayMultiplayer 127.0.0.1:25565 --username TestPlayer\" --jvm -Djava.awt.headless=true"
           xvfb-run -a java -jar "headlessmc-launcher-${{ env.HMC_VERSION }}.jar" \
-            --command "launch forge:1.21 -lwjgl -offline --uid 51.0.24 --jvm -Djava.awt.headless=true" \
-            --game-args "--quickPlayMultiplayer 127.0.0.1:25565 --username TestPlayer" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-output-persistence.log"
+            --command "$CMD" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-output-persistence.log"
       - name: Assert GameProfile property via server log (persistence)
         if: always()
         run: |
@@ -534,9 +534,9 @@ jobs:
       - name: Run E2E scenario - skin-set-mojang
         run: |
           cd "${{ env.HMC_DIR }}"
+          CMD="launch forge:1.12.2 -lwjgl -offline -specifics --game-args \"--server localhost --port 25565 --username TestPlayer\" --jvm -Djava.awt.headless=true"
           xvfb-run -a java -jar "headlessmc-launcher-wrapper-${{ env.HMC_VERSION }}.jar" \
-            --command "launch forge:1.12.2 -lwjgl -offline -specifics --jvm -Djava.awt.headless=true" \
-            --game-args "--server localhost --port 25565 --username TestPlayer" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-output-set.log"
+            --command "$CMD" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-output-set.log"
       - name: Verify skin file exists (after set)
         if: always()
         run: |
@@ -570,9 +570,9 @@ jobs:
       - name: Run E2E scenario - skin-clear
         run: |
           cd "${{ env.HMC_DIR }}"
+          CMD="launch forge:1.12.2 -lwjgl -offline -specifics --game-args \"--server localhost --port 25565 --username TestPlayer\" --jvm -Djava.awt.headless=true"
           xvfb-run -a java -jar "headlessmc-launcher-wrapper-${{ env.HMC_VERSION }}.jar" \
-            --command "launch forge:1.12.2 -lwjgl -offline -specifics --jvm -Djava.awt.headless=true" \
-            --game-args "--server localhost --port 25565 --username TestPlayer" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-output-clear.log"
+            --command "$CMD" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-output-clear.log"
       - name: Verify skin file cleared (after clear)
         if: always()
         run: |

--- a/test-infrastructure/run-e2e.sh
+++ b/test-infrastructure/run-e2e.sh
@@ -146,8 +146,7 @@ echo "[6/6] Running E2E test scenario: $SCENARIO (5-min fail-fast timeout)..."
 cd "$PROJECT_DIR"
 EXIT_CODE=0
 timeout --kill-after=10 300 java -jar "$HMC_DIR/headlessmc-launcher-wrapper.jar" \
-    --command launch forge:$MC_VERSION \
-    --game-args "$SERVER_ARGS" || EXIT_CODE=$?
+    --command "launch forge:$MC_VERSION --game-args \"$SERVER_ARGS\"" || EXIT_CODE=$?
 
 if [ $EXIT_CODE -eq 124 ]; then
     echo "=== E2E TEST TIMED OUT (no progress in 5 min) ==="


### PR DESCRIPTION
Per HeadlessMC 2.10.0 docs, --game-args must be inside the --command string, not outside. When outside, HeadlessMC's arg parser drops the required IP:PORT argument for --quickPlayMultiplayer (MC 1.20+) or the --server arg, causing the client to crash with OptionMissingRequiredArgumentException.

For 1.21: --quickPlayMultiplayer 127.0.0.1:25565
For mc1.12.2: --server localhost --port 25565 (kept, pre-1.20 args)

This is the root-cause fix identified by lib-3's audit of PR #111.