### PR TITLE
fix(1122): Forge 2860 -> 2847 canonical across all references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,17 +167,17 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.SERVER_DIR }}/forge-installer.jar
-          key: forge-1.12.2-14.23.5.2860-installer
+          key: forge-1.12.2-14.23.5.2847-installer
       - name: Download Forge installer
         if: steps.cache-forge.outputs.cache-hit != 'true'
         run: |
           curl -L -o "${{ env.SERVER_DIR }}/forge-installer.jar" \
-            "https://maven.minecraftforge.net/net/minecraftforge/forge/1.12.2-14.23.5.2860/forge-1.12.2-14.23.5.2860-installer.jar"
+            "https://maven.minecraftforge.net/net/minecraftforge/forge/1.12.2-14.23.5.2847/forge-1.12.2-14.23.5.2847-installer.jar"
       - name: Install Forge server
         run: |
           cd "${{ env.SERVER_DIR }}"
           java -jar forge-installer.jar --installServer "${{ env.SERVER_DIR }}"
-      - name: Install client Forge 14.23.5.2860 (bypass forgecli, incompatible with 1.12.2)
+      - name: Install client Forge 14.23.5.2847 (bypass forgecli, incompatible with 1.12.2)
         run: |
           mkdir -p "$HOME/.minecraft"
           echo '{"profiles":{}}' > "$HOME/.minecraft/launcher_profiles.json"
@@ -245,7 +245,7 @@ jobs:
           set -euo pipefail
           cd "${{ env.HMC_DIR }}"
           timeout --kill-after=10 300 xvfb-run -a java -jar "headlessmc-launcher-wrapper-${{ env.HMC_VERSION }}.jar" \
-            --command "launch forge:1.12.2 -lwjgl -offline --uid 14.23.5.2860 --jvm -Djava.awt.headless=true" \
+            --command "launch forge:1.12.2 -lwjgl -offline --uid 14.23.5.2847 --jvm -Djava.awt.headless=true" \
             --game-args "--server=127.0.0.1 --port=25565 --username TestPlayer" > "${{ env.HMC_DIR }}/hmc-output.log" 2>&1 &
           CLIENT_PID=$!
           JOINED=0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@
 
 ## Build facts and traps
 
-- Current configuration targets Minecraft `1.12.2`, Forge `14.23.5.2860`, Java 8 (Corretto `1.8.0_472-amzn` via SDKMAN), Gradle `4.10.3`, ForgeGradle `2.3`, MCP mappings `snapshot_20171003`. No Mixin annotation processor is configured (the leftover `mixin/server/MixinCommandManager.java` stub is excluded from the jar).
+- Current configuration targets Minecraft `1.12.2`, Forge `14.23.5.2847`, Java 8 (Corretto `1.8.0_472-amzn` via SDKMAN), Gradle `4.10.3`, ForgeGradle `2.3`, MCP mappings `snapshot_20171003`. No Mixin annotation processor is configured (the leftover `mixin/server/MixinCommandManager.java` stub is excluded from the jar).
 - Build with the repository wrapper. The current `gradlew` is LF-encoded and executable. Build with `./gradlew build`.
 - CI runs on every push to `1.21` and `mc1.12.2` branches: lint (yamllint) + build + unit tests (JUnit 5) + E2E (HeadlessMC + HMCSpecifics + Forge + WireMock).
 - `gradle.properties` contains stale metadata (`minecraft_version_range`, `curse_versions`, placeholder description, broad loader/Forge ranges). Treat executable dependency coordinates in `build.gradle` as authoritative until metadata is reconciled.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 ### Removed
 - HMCLite scenarios replaced with bash server-log smoke assertions
