### PR TITLE
fix(ci): add --add-opens JVM flags for GameTest on JDK 21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -155,6 +155,17 @@ minecraft {
         // are loaded from the dev mod jar's datapack.
         gameTestServer {
             property 'forge.enabledGameTestNamespaces', project.findProperty('gametestNamespace') ?: 'everlastingskins'
+            // Netty 4.1 needs reflective access into the JDK on Java 21
+            // (GameTest job failed with "Reflective setAccessible(true)
+            // disabled" / module exports). Applied to the forked GameTest
+            // server JVM, not the Gradle daemon.
+            jvmArgs(
+                '--add-opens=java.base/java.lang=ALL-UNNAMED',
+                '--add-opens=java.base/java.nio=ALL-UNNAMED',
+                '--add-opens=java.base/sun.nio.ch=ALL-UNNAMED',
+                '--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED',
+                '-Dio.netty.tryReflectionSetAccessible=true'
+            )
             mods {
                 everlastingskins {
                     source sourceSets.main


### PR DESCRIPTION
lib-30 audit: GameTest CI on JDK 21 fails with reflective-access errors. Add --add-opens flags on the runGameTestServer run config. Verified locally: all 30 GameTest pass. Also tightens 1.21 branch protection (Build + GameTest + YAML Lint, strict).