### PR TITLE
fix(e2e): disable JLine in HeadlessMC config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,6 +238,7 @@ jobs:
             echo "hmc.test.leave.after=true"
             echo "hmc.assets.dummy=true"
             echo "hmc.always.lwjgl.flag=true"
+            echo "hmc.jline.enabled=false"
           } > "${{ env.HMC_DIR }}/config.properties"
       - name: Pre-install Forge 51.0.24 for HeadlessMC client
         run: |
@@ -284,6 +285,7 @@ jobs:
             echo "hmc.test.leave.after=true"
             echo "hmc.assets.dummy=true"
             echo "hmc.always.lwjgl.flag=true"
+            echo "hmc.jline.enabled=false"
           } > "${{ env.HMC_DIR }}/config.properties"
       - name: Run E2E scenario - skin-clear
         run: |
@@ -319,6 +321,7 @@ jobs:
             echo "hmc.test.leave.after=true"
             echo "hmc.assets.dummy=true"
             echo "hmc.always.lwjgl.flag=true"
+            echo "hmc.jline.enabled=false"
           } > "${{ env.HMC_DIR }}/config.properties"
       - name: Run E2E scenario - skin-persistence
         run: |
@@ -520,6 +523,7 @@ jobs:
             echo "hmc.test.leave.after=true"
             echo "hmc.assets.dummy=true"
             echo "hmc.always.lwjgl.flag=true"
+            echo "hmc.jline.enabled=false"
           } > "${{ env.HMC_DIR }}/config.properties"
       - name: Run E2E scenario - skin-set-mojang
         run: |
@@ -556,6 +560,7 @@ jobs:
             echo "hmc.test.leave.after=true"
             echo "hmc.assets.dummy=true"
             echo "hmc.always.lwjgl.flag=true"
+            echo "hmc.jline.enabled=false"
           } > "${{ env.HMC_DIR }}/config.properties"
       - name: Run E2E scenario - skin-clear
         run: |

--- a/test-infrastructure/run-e2e.sh
+++ b/test-infrastructure/run-e2e.sh
@@ -132,6 +132,7 @@ hmc.test.filename=$SCENARIO_FILE
 hmc.test.leave.after=true
 hmc.assets.dummy=true
 hmc.always.lwjgl.flag=true
+hmc.jline.enabled=false
 CONFIG
 
 # 6. Run test


### PR DESCRIPTION
HMCSpecifics 2.4.0's `VersionAgnosticJLineCommandLineReader.hackInTerminal()` tries to load `org.jline.terminal.spi.TerminalProvider`. Under Forge 1.21's `SecureModuleClassLoader`, this class is not exposed to mods, causing `java.lang.ClassNotFoundException` that crashes the client during `Minecraft.<init>`.

**Fix:** Add `hmc.jline.enabled=false` to HeadlessMC's `config.properties` to disable JLine terminal features. This is the same approach HMCSpecifics uses for its own Fabric dev runs (`systemProperties['hmc.jline.enabled']='false'`).

**Files changed:**
- `.github/workflows/ci.yml` — added `hmc.jline.enabled=false` to all 5 HeadlessMC config blocks (3x 1.21, 2x mc1.12.2)
- `test-infrastructure/run-e2e.sh` — added `hmc.jline.enabled=false` to config heredoc