### PR TITLE
docs(1.21): correct TESTING.md test counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 - MojangProfileCache (TTL 1h, cap 1000)
 - /skin metrics command tree (human/json/players/cleanup/reset)
 - saveSkinAsync drain-coalesce writer (50ms debounce, race-safe latch)
-- 27 integration tests (GameTest) + wire-level packet assertions
+- 30 integration tests (GameTest) + wire-level packet assertions
 
 ### Changed
 - SkinRefreshHandler refactored (split into SkinRefreshHandler + SkinActionCommand + SkinMetricsCommand)

--- a/TESTING.md
+++ b/TESTING.md
@@ -3,8 +3,8 @@
 EverlastingSkins uses a three-tier testing pyramid:
 
 ## Tier 1: Pure Java unit tests (JUnit 5)
-- 257 tests on 1.21 branch
-- 205 tests on mc1.12.2 branch
+- 284 tests on 1.21 branch
+- 252 tests on mc1.12.2 branch
 - Coverage: provider fallback, HTTP outcomes, persistence atomicity, corruption handling, cache behavior, permission system, command dispatch, integration hooks
 - Run: `./gradlew test`
 
@@ -18,10 +18,10 @@ EverlastingSkins uses a three-tier testing pyramid:
 
 ### 1.21: GameTest (automated)
 
-The 1.21 branch uses Minecraft's GameTest framework for automated integration testing. The `gametest-121` CI job runs 27 tests covering the /skin command pipeline via mock players + EmbeddedChannel packet assertions.
+The 1.21 branch uses Minecraft's GameTest framework for automated integration testing. The `gametest-121` CI job runs 30 tests covering the /skin command pipeline via mock players + EmbeddedChannel packet assertions.
 
 Components:
-- `src/test/java/` — GameTest methods (skin-set, skin-clear, persistence, refresh)
+- `src/gametest/java/` — GameTest methods (skin-set, skin-clear, persistence, refresh)
 - `.github/workflows/ci.yml` — `gametest-121` job
 
 Run locally:


### PR DESCRIPTION
lib-28 audit found 1.21 TESTING.md claimed 257 unit / 27 GameTest, actual 284 / 30. Update counts.