### PR TITLE
chore(license): SPDX MIT headers on all .java files (83 files)

### DIFF
--- a/src/gametest/java/levosilimo/everlastingskins/gametest/EverlastingSkinsGameTest.java
+++ b/src/gametest/java/levosilimo/everlastingskins/gametest/EverlastingSkinsGameTest.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.gametest;
 
 import net.minecraftforge.fml.common.Mod;

--- a/src/gametest/java/levosilimo/everlastingskins/gametest/SkinVisibilityTest.java
+++ b/src/gametest/java/levosilimo/everlastingskins/gametest/SkinVisibilityTest.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.gametest;
 
 import com.google.gson.JsonObject;

--- a/src/main/java/levosilimo/everlastingskins/CommandRegistrationHandler.java
+++ b/src/main/java/levosilimo/everlastingskins/CommandRegistrationHandler.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins;
 
 import com.mojang.brigadier.CommandDispatcher;

--- a/src/main/java/levosilimo/everlastingskins/Config.java
+++ b/src/main/java/levosilimo/everlastingskins/Config.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins;
 
 import net.minecraftforge.common.ForgeConfigSpec;

--- a/src/main/java/levosilimo/everlastingskins/EverlastingSkins.java
+++ b/src/main/java/levosilimo/everlastingskins/EverlastingSkins.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins;
 
 import com.google.common.collect.Lists;

