### PR TITLE
fix(e2e): 2847 installer lacks --installClient; use 2860 installer for client profile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,13 +162,13 @@ jobs:
           cp "${{ steps.find-jar.outputs.jar_path }}" "${{ env.MODS_DIR }}/"
           cp "${{ github.workspace }}/test-infrastructure/server/server.properties" "${{ env.SERVER_DIR }}/"
           echo "eula=true" > "${{ env.SERVER_DIR }}/eula.txt"
-      - name: Cache Forge installer
+      - name: Cache Forge server installer
         id: cache-forge
         uses: actions/cache@v4
         with:
           path: ${{ env.SERVER_DIR }}/forge-installer.jar
           key: forge-1.12.2-14.23.5.2847-installer
-      - name: Download Forge installer
+      - name: Download Forge server installer
         if: steps.cache-forge.outputs.cache-hit != 'true'
         run: |
           curl -L -o "${{ env.SERVER_DIR }}/forge-installer.jar" \
@@ -177,11 +177,15 @@ jobs:
         run: |
           cd "${{ env.SERVER_DIR }}"
           java -jar forge-installer.jar --installServer "${{ env.SERVER_DIR }}"
-      - name: Install client Forge 14.23.5.2847 (bypass forgecli, incompatible with 1.12.2)
+      - name: Download client Forge installer 14.23.5.2860
+        run: |
+          curl -L -o "${{ env.SERVER_DIR }}/forge-client-installer.jar" \
+            "https://maven.minecraftforge.net/net/minecraftforge/forge/1.12.2-14.23.5.2860/forge-1.12.2-14.23.5.2860-installer.jar"
+      - name: Install client Forge 14.23.5.2860 (bypass forgecli, incompatible with 1.12.2; 2847 installer has no --installClient)
         run: |
           mkdir -p "$HOME/.minecraft"
           echo '{"profiles":{}}' > "$HOME/.minecraft/launcher_profiles.json"
-          java -jar "${{ env.SERVER_DIR }}/forge-installer.jar" --installClient "$HOME/.minecraft"
+          java -jar "${{ env.SERVER_DIR }}/forge-client-installer.jar" --installClient "$HOME/.minecraft"
       - name: Start Forge server (background)
         id: start-server
         run: |
@@ -245,7 +249,7 @@ jobs:
           set -euo pipefail
           cd "${{ env.HMC_DIR }}"
           timeout --kill-after=10 300 xvfb-run -a java -jar "headlessmc-launcher-wrapper-${{ env.HMC_VERSION }}.jar" \
-            --command "launch forge:1.12.2 -lwjgl -offline --uid 14.23.5.2847 --jvm -Djava.awt.headless=true" \
+            --command "launch forge:1.12.2 -lwjgl -offline --uid 14.23.5.2860 --jvm -Djava.awt.headless=true" \
             --game-args "--server=127.0.0.1 --port=25565 --username TestPlayer" > "${{ env.HMC_DIR }}/hmc-output.log" 2>&1 &
           CLIENT_PID=$!
           JOINED=0

