### PR TITLE
fix(discord): route announce message through I18nUtils

### DIFF
--- a/src/main/java/levosilimo/everlastingskins/Config.java
+++ b/src/main/java/levosilimo/everlastingskins/Config.java
@@ -68,6 +68,7 @@ public class Config {
     public static ForgeConfigSpec.ConfigValue<List<? extends String>> DEFAULT_SKINS_LIST;
     public static ForgeConfigSpec.BooleanValue URL_ALLOWLIST_ENABLED;
     public static ForgeConfigSpec.ConfigValue<List<? extends String>> URL_ALLOWLIST_DOMAINS;
+    public static ForgeConfigSpec.ConfigValue<String> MESSAGES_DISCORD_ANNOUNCE;
 
     static {
         ForgeConfigSpec.Builder builder = new ForgeConfigSpec.Builder();
@@ -96,6 +97,7 @@ public class Config {
         MESSAGES_METRICS_NO_REFRESHES = builder.define("messages_metrics_no_refreshes", "(no refreshes recorded)");
         MESSAGES_METRICS_CLEANUP = builder.define("messages_metrics_cleanup", "Metrics cleanup: pruned %d stale player entries");
         MESSAGES_METRICS_RESET = builder.define("messages_metrics_reset", "Metrics reset");
+        MESSAGES_DISCORD_ANNOUNCE = builder.define("messages_discord_announce", "**%s** changed their skin to: `%s`");
         builder.pop();
         builder.push("Integration");
         DISCORDSRV_ENABLED = builder.comment("Enable DiscordSRV skin change announcements")

--- a/src/main/java/levosilimo/everlastingskins/integration/discordsrv/DiscordSrvHook.java
+++ b/src/main/java/levosilimo/everlastingskins/integration/discordsrv/DiscordSrvHook.java
@@ -7,6 +7,7 @@
 
 package levosilimo.everlastingskins.integration.discordsrv;
 
+import levosilimo.everlastingskins.util.I18nUtils;
 import net.minecraft.server.level.ServerPlayer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -50,8 +51,7 @@ public final class DiscordSrvHook {
             }
 
             String label = skinSource != null ? skinSource : "default";
-            String message = String.format("**%s** changed their skin to: `%s`",
-                player.getScoreboardName(), label);
+            String message = I18nUtils.get("discord_announce", player.getScoreboardName(), label);
 
             Object messageAction = textChannelClass.getMethod("sendMessage", CharSequence.class)
                 .invoke(textChannel, message);

--- a/src/main/java/levosilimo/everlastingskins/util/I18nUtils.java
+++ b/src/main/java/levosilimo/everlastingskins/util/I18nUtils.java
@@ -48,7 +48,8 @@ public final class I18nUtils {
             Map.entry("metrics_refreshes", " refreshes"),
             Map.entry("metrics_no_refreshes", "(no refreshes recorded)"),
             Map.entry("metrics_cleanup", "Metrics cleanup: pruned %d stale player entries"),
-            Map.entry("metrics_reset", "Metrics reset")
+            Map.entry("metrics_reset", "Metrics reset"),
+            Map.entry("discord_announce", "**%s** changed their skin to: `%s`")
     );
 
     private static final Map<String, Map<String, String>> localizedStrings = new HashMap<>();
@@ -60,6 +61,7 @@ public final class I18nUtils {
         russianStrings.put("error", "Возникла ошибка при обработке скина.");
         russianStrings.put("timeout","Тайм-аут получения скина.");
         russianStrings.put("no_source", "Скин не установлен");
+        russianStrings.put("discord_announce", "**%s** изменил свой скин на: `%s`");
         localizedStrings.put("ru", russianStrings);
 
         Map<String, String> ukrainianStrings = new HashMap<>();
@@ -69,6 +71,7 @@ public final class I18nUtils {
         ukrainianStrings.put("error", "Сталася помилка при обробці скіна.");
         ukrainianStrings.put("timeout","Тайм-аут отримання скіна.");
         ukrainianStrings.put("no_source", "Cкіна не встановлено");
+        ukrainianStrings.put("discord_announce", "**%s** змінив свій скін на: `%s`");
         localizedStrings.put("uk", ukrainianStrings);
 
         Map<String, String> englishStrings = new HashMap<>();
@@ -231,6 +234,7 @@ public final class I18nUtils {
             case "metrics_no_refreshes" -> Config.MESSAGES_METRICS_NO_REFRESHES;
             case "metrics_cleanup" -> Config.MESSAGES_METRICS_CLEANUP;
             case "metrics_reset" -> Config.MESSAGES_METRICS_RESET;
+            case "discord_announce" -> Config.MESSAGES_DISCORD_ANNOUNCE;
             default -> null;
         };
         if (config == null) return null;


### PR DESCRIPTION
lib-51 audit item: Discord announce was hardcoded in DiscordSrvHook.

Uses the I18nUtils.get() API from #144: messages_discord_announce config key, DEFAULT_ENGLISH entry, ru/uk locale entries, and configValue switch case. No behavior change at defaults.