### PR TITLE
feat(security): URL domain allowlist for /skin set web

### DIFF
--- a/src/main/java/levosilimo/everlastingskins/Config.java
+++ b/src/main/java/levosilimo/everlastingskins/Config.java
@@ -66,6 +66,8 @@ public class Config {
     public static ForgeConfigSpec.BooleanValue DEFAULT_SKINS_ENABLED;
     public static ForgeConfigSpec.BooleanValue DEFAULT_SKINS_APPLY_FOR_PREMIUM;
     public static ForgeConfigSpec.ConfigValue<List<? extends String>> DEFAULT_SKINS_LIST;
+    public static ForgeConfigSpec.BooleanValue URL_ALLOWLIST_ENABLED;
+    public static ForgeConfigSpec.ConfigValue<List<? extends String>> URL_ALLOWLIST_DOMAINS;
 
     static {
         ForgeConfigSpec.Builder builder = new ForgeConfigSpec.Builder();
@@ -150,6 +152,16 @@ public class Config {
         DEFAULT_SKINS_LIST = builder.comment("Default skins list: Mojang usernames or the literal '<random>' token"
                 + " (random Mojang username on each login)")
             .defineList("list", List.of("Steve", "<random>"), o -> o instanceof String);
+        builder.pop();
+        builder.push("Security");
+        URL_ALLOWLIST_ENABLED = builder.comment("Enable URL domain allowlist for /skin set web (empty list = deny all)")
+            .define("urlAllowlistEnabled", false);
+        URL_ALLOWLIST_DOMAINS = builder.comment("Domains allowed for /skin set web (eTLD+1 suffix match; one entry covers all subdomains)")
+            .defineList("urlAllowlistDomains", List.of(
+                "imgur.com", "storage.googleapis.com", "cdn.discordapp.com",
+                "textures.minecraft.net", "namemc.com", "crafatar.com",
+                "mc-heads.net", "githubusercontent.com", "minecraftskins.com"
+            ), o -> o instanceof String);
         builder.pop();
         COMMON_CONFIG = builder.build();
     }

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/MineSkinApiHttpImpl.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/MineSkinApiHttpImpl.java
@@ -60,6 +60,9 @@ public class MineSkinApiHttpImpl implements MineSkinAPI {
 
     Optional<MineSkinResponse> genSkinInternal(String url, @Nullable SkinVariant variant) {
         String processedUrl = EverlastingHelpers.sanitizeImageURL(url);
+        if (!UrlAllowlist.isAllowed(processedUrl, Config.URL_ALLOWLIST_ENABLED.get(), Config.URL_ALLOWLIST_DOMAINS.get())) {
+            return Optional.empty();
+        }
 
         try {
             JsonObject requestBody = new JsonObject();

--- a/src/main/java/levosilimo/everlastingskins/util/UrlAllowlist.java
+++ b/src/main/java/levosilimo/everlastingskins/util/UrlAllowlist.java
@@ -1,0 +1,48 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.util;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * eTLD+1 domain matching for /skin set web URLs (FabricTailor-style).
+ * A single entry covers the domain itself and all subdomains.
+ */
+public final class UrlAllowlist {
+    private UrlAllowlist() {}
+
+    public static boolean isAllowed(String url, boolean enabled, List<? extends String> domains) {
+        if (!enabled) {
+            return true;
+        }
+        if (url == null) {
+            return false;
+        }
+        if (domains == null || domains.isEmpty()) {
+            return false;
+        }
+        try {
+            URI uri = URI.create(url);
+            String host = uri.getHost();
+            if (host == null) {
+                return false;
+            }
+            host = host.toLowerCase(Locale.ROOT);
+            for (String domain : domains) {
+                String normalized = domain.toLowerCase(Locale.ROOT);
+                if (host.equals(normalized) || host.endsWith("." + normalized)) {
+                    return true;
+                }
+            }
+            return false;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+}

--- a/src/test/java/levosilimo/everlastingskins/util/UrlAllowlistTest.java
+++ b/src/test/java/levosilimo/everlastingskins/util/UrlAllowlistTest.java
@@ -1,0 +1,76 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class UrlAllowlistTest {
+
+    private static final List<String> DOMAINS = Arrays.asList(
+            "imgur.com", "storage.googleapis.com", "cdn.discordapp.com");
+
+    @Test
+    void disabledAllowsEverything() {
+        assertTrue(UrlAllowlist.isAllowed("https://evil.example.org/x.png", false, DOMAINS));
+        assertTrue(UrlAllowlist.isAllowed("https://i.imgur.com/x.png", false, DOMAINS));
+        assertTrue(UrlAllowlist.isAllowed(null, false, DOMAINS));
+        assertTrue(UrlAllowlist.isAllowed("https://imgur.com/x.png", false, Collections.emptyList()));
+    }
+
+    @Test
+    void enabledWithEmptyListDeniesAll() {
+        assertFalse(UrlAllowlist.isAllowed("https://i.imgur.com/x.png", true, Collections.emptyList()));
+        assertFalse(UrlAllowlist.isAllowed("https://imgur.com/x.png", true, Collections.emptyList()));
+        assertFalse(UrlAllowlist.isAllowed(null, true, Collections.emptyList()));
+    }
+
+    @Test
+    void allowsListedSubdomain() {
+        assertTrue(UrlAllowlist.isAllowed("https://i.imgur.com/skin.png", true, DOMAINS));
+        assertTrue(UrlAllowlist.isAllowed("https://a.b.c.imgur.com/skin.png", true, DOMAINS));
+    }
+
+    @Test
+    void allowsParentDomainItself() {
+        assertTrue(UrlAllowlist.isAllowed("https://imgur.com/skin.png", true, DOMAINS));
+        assertTrue(UrlAllowlist.isAllowed("http://imgur.com", true, DOMAINS));
+    }
+
+    @Test
+    void allowsSchemePortAndCaseVariants() {
+        assertTrue(UrlAllowlist.isAllowed("http://imgur.com/skin.png", true, DOMAINS));
+        assertTrue(UrlAllowlist.isAllowed("https://imgur.com:8443/skin.png", true, DOMAINS));
+        assertTrue(UrlAllowlist.isAllowed("https://I.IMGUR.COM/skin.png", true, DOMAINS));
+    }
+
+    @Test
+    void deniesSuffixLookalikeDomain() {
+        assertFalse(UrlAllowlist.isAllowed("https://evil-imgur.com/skin.png", true, DOMAINS));
+        assertFalse(UrlAllowlist.isAllowed("https://imgur.com.evil.net/skin.png", true, DOMAINS));
+    }
+
+    @Test
+    void deniesUnlistedDomain() {
+        assertFalse(UrlAllowlist.isAllowed("https://randomcdn.net/skin.png", true, DOMAINS));
+        assertFalse(UrlAllowlist.isAllowed("https://cdn.discordapp.net/skin.png", true, DOMAINS));
+    }
+
+    @Test
+    void deniesNullOrMalformedUrl() {
+        assertFalse(UrlAllowlist.isAllowed(null, true, DOMAINS));
+        assertFalse(UrlAllowlist.isAllowed("", true, DOMAINS));
+        assertFalse(UrlAllowlist.isAllowed("not a url", true, DOMAINS));
+        assertFalse(UrlAllowlist.isAllowed("https:///no-host", true, DOMAINS));
+    }
+}


### PR DESCRIPTION
Implements lib-48 HIGH-priority recommendation. Default list of common skin hosts; FabricTailor eTLD+1 matching.

- Config.Security.urlAllowlistEnabled (default false) + urlAllowlistDomains (9 default hosts)
- eTLD+1 suffix match (host == domain || host.endsWith("." + domain)), case-insensitive
- Enforced in MineSkinApiHttpImpl AFTER sanitizeImageURL (post namemc.com rewrite)
- Empty list + enabled = deny-all
- UrlAllowlistTest: 8 cases (disabled passthrough, deny-all, subdomain/parent match, suffix lookalike denial, scheme/port/case variants, malformed/null URLs)
- 292 tests pass, aislop 100/100