--- a/test-infrastructure/README.md
+++ b/test-infrastructure/README.md
@@ -20,9 +20,11 @@ lives in the JUnit integration tests; this E2E is a boot smoke test.
 bash test-infrastructure/run-e2e.sh mc1.12.2
 ```
 
-`run-e2e.sh` builds the mod, installs Forge 14.23.5.2847 (server +
-pre-installed client profile), launches the server, and drives the client
-through the HeadlessMC wrapper (`-lwjgl -offline --uid 14.23.5.2847`).
+`run-e2e.sh` builds the mod, installs Forge 14.23.5.2847 server with a
+client profile pre-installed via the 14.23.5.2860 installer (the 2847
+installer has no `--installClient` CLI), launches the server, and drives
+the client through the HeadlessMC wrapper (`-lwjgl -offline
+--uid 14.23.5.2860`).
 
 ## Why no scenario files
 

--- a/test-infrastructure/run-e2e.sh
+++ b/test-infrastructure/run-e2e.sh
@@ -69,16 +69,30 @@ if [ ! -f "$HOME/.cache/everlastingskins/$FORGE_INSTALLER" ]; then
     echo "  Downloading $FORGE_URL..."
     curl -L -o "$HOME/.cache/everlastingskins/$FORGE_INSTALLER" "$FORGE_URL"
 fi
-java -jar "$HOME/.cache/everlastingskins/$FORGE_INSTALLER" --installServer "$SERVER_DIR"
+# The 2847 installer ignores a --installServer target arg and installs
+# into the current directory, so cd into the server dir first.
+(
+    cd "$SERVER_DIR"
+    java -jar "$HOME/.cache/everlastingskins/$FORGE_INSTALLER" --installServer
+)
 
 # HMCLite's forgecli crashes on 1.12.2 installers (NoSuchMethodError on
 # ClientInstall.run); pre-install the client Forge profile matching the
 # server so the launcher skips its own forge install.
+# The 14.23.5.2847 installer has no --installClient CLI; the 14.23.5.2860
+# rebuild does, so the client profile is installed with it (server stays
+# 2847, the canonical build version).
 if [ "$BRANCH" = "mc1.12.2" ]; then
-    echo "  Pre-installing client Forge $FORGE_VERSION (bypasses forgecli)..."
+    echo "  Pre-installing client Forge 14.23.5.2860 (bypasses forgecli)..."
+    CLIENT_INSTALLER="forge-1.12.2-14.23.5.2860-installer.jar"
+    if [ ! -f "$HOME/.cache/everlastingskins/$CLIENT_INSTALLER" ]; then
+        mkdir -p "$HOME/.cache/everlastingskins"
+        curl -L -o "$HOME/.cache/everlastingskins/$CLIENT_INSTALLER" \
+            "https://maven.minecraftforge.net/net/minecraftforge/forge/1.12.2-14.23.5.2860/forge-1.12.2-14.23.5.2860-installer.jar"
+    fi
     mkdir -p "$HOME/.minecraft"
     echo '{"profiles":{}}' > "$HOME/.minecraft/launcher_profiles.json"
-    java -jar "$HOME/.cache/everlastingskins/$FORGE_INSTALLER" --installClient "$HOME/.minecraft"
+    java -jar "$HOME/.cache/everlastingskins/$CLIENT_INSTALLER" --installClient "$HOME/.minecraft"
 fi
 
 # 4. Start server
@@ -142,8 +156,11 @@ CONFIG
 # 6. Launch client and assert on the server log
 echo "[6/6] Launching client and asserting server log..."
 cd "$PROJECT_DIR"
+# Client profile was installed with the 2860 installer, so the uid must
+# match that profile even though the server runs the canonical 2847 build.
+CLIENT_UID="14.23.5.2860"
 timeout --kill-after=10 300 xvfb-run -a java -jar "$HMC_DIR/headlessmc-launcher-wrapper.jar" \
-    --command "launch forge:$MC_VERSION -lwjgl -offline --uid $FORGE_VERSION --jvm -Djava.awt.headless=true" \
+    --command "launch forge:$MC_VERSION -lwjgl -offline --uid $CLIENT_UID --jvm -Djava.awt.headless=true" \
     --game-args "--server=127.0.0.1 --port=25565 --username TestPlayer" > "$HMC_DIR/client.log" 2>&1 &
 CLIENT_PID=$!
 


### PR DESCRIPTION
Fixes post-#132 E2E regression on mc1.12.2.

## Problem
PR #132 switched the E2E client-install step to the Forge 14.23.5.2847 installer. That installer's SimpleInstaller CLI only supports `--installServer`/`--extract`/`--help`/`--offline` — no `--installClient` (verified from jar bytecode; the 2860 installer's 2024 rebuild added it). Post-merge CI failed:

```
Exception in thread main joptsimple.UnrecognizedOptionException: 'installClient' is not a recognized option
```

PR #132's E2E check was skipped (job runs only on push to mc1.12.2), so the regression merged.

## Fix
- Server stays canonical **14.23.5.2847** (installer handles `--installServer`).
- Client profile installed with the **14.23.5.2860** installer (only 1.12.2 installer supporting `--installClient`).
- HeadlessMC launch uid changed to **14.23.5.2860** to match the installed client profile.
- Same fix applied to local `test-infrastructure/run-e2e.sh` + README.

## Verification
- Full local E2E run: 2860 client joins 2847 server, all 3 assertions PASS (server booted, mod discovered, client connected).
- yamllint clean on ci.yml.