### PR TITLE
fix(ci): E2E join assertion matches actual offline client name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,7 +250,7 @@ jobs:
           CLIENT_PID=$!
           JOINED=0
           for i in $(seq 1 90); do
-            if grep -q "TestPlayer joined the game" "${{ env.SERVER_DIR }}/logs/latest.log" 2>/dev/null; then
+            if grep -q " joined the game" "${{ env.SERVER_DIR }}/logs/latest.log" 2>/dev/null; then
               JOINED=1
               break
             fi


### PR DESCRIPTION
The restructured E2E step (from #122) greps for 'TestPlayer joined the game', but the HeadlessMC offline client connects as 'Offline'. The client does connect (observed 06:23:41, within window); only the assertion pattern never matches, so every push run on mc1.12.2 fails E2E. Loosen the pattern to ' joined the game'.