### PR TITLE
fix(comments): remove narrative what-not-why comments

### DIFF
--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinCommand.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinCommand.java
@@ -108,7 +108,6 @@ public class SkinCommand {
 
     private static LiteralArgumentBuilder<CommandSourceStack> buildSetSubcommand() {
         return Commands.literal("set")
-                // /skin set mojang
                 .then(Commands.literal("mojang")
                         .then(Commands.argument("skin_name", StringArgumentType.word())
                                 .executes(context -> SkinActionCommand.execute(context, new SkinActionParameters(
@@ -125,7 +124,6 @@ public class SkinCommand {
                                 )
                         )
                 )
-                // /skin set web
                 .then(Commands.literal("web")
                         .then(Commands.literal("classic")
                                 .then(Commands.argument("url", StringArgumentType.string())
@@ -161,7 +159,6 @@ public class SkinCommand {
 
                         )
                 )
-                // /skin set random
                 .then(Commands.literal("random")
                         .executes(context -> SkinActionCommand.execute(context, new SkinActionParameters(
                                 Collections.singleton(context.getSource().getPlayer()),

--- a/src/main/java/levosilimo/everlastingskins/util/EndpointsConfig.java
+++ b/src/main/java/levosilimo/everlastingskins/util/EndpointsConfig.java
@@ -44,7 +44,6 @@ public class EndpointsConfig {
         if (sysProp != null && !sysProp.isEmpty()) {
             return sysProp;
         }
-        // Existing resource-based lookup
         String value = props.getProperty(key);
         if (value == null || value.isEmpty()) {
             EverlastingSkins.logger.warn("Missing endpoint property: {}, returning empty fallback", key);

--- a/src/main/java/levosilimo/everlastingskins/util/UUIDUtils.java
+++ b/src/main/java/levosilimo/everlastingskins/util/UUIDUtils.java
@@ -15,7 +15,6 @@ public class UUIDUtils {
         try {
             return Optional.of(UUID.fromString(str));
         } catch (IllegalArgumentException ignored) {
-            // If we have a non-dashed UUID, we can try to convert it to dashed.
             if (str.length() == 32) {
                 try {
                     return Optional.of(convertToDashed(str));


### PR DESCRIPTION
Aislop + manual audit. Remove 5 comments that duplicate the next line's intent (command-syntax labels in SkinCommand, branch narration in UUIDUtils, lookup narration in EndpointsConfig). Keep 'why' comments (rationale, gotchas, race fixes, external constraints). No behavior change; 284 tests pass; aislop 100/100.