### PR TITLE
feat(messages): custom messages config tree + I18n routing

### DIFF
--- a/src/main/java/levosilimo/everlastingskins/Config.java
+++ b/src/main/java/levosilimo/everlastingskins/Config.java
@@ -40,7 +40,27 @@ public class Config {
     public static ForgeConfigSpec.BooleanValue MOJANG_CACHE_ENABLED;
     public static ForgeConfigSpec.LongValue MOJANG_CACHE_TTL_MS;
     public static ForgeConfigSpec.IntValue MOJANG_CACHE_MAX_SIZE;
-
+    public static ForgeConfigSpec.ConfigValue<String> MESSAGES_CHANGE;
+    public static ForgeConfigSpec.ConfigValue<String> MESSAGES_FULFILLED;
+    public static ForgeConfigSpec.ConfigValue<String> MESSAGES_TIMEOUT;
+    public static ForgeConfigSpec.ConfigValue<String> MESSAGES_ERROR;
+    public static ForgeConfigSpec.ConfigValue<String> MESSAGES_RESTORED_FROM;
+    public static ForgeConfigSpec.ConfigValue<String> MESSAGES_CLEARED_NO_PROFILE;
+    public static ForgeConfigSpec.ConfigValue<String> MESSAGES_NO_SOURCE;
+    public static ForgeConfigSpec.ConfigValue<String> MESSAGES_PLAYER_ONLY;
+    public static ForgeConfigSpec.ConfigValue<String> MESSAGES_PERMISSION_DENIED;
+    public static ForgeConfigSpec.ConfigValue<String> MESSAGES_COOLDOWN;
+    public static ForgeConfigSpec.ConfigValue<String> MESSAGES_RATE_LIMITED;
+    public static ForgeConfigSpec.ConfigValue<String> MESSAGES_NO_SKIN_FOUND;
+    public static ForgeConfigSpec.ConfigValue<String> MESSAGES_NO_SKIN_FOUND_PLAIN;
+    public static ForgeConfigSpec.ConfigValue<String> MESSAGES_MINESKIN_REJECTED;
+    public static ForgeConfigSpec.ConfigValue<String> MESSAGES_NO_RANDOM_USERNAME;
+    public static ForgeConfigSpec.ConfigValue<String> MESSAGES_PROVIDER_NO_RESULT;
+    public static ForgeConfigSpec.ConfigValue<String> MESSAGES_METRICS_TOP_PLAYERS;
+    public static ForgeConfigSpec.ConfigValue<String> MESSAGES_METRICS_REFRESHES;
+    public static ForgeConfigSpec.ConfigValue<String> MESSAGES_METRICS_NO_REFRESHES;
+    public static ForgeConfigSpec.ConfigValue<String> MESSAGES_METRICS_CLEANUP;
+    public static ForgeConfigSpec.ConfigValue<String> MESSAGES_METRICS_RESET;
 
     static {
         ForgeConfigSpec.Builder builder = new ForgeConfigSpec.Builder();
@@ -48,6 +68,27 @@ public class Config {
         LANGUAGE = builder.comment("Language of mod messages").define("localization","en");
         TOGGLE = builder.comment("Display mod messages").define("display",true);
         MINESKIN_API_KEY = builder.comment("Mineskin api key").define("key","");
+        MESSAGES_CHANGE = builder.define("messages_change", "Skin change queued");
+        MESSAGES_FULFILLED = builder.define("messages_fulfilled", "Skin has been applied.");
+        MESSAGES_TIMEOUT = builder.define("messages_timeout", "Skin fetch timed out.");
+        MESSAGES_ERROR = builder.define("messages_error", "Skin fetch failed.");
+        MESSAGES_RESTORED_FROM = builder.define("messages_restored_from", "Skin restored from %s");
+        MESSAGES_CLEARED_NO_PROFILE = builder.define("messages_cleared_no_profile", "Skin cleared (no Mojang profile found)");
+        MESSAGES_NO_SOURCE = builder.define("messages_no_source", "No source available");
+        MESSAGES_PLAYER_ONLY = builder.define("messages_player_only", "Player only command");
+        MESSAGES_PERMISSION_DENIED = builder.define("messages_permission_denied", "Permission denied");
+        MESSAGES_COOLDOWN = builder.define("messages_cooldown", "Please wait %ds before using /skin again");
+        MESSAGES_RATE_LIMITED = builder.define("messages_rate_limited", "Too many /skin commands. Try again later.");
+        MESSAGES_NO_SKIN_FOUND = builder.define("messages_no_skin_found", "No skin found for \"%s\"");
+        MESSAGES_NO_SKIN_FOUND_PLAIN = builder.define("messages_no_skin_found_plain", "No skin found");
+        MESSAGES_MINESKIN_REJECTED = builder.define("messages_mineskin_rejected", "MineSkin rejected the URL");
+        MESSAGES_NO_RANDOM_USERNAME = builder.define("messages_no_random_username", "No random username available");
+        MESSAGES_PROVIDER_NO_RESULT = builder.define("messages_provider_no_result", "Provider returned no result");
+        MESSAGES_METRICS_TOP_PLAYERS = builder.define("messages_metrics_top_players", "Top players by refresh count:");
+        MESSAGES_METRICS_REFRESHES = builder.define("messages_metrics_refreshes", " refreshes");
+        MESSAGES_METRICS_NO_REFRESHES = builder.define("messages_metrics_no_refreshes", "(no refreshes recorded)");
+        MESSAGES_METRICS_CLEANUP = builder.define("messages_metrics_cleanup", "Metrics cleanup: pruned %d stale player entries");
+        MESSAGES_METRICS_RESET = builder.define("messages_metrics_reset", "Metrics reset");
         builder.pop();
         builder.push("Integration");
         DISCORDSRV_ENABLED = builder.comment("Enable DiscordSRV skin change announcements")

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinCommand.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinCommand.java
@@ -18,6 +18,7 @@ import levosilimo.everlastingskins.permission.PermissionContext;
 import levosilimo.everlastingskins.permission.PermissionServiceManager;
 import levosilimo.everlastingskins.skinchanger.command.SkinActionCommand;
 import levosilimo.everlastingskins.skinchanger.command.SkinMetricsCommand;
+import levosilimo.everlastingskins.util.I18nUtils;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.commands.arguments.EntityArgument;
@@ -230,7 +231,7 @@ public class SkinCommand {
         String source = SkinRestorer.getSkinStorage().getSource(uuid);
         MutableComponent message = source != null
             ? Component.literal(FEEDBACK_PREFIX + " " + source)
-            : Component.literal(FEEDBACK_PREFIX + " No source available");
+            : Component.literal(FEEDBACK_PREFIX + " " + I18nUtils.get("no_source"));
         context.getSource().sendSuccess(() -> message, false);
         return 1;
     }

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRefreshHandler.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRefreshHandler.java
@@ -243,22 +243,22 @@ public class SkinRefreshHandler {
         switch (type) {
             case username:
                 return customSource != null
-                        ? "No skin found for \"" + customSource + "\""
-                        : "No skin found";
+                        ? I18nUtils.get("no_skin_found", customSource)
+                        : I18nUtils.get("no_skin_found_plain");
             case url: {
                 if (customSource != null) {
                     String sanitized = EverlastingHelpers.sanitizeSkinInput(customSource);
                     if (!sanitized.equals(customSource)) {
-                        return "No skin found for \"" + sanitized + "\"";
+                        return I18nUtils.get("no_skin_found", sanitized);
                     }
                 }
-                return "MineSkin rejected the URL";
+                return I18nUtils.get("mineskin_rejected");
             }
             case random:
             case NEW:
-                return "No random username available";
+                return I18nUtils.get("no_random_username");
             default:
-                return "Provider returned no result";
+                return I18nUtils.get("provider_no_result");
         }
     }
 }

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/command/SkinActionCommand.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/command/SkinActionCommand.java
@@ -23,6 +23,7 @@ import levosilimo.everlastingskins.skinchanger.SkinRestorer;
 import levosilimo.everlastingskins.skinchanger.responses.mojang.MojangSkinDataResult;
 import levosilimo.everlastingskins.util.CustomSkinProperty;
 import levosilimo.everlastingskins.util.EverlastingHelpers;
+import levosilimo.everlastingskins.util.I18nUtils;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
@@ -95,14 +96,14 @@ public final class SkinActionCommand {
         String customSource = params.customSource();
         ServerPlayer selfPlayer = context.getSource().getPlayer();
         if (selfPlayer == null) {
-            context.getSource().sendFailure(Component.literal("Player only command"));
+            context.getSource().sendFailure(I18nUtils.getLocalizedComponent("player_only"));
             return 0;
         }
         boolean targetingOthers = targets.stream().anyMatch(t -> !t.equals(selfPlayer));
         if (!PermissionServiceManager.hasPermission(
                 PermissionContext.of(selfPlayer.getUUID(), selfPlayer.hasPermissions(2)),
                 resolvePermissionNode(type, targetingOthers))) {
-            context.getSource().sendFailure(Component.literal(FEEDBACK_PREFIX + " Permission denied"));
+            context.getSource().sendFailure(Component.literal(FEEDBACK_PREFIX + " " + I18nUtils.get("permission_denied")));
             return 0;
         }
         if (Config.RATE_LIMIT_ENABLED.get() && isRateLimited(selfPlayer.getUUID(), context)) {
@@ -114,9 +115,9 @@ public final class SkinActionCommand {
         targets.forEach(player -> {
             if (Config.TOGGLE.get()) {
                 if (player == context.getSource().getEntity()) {
-                    context.getSource().sendSuccess(() -> Component.literal(FEEDBACK_PREFIX + " " + SkinRefreshHandler.getLocalizedString("change")), false);
+                    context.getSource().sendSuccess(() -> Component.literal(FEEDBACK_PREFIX + " " + I18nUtils.get("change")), false);
                 } else {
-                    player.sendSystemMessage(Component.literal(FEEDBACK_PREFIX + " " + SkinRefreshHandler.getLocalizedString("change")));
+                    player.sendSystemMessage(Component.literal(FEEDBACK_PREFIX + " " + I18nUtils.get("change")));
                 }
             }
         });
@@ -134,9 +135,9 @@ public final class SkinActionCommand {
         long fetchStart = System.nanoTime();
         ScheduledFuture<?> timeoutFuture = skinCommandExecutor.schedule(() -> {
             if (future.completeExceptionally(new TimeoutException("Skin fetch timeout occurred"))) {
-                EverlastingSkins.logger.error(SkinRefreshHandler.getLocalizedString("timeout"));
+                EverlastingSkins.logger.error(I18nUtils.get("timeout"));
                 for (ServerPlayer player : targets) {
-                    player.sendSystemMessage(Component.literal(FEEDBACK_PREFIX + " " + SkinRefreshHandler.getLocalizedString("timeout")));
+                    player.sendSystemMessage(Component.literal(FEEDBACK_PREFIX + " " + I18nUtils.get("timeout")));
                 }
             }
         }, 10000, TimeUnit.MILLISECONDS);
@@ -232,7 +233,7 @@ public final class SkinActionCommand {
                 } else {
                     SkinMetrics.INSTANCE.recordRefreshFailed(player.getUUID());
                 }
-                player.sendSystemMessage(Component.literal(FEEDBACK_PREFIX + " " + SkinRefreshHandler.getLocalizedString("error")));
+                player.sendSystemMessage(Component.literal(FEEDBACK_PREFIX + " " + I18nUtils.get("error")));
             }
             return;
         }
@@ -252,7 +253,7 @@ public final class SkinActionCommand {
                 EverlastingSkins.logger.info("Skin cleared for player {} — no Mojang profile found", player.getGameProfile().getName());
                 SkinRestorer.getSkinStorage().setSkin(uuid, null);
                 if (Config.TOGGLE.get()) {
-                    player.sendSystemMessage(Component.literal(FEEDBACK_PREFIX + " Skin cleared (no Mojang profile found)"));
+                    player.sendSystemMessage(Component.literal(FEEDBACK_PREFIX + " " + I18nUtils.get("cleared_no_profile")));
                 }
                 continue;
             }
@@ -265,8 +266,8 @@ public final class SkinActionCommand {
             SkinRestorer.getSkinStorage().setSkin(uuid, skinProperty);
             if (Config.TOGGLE.get()) {
                 String msg = isRestore
-                    ? "Skin restored from " + skinProperty.getSource()
-                    : SkinRefreshHandler.getLocalizedString("fulfilled");
+                    ? I18nUtils.get("restored_from", skinProperty.getSource())
+                    : I18nUtils.get("fulfilled");
                 if (player == context.getSource().getEntity()) {
                     context.getSource().sendSuccess(() -> Component.literal(FEEDBACK_PREFIX + " " + msg), false);
                 } else {
@@ -322,7 +323,7 @@ public final class SkinActionCommand {
         if (lastCommand > 0 && elapsed < cooldownMs) {
             SkinMetrics.INSTANCE.recordRateLimited(playerUuid);
             context.getSource().sendFailure(Component.literal(
-                    "Please wait " + ((cooldownMs - elapsed) / 1000) + "s before using /skin again"));
+                    I18nUtils.get("cooldown", (cooldownMs - elapsed) / 1000)));
             return true;
         }
         ArrayDeque<Long> window = commandTimestampsByPlayer.computeIfAbsent(playerUuid, k -> new ArrayDeque<>());
@@ -333,7 +334,7 @@ public final class SkinActionCommand {
             if (window.size() >= Config.MAX_COMMANDS_PER_MINUTE.get()) {
                 SkinMetrics.INSTANCE.recordRateLimited(playerUuid);
                 context.getSource().sendFailure(Component.literal(
-                        "Too many /skin commands. Try again later."));
+                        I18nUtils.get("rate_limited")));
                 return true;
             }
             window.addLast(now);

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/command/SkinMetricsCommand.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/command/SkinMetricsCommand.java
@@ -13,6 +13,7 @@ import levosilimo.everlastingskins.metrics.MetricsFormat;
 import levosilimo.everlastingskins.metrics.SkinMetrics;
 import levosilimo.everlastingskins.permission.PermissionContext;
 import levosilimo.everlastingskins.permission.PermissionServiceManager;
+import levosilimo.everlastingskins.util.I18nUtils;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.network.chat.Component;
@@ -47,7 +48,7 @@ public final class SkinMetricsCommand {
     private static int metrics(CommandContext<CommandSourceStack> context, boolean asJson) {
         ServerPlayer player = context.getSource().getPlayer();
         if (player == null) {
-            context.getSource().sendFailure(Component.literal("Player only command"));
+            context.getSource().sendFailure(I18nUtils.getLocalizedComponent("player_only"));
             return 0;
         }
         if (!hasPermission(context, "everlastingskins.command.metrics")) return 0;
@@ -60,14 +61,14 @@ public final class SkinMetricsCommand {
     private static int players(CommandContext<CommandSourceStack> context) {
         ServerPlayer player = context.getSource().getPlayer();
         if (player == null || !hasPermission(context, "everlastingskins.command.metrics")) return 0;
-        StringBuilder sb = new StringBuilder(FEEDBACK_PREFIX + " Top players by refresh count:");
+        StringBuilder sb = new StringBuilder(FEEDBACK_PREFIX + " " + I18nUtils.get("metrics_top_players"));
         int rank = 0;
         for (Map.Entry<UUID, SkinMetrics.PlayerSnapshot> e : SkinMetrics.INSTANCE.topPlayers(10)) {
             sb.append("\n  ").append(++rank).append(". ")
                     .append(e.getKey()).append(" — ")
-                    .append(e.getValue().refreshCount()).append(" refreshes");
+                    .append(e.getValue().refreshCount()).append(I18nUtils.get("metrics_refreshes"));
         }
-        if (rank == 0) sb.append("\n  (no refreshes recorded)");
+        if (rank == 0) sb.append("\n  ").append(I18nUtils.get("metrics_no_refreshes"));
         context.getSource().sendSuccess(() -> Component.literal(sb.toString()), false);
         return 1;
     }
@@ -76,14 +77,14 @@ public final class SkinMetricsCommand {
         if (!hasPermission(context, "everlastingskins.command.metrics.reset")) return 0;
         int removed = SkinMetrics.INSTANCE.cleanupStalePlayers(CLEANUP_OLDER_THAN_MS);
         context.getSource().sendSuccess(() -> Component.literal(
-                FEEDBACK_PREFIX + " Metrics cleanup: pruned " + removed + " stale player entries"), false);
+                FEEDBACK_PREFIX + " " + I18nUtils.get("metrics_cleanup", removed)), false);
         return 1;
     }
 
     private static int reset(CommandContext<CommandSourceStack> context) {
         if (!hasPermission(context, "everlastingskins.command.metrics.reset")) return 0;
         SkinMetrics.INSTANCE.reset();
-        context.getSource().sendSuccess(() -> Component.literal(FEEDBACK_PREFIX + " Metrics reset"), false);
+        context.getSource().sendSuccess(() -> Component.literal(FEEDBACK_PREFIX + " " + I18nUtils.get("metrics_reset")), false);
         return 1;
     }
 
@@ -93,7 +94,7 @@ public final class SkinMetricsCommand {
         PermissionContext ctx = PermissionContext.of(player.getUUID(), player.hasPermissions(2));
         boolean allowed = PermissionServiceManager.hasPermission(ctx, node);
         if (!allowed) {
-            context.getSource().sendFailure(Component.literal(FEEDBACK_PREFIX + " Permission denied"));
+            context.getSource().sendFailure(Component.literal(FEEDBACK_PREFIX + " " + I18nUtils.get("permission_denied")));
         }
         return allowed;
     }

--- a/src/main/java/levosilimo/everlastingskins/util/I18nUtils.java
+++ b/src/main/java/levosilimo/everlastingskins/util/I18nUtils.java
@@ -7,13 +7,17 @@
 
 package levosilimo.everlastingskins.util;
 
+import levosilimo.everlastingskins.Config;
 import levosilimo.everlastingskins.EverlastingSkins;
 import levosilimo.everlastingskins.skinchanger.SkinRestorer;
+import net.minecraft.network.chat.Component;
+import net.minecraftforge.common.ForgeConfigSpec;
 
 import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.IllegalFormatException;
 import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Stream;
@@ -21,6 +25,31 @@ import java.util.stream.Stream;
 public final class I18nUtils {
     private static volatile I18nUtils INSTANCE;
     private static volatile boolean initialized = false;
+
+    /** Canonical English text per message key; mirrors the Messages config defaults. */
+    private static final Map<String, String> DEFAULT_ENGLISH = Map.ofEntries(
+            Map.entry("change", "Skin change queued"),
+            Map.entry("fulfilled", "Skin has been applied."),
+            Map.entry("timeout", "Skin fetch timed out."),
+            Map.entry("error", "Skin fetch failed."),
+            Map.entry("restored_from", "Skin restored from %s"),
+            Map.entry("cleared_no_profile", "Skin cleared (no Mojang profile found)"),
+            Map.entry("no_source", "No source available"),
+            Map.entry("player_only", "Player only command"),
+            Map.entry("permission_denied", "Permission denied"),
+            Map.entry("cooldown", "Please wait %ds before using /skin again"),
+            Map.entry("rate_limited", "Too many /skin commands. Try again later."),
+            Map.entry("no_skin_found", "No skin found for \"%s\""),
+            Map.entry("no_skin_found_plain", "No skin found"),
+            Map.entry("mineskin_rejected", "MineSkin rejected the URL"),
+            Map.entry("no_random_username", "No random username available"),
+            Map.entry("provider_no_result", "Provider returned no result"),
+            Map.entry("metrics_top_players", "Top players by refresh count:"),
+            Map.entry("metrics_refreshes", " refreshes"),
+            Map.entry("metrics_no_refreshes", "(no refreshes recorded)"),
+            Map.entry("metrics_cleanup", "Metrics cleanup: pruned %d stale player entries"),
+            Map.entry("metrics_reset", "Metrics reset")
+    );
 
     private static final Map<String, Map<String, String>> localizedStrings = new HashMap<>();
     static {
@@ -48,7 +77,10 @@ public final class I18nUtils {
         englishStrings.put("fulfilled", "Skin has been applied.");
         englishStrings.put("error", "Skin process error occurred.");
         englishStrings.put("timeout","Skin fetch timeout occurred.");
-        englishStrings.put("no_source", "Skin is not set");
+        englishStrings.put("no_source", "No source available");
+        // The full message-key inventory so generated config/EverlastingSkins/en
+        // exposes every key for per-locale override.
+        DEFAULT_ENGLISH.forEach(englishStrings::putIfAbsent);
         localizedStrings.put("en", englishStrings);
     }
 
@@ -140,5 +172,85 @@ public final class I18nUtils {
             return localizedMap.getOrDefault(key, key);
         }
         return key;
+    }
+
+    /**
+     * Resolves a message key with the priority: operator override in the
+     * Messages config section, per-locale resource file, then the Messages
+     * config default, then the raw key. {@code %s}/{@code %d} specifiers in
+     * the resolved template are filled from {@code args}.
+     */
+    public static String get(String key, Object... args) {
+        if (key == null) return null;
+        ensureInitialized();
+        String configValue = configValue(key);
+        if (configValue != null && !configValue.equals(DEFAULT_ENGLISH.get(key))) {
+            return format(configValue, args);
+        }
+        String localized = getInstance().getLocalizedString(key, currentLocale());
+        if (localized != null && !localized.equals(key)) {
+            return format(localized, args);
+        }
+        return format(configValue != null ? configValue : key, args);
+    }
+
+    /** {@link #get} wrapped in a plain text Component for command feedback. */
+    public static Component getLocalizedComponent(String key, Object... args) {
+        return Component.literal(get(key, args));
+    }
+
+    private static String currentLocale() {
+        try {
+            return Config.LANGUAGE.get();
+        } catch (Exception e) {
+            return "en";
+        }
+    }
+
+    /** Config entry for a message key, or null when the key has no Messages entry. */
+    private static String configValue(String key) {
+        ForgeConfigSpec.ConfigValue<String> config = switch (key) {
+            case "change" -> Config.MESSAGES_CHANGE;
+            case "fulfilled" -> Config.MESSAGES_FULFILLED;
+            case "timeout" -> Config.MESSAGES_TIMEOUT;
+            case "error" -> Config.MESSAGES_ERROR;
+            case "restored_from" -> Config.MESSAGES_RESTORED_FROM;
+            case "cleared_no_profile" -> Config.MESSAGES_CLEARED_NO_PROFILE;
+            case "no_source" -> Config.MESSAGES_NO_SOURCE;
+            case "player_only" -> Config.MESSAGES_PLAYER_ONLY;
+            case "permission_denied" -> Config.MESSAGES_PERMISSION_DENIED;
+            case "cooldown" -> Config.MESSAGES_COOLDOWN;
+            case "rate_limited" -> Config.MESSAGES_RATE_LIMITED;
+            case "no_skin_found" -> Config.MESSAGES_NO_SKIN_FOUND;
+            case "no_skin_found_plain" -> Config.MESSAGES_NO_SKIN_FOUND_PLAIN;
+            case "mineskin_rejected" -> Config.MESSAGES_MINESKIN_REJECTED;
+            case "no_random_username" -> Config.MESSAGES_NO_RANDOM_USERNAME;
+            case "provider_no_result" -> Config.MESSAGES_PROVIDER_NO_RESULT;
+            case "metrics_top_players" -> Config.MESSAGES_METRICS_TOP_PLAYERS;
+            case "metrics_refreshes" -> Config.MESSAGES_METRICS_REFRESHES;
+            case "metrics_no_refreshes" -> Config.MESSAGES_METRICS_NO_REFRESHES;
+            case "metrics_cleanup" -> Config.MESSAGES_METRICS_CLEANUP;
+            case "metrics_reset" -> Config.MESSAGES_METRICS_RESET;
+            default -> null;
+        };
+        if (config == null) return null;
+        try {
+            return config.get();
+        } catch (Exception e) {
+            // Config may not be loaded yet; locale defaults still apply.
+            EverlastingSkins.logger.debug("Message config '{}' unavailable, using locale defaults", key, e);
+            return null;
+        }
+    }
+
+    private static String format(String template, Object... args) {
+        if (args == null || args.length == 0) return template;
+        try {
+            return String.format(template, args);
+        } catch (IllegalFormatException e) {
+            // Message templates are admin-editable; a malformed one must not break commands.
+            EverlastingSkins.logger.debug("Invalid message format string: '{}'", template, e);
+            return template;
+        }
     }
 }

--- a/src/test/java/levosilimo/everlastingskins/ConfigTest.java
+++ b/src/test/java/levosilimo/everlastingskins/ConfigTest.java
@@ -72,6 +72,16 @@ class ConfigTest {
         void defaultDiscordSrvChannelIdIsEmpty() {
             assertEquals("", Config.DISCORDSRV_CHANNEL_ID.get());
         }
+
+        @Test
+        @DisplayName("Default message keys resolve to canonical English text")
+        void defaultMessageKeys() {
+            assertEquals("Skin change queued", Config.MESSAGES_CHANGE.get());
+            assertEquals("Permission denied", Config.MESSAGES_PERMISSION_DENIED.get());
+            assertEquals("Please wait %ds before using /skin again", Config.MESSAGES_COOLDOWN.get());
+            assertEquals("No skin found for \"%s\"", Config.MESSAGES_NO_SKIN_FOUND.get());
+            assertEquals("Metrics cleanup: pruned %d stale player entries", Config.MESSAGES_METRICS_CLEANUP.get());
+        }
     }
 
     /* ================================================================== */

--- a/src/test/java/levosilimo/everlastingskins/util/I18nUtilsTest.java
+++ b/src/test/java/levosilimo/everlastingskins/util/I18nUtilsTest.java
@@ -7,6 +7,10 @@
 
 package levosilimo.everlastingskins.util;
 
+import levosilimo.everlastingskins.Config;
+import com.electronwill.nightconfig.core.InMemoryCommentedFormat;
+import net.minecraftforge.common.ForgeConfigSpec;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -17,15 +21,24 @@ import org.junit.jupiter.params.provider.ValueSource;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Tests for {@link I18nUtils} — locale loading and property merging logic.
+ * Tests for {@link I18nUtils} — locale loading, property merging, and the
+ * config-first message lookup.
  *
  * <p>I18nUtils uses a static initializer to populate three built-in locales
- * (en, ru, uk) with six translation keys each.  {@code ensureInitialized()}
- * is a no-op when {@code SkinRestorer.server == null} (the normal test
- * environment), so file-backed property loading is not exercised; only
- * compile-time defaults are tested here.</p>
+ * (en, ru, uk). The en locale carries the full message-key inventory; ru/uk
+ * carry the six legacy keys.  {@code ensureInitialized()} is a no-op when
+ * {@code SkinRestorer.server == null} (the normal test environment), so
+ * file-backed property loading is not exercised; only compile-time defaults
+ * are tested here.</p>
  */
 class I18nUtilsTest {
+
+    @BeforeAll
+    static void loadConfig() {
+        // Serve Config defaults so the Messages config override path is testable.
+        Config.COMMON_CONFIG.setConfig(
+                InMemoryCommentedFormat.defaultInstance().createConfig(java.util.HashMap::new));
+    }
 
     @Nested
     @DisplayName("getLocalizedString")
@@ -80,7 +93,7 @@ class I18nUtilsTest {
         @DisplayName("No source returns skin-not-set message")
         void noSourceKey() {
             I18nUtils i18n = I18nUtils.getInstance();
-            assertEquals("Skin is not set", i18n.getLocalizedString("no_source", "en"));
+            assertEquals("No source available", i18n.getLocalizedString("no_source", "en"));
             assertEquals("Скин не установлен", i18n.getLocalizedString("no_source", "ru"));
             assertEquals("Cкіна не встановлено", i18n.getLocalizedString("no_source", "uk"));
         }
@@ -157,6 +170,57 @@ class I18nUtilsTest {
                         () -> "Key '" + key + "' produced empty string in locale '" + locale + "'");
                 }
             }
+        }
+    }
+
+    @Nested
+    @DisplayName("get (config-first message lookup)")
+    class Get {
+
+        @Test
+        @DisplayName("Existing key falls back to built-in locale text at defaults")
+        void existingKeyUsesLocaleText() {
+            assertEquals("Processing...", I18nUtils.get("change"));
+        }
+
+        @Test
+        @DisplayName("New key falls back to the config default")
+        void newKeyUsesConfigDefault() {
+            assertEquals("Permission denied", I18nUtils.get("permission_denied"));
+            assertEquals("No random username available", I18nUtils.get("no_random_username"));
+        }
+
+        @Test
+        @DisplayName("Format specifiers are applied to the resolved template")
+        void formatArgsApplied() {
+            assertEquals("No skin found for \"Steve\"", I18nUtils.get("no_skin_found", "Steve"));
+            assertEquals("Metrics cleanup: pruned 3 stale player entries", I18nUtils.get("metrics_cleanup", 3));
+            assertEquals("Please wait 2s before using /skin again", I18nUtils.get("cooldown", 2));
+        }
+
+        @Test
+        @DisplayName("Messages config override wins over locale text")
+        void configOverrideWins() {
+            ForgeConfigSpec.ConfigValue<String> cfg = Config.MESSAGES_CHANGE;
+            String original = cfg.get();
+            try {
+                cfg.set("Custom change message");
+                assertEquals("Custom change message", I18nUtils.get("change"));
+            } finally {
+                cfg.set(original);
+            }
+        }
+
+        @Test
+        @DisplayName("Null key returns null")
+        void nullKey() {
+            assertNull(I18nUtils.get(null));
+        }
+
+        @Test
+        @DisplayName("getLocalizedComponent wraps get() in a literal component")
+        void componentWrap() {
+            assertEquals("Processing...", I18nUtils.getLocalizedComponent("change").getString());
         }
     }
 


### PR DESCRIPTION
lib-44 + lib-45 HIGH-priority. 21 message keys, all hardcoded literals routed through I18nUtils. Config overrides win only when they differ from the built-in default, so existing locale text (en/ru/uk) is preserved at defaults. No behavior change at defaults. 291 tests pass (284 baseline + 7 new), aislop 100/100.