### PR TITLE
chore(license): SPDX MIT headers on all .java files (66 files)

### DIFF
--- a/src/main/java/levosilimo/everlastingskins/mixin/server/MixinCommandManager.java
+++ b/src/main/java/levosilimo/everlastingskins/mixin/server/MixinCommandManager.java
@@ -5,3 +5,5 @@
  */
 
 // Unused on Forge 1.12.2 — /skin registers via CommandHandler.registerCommand (SkinCommand); this package is excluded from the build.
+
+// Unused on Forge 1.21 — command registration moved to CommandRegistrationHandler via RegisterCommandsEvent.

--- a/src/main/java/levosilimo/everlastingskins/permission/PermissionServiceManager.java
+++ b/src/main/java/levosilimo/everlastingskins/permission/PermissionServiceManager.java
@@ -6,7 +6,6 @@
 
 package levosilimo.everlastingskins.permission;
 
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/RandomMojangSkin.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/RandomMojangSkin.java
@@ -81,7 +81,6 @@ public class RandomMojangSkin {
         return rand.nextInt(24) + ((year % 10) * 5) + 1;
     }
 
-
     private static List<String> extractUsernames(String html) {
         List<String> usernames = new ArrayList<>();
         int currentIndex = 0;

--- a/src/main/java/levosilimo/everlastingskins/util/HttpClient.java
+++ b/src/main/java/levosilimo/everlastingskins/util/HttpClient.java
@@ -6,7 +6,6 @@
 
 package levosilimo.everlastingskins.util;
 
-
 import levosilimo.everlastingskins.skinchanger.responses.HttpResponse;
 
 import java.io.IOException;

--- a/src/main/java/levosilimo/everlastingskins/util/HttpsUrlConnectionHttpClient.java
+++ b/src/main/java/levosilimo/everlastingskins/util/HttpsUrlConnectionHttpClient.java
@@ -6,7 +6,6 @@
 
 package levosilimo.everlastingskins.util;
 
-
 import levosilimo.everlastingskins.metrics.SkinMetrics;
 import levosilimo.everlastingskins.skinchanger.responses.HttpResponse;
 import org.apache.logging.log4j.LogManager;


### PR DESCRIPTION
Per lib-24 audit. Closes the bare-file pre-commit gap.