### PR TITLE
feat(config): add MojangProfileCache TTL/size config keys

### DIFF
--- a/src/main/java/levosilimo/everlastingskins/Config.java
+++ b/src/main/java/levosilimo/everlastingskins/Config.java
@@ -37,6 +37,10 @@ public class Config {
     public static ForgeConfigSpec.ConfigValue<String> HTTP_CLIENT_VERSION;
     public static ForgeConfigSpec.IntValue HTTP_CONNECT_TIMEOUT_SECONDS;
 
+    public static ForgeConfigSpec.BooleanValue MOJANG_CACHE_ENABLED;
+    public static ForgeConfigSpec.LongValue MOJANG_CACHE_TTL_MS;
+    public static ForgeConfigSpec.IntValue MOJANG_CACHE_MAX_SIZE;
+
 
     static {
         ForgeConfigSpec.Builder builder = new ForgeConfigSpec.Builder();
@@ -82,6 +86,14 @@ public class Config {
             .define("http_client_version", "HTTP_2");
         HTTP_CONNECT_TIMEOUT_SECONDS = builder.comment("Connection timeout for provider requests (seconds)")
             .defineInRange("http_connect_timeout_seconds", 5, 1, 60);
+        builder.pop();
+        builder.push("MojangCache");
+        MOJANG_CACHE_ENABLED = builder.comment("Enable the in-process Mojang profile cache")
+            .define("mojang_profile_cache_enabled", true);
+        MOJANG_CACHE_TTL_MS = builder.comment("Mojang profile cache entry lifetime (milliseconds; 0 disables caching)")
+            .defineInRange("mojang_profile_cache_ttl_ms", 3600000L, 0L, 604800000L);
+        MOJANG_CACHE_MAX_SIZE = builder.comment("Max Mojang profile cache entries (oldest evicted first)")
+            .defineInRange("mojang_profile_cache_max_size", 1000, 0, 1000000);
         builder.pop();
         COMMON_CONFIG = builder.build();
     }

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/MojangProfileCache.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/MojangProfileCache.java
@@ -7,11 +7,11 @@
 
 package levosilimo.everlastingskins.skinchanger;
 
+import levosilimo.everlastingskins.Config;
 import levosilimo.everlastingskins.metrics.SkinMetrics;
 import levosilimo.everlastingskins.util.CustomSkinProperty;
 
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Small TTL + cap cache for Mojang profile lookups. Keyed by lower-case
@@ -28,7 +28,7 @@ public class MojangProfileCache {
     private final int maxEntries;
 
     public MojangProfileCache() {
-        this(TimeUnit.HOURS.toMillis(1), 1000);
+        this(Config.MOJANG_CACHE_TTL_MS.get(), Config.MOJANG_CACHE_MAX_SIZE.get());
     }
 
     public MojangProfileCache(long ttlMs, int maxEntries) {
@@ -36,8 +36,14 @@ public class MojangProfileCache {
         this.maxEntries = maxEntries;
     }
 
+    /** True when the cache is active per config; a disabled cache never stores or serves entries. */
+    public boolean isEnabled() {
+        return Config.MOJANG_CACHE_ENABLED.get();
+    }
+
     /** Returns the cached skin for the username, or null when absent/expired. */
     public CustomSkinProperty get(String username) {
+        if (!isEnabled()) return null;
         if (username == null) return null;
         String key = username.toLowerCase();
         CacheEntry entry = entries.get(key);
@@ -56,6 +62,7 @@ public class MojangProfileCache {
 
     /** Stores a fetched skin, evicting the oldest entry when over capacity. */
     public void put(String username, CustomSkinProperty property) {
+        if (!isEnabled()) return;
         if (username == null || property == null) return;
         String key = username.toLowerCase();
         if (entries.containsKey(key)) {

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/MojangProfileCacheTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/MojangProfileCacheTest.java
@@ -7,6 +7,7 @@
 
 package levosilimo.everlastingskins.skinchanger;
 
+import levosilimo.everlastingskins.Config;
 import levosilimo.everlastingskins.metrics.SkinMetrics;
 import levosilimo.everlastingskins.util.CustomSkinProperty;
 import org.junit.jupiter.api.DisplayName;
@@ -87,5 +88,54 @@ class MojangProfileCacheTest {
         SkinMetrics.Snapshot s = SkinMetrics.INSTANCE.snapshot();
         assertEquals(2, s.cacheHits());
         assertEquals(1, s.cacheMisses());
+    }
+
+    @Test
+    @DisplayName("a cache disabled via config never serves or stores entries")
+    void disabledCache_returnsNull() {
+        boolean original = Config.MOJANG_CACHE_ENABLED.get();
+        try {
+            Config.MOJANG_CACHE_ENABLED.set(false);
+            MojangProfileCache cache = new MojangProfileCache();
+            cache.put(USERNAME, SKIN);
+
+            assertFalse(cache.isEnabled());
+            assertNull(cache.get(USERNAME));
+            assertEquals(0, cache.size());
+        } finally {
+            Config.MOJANG_CACHE_ENABLED.set(original);
+        }
+    }
+
+    @Test
+    @DisplayName("a zero TTL expires every entry immediately")
+    void zeroTtl_expiresImmediately() {
+        MojangProfileCache cache = new MojangProfileCache(0, 100);
+        cache.put(USERNAME, SKIN);
+
+        try {
+            Thread.sleep(5);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            fail("interrupted");
+        }
+        assertNull(cache.get(USERNAME));
+        assertEquals(0, cache.size());
+    }
+
+    @Test
+    @DisplayName("the configured max size is honored by the default constructor")
+    void configuredMaxSize_isHonored() {
+        int original = Config.MOJANG_CACHE_MAX_SIZE.get();
+        try {
+            Config.MOJANG_CACHE_MAX_SIZE.set(1);
+            MojangProfileCache cache = new MojangProfileCache();
+            cache.put("a", SKIN);
+            cache.put("b", SKIN);
+
+            assertEquals(1, cache.size());
+        } finally {
+            Config.MOJANG_CACHE_MAX_SIZE.set(original);
+        }
     }
 }


### PR DESCRIPTION
1.21 parity with mc1.12.2. Top-priority config item from lib-45 audit.

- Config.MOJANG_CACHE_ENABLED (default true)
- Config.MOJANG_CACHE_TTL_MS (default 3600000, range 0-7d)
- Config.MOJANG_CACHE_MAX_SIZE (default 1000, range 0-1M)

Default MojangProfileCache constructor now reads TTL/size from Config; isEnabled() gates both get() and put(). 3 new tests. 287 tests pass, aislop 100/100.