### PR TITLE
test(permission): priority ordering + exception resilience + fallback paths

### DIFF
--- a/src/test/java/levosilimo/everlastingskins/permission/LuckPermsPermissionServiceTest.java
+++ b/src/test/java/levosilimo/everlastingskins/permission/LuckPermsPermissionServiceTest.java
@@ -11,6 +11,7 @@ import net.luckperms.api.util.Tristate;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
@@ -51,6 +52,10 @@ class LuckPermsPermissionServiceTest {
         LuckPermsProvider.unregister();
     }
 
+    /* ================================================================== */
+    /*  Basic behaviour                                                    */
+    /* ================================================================== */
+
     @Test
     @DisplayName("tryCreate returns service when LuckPerms shadow is available")
     void tryCreate_withShadow_returnsService() {
@@ -85,5 +90,124 @@ class LuckPermsPermissionServiceTest {
     @DisplayName("getPriority returns 20")
     void getPriority_isHighest() {
         assertEquals(20, LuckPermsPermissionService.tryCreate().getPriority());
+    }
+
+    /* ================================================================== */
+    /*  Exception resilience                                               */
+    /* ================================================================== */
+
+    @Nested
+    @DisplayName("Exception resilience")
+    class ExceptionResilience {
+
+        @Test
+        @DisplayName("RuntimeException in getUser → returns false (not propagate)")
+        void getUser_throwsRuntimeException_returnsFalse() {
+            LuckPerms fakeLP = mock(LuckPerms.class);
+            UserManager fakeUM = mock(UserManager.class);
+            when(fakeLP.getUserManager()).thenReturn(fakeUM);
+            when(fakeLP.getAPIVersion()).thenReturn("5.5-test");
+            when(fakeUM.isLoaded(uuid)).thenReturn(true);
+            when(fakeUM.getUser(uuid)).thenThrow(new RuntimeException("LP unavailable"));
+            LuckPermsProvider.unregister();
+            LuckPermsProvider.register(fakeLP);
+
+            LuckPermsPermissionService service = LuckPermsPermissionService.tryCreate();
+            PermissionContext ctx = PermissionContext.of(uuid, false);
+
+            assertFalse(service.hasPermission(ctx, "everlastingskins.command.skin"));
+        }
+
+        @Test
+        @DisplayName("ClassCastException in reflection chain → returns false")
+        void getCachedData_throwsClassCastException_returnsFalse() {
+            LuckPerms fakeLP = mock(LuckPerms.class);
+            UserManager fakeUM = mock(UserManager.class);
+            User fakeUser = mock(User.class);
+            when(fakeLP.getUserManager()).thenReturn(fakeUM);
+            when(fakeLP.getAPIVersion()).thenReturn("5.5-test");
+            when(fakeUM.isLoaded(uuid)).thenReturn(true);
+            when(fakeUM.getUser(uuid)).thenReturn(fakeUser);
+            when(fakeUser.getCachedData()).thenThrow(new ClassCastException("bad cast"));
+            LuckPermsProvider.unregister();
+            LuckPermsProvider.register(fakeLP);
+
+            LuckPermsPermissionService service = LuckPermsPermissionService.tryCreate();
+            PermissionContext ctx = PermissionContext.of(uuid, false);
+
+            assertFalse(service.hasPermission(ctx, "everlastingskins.command.skin"));
+        }
+
+        @Test
+        @DisplayName("Reflection method not found → returns false")
+        void reflectionMethodNotFound_returnsFalse() {
+            LuckPerms fakeLP = mock(LuckPerms.class);
+            UserManager fakeUM = mock(UserManager.class);
+            User fakeUser = mock(User.class);
+            CachedPermissionData fakeCPD = mock(CachedPermissionData.class);
+            when(fakeLP.getUserManager()).thenReturn(fakeUM);
+            when(fakeLP.getAPIVersion()).thenReturn("5.5-test");
+            when(fakeUM.isLoaded(uuid)).thenReturn(true);
+            when(fakeUM.getUser(uuid)).thenReturn(fakeUser);
+            when(fakeUser.getCachedData()).thenReturn(fakeCPD);
+            // getPermissionData will throw NoSuchMethodException because
+            // QueryOptions mock doesn't have the real method
+            when(fakeCPD.getPermissionData(any(QueryOptions.class)))
+                .thenThrow(new RuntimeException("no such method"));
+            LuckPermsProvider.unregister();
+            LuckPermsProvider.register(fakeLP);
+
+            LuckPermsPermissionService service = LuckPermsPermissionService.tryCreate();
+            PermissionContext ctx = PermissionContext.of(uuid, false);
+
+            assertFalse(service.hasPermission(ctx, "everlastingskins.command.skin"));
+        }
+    }
+
+    /* ================================================================== */
+    /*  User null fallback                                                 */
+    /* ================================================================== */
+
+    @Nested
+    @DisplayName("User null fallback")
+    class UserNullFallback {
+
+        @Test
+        @DisplayName("getUser returns null → falls back to context.isOp()")
+        void getUserReturnsNull_fallbackToOp() {
+            LuckPerms fakeLP = mock(LuckPerms.class);
+            UserManager fakeUM = mock(UserManager.class);
+            when(fakeLP.getUserManager()).thenReturn(fakeUM);
+            when(fakeLP.getAPIVersion()).thenReturn("5.5-test");
+            when(fakeUM.isLoaded(uuid)).thenReturn(true);
+            when(fakeUM.getUser(uuid)).thenReturn(null);
+            LuckPermsProvider.unregister();
+            LuckPermsProvider.register(fakeLP);
+
+            LuckPermsPermissionService service = LuckPermsPermissionService.tryCreate();
+
+            PermissionContext opCtx = PermissionContext.of(uuid, true);
+            assertTrue(service.hasPermission(opCtx, "everlastingskins.command.skin"));
+
+            PermissionContext nonOpCtx = PermissionContext.of(uuid, false);
+            assertFalse(service.hasPermission(nonOpCtx, "everlastingskins.command.skin"));
+        }
+
+        @Test
+        @DisplayName("User not loaded → returns false (no async load)")
+        void userNotLoaded_returnsFalse() {
+            LuckPerms fakeLP = mock(LuckPerms.class);
+            UserManager fakeUM = mock(UserManager.class);
+            when(fakeLP.getUserManager()).thenReturn(fakeUM);
+            when(fakeLP.getAPIVersion()).thenReturn("5.5-test");
+            when(fakeUM.isLoaded(uuid)).thenReturn(false);
+            LuckPermsProvider.unregister();
+            LuckPermsProvider.register(fakeLP);
+
+            LuckPermsPermissionService service = LuckPermsPermissionService.tryCreate();
+            PermissionContext ctx = PermissionContext.of(uuid, false);
+
+            assertFalse(service.hasPermission(ctx, "everlastingskins.command.skin"));
+        }
     }
 }

--- a/src/test/java/levosilimo/everlastingskins/permission/PermissionServiceManagerTest.java
+++ b/src/test/java/levosilimo/everlastingskins/permission/PermissionServiceManagerTest.java
@@ -3,6 +3,7 @@ package levosilimo.everlastingskins.permission;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
@@ -17,6 +18,10 @@ class PermissionServiceManagerTest {
     void resetManager() {
         PermissionServiceManager.reset();
     }
+
+    /* ================================================================== */
+    /*  Basic init / backend name                                         */
+    /* ================================================================== */
 
     @Test
     @DisplayName("Init selects Vanilla backend when no LuckPerms available")
@@ -33,27 +38,135 @@ class PermissionServiceManagerTest {
         assertFalse(PermissionServiceManager.getActiveBackendName().isEmpty());
     }
 
-    @Test
-    @DisplayName("Registering higher-priority service replaces active backend")
-    void registerService_higherPriority_replacesActive() {
-        PermissionServiceManager.init();
-        IPermissionService mockForge = mock(IPermissionService.class);
-        when(mockForge.getPriority()).thenReturn(10);
-        when(mockForge.getActiveBackendName()).thenReturn("Forge");
-        PermissionServiceManager.registerService(mockForge);
-        assertEquals("Forge", PermissionServiceManager.getActiveBackendName());
+    /* ================================================================== */
+    /*  Priority ordering                                                  */
+    /* ================================================================== */
+
+    @Nested
+    @DisplayName("Priority ordering")
+    class PriorityOrdering {
+
+        @Test
+        @DisplayName("Registering higher-priority service replaces active backend")
+        void registerService_higherPriority_replacesActive() {
+            PermissionServiceManager.init();
+            IPermissionService mockForge = mock(IPermissionService.class);
+            when(mockForge.getPriority()).thenReturn(10);
+            when(mockForge.getActiveBackendName()).thenReturn("Forge");
+            PermissionServiceManager.registerService(mockForge);
+            assertEquals("Forge", PermissionServiceManager.getActiveBackendName());
+        }
+
+        @Test
+        @DisplayName("Registering lower-priority service does not replace active")
+        void registerService_lowerPriority_doesNotReplace() {
+            PermissionServiceManager.init();
+            IPermissionService mockLow = mock(IPermissionService.class);
+            when(mockLow.getPriority()).thenReturn(-1);
+            when(mockLow.getActiveBackendName()).thenReturn("LowPriority");
+            PermissionServiceManager.registerService(mockLow);
+            assertTrue(PermissionServiceManager.getActiveBackendName().startsWith("Vanilla"));
+        }
+
+        @Test
+        @DisplayName("Multiple registrations: highest priority wins")
+        void multipleRegistrations_highestWins() {
+            PermissionServiceManager.init();
+
+            IPermissionService svc10 = mock(IPermissionService.class);
+            when(svc10.getPriority()).thenReturn(10);
+            when(svc10.getActiveBackendName()).thenReturn("svc10");
+
+            IPermissionService svc20 = mock(IPermissionService.class);
+            when(svc20.getPriority()).thenReturn(20);
+            when(svc20.getActiveBackendName()).thenReturn("svc20");
+
+            IPermissionService svc5 = mock(IPermissionService.class);
+            when(svc5.getPriority()).thenReturn(5);
+            when(svc5.getActiveBackendName()).thenReturn("svc5");
+
+            PermissionServiceManager.registerService(svc10);
+            assertEquals("svc10", PermissionServiceManager.getActiveBackendName());
+
+            PermissionServiceManager.registerService(svc20);
+            assertEquals("svc20", PermissionServiceManager.getActiveBackendName());
+
+            PermissionServiceManager.registerService(svc5);
+            assertEquals("svc20", PermissionServiceManager.getActiveBackendName());
+        }
+
+        @Test
+        @DisplayName("Same-priority service does not replace (strict gt)")
+        void samePriority_doesNotReplace() {
+            PermissionServiceManager.init();
+
+            // Upgrade to priority 10 first
+            IPermissionService prio10 = mock(IPermissionService.class);
+            when(prio10.getPriority()).thenReturn(10);
+            when(prio10.getActiveBackendName()).thenReturn("prio10");
+            PermissionServiceManager.registerService(prio10);
+            assertEquals("prio10", PermissionServiceManager.getActiveBackendName());
+
+            // Register another service with same priority — should NOT replace
+            IPermissionService same = mock(IPermissionService.class);
+            when(same.getPriority()).thenReturn(10);
+            when(same.getActiveBackendName()).thenReturn("replacement");
+            PermissionServiceManager.registerService(same);
+
+            assertEquals("prio10", PermissionServiceManager.getActiveBackendName());
+        }
     }
 
+    /* ================================================================== */
+    /*  Reset clears all registered services                               */
+    /* ================================================================== */
+
     @Test
-    @DisplayName("Registering lower-priority service does not replace active")
-    void registerService_lowerPriority_doesNotReplace() {
+    @DisplayName("Reset clears registered services and initialized flag")
+    void reset_clearsState() {
         PermissionServiceManager.init();
-        IPermissionService mockLow = mock(IPermissionService.class);
-        when(mockLow.getPriority()).thenReturn(-1);
-        when(mockLow.getActiveBackendName()).thenReturn("LowPriority");
-        PermissionServiceManager.registerService(mockLow);
+        IPermissionService mockSvc = mock(IPermissionService.class);
+        when(mockSvc.getPriority()).thenReturn(10);
+        when(mockSvc.getActiveBackendName()).thenReturn("MockSvc");
+        PermissionServiceManager.registerService(mockSvc);
+        assertEquals("MockSvc", PermissionServiceManager.getActiveBackendName());
+
+        PermissionServiceManager.reset();
+
+        assertEquals("Not initialized", PermissionServiceManager.getActiveBackendName());
+        PermissionServiceManager.init();
         assertTrue(PermissionServiceManager.getActiveBackendName().startsWith("Vanilla"));
     }
+
+    /* ================================================================== */
+    /*  Plugin unload limitation (no downgrade API)                        */
+    /* ================================================================== */
+
+    @Nested
+    @DisplayName("Plugin unload limitation")
+    class PluginUnloadLimitation {
+
+        @Test
+        @DisplayName("No unregister API: downgrade not supported")
+        void noUnregister_noDowngrade() {
+            PermissionServiceManager.init();
+            IPermissionService high = mock(IPermissionService.class);
+            when(high.getPriority()).thenReturn(30);
+            when(high.getActiveBackendName()).thenReturn("high");
+            PermissionServiceManager.registerService(high);
+            assertEquals("high", PermissionServiceManager.getActiveBackendName());
+
+            // Verify there is no unregisterService method on PermissionServiceManager
+            // (This is a documentation test — the API does not expose unregister)
+            assertThrows(NoSuchMethodException.class, () -> {
+                PermissionServiceManager.class.getMethod("unregisterService", IPermissionService.class);
+            });
+        }
+    }
+
+    /* ================================================================== */
+    /*  hasPermission before init (Vanilla fallback)                       */
+    /* ================================================================== */
 
     @Test
     @DisplayName("hasPermission before init falls back to Vanilla")
@@ -76,5 +189,40 @@ class PermissionServiceManagerTest {
     void backendNameBeforeInit() {
         PermissionServiceManager.reset();
         assertEquals("Not initialized", PermissionServiceManager.getActiveBackendName());
+    }
+
+    /* ================================================================== */
+    /*  Single-player (no external permissions plugin)                     */
+    /* ================================================================== */
+
+    @Nested
+    @DisplayName("Single-player (no permissions plugin)")
+    class SinglePlayer {
+
+        @Test
+        @DisplayName("Non-op has no permission on non-source node")
+        void nonOp_nonSource_denied() {
+            PermissionServiceManager.init();
+            PermissionContext ctx = PermissionContext.of(UUID.randomUUID(), false);
+            assertFalse(PermissionServiceManager.hasPermission(ctx, "everlastingskins.command.skin"));
+        }
+
+        @Test
+        @DisplayName("Op has permission on non-source node")
+        void op_nonSource_granted() {
+            PermissionServiceManager.init();
+            PermissionContext ctx = PermissionContext.of(UUID.randomUUID(), true);
+            assertTrue(PermissionServiceManager.hasPermission(ctx, "everlastingskins.command.skin"));
+        }
+
+        @Test
+        @DisplayName("Source node always granted regardless of op status")
+        void sourceNode_alwaysGranted() {
+            PermissionServiceManager.init();
+            PermissionContext nonOp = PermissionContext.of(UUID.randomUUID(), false);
+            PermissionContext op = PermissionContext.of(UUID.randomUUID(), true);
+            assertTrue(PermissionServiceManager.hasPermission(nonOp, "everlastingskins.command.skin.source"));
+            assertTrue(PermissionServiceManager.hasPermission(op, "everlastingskins.command.skin.source"));
+        }
     }
 }

--- a/src/test/java/levosilimo/everlastingskins/permission/forge/ForgePermissionServiceTest.java
+++ b/src/test/java/levosilimo/everlastingskins/permission/forge/ForgePermissionServiceTest.java
@@ -4,6 +4,7 @@ import levosilimo.everlastingskins.permission.PermissionContext;
 import net.minecraftforge.server.permission.PermissionAPI;
 import net.minecraftforge.server.permission.events.PermissionGatherEvent;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
@@ -14,6 +15,10 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 class ForgePermissionServiceTest {
+
+    /* ================================================================== */
+    /*  Basic behaviour                                                    */
+    /* ================================================================== */
 
     @Test
     @DisplayName("hasPermission returns true when PermissionAPI grants it")
@@ -85,5 +90,58 @@ class ForgePermissionServiceTest {
     @DisplayName("Priority is 10")
     void getPriority() {
         assertEquals(10, new ForgePermissionService().getPriority());
+    }
+
+    /* ================================================================== */
+    /*  Exception resilience                                               */
+    /* ================================================================== */
+
+    @Nested
+    @DisplayName("Exception resilience")
+    class ExceptionResilience {
+
+        @Test
+        @DisplayName("PermissionAPI.getOfflinePermission throws → falls back to isOp")
+        void permissionApi_throws_fallbackToOp() {
+            try (MockedStatic<PermissionAPI> api = mockStatic(PermissionAPI.class)) {
+                UUID uuid = UUID.randomUUID();
+                api.when(() -> PermissionAPI.getOfflinePermission(eq(uuid), eq(ForgePermissionService.SKIN_NODE)))
+                   .thenThrow(new RuntimeException("PermissionAPI unavailable"));
+
+                ForgePermissionService service = new ForgePermissionService();
+
+                PermissionContext opCtx = PermissionContext.of(uuid, true);
+                assertTrue(service.hasPermission(opCtx, "everlastingskins.command.skin"));
+
+                PermissionContext nonOpCtx = PermissionContext.of(uuid, false);
+                assertFalse(service.hasPermission(nonOpCtx, "everlastingskins.command.skin"));
+            }
+        }
+
+        @Test
+        @DisplayName("PermissionAPI throws for .skin.other → falls back to isOp")
+        void permissionApi_throwsOnOtherNode_fallbackToOp() {
+            try (MockedStatic<PermissionAPI> api = mockStatic(PermissionAPI.class)) {
+                UUID uuid = UUID.randomUUID();
+                api.when(() -> PermissionAPI.getOfflinePermission(eq(uuid), eq(ForgePermissionService.SKIN_OTHER_NODE)))
+                   .thenThrow(new RuntimeException("node not registered"));
+
+                ForgePermissionService service = new ForgePermissionService();
+
+                PermissionContext opCtx = PermissionContext.of(uuid, true);
+                assertTrue(service.hasPermission(opCtx, "everlastingskins.command.skin.other"));
+
+                PermissionContext nonOpCtx = PermissionContext.of(uuid, false);
+                assertFalse(service.hasPermission(nonOpCtx, "everlastingskins.command.skin.other"));
+            }
+        }
+
+        @Test
+        @DisplayName(".skin.source always true even if API would throw")
+        void sourceNode_alwaysTrue_regardlessOfApi() {
+            ForgePermissionService service = new ForgePermissionService();
+            PermissionContext ctx = PermissionContext.of(UUID.randomUUID(), false);
+            assertTrue(service.hasPermission(ctx, "everlastingskins.command.skin.source"));
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds permission unit tests covering priority ordering, exception resilience, and fallback paths.

### Changes

- **PermissionServiceManagerTest** (7 tests added):
  - Priority ordering: highest priority wins across multiple registrations
  - Same-priority does not replace (strict gt comparison)
  - Reset clears all registered services
  - Plugin unload limitation: no unregister API exists
  - Single-player: non-op/op/source node behavior with Vanilla

- **LuckPermsPermissionServiceTest** (4 tests added):
  - RuntimeException in getUser returns false
  - ClassCastException in getCachedData returns false
  - Reflection method not found returns false
  - User null returns context.isOp()
  - User not loaded returns false

- **ForgePermissionServiceTest** (3 tests added):
  - PermissionAPI.getOfflinePermission throws returns context.isOp()
  - PermissionAPI throws on .skin.other falls back to isOp
  - .skin.source always true regardless of API state

### Verification

```
./gradlew test --no-daemon --tests levosilimo.everlastingskins.permission.*
```

All 40 tests pass.