-- Forge 14.23.5.2860 pinned (was: version drift 2847/2860)
+- Forge 14.23.5.2860 pin reverted to canonical 14.23.5.2847 (2860 does not work in CI env)
 - Stale `IMPLEMENTATION_PLAN.md` references from AGENTS.md
 - SkinsRestorer-derived code patterns (clean-room rewrite of MojangApiHttpImpl, MineSkinApiHttpImpl, EverlastingHelpers)
 - Stale "Phase 5 viability gate" comments in Config.java

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Each branch is isolated with its own toolchain, Forge version, and Java runtime.
 | Branch | Minecraft | Forge | Java | Status |
 |--------|-----------|-------|------|--------|
 | [1.21](https://github.com/Levosilimo/Everlasting-Skins/tree/1.21) | 1.21 | 51.0.24 | 21 | Active |
-| [mc1.12.2](https://github.com/Levosilimo/Everlasting-Skins/tree/mc1.12.2) | 1.12.2 | 14.23.5.2860 | 8 | Active |
+| [mc1.12.2](https://github.com/Levosilimo/Everlasting-Skins/tree/mc1.12.2) | 1.12.2 | 14.23.5.2847 | 8 | Active |
 
 Each branch has its own README with version-specific installation instructions, config paths, and command documentation.
 
@@ -35,7 +35,7 @@ Each branch has its own README with version-specific installation instructions, 
 
 ## 📦 Installation
 
-1. Install [Forge for Minecraft 1.12.2](https://files.minecraftforge.net/net/minecraftforge/forge/index_1.12.2.html) (14.23.5.2860 or later 1.12.2 build).
+1. Install [Forge for Minecraft 1.12.2](https://files.minecraftforge.net/net/minecraftforge/forge/index_1.12.2.html) (14.23.5.2847 or later 1.12.2 build).
 2. Download `everlastingskins-1.12.2-2.0.0.jar` from the [Releases page](https://github.com/Levosilimo/Everlasting-Skins/releases).
 3. Place the JAR in your server's `mods/` folder.
 4. Restart the server.
@@ -82,7 +82,7 @@ Mojang profile lookups are cached in-memory (MojangProfileCache, TTL 1h, cap 100
 
 ## ⚠️ Compatibility
 
-- Forge 1.12.2 only. Compatible with major 1.12.2 modpacks (e.g., FTB, ATLauncher packs that use Forge 1.12.2). Tested with Forge 14.23.5.2860. Not compatible with NeoForge or Fabric.
+- Forge 1.12.2 only. Compatible with major 1.12.2 modpacks (e.g., FTB, ATLauncher packs that use Forge 1.12.2). Tested with Forge 14.23.5.2847. Not compatible with NeoForge or Fabric.
 - Server-side only — players do not need to install the mod.
 - Other skin mods that modify player GameProfiles are incompatible.
 - Anti-cheat plugins may need to whitelist skin-related packet sequences.

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,6 +13,6 @@ mod_description=Server-side persistent custom skins on pure Forge legacy servers
 
 minecraft_version=1.12.2
 minecraft_version_range=[1.12.2,1.13)
-forge_version=14.23.5.2860
-forge_version_range=[14.23.5.2860,15)
-loader_version_range=[14.23.5.2860,15)
+forge_version=14.23.5.2847
+forge_version_range=[14.23.5.2847,15)
+loader_version_range=[14.23.5.2847,15)

--- a/test-infrastructure/README.md
+++ b/test-infrastructure/README.md
@@ -20,9 +20,9 @@ lives in the JUnit integration tests; this E2E is a boot smoke test.
 bash test-infrastructure/run-e2e.sh mc1.12.2
 ```
 
-`run-e2e.sh` builds the mod, installs Forge 14.23.5.2860 (server +
+`run-e2e.sh` builds the mod, installs Forge 14.23.5.2847 (server +
 pre-installed client profile), launches the server, and drives the client
-through the HeadlessMC wrapper (`-lwjgl -offline --uid 14.23.5.2860`).
+through the HeadlessMC wrapper (`-lwjgl -offline --uid 14.23.5.2847`).
 
 ## Why no scenario files
 


### PR DESCRIPTION
Per user directive: 2860 doesn't work, make 2847 canonical everywhere on mc1.12.2.

- gradle.properties: forge_version / ranges 2860 -> 2847
- README.md / AGENTS.md / test-infrastructure/README.md: 2860 -> 2847
- .github/workflows/ci.yml: cache key, installer URL, launch --uid 2860 -> 2847
- CHANGELOG.md: 2860 pin reverted to 2847 (record kept)
- build.gradle / run-e2e.sh: already 2847, no change

Verified: compileJava success, 252 tests pass, aislop 100/100.