### PR TITLE
feat(default-skins): list with <random> + applyForPremium flag

### DIFF
--- a/src/main/java/levosilimo/everlastingskins/Config.java
+++ b/src/main/java/levosilimo/everlastingskins/Config.java
@@ -10,6 +10,8 @@ package levosilimo.everlastingskins;
 import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.fml.common.Mod;
 
+import java.util.List;
+
 @Mod.EventBusSubscriber
 public class Config {
     public static ForgeConfigSpec COMMON_CONFIG;
@@ -61,6 +63,9 @@ public class Config {
     public static ForgeConfigSpec.ConfigValue<String> MESSAGES_METRICS_NO_REFRESHES;
     public static ForgeConfigSpec.ConfigValue<String> MESSAGES_METRICS_CLEANUP;
     public static ForgeConfigSpec.ConfigValue<String> MESSAGES_METRICS_RESET;
+    public static ForgeConfigSpec.BooleanValue DEFAULT_SKINS_ENABLED;
+    public static ForgeConfigSpec.BooleanValue DEFAULT_SKINS_APPLY_FOR_PREMIUM;
+    public static ForgeConfigSpec.ConfigValue<List<? extends String>> DEFAULT_SKINS_LIST;
 
     static {
         ForgeConfigSpec.Builder builder = new ForgeConfigSpec.Builder();
@@ -135,6 +140,16 @@ public class Config {
             .defineInRange("mojang_profile_cache_ttl_ms", 3600000L, 0L, 604800000L);
         MOJANG_CACHE_MAX_SIZE = builder.comment("Max Mojang profile cache entries (oldest evicted first)")
             .defineInRange("mojang_profile_cache_max_size", 1000, 0, 1000000);
+        builder.pop();
+        builder.push("DefaultSkins");
+        DEFAULT_SKINS_ENABLED = builder.comment("Apply a default skin from 'list' to players without a saved custom skin")
+            .define("enabled", false);
+        DEFAULT_SKINS_APPLY_FOR_PREMIUM = builder.comment("Also apply the default skin to players WITH a saved custom skin"
+                + " (display-only override; their stored custom skin is preserved)")
+            .define("applyForPremium", false);
+        DEFAULT_SKINS_LIST = builder.comment("Default skins list: Mojang usernames or the literal '<random>' token"
+                + " (random Mojang username on each login)")
+            .defineList("list", List.of("Steve", "<random>"), o -> o instanceof String);
         builder.pop();
         COMMON_CONFIG = builder.build();
     }

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/DefaultSkinResolver.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/DefaultSkinResolver.java
@@ -1,0 +1,80 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
+package levosilimo.everlastingskins.skinchanger;
+
+import com.mojang.authlib.properties.Property;
+import levosilimo.everlastingskins.EverlastingSkins;
+import levosilimo.everlastingskins.enums.SkinVariant;
+import levosilimo.everlastingskins.skinchanger.responses.mojang.MojangSkinDataResult;
+import levosilimo.everlastingskins.util.CustomSkinProperty;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Supplier;
+
+/**
+ * Resolves a default skin from the configured DefaultSkins list
+ * (SkinsRestorer storage.defaultSkins pattern):
+ * <ul>
+ *   <li>single-entry list - always that entry</li>
+ *   <li>list contains the "&lt;random&gt;" token - random Mojang username via
+ *       {@link RandomMojangSkin} resolved through the Mojang API</li>
+ *   <li>multiple entries - uniform random pick</li>
+ *   <li>empty or null list - null (caller falls back to the static
+ *       default-skin.properties)</li>
+ * </ul>
+ */
+public final class DefaultSkinResolver {
+
+    public static final String RANDOM_TOKEN = "<random>";
+
+    private DefaultSkinResolver() {}
+
+    @Nullable
+    public static Property resolveDefault(List<? extends String> list, MojangAPI mojangAPI) {
+        return resolveDefault(list, mojangAPI, DefaultSkinResolver::randomUsername);
+    }
+
+    /** Test seam: injects the random-username supplier instead of {@link RandomMojangSkin}. */
+    @Nullable
+    static Property resolveDefault(List<? extends String> list, MojangAPI mojangAPI, Supplier<String> randomNameSupplier) {
+        if (list == null || list.isEmpty()) return null;
+        String pick = pickEntry(list);
+        if (RANDOM_TOKEN.equals(pick)) {
+            String randomName = randomNameSupplier.get();
+            if (randomName == null) return null;
+            return skinProperty(mojangAPI, randomName);
+        }
+        return skinProperty(mojangAPI, pick);
+    }
+
+    /** Uniform pick; a single-entry list always yields that entry. */
+    static String pickEntry(List<? extends String> list) {
+        return list.size() == 1 ? list.get(0) : list.get(ThreadLocalRandom.current().nextInt(list.size()));
+    }
+
+    @Nullable
+    private static String randomUsername() {
+        try {
+            return RandomMojangSkin.randomUsername(false, SkinVariant.CLASSIC);
+        } catch (IOException e) {
+            EverlastingSkins.logger.warn("Failed to pick random default-skin username", e);
+            return null;
+        }
+    }
+
+    @Nullable
+    private static Property skinProperty(MojangAPI mojangAPI, String name) {
+        return mojangAPI.getSkin(name)
+                .map(MojangSkinDataResult::skinProperty)
+                .map(CustomSkinProperty::getOriginalProperty)
+                .orElse(null);
+    }
+}

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRestorer.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRestorer.java
@@ -7,6 +7,8 @@
 
 package levosilimo.everlastingskins.skinchanger;
 
+import com.mojang.authlib.properties.Property;
+import levosilimo.everlastingskins.Config;
 import levosilimo.everlastingskins.metrics.SkinMetrics;
 import levosilimo.everlastingskins.skinchanger.command.SkinActionCommand;
 import levosilimo.everlastingskins.skinchanger.responses.mojang.MojangSkinDataResult;
@@ -74,13 +76,36 @@ public class SkinRestorer {
         if (!(event.getEntity() instanceof ServerPlayer player)) return;
         SkinMetrics.INSTANCE.recordPlayerJoined();
 
-        if (skinStorage.hasDefaultSkin(player.getUUID())) {
+        UUID uuid = player.getUUID();
+        boolean hasCustomSkin = !skinStorage.hasDefaultSkin(uuid);
+        // applyForPremium=false (default): the default skin only applies when the
+        // player has no saved custom skin. true: it also overrides players WITH a
+        // saved custom skin — display-only; the stored custom skin is preserved.
+        boolean applyDefault = Config.DEFAULT_SKINS_APPLY_FOR_PREMIUM.get() || !hasCustomSkin;
+
+        if (applyDefault) {
             // Never block the login thread on the 3-provider HTTP chain: fetch
             // on the shared executor and apply back on the server thread.
             MinecraftServer srv = server;
-            UUID uuid = player.getUUID();
             String name = player.getGameProfile().getName();
             loginExecutor.submit(() -> {
+                // Config list takes precedence; the static default-skin.properties
+                // restore is the fallback when the list is disabled or empty.
+                if (Config.DEFAULT_SKINS_ENABLED.get() && !Config.DEFAULT_SKINS_LIST.get().isEmpty()) {
+                    Property defaultProp = DefaultSkinResolver.resolveDefault(
+                            Config.DEFAULT_SKINS_LIST.get(), SkinCommand.getMojangAPI());
+                    if (defaultProp == null) return;
+                    srv.execute(() -> {
+                        // Re-check: skip unless the player still qualifies — unless
+                        // applyForPremium explicitly allows overriding a saved custom skin.
+                        if (!Config.DEFAULT_SKINS_APPLY_FOR_PREMIUM.get() && !skinStorage.hasDefaultSkin(uuid)) return;
+                        ServerPlayer online = srv.getPlayerList().getPlayer(uuid);
+                        if (online == null) return;
+                        online.getGameProfile().getProperties().removeAll("textures");
+                        online.getGameProfile().getProperties().put("textures", defaultProp);
+                    });
+                    return;
+                }
                 MojangSkinDataResult skinDataResult = SkinCommand.getMojangAPI().getSkin(name).orElse(null);
                 if (skinDataResult == null) return;
                 CustomSkinProperty property = skinDataResult.skinProperty();

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/DefaultSkinResolverTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/DefaultSkinResolverTest.java
@@ -1,0 +1,175 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
+package levosilimo.everlastingskins.skinchanger;
+
+import com.mojang.authlib.properties.Property;
+import levosilimo.everlastingskins.skinchanger.SkinCommandTest.FakeMojangAPI;
+import levosilimo.everlastingskins.util.CustomSkinProperty;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link DefaultSkinResolver}.
+ *
+ * <p>The 3-argument overload injects the random-username supplier so the
+ * "&lt;random&gt;" token path is exercised without the network-backed
+ * {@link RandomMojangSkin}.
+ */
+class DefaultSkinResolverTest {
+
+    private static final String STEVE = "Steve";
+    private static final String ALEX = "Alex";
+    private static final String NOTCH = "Notch";
+    private static final String FAKE_VALUE = "validTextureValue";
+    private static final String FAKE_SIG = "validSignature";
+
+    private static FakeMojangAPI apiWithNames(String... names) {
+        FakeMojangAPI api = new FakeMojangAPI();
+        for (String name : names) {
+            api.addSkin(name, new CustomSkinProperty(FAKE_VALUE, FAKE_SIG, name));
+        }
+        return api;
+    }
+
+    @Nested
+    @DisplayName("list guards")
+    class ListGuards {
+
+        @Test
+        @DisplayName("null list returns null")
+        void nullList_returnsNull() {
+            assertNull(DefaultSkinResolver.resolveDefault(null, new FakeMojangAPI()));
+        }
+
+        @Test
+        @DisplayName("empty list returns null")
+        void emptyList_returnsNull() {
+            assertNull(DefaultSkinResolver.resolveDefault(List.of(), new FakeMojangAPI()));
+        }
+    }
+
+    @Nested
+    @DisplayName("single entry")
+    class SingleEntry {
+
+        @Test
+        @DisplayName("always picks the only entry")
+        void singleEntry_alwaysThatEntry() {
+            for (int i = 0; i < 100; i++) {
+                assertEquals(NOTCH, DefaultSkinResolver.pickEntry(List.of(NOTCH)));
+            }
+        }
+
+        @Test
+        @DisplayName("resolves the single entry through the Mojang API")
+        void singleEntry_resolves() {
+            Property prop = DefaultSkinResolver.resolveDefault(List.of(NOTCH), apiWithNames(NOTCH));
+            assertNotNull(prop);
+            assertEquals(FAKE_VALUE, prop.value());
+        }
+
+        @Test
+        @DisplayName("unknown single entry returns null")
+        void singleEntry_unknown_returnsNull() {
+            assertNull(DefaultSkinResolver.resolveDefault(List.of("Nobody_xyz"), new FakeMojangAPI()));
+        }
+    }
+
+    @Nested
+    @DisplayName("multi entry")
+    class MultiEntry {
+
+        @Test
+        @DisplayName("picks entries roughly uniformly")
+        void multiEntry_uniformDistribution() {
+            List<String> list = List.of(STEVE, ALEX, NOTCH);
+            Map<String, Integer> counts = new HashMap<>();
+            for (int i = 0; i < 3000; i++) {
+                String pick = DefaultSkinResolver.pickEntry(list);
+                counts.merge(pick, 1, Integer::sum);
+            }
+            assertEquals(3, counts.size());
+            // expected 1000 per entry; ±200 is a ~7.7 sigma window
+            for (String entry : list) {
+                int n = counts.getOrDefault(entry, 0);
+                assertTrue(n >= 800 && n <= 1200, entry + " picked " + n + " times (expected ~1000)");
+            }
+        }
+
+        @Test
+        @DisplayName("random token is sometimes picked in a multi-entry list")
+        void randomToken_sometimesPicked() {
+            List<String> list = List.of(STEVE, DefaultSkinResolver.RANDOM_TOKEN, ALEX);
+            int randomPicks = 0;
+            for (int i = 0; i < 3000; i++) {
+                if (DefaultSkinResolver.RANDOM_TOKEN.equals(DefaultSkinResolver.pickEntry(list))) {
+                    randomPicks++;
+                }
+            }
+            // expected ~1000; even 500 is a ~19 sigma floor
+            assertTrue(randomPicks >= 500, "<random> picked only " + randomPicks + " times");
+        }
+    }
+
+    @Nested
+    @DisplayName("random token resolution")
+    class RandomToken {
+
+        @Test
+        @DisplayName("resolves the supplier's username through the Mojang API")
+        void randomToken_resolvesSupplierUsername() {
+            Property prop = DefaultSkinResolver.resolveDefault(
+                    List.of(DefaultSkinResolver.RANDOM_TOKEN), apiWithNames(NOTCH), () -> NOTCH);
+            assertNotNull(prop);
+            assertEquals(FAKE_VALUE, prop.value());
+        }
+
+        @Test
+        @DisplayName("supplier returning null yields null")
+        void randomToken_nullSupplier_returnsNull() {
+            assertNull(DefaultSkinResolver.resolveDefault(
+                    List.of(DefaultSkinResolver.RANDOM_TOKEN), new FakeMojangAPI(), () -> null));
+        }
+
+        @Test
+        @DisplayName("supplier is only invoked when the random token is picked")
+        void supplierOnlyInvokedOnRandomToken() {
+            AtomicInteger calls = new AtomicInteger();
+            Property prop = DefaultSkinResolver.resolveDefault(
+                    List.of(STEVE), apiWithNames(STEVE), () -> {
+                        calls.incrementAndGet();
+                        return NOTCH;
+                    });
+            assertNotNull(prop);
+            assertEquals(0, calls.get(), "supplier must not run for a plain username pick");
+
+            prop = DefaultSkinResolver.resolveDefault(
+                    List.of(DefaultSkinResolver.RANDOM_TOKEN), apiWithNames(NOTCH), () -> {
+                        calls.incrementAndGet();
+                        return NOTCH;
+                    });
+            assertNotNull(prop);
+            assertEquals(1, calls.get(), "supplier must run exactly once for <random>");
+        }
+
+        @Test
+        @DisplayName("unknown random username yields null")
+        void randomToken_unknownUsername_returnsNull() {
+            assertNull(DefaultSkinResolver.resolveDefault(
+                    List.of(DefaultSkinResolver.RANDOM_TOKEN), new FakeMojangAPI(), () -> "Nobody_xyz"));
+        }
+    }
+}


### PR DESCRIPTION
Implements lib-48 default-skins pattern. Default list supports Mojang usernames + <random> token. applyForPremium semantic flagged for review (display-only override; stored custom skin preserved).