### PR TITLE
fix(e2e): remove duplicate --username from --game-args

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,7 +252,7 @@ jobs:
       - name: Run E2E scenario - skin-set-mojang
         run: |
           cd "${{ env.HMC_DIR }}"
-          CMD="launch forge:1.21 -lwjgl -offline --uid 51.0.24 --game-args \"--quickPlayMultiplayer 127.0.0.1:25565 --username TestPlayer\" --jvm -Djava.awt.headless=true"
+          CMD="launch forge:1.21 -lwjgl -offline --uid 51.0.24 --game-args \"--quickPlayMultiplayer 127.0.0.1:25565\" --jvm -Djava.awt.headless=true"
           xvfb-run -a java -jar "headlessmc-launcher-${{ env.HMC_VERSION }}.jar" \
             --command "$CMD" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-output-set.log"
       - name: Assert GameProfile property via server log
@@ -293,7 +293,7 @@ jobs:
       - name: Run E2E scenario - skin-clear
         run: |
           cd "${{ env.HMC_DIR }}"
-          CMD="launch forge:1.21 -lwjgl -offline --uid 51.0.24 --game-args \"--quickPlayMultiplayer 127.0.0.1:25565 --username TestPlayer\" --jvm -Djava.awt.headless=true"
+          CMD="launch forge:1.21 -lwjgl -offline --uid 51.0.24 --game-args \"--quickPlayMultiplayer 127.0.0.1:25565\" --jvm -Djava.awt.headless=true"
           xvfb-run -a java -jar "headlessmc-launcher-${{ env.HMC_VERSION }}.jar" \
             --command "$CMD" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-output-clear.log"
       - name: Verify skin file cleared (after clear)
@@ -328,7 +328,7 @@ jobs:
       - name: Run E2E scenario - skin-persistence
         run: |
           cd "${{ env.HMC_DIR }}"
-          CMD="launch forge:1.21 -lwjgl -offline --uid 51.0.24 --game-args \"--quickPlayMultiplayer 127.0.0.1:25565 --username TestPlayer\" --jvm -Djava.awt.headless=true"
+          CMD="launch forge:1.21 -lwjgl -offline --uid 51.0.24 --game-args \"--quickPlayMultiplayer 127.0.0.1:25565\" --jvm -Djava.awt.headless=true"
           xvfb-run -a java -jar "headlessmc-launcher-${{ env.HMC_VERSION }}.jar" \
             --command "$CMD" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-output-persistence.log"
       - name: Assert GameProfile property via server log (persistence)
@@ -534,7 +534,7 @@ jobs:
       - name: Run E2E scenario - skin-set-mojang
         run: |
           cd "${{ env.HMC_DIR }}"
-          CMD="launch forge:1.12.2 -lwjgl -offline -specifics --game-args \"--server localhost --port 25565 --username TestPlayer\" --jvm -Djava.awt.headless=true"
+          CMD="launch forge:1.12.2 -lwjgl -offline -specifics --game-args \"--server localhost --port 25565\" --jvm -Djava.awt.headless=true"
           xvfb-run -a java -jar "headlessmc-launcher-wrapper-${{ env.HMC_VERSION }}.jar" \
             --command "$CMD" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-output-set.log"
       - name: Verify skin file exists (after set)
@@ -570,7 +570,7 @@ jobs:
       - name: Run E2E scenario - skin-clear
         run: |
           cd "${{ env.HMC_DIR }}"
-          CMD="launch forge:1.12.2 -lwjgl -offline -specifics --game-args \"--server localhost --port 25565 --username TestPlayer\" --jvm -Djava.awt.headless=true"
+          CMD="launch forge:1.12.2 -lwjgl -offline -specifics --game-args \"--server localhost --port 25565\" --jvm -Djava.awt.headless=true"
           xvfb-run -a java -jar "headlessmc-launcher-wrapper-${{ env.HMC_VERSION }}.jar" \
             --command "$CMD" 2>&1 | tee "${{ env.HMC_DIR }}/hmc-output-clear.log"
       - name: Verify skin file cleared (after clear)

--- a/test-infrastructure/run-e2e.sh
+++ b/test-infrastructure/run-e2e.sh
@@ -136,9 +136,9 @@ CONFIG
 
 # 6. Run test
 if [ "$BRANCH" = "1.21" ]; then
-    SERVER_ARGS="--quickPlayMultiplayer 127.0.0.1:25565 --username TestPlayer"
+    SERVER_ARGS="--quickPlayMultiplayer 127.0.0.1:25565"
 else
-    SERVER_ARGS="--server localhost --port 25565 --username TestPlayer"
+    SERVER_ARGS="--server localhost --port 25565"
 fi
 
 echo "  Server args: $SERVER_ARGS"


### PR DESCRIPTION
HeadlessMC's `hmc.offline.username=TestPlayer` config is injected via `${auth_player_name}` in Minecraft's version JSON argument template. `JavaLaunchCommandBuilder` appends `--game-args` AFTER the adapter output, so passing `--username TestPlayer` in `--game-args` creates a duplicate that Forge's jopt-simple parser rejects with `MultipleArgumentsForOptionException` at Main.java:173.

**Fix:** Remove `--username TestPlayer` from `--game-args` in both branches. HeadlessMC already provides it via `hmc.offline.username`.

**Files changed:**
- `.github/workflows/ci.yml` — removed `--username TestPlayer` from all 5 E2E CMD strings (3x 1.21, 2x mc1.12.2)
- `test-infrastructure/run-e2e.sh` — removed `--username TestPlayer` from both branch SERVER_ARGS