--- a/src/main/java/levosilimo/everlastingskins/enums/LanguageEnum.java
+++ b/src/main/java/levosilimo/everlastingskins/enums/LanguageEnum.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.enums;
 
 public enum LanguageEnum {

--- a/src/main/java/levosilimo/everlastingskins/enums/SkinActionType.java
+++ b/src/main/java/levosilimo/everlastingskins/enums/SkinActionType.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.enums;
 
 public enum SkinActionType {

--- a/src/main/java/levosilimo/everlastingskins/enums/SkinVariant.java
+++ b/src/main/java/levosilimo/everlastingskins/enums/SkinVariant.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.enums;
 
 public enum SkinVariant {

--- a/src/main/java/levosilimo/everlastingskins/integration/discordsrv/DiscordSrvConfig.java
+++ b/src/main/java/levosilimo/everlastingskins/integration/discordsrv/DiscordSrvConfig.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.integration.discordsrv;
 
 import levosilimo.everlastingskins.Config;

--- a/src/main/java/levosilimo/everlastingskins/integration/discordsrv/DiscordSrvHook.java
+++ b/src/main/java/levosilimo/everlastingskins/integration/discordsrv/DiscordSrvHook.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.integration.discordsrv;
 
 import net.minecraft.server.level.ServerPlayer;

--- a/src/main/java/levosilimo/everlastingskins/integration/placeholderapi/EverlastingSkinsExpansion.java
+++ b/src/main/java/levosilimo/everlastingskins/integration/placeholderapi/EverlastingSkinsExpansion.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.integration.placeholderapi;
 
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;

--- a/src/main/java/levosilimo/everlastingskins/integration/placeholderapi/PlaceholderApiHook.java
+++ b/src/main/java/levosilimo/everlastingskins/integration/placeholderapi/PlaceholderApiHook.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.integration.placeholderapi;
 
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/levosilimo/everlastingskins/metrics/LatencyHistogram.java
+++ b/src/main/java/levosilimo/everlastingskins/metrics/LatencyHistogram.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.metrics;
 
 import java.util.LinkedHashMap;

--- a/src/main/java/levosilimo/everlastingskins/metrics/MetricsDumper.java
+++ b/src/main/java/levosilimo/everlastingskins/metrics/MetricsDumper.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.metrics;
 
 import levosilimo.everlastingskins.Config;

--- a/src/main/java/levosilimo/everlastingskins/metrics/MetricsFormat.java
+++ b/src/main/java/levosilimo/everlastingskins/metrics/MetricsFormat.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.metrics;
 
 import java.util.Map;

--- a/src/main/java/levosilimo/everlastingskins/metrics/NetworkMetricsHandler.java
+++ b/src/main/java/levosilimo/everlastingskins/metrics/NetworkMetricsHandler.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.metrics;
 
 import io.netty.buffer.ByteBuf;

--- a/src/main/java/levosilimo/everlastingskins/metrics/SkinMetrics.java
+++ b/src/main/java/levosilimo/everlastingskins/metrics/SkinMetrics.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.metrics;
 
 import java.util.Comparator;

--- a/src/main/java/levosilimo/everlastingskins/mixin/server/MixinCommandManager.java
+++ b/src/main/java/levosilimo/everlastingskins/mixin/server/MixinCommandManager.java
@@ -1,1 +1,8 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 // Unused on Forge 1.21 — command registration moved to CommandRegistrationHandler via RegisterCommandsEvent.

--- a/src/main/java/levosilimo/everlastingskins/permission/IPermissionService.java
+++ b/src/main/java/levosilimo/everlastingskins/permission/IPermissionService.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.permission;
 
 public interface IPermissionService {

--- a/src/main/java/levosilimo/everlastingskins/permission/LuckPermsPermissionService.java
+++ b/src/main/java/levosilimo/everlastingskins/permission/LuckPermsPermissionService.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.permission;
 
 

--- a/src/main/java/levosilimo/everlastingskins/permission/PermissionContext.java
+++ b/src/main/java/levosilimo/everlastingskins/permission/PermissionContext.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.permission;
 
 import java.util.UUID;

--- a/src/main/java/levosilimo/everlastingskins/permission/PermissionServiceManager.java
+++ b/src/main/java/levosilimo/everlastingskins/permission/PermissionServiceManager.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.permission;
 
 

--- a/src/main/java/levosilimo/everlastingskins/permission/VanillaPermissionService.java
+++ b/src/main/java/levosilimo/everlastingskins/permission/VanillaPermissionService.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.permission;
 
 public class VanillaPermissionService implements IPermissionService {

--- a/src/main/java/levosilimo/everlastingskins/permission/forge/ForgePermissionService.java
+++ b/src/main/java/levosilimo/everlastingskins/permission/forge/ForgePermissionService.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.permission.forge;
 
 import levosilimo.everlastingskins.permission.IPermissionService;

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/HttpResult.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/HttpResult.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.skinchanger;
 
 import levosilimo.everlastingskins.skinchanger.responses.HttpResponse;

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/MineSkinAPI.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/MineSkinAPI.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.skinchanger;
 
 import levosilimo.everlastingskins.enums.SkinVariant;

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/MojangAPI.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/MojangAPI.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.skinchanger;
 
 import levosilimo.everlastingskins.skinchanger.responses.mojang.MojangSkinDataResult;

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/MojangEndpoints.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/MojangEndpoints.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.skinchanger;
 
 import levosilimo.everlastingskins.util.EndpointsConfig;

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/MojangProfileCache.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/MojangProfileCache.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.skinchanger;
 
 import levosilimo.everlastingskins.metrics.SkinMetrics;

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/ProfileLookup.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/ProfileLookup.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.skinchanger;
 
 import java.util.UUID;

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/RandomMojangSkin.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/RandomMojangSkin.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.skinchanger;
 
 import com.google.gson.JsonObject;

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinCommand.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinCommand.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.skinchanger;
 
 import com.mojang.brigadier.CommandDispatcher;

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinIO.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinIO.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.skinchanger;
 
 import com.google.gson.JsonElement;

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRefreshHandler.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRefreshHandler.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.skinchanger;
 
 import io.netty.buffer.Unpooled;

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRestorer.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRestorer.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.skinchanger;
 
 import levosilimo.everlastingskins.metrics.SkinMetrics;

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinStorage.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinStorage.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.skinchanger;
 
 import levosilimo.everlastingskins.util.CustomSkinProperty;

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/command/SkinActionCommand.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/command/SkinActionCommand.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.skinchanger.command;
 
 import com.mojang.brigadier.context.CommandContext;

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/command/SkinMetricsCommand.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/command/SkinMetricsCommand.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.skinchanger.command;
 
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/requests/mineskin/MineSkinUrlRequest.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/requests/mineskin/MineSkinUrlRequest.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.skinchanger.requests.mineskin;
 
 import levosilimo.everlastingskins.enums.SkinVariant;

--- a/src/main/java/levosilimo/everlastingskins/util/CustomSkinProperty.java
+++ b/src/main/java/levosilimo/everlastingskins/util/CustomSkinProperty.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.util;
 
 import com.mojang.authlib.properties.Property;

--- a/src/main/java/levosilimo/everlastingskins/util/EndpointsConfig.java
+++ b/src/main/java/levosilimo/everlastingskins/util/EndpointsConfig.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.util;
 
 import levosilimo.everlastingskins.EverlastingSkins;

--- a/src/main/java/levosilimo/everlastingskins/util/HttpClient.java
+++ b/src/main/java/levosilimo/everlastingskins/util/HttpClient.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.util;
 
 

--- a/src/main/java/levosilimo/everlastingskins/util/HttpsUrlConnectionHttpClient.java
+++ b/src/main/java/levosilimo/everlastingskins/util/HttpsUrlConnectionHttpClient.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.util;
 
 

--- a/src/main/java/levosilimo/everlastingskins/util/I18nUtils.java
+++ b/src/main/java/levosilimo/everlastingskins/util/I18nUtils.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.util;
 
 import levosilimo.everlastingskins.EverlastingSkins;

--- a/src/main/java/levosilimo/everlastingskins/util/JavaHttpClient.java
+++ b/src/main/java/levosilimo/everlastingskins/util/JavaHttpClient.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.util;
 
 import levosilimo.everlastingskins.metrics.SkinMetrics;

--- a/src/main/java/levosilimo/everlastingskins/util/JsonUtils.java
+++ b/src/main/java/levosilimo/everlastingskins/util/JsonUtils.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.util;
 
 import com.google.gson.Gson;

--- a/src/main/java/levosilimo/everlastingskins/util/PropertyUtils.java
+++ b/src/main/java/levosilimo/everlastingskins/util/PropertyUtils.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.util;
 
 import com.google.gson.Gson;

--- a/src/main/java/levosilimo/everlastingskins/util/SkinUtils.java
+++ b/src/main/java/levosilimo/everlastingskins/util/SkinUtils.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.util;
 
 import java.io.IOException;

--- a/src/main/java/levosilimo/everlastingskins/util/UUIDUtils.java
+++ b/src/main/java/levosilimo/everlastingskins/util/UUIDUtils.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.util;
 
 import java.util.Optional;

--- a/src/test/java/levosilimo/everlastingskins/ConfigTest.java
+++ b/src/test/java/levosilimo/everlastingskins/ConfigTest.java
@@ -1,3 +1,9 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
 package levosilimo.everlastingskins;
 
 import levosilimo.everlastingskins.enums.SkinVariant;

--- a/src/test/java/levosilimo/everlastingskins/FakeHttpClient.java
+++ b/src/test/java/levosilimo/everlastingskins/FakeHttpClient.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins;
 
 import levosilimo.everlastingskins.skinchanger.responses.HttpResponse;

--- a/src/test/java/levosilimo/everlastingskins/integration/discordsrv/DiscordSrvHookTest.java
+++ b/src/test/java/levosilimo/everlastingskins/integration/discordsrv/DiscordSrvHookTest.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.integration.discordsrv;
 
 import github.scarsz.discordsrv.DiscordSRV;

--- a/src/test/java/levosilimo/everlastingskins/integration/placeholderapi/EverlastingSkinsExpansionTest.java
+++ b/src/test/java/levosilimo/everlastingskins/integration/placeholderapi/EverlastingSkinsExpansionTest.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.integration.placeholderapi;
 
 import levosilimo.everlastingskins.skinchanger.SkinRestorer;

--- a/src/test/java/levosilimo/everlastingskins/integration/placeholderapi/PlaceholderApiHookTest.java
+++ b/src/test/java/levosilimo/everlastingskins/integration/placeholderapi/PlaceholderApiHookTest.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.integration.placeholderapi;
 
 import me.clip.placeholderapi.PlaceholderAPI;

--- a/src/test/java/levosilimo/everlastingskins/metrics/SkinMetricsTest.java
+++ b/src/test/java/levosilimo/everlastingskins/metrics/SkinMetricsTest.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.metrics;
 
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/levosilimo/everlastingskins/permission/LuckPermsPermissionServiceTest.java
+++ b/src/test/java/levosilimo/everlastingskins/permission/LuckPermsPermissionServiceTest.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.permission;
 
 import net.luckperms.api.LuckPerms;

--- a/src/test/java/levosilimo/everlastingskins/permission/PermissionServiceManagerTest.java
+++ b/src/test/java/levosilimo/everlastingskins/permission/PermissionServiceManagerTest.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.permission;
 
 import org.junit.jupiter.api.AfterEach;

--- a/src/test/java/levosilimo/everlastingskins/permission/VanillaPermissionServiceTest.java
+++ b/src/test/java/levosilimo/everlastingskins/permission/VanillaPermissionServiceTest.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.permission;
 
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/levosilimo/everlastingskins/permission/forge/ForgePermissionServiceTest.java
+++ b/src/test/java/levosilimo/everlastingskins/permission/forge/ForgePermissionServiceTest.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.permission.forge;
 
 import levosilimo.everlastingskins.permission.PermissionContext;

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/HttpResultTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/HttpResultTest.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.skinchanger;
 
 import levosilimo.everlastingskins.skinchanger.responses.HttpResponse;

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/MineSkinApiHttpImplTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/MineSkinApiHttpImplTest.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.skinchanger;
 
 import levosilimo.everlastingskins.FakeHttpClient;

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/MojangApiHttpImplTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/MojangApiHttpImplTest.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.skinchanger;
 
 import levosilimo.everlastingskins.FakeHttpClient;

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/MojangProfileCacheTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/MojangProfileCacheTest.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.skinchanger;
 
 import levosilimo.everlastingskins.metrics.SkinMetrics;

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/RandomMojangSkinTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/RandomMojangSkinTest.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.skinchanger;
 
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/SkinCommandPermissionTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/SkinCommandPermissionTest.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.skinchanger;
 
 import com.mojang.brigadier.CommandDispatcher;

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/SkinCommandTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/SkinCommandTest.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.skinchanger;
 
 import levosilimo.everlastingskins.skinchanger.responses.mojang.MojangSkinDataResult;

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/SkinIOTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/SkinIOTest.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.skinchanger;
 
 import levosilimo.everlastingskins.util.CustomSkinProperty;

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/SkinRestorerTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/SkinRestorerTest.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.skinchanger;
 
 import levosilimo.everlastingskins.util.CustomSkinProperty;

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/SkinStorageTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/SkinStorageTest.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.skinchanger;
 
 import levosilimo.everlastingskins.util.CustomSkinProperty;

--- a/src/test/java/levosilimo/everlastingskins/util/CustomSkinPropertyTest.java
+++ b/src/test/java/levosilimo/everlastingskins/util/CustomSkinPropertyTest.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.util;
 
 import org.junit.jupiter.api.AfterEach;

--- a/src/test/java/levosilimo/everlastingskins/util/EverlastingHelpersTest.java
+++ b/src/test/java/levosilimo/everlastingskins/util/EverlastingHelpersTest.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.util;
 
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/levosilimo/everlastingskins/util/I18nUtilsTest.java
+++ b/src/test/java/levosilimo/everlastingskins/util/I18nUtilsTest.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.util;
 
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/levosilimo/everlastingskins/util/PropertyUtilsTest.java
+++ b/src/test/java/levosilimo/everlastingskins/util/PropertyUtilsTest.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.util;
 
 import levosilimo.everlastingskins.enums.SkinVariant;

--- a/src/test/java/levosilimo/everlastingskins/util/SkinUtilsTest.java
+++ b/src/test/java/levosilimo/everlastingskins/util/SkinUtilsTest.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.util;
 
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/levosilimo/everlastingskins/util/UUIDUtilsTest.java
+++ b/src/test/java/levosilimo/everlastingskins/util/UUIDUtilsTest.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package levosilimo.everlastingskins.util;
 
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/net/luckperms/api/LuckPerms.java
+++ b/src/test/java/net/luckperms/api/LuckPerms.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package net.luckperms.api;
 
 public interface LuckPerms {

--- a/src/test/java/net/luckperms/api/LuckPermsProvider.java
+++ b/src/test/java/net/luckperms/api/LuckPermsProvider.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package net.luckperms.api;
 
 public final class LuckPermsProvider {

--- a/src/test/java/net/luckperms/api/PermissionData.java
+++ b/src/test/java/net/luckperms/api/PermissionData.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package net.luckperms.api;
 
 import net.luckperms.api.util.Tristate;

--- a/src/test/java/net/luckperms/api/User.java
+++ b/src/test/java/net/luckperms/api/User.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package net.luckperms.api;
 
 import net.luckperms.api.cacheddata.CachedPermissionData;

--- a/src/test/java/net/luckperms/api/UserManager.java
+++ b/src/test/java/net/luckperms/api/UserManager.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package net.luckperms.api;
 
 import java.util.UUID;

--- a/src/test/java/net/luckperms/api/cacheddata/CachedPermissionData.java
+++ b/src/test/java/net/luckperms/api/cacheddata/CachedPermissionData.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package net.luckperms.api.cacheddata;
 
 import net.luckperms.api.PermissionData;

--- a/src/test/java/net/luckperms/api/query/DefaultQueryOptions.java
+++ b/src/test/java/net/luckperms/api/query/DefaultQueryOptions.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package net.luckperms.api.query;
 
 class DefaultQueryOptions implements QueryOptions {}

--- a/src/test/java/net/luckperms/api/query/QueryOptions.java
+++ b/src/test/java/net/luckperms/api/query/QueryOptions.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package net.luckperms.api.query;
 
 public interface QueryOptions {

--- a/src/test/java/net/luckperms/api/util/Tristate.java
+++ b/src/test/java/net/luckperms/api/util/Tristate.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
 package net.luckperms.api.util;
 
 public enum Tristate {


### PR DESCRIPTION
Per lib-24 audit. Closes the bare-file pre-commit gap.