### PR TITLE
feat(security): URL domain allowlist (1.12.2 port)

### DIFF
--- a/src/main/java/levosilimo/everlastingskins/Config.java
+++ b/src/main/java/levosilimo/everlastingskins/Config.java
@@ -28,6 +28,13 @@ public final class Config {
     public static int MAX_COMMANDS_PER_MINUTE = 5;
     public static int DEBOUNCE_MILLIS = 100;
 
+    public static boolean urlAllowlistEnabled = false;
+    public static String[] urlAllowlistDomains = new String[]{
+        "imgur.com", "storage.googleapis.com", "cdn.discordapp.com",
+        "textures.minecraft.net", "namemc.com", "crafatar.com",
+        "mc-heads.net", "githubusercontent.com", "minecraftskins.com"
+    };
+
     public static boolean mojangProfileCacheEnabled = true;
     public static long mojangProfileCacheTtlMs = TimeUnit.HOURS.toMillis(1);
     public static int mojangProfileCacheMaxSize = 1000;
@@ -70,6 +77,10 @@ public final class Config {
                 "Also apply the default skin to players WITH a saved custom skin (display-only override)");
             DEFAULT_SKINS_LIST = cfg.getStringList("list", "DefaultSkins", DEFAULT_SKINS_LIST,
                 "Default skins list: Mojang usernames or the literal '<random>' token");
+            urlAllowlistEnabled = cfg.getBoolean("urlAllowlistEnabled", "Security", urlAllowlistEnabled,
+                "Enable URL domain allowlist for /skin set web (empty list = deny all)");
+            urlAllowlistDomains = cfg.getStringList("urlAllowlistDomains", "Security", urlAllowlistDomains,
+                "Domains allowed for /skin set web (eTLD+1 suffix match; one entry covers all subdomains)");
         } catch (Exception e) {
             EverlastingSkins.logger.error("Failed to load config", e);
         } finally {

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/MineSkinApiHttpImpl.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/MineSkinApiHttpImpl.java
@@ -18,10 +18,12 @@ import levosilimo.everlastingskins.util.EverlastingHelpers;
 import levosilimo.everlastingskins.util.HttpClient;
 import levosilimo.everlastingskins.util.HttpsUrlConnectionHttpClient;
 import levosilimo.everlastingskins.util.JsonUtils;
+import levosilimo.everlastingskins.util.UrlAllowlist;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -76,6 +78,9 @@ public class MineSkinApiHttpImpl implements MineSkinAPI {
 
     Optional<MineSkinResponse> genSkinInternal(String url, @Nullable SkinVariant variant) {
         String processedUrl = EverlastingHelpers.sanitizeImageURL(url);
+        if (!UrlAllowlist.isAllowed(processedUrl, Config.urlAllowlistEnabled, Arrays.asList(Config.urlAllowlistDomains))) {
+            return Optional.empty();
+        }
 
         try {
             HttpResponse response = httpClient.execute(

--- a/src/main/java/levosilimo/everlastingskins/util/UrlAllowlist.java
+++ b/src/main/java/levosilimo/everlastingskins/util/UrlAllowlist.java
@@ -1,0 +1,48 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.util;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * eTLD+1 domain matching for /skin set web URLs (FabricTailor-style).
+ * A single entry covers the domain itself and all subdomains.
+ */
+public final class UrlAllowlist {
+    private UrlAllowlist() {}
+
+    public static boolean isAllowed(String url, boolean enabled, List<? extends String> domains) {
+        if (!enabled) {
+            return true;
+        }
+        if (url == null) {
+            return false;
+        }
+        if (domains == null || domains.isEmpty()) {
+            return false;
+        }
+        try {
+            URI uri = URI.create(url);
+            String host = uri.getHost();
+            if (host == null) {
+                return false;
+            }
+            host = host.toLowerCase(Locale.ROOT);
+            for (String domain : domains) {
+                String normalized = domain.toLowerCase(Locale.ROOT);
+                if (host.equals(normalized) || host.endsWith("." + normalized)) {
+                    return true;
+                }
+            }
+            return false;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+}

--- a/src/test/java/levosilimo/everlastingskins/util/UrlAllowlistTest.java
+++ b/src/test/java/levosilimo/everlastingskins/util/UrlAllowlistTest.java
@@ -1,0 +1,76 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class UrlAllowlistTest {
+
+    private static final List<String> DOMAINS = Arrays.asList(
+            "imgur.com", "storage.googleapis.com", "cdn.discordapp.com");
+
+    @Test
+    void disabledAllowsEverything() {
+        assertTrue(UrlAllowlist.isAllowed("https://evil.example.org/x.png", false, DOMAINS));
+        assertTrue(UrlAllowlist.isAllowed("https://i.imgur.com/x.png", false, DOMAINS));
+        assertTrue(UrlAllowlist.isAllowed(null, false, DOMAINS));
+        assertTrue(UrlAllowlist.isAllowed("https://imgur.com/x.png", false, Collections.emptyList()));
+    }
+
+    @Test
+    void enabledWithEmptyListDeniesAll() {
+        assertFalse(UrlAllowlist.isAllowed("https://i.imgur.com/x.png", true, Collections.emptyList()));
+        assertFalse(UrlAllowlist.isAllowed("https://imgur.com/x.png", true, Collections.emptyList()));
+        assertFalse(UrlAllowlist.isAllowed(null, true, Collections.emptyList()));
+    }
+
+    @Test
+    void allowsListedSubdomain() {
+        assertTrue(UrlAllowlist.isAllowed("https://i.imgur.com/skin.png", true, DOMAINS));
+        assertTrue(UrlAllowlist.isAllowed("https://a.b.c.imgur.com/skin.png", true, DOMAINS));
+    }
+
+    @Test
+    void allowsParentDomainItself() {
+        assertTrue(UrlAllowlist.isAllowed("https://imgur.com/skin.png", true, DOMAINS));
+        assertTrue(UrlAllowlist.isAllowed("http://imgur.com", true, DOMAINS));
+    }
+
+    @Test
+    void allowsSchemePortAndCaseVariants() {
+        assertTrue(UrlAllowlist.isAllowed("http://imgur.com/skin.png", true, DOMAINS));
+        assertTrue(UrlAllowlist.isAllowed("https://imgur.com:8443/skin.png", true, DOMAINS));
+        assertTrue(UrlAllowlist.isAllowed("https://I.IMGUR.COM/skin.png", true, DOMAINS));
+    }
+
+    @Test
+    void deniesSuffixLookalikeDomain() {
+        assertFalse(UrlAllowlist.isAllowed("https://evil-imgur.com/skin.png", true, DOMAINS));
+        assertFalse(UrlAllowlist.isAllowed("https://imgur.com.evil.net/skin.png", true, DOMAINS));
+    }
+
+    @Test
+    void deniesUnlistedDomain() {
+        assertFalse(UrlAllowlist.isAllowed("https://randomcdn.net/skin.png", true, DOMAINS));
+        assertFalse(UrlAllowlist.isAllowed("https://cdn.discordapp.net/skin.png", true, DOMAINS));
+    }
+
+    @Test
+    void deniesNullOrMalformedUrl() {
+        assertFalse(UrlAllowlist.isAllowed(null, true, DOMAINS));
+        assertFalse(UrlAllowlist.isAllowed("", true, DOMAINS));
+        assertFalse(UrlAllowlist.isAllowed("not a url", true, DOMAINS));
+        assertFalse(UrlAllowlist.isAllowed("https:///no-host", true, DOMAINS));
+    }
+}


### PR DESCRIPTION
Backport of fix/1.21-url-allowlist (#146). Same semantics, Forge 1.12.2 Configuration API.

- Config.Security.urlAllowlistEnabled (default false) + urlAllowlistDomains (9 default hosts, String[])
- eTLD+1 suffix match, case-insensitive
- Enforced in MineSkinApiHttpImpl AFTER sanitizeImageURL
- Empty list + enabled = deny-all
- 260 tests pass, aislop 100/100