### PR TITLE
feat(permissions): per-command op level + bypass.cooldown node

### DIFF
--- a/src/gametest/java/levosilimo/everlastingskins/gametest/SkinVisibilityTest.java
+++ b/src/gametest/java/levosilimo/everlastingskins/gametest/SkinVisibilityTest.java
@@ -193,31 +193,37 @@ public class SkinVisibilityTest {
         placePlayer(helper, observer);
         drain(observer);
 
-        int result = dispatch(server, "skin set mojang Notch", playerA.createCommandSourceStack(), helper);
-        if (result != 0) {
-            helper.fail("non-OP dispatch must be rejected (return 0), got " + result);
-            return;
-        }
+        // /skin set web (op_level.url = 2) must be rejected for a non-OP; the
+        // mojang node is intentionally open (op_level.mojang = 0) since PR #152.
+        int result = dispatch(server, "skin set web classic \"http://example.com/skin.png\"",
+                playerA.createCommandSourceStack(), helper);
+        try {
+            if (result != 0) {
+                helper.fail("non-OP dispatch must be rejected (return 0), got " + result);
+                return;
+            }
 
-        boolean feedback = drain(playerA).stream()
-                .filter(ClientboundSystemChatPacket.class::isInstance)
-                .map(ClientboundSystemChatPacket.class::cast)
-                .anyMatch(p -> p.content().getString().contains("Permission denied"));
-        if (!feedback) {
-            helper.fail("non-OP player received no 'Permission denied' failure feedback");
-            return;
+            boolean feedback = drain(playerA).stream()
+                    .filter(ClientboundSystemChatPacket.class::isInstance)
+                    .map(ClientboundSystemChatPacket.class::cast)
+                    .anyMatch(p -> p.content().getString().contains("Permission denied"));
+            if (!feedback) {
+                helper.fail("non-OP player received no 'Permission denied' failure feedback");
+                return;
+            }
+            if (storage.getSkin(playerId) != null) {
+                helper.fail("permission-denied dispatch must not store a skin");
+                return;
+            }
+            if (findTexturesFor(drain(observer), playerId) != null) {
+                helper.fail("permission-denied dispatch must not broadcast textures");
+                return;
+            }
+            helper.succeed();
+        } finally {
+            removeQuietly(server, playerA);
+            removeQuietly(server, observer);
         }
-        if (storage.getSkin(playerId) != null) {
-            helper.fail("permission-denied dispatch must not store a skin");
-            return;
-        }
-        if (findTexturesFor(drain(observer), playerId) != null) {
-            helper.fail("permission-denied dispatch must not broadcast textures");
-            return;
-        }
-        removeQuietly(server, playerA);
-        removeQuietly(server, observer);
-        helper.succeed();
     }
 
     @GameTest(template = "everlastingskins:empty", timeoutTicks = 60000, batch = "everlastingskins:cmd_clear")
@@ -929,7 +935,8 @@ public class SkinVisibilityTest {
         ensureStorage(helper);
         MinecraftServer server = helper.getLevel().getServer();
         ServerPlayer playerA = mockPlayer(helper, "RateLimitA");
-        makeOp(playerA);
+        // Intentionally NOT op: everlastingskins.bypass.cooldown (op >= 2)
+        // would short-circuit the rate limiter.
         UUID uuidA = playerA.getUUID();
         try {
             placePlayer(helper, playerA);
@@ -941,6 +948,32 @@ public class SkinVisibilityTest {
             int second = dispatch(server, "skin set mojang Notch", playerA.createCommandSourceStack(), helper);
             helper.assertTrue(first == 1, "first dispatch must be accepted, got " + first);
             helper.assertTrue(second == 0, "second dispatch inside cooldown must be rejected, got " + second);
+            helper.succeed();
+        } finally {
+            Config.COOLDOWN_SECONDS.set(3);
+            SkinActionCommand.clearRateLimitState(uuidA);
+            removeQuietly(server, playerA);
+        }
+    }
+
+    @GameTest(template = "everlastingskins:empty", timeoutTicks = 200, batch = "everlastingskins:r8_ratelimit")
+    public void rateLimitBypassedForOps(GameTestHelper helper) {
+        installFakeMojangAPI(true);
+        ensureStorage(helper);
+        MinecraftServer server = helper.getLevel().getServer();
+        ServerPlayer playerA = mockPlayer(helper, "RateLimitBypassA");
+        makeOp(playerA); // op level 4 -> everlastingskins.bypass.cooldown applies
+        UUID uuidA = playerA.getUUID();
+        try {
+            placePlayer(helper, playerA);
+            SkinActionCommand.clearRateLimitState(uuidA);
+            Config.RATE_LIMIT_ENABLED.set(true);
+            Config.COOLDOWN_SECONDS.set(60);
+
+            int first = dispatch(server, "skin set mojang Notch", playerA.createCommandSourceStack(), helper);
+            int second = dispatch(server, "skin set mojang Dinnerbone", playerA.createCommandSourceStack(), helper);
+            helper.assertTrue(first == 1, "first dispatch must be accepted, got " + first);
+            helper.assertTrue(second == 1, "op player must bypass the cooldown, got " + second);
             helper.succeed();
         } finally {
             Config.COOLDOWN_SECONDS.set(3);

--- a/src/main/java/levosilimo/everlastingskins/Config.java
+++ b/src/main/java/levosilimo/everlastingskins/Config.java
@@ -69,6 +69,14 @@ public class Config {
     public static ForgeConfigSpec.BooleanValue URL_ALLOWLIST_ENABLED;
     public static ForgeConfigSpec.ConfigValue<List<? extends String>> URL_ALLOWLIST_DOMAINS;
 
+    public static ForgeConfigSpec.IntValue PERMISSIONS_OP_LEVEL_MOJANG;
+    public static ForgeConfigSpec.IntValue PERMISSIONS_OP_LEVEL_URL;
+    public static ForgeConfigSpec.IntValue PERMISSIONS_OP_LEVEL_CLEAR;
+    public static ForgeConfigSpec.IntValue PERMISSIONS_OP_LEVEL_RANDOM;
+    public static ForgeConfigSpec.IntValue PERMISSIONS_OP_LEVEL_OTHER;
+    public static ForgeConfigSpec.IntValue PERMISSIONS_OP_LEVEL_METRICS;
+    public static ForgeConfigSpec.IntValue PERMISSIONS_OP_LEVEL_METRICS_RESET;
+
     static {
         ForgeConfigSpec.Builder builder = new ForgeConfigSpec.Builder();
         builder.push("Messages");
@@ -162,6 +170,22 @@ public class Config {
                 "textures.minecraft.net", "namemc.com", "crafatar.com",
                 "mc-heads.net", "githubusercontent.com", "minecraftskins.com"
             ), o -> o instanceof String);
+        builder.pop();
+        builder.push("Permissions");
+        PERMISSIONS_OP_LEVEL_MOJANG = builder.comment("Required op level for /skin set <mojang>")
+            .defineInRange("op_level.mojang", 0, 0, 4);
+        PERMISSIONS_OP_LEVEL_URL = builder.comment("Required op level for /skin set web")
+            .defineInRange("op_level.url", 2, 0, 4);
+        PERMISSIONS_OP_LEVEL_CLEAR = builder.comment("Required op level for /skin clear")
+            .defineInRange("op_level.clear", 0, 0, 4);
+        PERMISSIONS_OP_LEVEL_RANDOM = builder.comment("Required op level for /skin set random")
+            .defineInRange("op_level.random", 0, 0, 4);
+        PERMISSIONS_OP_LEVEL_OTHER = builder.comment("Required op level for changing another player's skin")
+            .defineInRange("op_level.other", 2, 0, 4);
+        PERMISSIONS_OP_LEVEL_METRICS = builder.comment("Required op level for /skin metrics")
+            .defineInRange("op_level.metrics", 2, 0, 4);
+        PERMISSIONS_OP_LEVEL_METRICS_RESET = builder.comment("Required op level for /skin metrics cleanup/reset")
+            .defineInRange("op_level.metrics_reset", 2, 0, 4);
         builder.pop();
         COMMON_CONFIG = builder.build();
     }

--- a/src/main/java/levosilimo/everlastingskins/permission/LuckPermsPermissionService.java
+++ b/src/main/java/levosilimo/everlastingskins/permission/LuckPermsPermissionService.java
@@ -57,12 +57,12 @@ public class LuckPermsPermissionService implements IPermissionService {
                 Method getUserMethod = userManager.getClass().getMethod("getUser", UUID.class);
                 user = getUserMethod.invoke(userManager, uuid);
             } else {
-                LOGGER.debug("LP user {} not pre-loaded, falling back to op status", uuid);
-                return context.isOp();
+                LOGGER.debug("LP user {} not pre-loaded, falling back to vanilla per-node levels", uuid);
+                return vanillaFallback(context, permissionNode);
             }
             if (user == null) {
-                LOGGER.warn("LP user {} returned null from getUser, falling back to op status", uuid);
-                return context.isOp();
+                LOGGER.warn("LP user {} returned null from getUser, falling back to vanilla per-node levels", uuid);
+                return vanillaFallback(context, permissionNode);
             }
 
             Method getCachedDataMethod = user.getClass().getMethod("getCachedData");
@@ -87,6 +87,10 @@ public class LuckPermsPermissionService implements IPermissionService {
             LOGGER.debug("LuckPerms permission check failed for node {}: {}", permissionNode, e.getMessage());
             return false;
         }
+    }
+
+    private boolean vanillaFallback(PermissionContext context, String permissionNode) {
+        return new VanillaPermissionService().hasPermission(context, permissionNode);
     }
 
     @Override

--- a/src/main/java/levosilimo/everlastingskins/permission/PermissionContext.java
+++ b/src/main/java/levosilimo/everlastingskins/permission/PermissionContext.java
@@ -7,15 +7,38 @@
 
 package levosilimo.everlastingskins.permission;
 
+import net.minecraft.server.level.ServerPlayer;
+
+import java.util.Objects;
 import java.util.UUID;
 
 /**
  * Lightweight context for permission checks. Decouples the permission system
  * from Minecraft's ServerPlayer/EntityPlayerMP, which can't be instantiated
  * in unit tests due to EntityDataSerializers static init.
+ *
+ * @param uuid    the player
+ * @param opLevel the player's effective op level (0-4, 0 = not an op)
  */
-public record PermissionContext(UUID uuid, boolean isOp) {
-    public static PermissionContext of(UUID uuid, boolean isOp) {
-        return new PermissionContext(uuid, isOp);
+public record PermissionContext(UUID uuid, int opLevel) {
+
+    public PermissionContext {
+        Objects.requireNonNull(uuid, "uuid");
+        if (opLevel < 0 || opLevel > 4) {
+            throw new IllegalArgumentException("opLevel must be 0-4, got " + opLevel);
+        }
+    }
+
+    public static PermissionContext of(UUID uuid, int opLevel) {
+        return new PermissionContext(uuid, opLevel);
+    }
+
+    public static PermissionContext of(UUID uuid, ServerPlayer player) {
+        return new PermissionContext(uuid, effectiveOpLevel(player));
+    }
+
+    private static int effectiveOpLevel(ServerPlayer player) {
+        if (player == null) return 0;
+        return player.server.getProfilePermissions(player.getGameProfile());
     }
 }

--- a/src/main/java/levosilimo/everlastingskins/permission/VanillaPermissionService.java
+++ b/src/main/java/levosilimo/everlastingskins/permission/VanillaPermissionService.java
@@ -7,19 +7,37 @@
 
 package levosilimo.everlastingskins.permission;
 
+import levosilimo.everlastingskins.Config;
+
 public class VanillaPermissionService implements IPermissionService {
 
-    private static final int REQUIRED_OP_LEVEL = 2;
+    private static final int BYPASS_COOLDOWN_OP_LEVEL = 2;
 
     @Override
     public boolean hasPermission(PermissionContext context, String permissionNode) {
         if (permissionNode.endsWith(".source")) return true;
-        return context.isOp();
+        if (permissionNode.endsWith(".bypass.cooldown")) {
+            return context.opLevel() >= BYPASS_COOLDOWN_OP_LEVEL;
+        }
+        return context.opLevel() >= requiredOpLevel(permissionNode);
+    }
+
+    private static int requiredOpLevel(String permissionNode) {
+        return switch (permissionNode) {
+            case "everlastingskins.command.skin" -> Config.PERMISSIONS_OP_LEVEL_MOJANG.get();
+            case "everlastingskins.command.skin.url" -> Config.PERMISSIONS_OP_LEVEL_URL.get();
+            case "everlastingskins.command.skin.clear" -> Config.PERMISSIONS_OP_LEVEL_CLEAR.get();
+            case "everlastingskins.command.skin.random" -> Config.PERMISSIONS_OP_LEVEL_RANDOM.get();
+            case "everlastingskins.command.skin.other" -> Config.PERMISSIONS_OP_LEVEL_OTHER.get();
+            case "everlastingskins.command.metrics" -> Config.PERMISSIONS_OP_LEVEL_METRICS.get();
+            case "everlastingskins.command.metrics.reset" -> Config.PERMISSIONS_OP_LEVEL_METRICS_RESET.get();
+            default -> 0;
+        };
     }
 
     @Override
     public String getActiveBackendName() {
-        return "Vanilla (op level " + REQUIRED_OP_LEVEL + ")";
+        return "Vanilla (per-command op levels)";
     }
 
     @Override

--- a/src/main/java/levosilimo/everlastingskins/permission/forge/ForgePermissionService.java
+++ b/src/main/java/levosilimo/everlastingskins/permission/forge/ForgePermissionService.java
@@ -10,6 +10,7 @@ package levosilimo.everlastingskins.permission.forge;
 import levosilimo.everlastingskins.permission.IPermissionService;
 import levosilimo.everlastingskins.permission.PermissionContext;
 import levosilimo.everlastingskins.permission.PermissionServiceManager;
+import levosilimo.everlastingskins.permission.VanillaPermissionService;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.server.ServerLifecycleHooks;
@@ -52,13 +53,23 @@ public class ForgePermissionService implements IPermissionService {
             PermissionTypes.BOOLEAN,
             (player, uuid, context) -> player != null && player.hasPermissions(2));
 
+    public static final PermissionNode<Boolean> SOURCE_NODE =
+        new PermissionNode<>("everlastingskins", "command.skin.source",
+            PermissionTypes.BOOLEAN,
+            (player, uuid, context) -> true);
+
+    public static final PermissionNode<Boolean> BYPASS_COOLDOWN_NODE =
+        new PermissionNode<>("everlastingskins", "bypass.cooldown",
+            PermissionTypes.BOOLEAN,
+            (player, uuid, context) -> player != null && player.hasPermissions(2));
+
     public static void registerNodes() {
         PermissionServiceManager.registerService(new ForgePermissionService());
     }
 
     public static void onPermissionGather(PermissionGatherEvent.Nodes event) {
         event.addNodes(SKIN_NODE, SKIN_OTHER_NODE, SKIN_URL_NODE, SKIN_CLEAR_NODE,
-                METRICS_NODE, METRICS_RESET_NODE);
+                METRICS_NODE, METRICS_RESET_NODE, SOURCE_NODE, BYPASS_COOLDOWN_NODE);
     }
 
     @Override
@@ -71,7 +82,9 @@ public class ForgePermissionService implements IPermissionService {
         } else if (permissionNode.endsWith(".skin.clear")) {
             node = SKIN_CLEAR_NODE;
         } else if (permissionNode.endsWith(".skin.source")) {
-            return true;
+            node = SOURCE_NODE;
+        } else if (permissionNode.endsWith(".bypass.cooldown")) {
+            node = BYPASS_COOLDOWN_NODE;
         } else if (permissionNode.endsWith(".metrics.reset")) {
             node = METRICS_RESET_NODE;
         } else if (permissionNode.endsWith(".metrics")) {
@@ -88,7 +101,7 @@ public class ForgePermissionService implements IPermissionService {
         try {
             return PermissionAPI.getOfflinePermission(context.uuid(), node);
         } catch (Exception e) {
-            return context.isOp();
+            return new VanillaPermissionService().hasPermission(context, permissionNode);
         }
     }
 

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinCommand.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinCommand.java
@@ -80,7 +80,7 @@ public class SkinCommand {
     private static boolean canTargetOthers(CommandSourceStack source) {
         ServerPlayer player = source.getPlayer();
         if (player == null) return false;
-        PermissionContext ctx = PermissionContext.of(player.getUUID(), player.hasPermissions(2));
+        PermissionContext ctx = PermissionContext.of(player.getUUID(), player);
         return PermissionServiceManager.hasPermission(ctx, "everlastingskins.command.skin.other");
     }
 

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/command/SkinActionCommand.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/command/SkinActionCommand.java
@@ -101,7 +101,7 @@ public final class SkinActionCommand {
         }
         boolean targetingOthers = targets.stream().anyMatch(t -> !t.equals(selfPlayer));
         if (!PermissionServiceManager.hasPermission(
-                PermissionContext.of(selfPlayer.getUUID(), selfPlayer.hasPermissions(2)),
+                PermissionContext.of(selfPlayer.getUUID(), selfPlayer),
                 resolvePermissionNode(type, targetingOthers))) {
             context.getSource().sendFailure(Component.literal(FEEDBACK_PREFIX + " " + I18nUtils.get("permission_denied")));
             return 0;
@@ -316,6 +316,12 @@ public final class SkinActionCommand {
 
     /** Per-player cooldown plus a sliding per-minute window. */
     private static boolean isRateLimited(UUID playerUuid, CommandContext<CommandSourceStack> context) {
+        ServerPlayer player = context.getSource().getPlayer();
+        if (player != null && PermissionServiceManager.hasPermission(
+                PermissionContext.of(player.getUUID(), player),
+                "everlastingskins.bypass.cooldown")) {
+            return false;
+        }
         long now = System.currentTimeMillis();
         long cooldownMs = Config.COOLDOWN_SECONDS.get() * 1000L;
         long lastCommand = lastCommandByPlayer.getOrDefault(playerUuid, 0L);

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/command/SkinMetricsCommand.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/command/SkinMetricsCommand.java
@@ -91,7 +91,7 @@ public final class SkinMetricsCommand {
     private static boolean hasPermission(CommandContext<CommandSourceStack> context, String node) {
         ServerPlayer player = context.getSource().getPlayer();
         if (player == null) return false;
-        PermissionContext ctx = PermissionContext.of(player.getUUID(), player.hasPermissions(2));
+        PermissionContext ctx = PermissionContext.of(player.getUUID(), player);
         boolean allowed = PermissionServiceManager.hasPermission(ctx, node);
         if (!allowed) {
             context.getSource().sendFailure(Component.literal(FEEDBACK_PREFIX + " " + I18nUtils.get("permission_denied")));

--- a/src/test/java/levosilimo/everlastingskins/permission/LuckPermsPermissionServiceTest.java
+++ b/src/test/java/levosilimo/everlastingskins/permission/LuckPermsPermissionServiceTest.java
@@ -16,6 +16,7 @@ import net.luckperms.api.cacheddata.CachedPermissionData;
 import net.luckperms.api.query.QueryOptions;
 import net.luckperms.api.util.Tristate;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -31,6 +32,11 @@ import static org.mockito.Mockito.*;
 class LuckPermsPermissionServiceTest {
 
     private UUID uuid;
+
+    @BeforeAll
+    static void loadConfig() {
+        TestConfigSupport.loadDefaults();
+    }
 
     @BeforeEach
     void setUp() {
@@ -73,7 +79,7 @@ class LuckPermsPermissionServiceTest {
     @DisplayName("hasPermission returns true for granted node")
     void hasPermission_granted_returnsTrue() {
         LuckPermsPermissionService service = LuckPermsPermissionService.tryCreate();
-        PermissionContext ctx = PermissionContext.of(uuid, false);
+        PermissionContext ctx = PermissionContext.of(uuid, 0);
         assertTrue(service.hasPermission(ctx, "everlastingskins.command.skin"));
     }
 
@@ -81,7 +87,7 @@ class LuckPermsPermissionServiceTest {
     @DisplayName("hasPermission returns false for denied node")
     void hasPermission_denied_returnsFalse() {
         LuckPermsPermissionService service = LuckPermsPermissionService.tryCreate();
-        PermissionContext ctx = PermissionContext.of(uuid, false);
+        PermissionContext ctx = PermissionContext.of(uuid, 0);
         assertFalse(service.hasPermission(ctx, "other.node"));
     }
 
@@ -120,7 +126,7 @@ class LuckPermsPermissionServiceTest {
             LuckPermsProvider.register(fakeLP);
 
             LuckPermsPermissionService service = LuckPermsPermissionService.tryCreate();
-            PermissionContext ctx = PermissionContext.of(uuid, false);
+            PermissionContext ctx = PermissionContext.of(uuid, 0);
 
             assertFalse(service.hasPermission(ctx, "everlastingskins.command.skin"));
         }
@@ -140,7 +146,7 @@ class LuckPermsPermissionServiceTest {
             LuckPermsProvider.register(fakeLP);
 
             LuckPermsPermissionService service = LuckPermsPermissionService.tryCreate();
-            PermissionContext ctx = PermissionContext.of(uuid, false);
+            PermissionContext ctx = PermissionContext.of(uuid, 0);
 
             assertFalse(service.hasPermission(ctx, "everlastingskins.command.skin"));
         }
@@ -165,7 +171,7 @@ class LuckPermsPermissionServiceTest {
             LuckPermsProvider.register(fakeLP);
 
             LuckPermsPermissionService service = LuckPermsPermissionService.tryCreate();
-            PermissionContext ctx = PermissionContext.of(uuid, false);
+            PermissionContext ctx = PermissionContext.of(uuid, 0);
 
             assertFalse(service.hasPermission(ctx, "everlastingskins.command.skin"));
         }
@@ -193,11 +199,11 @@ class LuckPermsPermissionServiceTest {
 
             LuckPermsPermissionService service = LuckPermsPermissionService.tryCreate();
 
-            PermissionContext opCtx = PermissionContext.of(uuid, true);
-            assertTrue(service.hasPermission(opCtx, "everlastingskins.command.skin"));
+            PermissionContext opCtx = PermissionContext.of(uuid, 2);
+            assertTrue(service.hasPermission(opCtx, "everlastingskins.command.metrics"));
 
-            PermissionContext nonOpCtx = PermissionContext.of(uuid, false);
-            assertFalse(service.hasPermission(nonOpCtx, "everlastingskins.command.skin"));
+            PermissionContext nonOpCtx = PermissionContext.of(uuid, 0);
+            assertFalse(service.hasPermission(nonOpCtx, "everlastingskins.command.metrics"));
         }
 
         @Test
@@ -212,9 +218,9 @@ class LuckPermsPermissionServiceTest {
             LuckPermsProvider.register(fakeLP);
 
             LuckPermsPermissionService service = LuckPermsPermissionService.tryCreate();
-            PermissionContext ctx = PermissionContext.of(uuid, false);
+            PermissionContext ctx = PermissionContext.of(uuid, 0);
 
-            assertFalse(service.hasPermission(ctx, "everlastingskins.command.skin"));
+            assertFalse(service.hasPermission(ctx, "everlastingskins.command.metrics"));
         }
     }
 }

--- a/src/test/java/levosilimo/everlastingskins/permission/PermissionServiceManagerTest.java
+++ b/src/test/java/levosilimo/everlastingskins/permission/PermissionServiceManagerTest.java
@@ -8,6 +8,7 @@
 package levosilimo.everlastingskins.permission;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -19,6 +20,11 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 class PermissionServiceManagerTest {
+
+    @BeforeAll
+    static void loadConfig() {
+        TestConfigSupport.loadDefaults();
+    }
 
     @BeforeEach
     @AfterEach
@@ -179,7 +185,7 @@ class PermissionServiceManagerTest {
     @DisplayName("hasPermission before init falls back to Vanilla")
     void hasPermission_beforeInit_returnsFallback() {
         PermissionServiceManager.reset();
-        PermissionContext ctx = PermissionContext.of(UUID.randomUUID(), true);
+        PermissionContext ctx = PermissionContext.of(UUID.randomUUID(), 2);
         assertTrue(PermissionServiceManager.hasPermission(ctx, "any.node"));
     }
 
@@ -207,18 +213,18 @@ class PermissionServiceManagerTest {
     class SinglePlayer {
 
         @Test
-        @DisplayName("Non-op has no permission on non-source node")
+        @DisplayName("Non-op lacks permission on level-2 node")
         void nonOp_nonSource_denied() {
             PermissionServiceManager.init();
-            PermissionContext ctx = PermissionContext.of(UUID.randomUUID(), false);
-            assertFalse(PermissionServiceManager.hasPermission(ctx, "everlastingskins.command.skin"));
+            PermissionContext ctx = PermissionContext.of(UUID.randomUUID(), 0);
+            assertFalse(PermissionServiceManager.hasPermission(ctx, "everlastingskins.command.metrics"));
         }
 
         @Test
         @DisplayName("Op has permission on non-source node")
         void op_nonSource_granted() {
             PermissionServiceManager.init();
-            PermissionContext ctx = PermissionContext.of(UUID.randomUUID(), true);
+            PermissionContext ctx = PermissionContext.of(UUID.randomUUID(), 2);
             assertTrue(PermissionServiceManager.hasPermission(ctx, "everlastingskins.command.skin"));
         }
 
@@ -226,8 +232,8 @@ class PermissionServiceManagerTest {
         @DisplayName("Source node always granted regardless of op status")
         void sourceNode_alwaysGranted() {
             PermissionServiceManager.init();
-            PermissionContext nonOp = PermissionContext.of(UUID.randomUUID(), false);
-            PermissionContext op = PermissionContext.of(UUID.randomUUID(), true);
+            PermissionContext nonOp = PermissionContext.of(UUID.randomUUID(), 0);
+            PermissionContext op = PermissionContext.of(UUID.randomUUID(), 2);
             assertTrue(PermissionServiceManager.hasPermission(nonOp, "everlastingskins.command.skin.source"));
             assertTrue(PermissionServiceManager.hasPermission(op, "everlastingskins.command.skin.source"));
         }

--- a/src/test/java/levosilimo/everlastingskins/permission/TestConfigSupport.java
+++ b/src/test/java/levosilimo/everlastingskins/permission/TestConfigSupport.java
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
+package levosilimo.everlastingskins.permission;
+
+import com.electronwill.nightconfig.core.CommentedConfig;
+import levosilimo.everlastingskins.Config;
+
+/** Loads the common config in unit tests so Config values are readable without FML boot. */
+public final class TestConfigSupport {
+
+    private TestConfigSupport() {
+    }
+
+    public static void loadDefaults() {
+        Config.COMMON_CONFIG.setConfig(CommentedConfig.inMemory());
+    }
+}

--- a/src/test/java/levosilimo/everlastingskins/permission/VanillaPermissionServiceTest.java
+++ b/src/test/java/levosilimo/everlastingskins/permission/VanillaPermissionServiceTest.java
@@ -7,6 +7,7 @@
 
 package levosilimo.everlastingskins.permission;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -18,10 +19,15 @@ class VanillaPermissionServiceTest {
 
     private final VanillaPermissionService service = new VanillaPermissionService();
 
+    @BeforeAll
+    static void loadConfig() {
+        TestConfigSupport.loadDefaults();
+    }
+
     @Test
     @DisplayName("Backend name is correct")
     void backendName() {
-        assertEquals("Vanilla (op level 2)", service.getActiveBackendName());
+        assertEquals("Vanilla (per-command op levels)", service.getActiveBackendName());
     }
 
     @Test
@@ -37,23 +43,62 @@ class VanillaPermissionServiceTest {
     }
 
     @Test
-    @DisplayName("OP player has permission")
-    void hasPermission_opPlayer_returnsTrue() {
-        PermissionContext ctx = PermissionContext.of(UUID.randomUUID(), true);
+    @DisplayName("opLevel 0 meets required level 0 (mojang node default)")
+    void opLevel0_required0_granted() {
+        PermissionContext ctx = PermissionContext.of(UUID.randomUUID(), 0);
+        assertTrue(service.hasPermission(ctx, "everlastingskins.command.skin"));
+    }
+
+    @Test
+    @DisplayName("opLevel 0 lacks required level 2 (metrics node default)")
+    void opLevel0_required2_denied() {
+        PermissionContext ctx = PermissionContext.of(UUID.randomUUID(), 0);
+        assertFalse(service.hasPermission(ctx, "everlastingskins.command.metrics"));
+    }
+
+    @Test
+    @DisplayName("opLevel 2 meets required level 2")
+    void opLevel2_required2_granted() {
+        PermissionContext ctx = PermissionContext.of(UUID.randomUUID(), 2);
+        assertTrue(service.hasPermission(ctx, "everlastingskins.command.metrics"));
+    }
+
+    @Test
+    @DisplayName("opLevel 4 meets required level 2")
+    void opLevel4_required2_granted() {
+        PermissionContext ctx = PermissionContext.of(UUID.randomUUID(), 4);
+        assertTrue(service.hasPermission(ctx, "everlastingskins.command.skin.other"));
+    }
+
+    @Test
+    @DisplayName("Source node is always granted regardless of op level")
+    void hasPermission_sourceNode_returnsTrueForNonOp() {
+        PermissionContext ctx = PermissionContext.of(UUID.randomUUID(), 0);
+        assertTrue(service.hasPermission(ctx, "everlastingskins.command.skin.source"));
+    }
+
+    @Test
+    @DisplayName("Bypass cooldown node requires op level 2")
+    void bypassCooldown_requiresOpLevel2() {
+        assertTrue(service.hasPermission(PermissionContext.of(UUID.randomUUID(), 2),
+                "everlastingskins.bypass.cooldown"));
+        assertFalse(service.hasPermission(PermissionContext.of(UUID.randomUUID(), 0),
+                "everlastingskins.bypass.cooldown"));
+    }
+
+    @Test
+    @DisplayName("Unknown nodes default to required level 0")
+    void unknownNode_defaultsToAll() {
+        PermissionContext ctx = PermissionContext.of(UUID.randomUUID(), 0);
         assertTrue(service.hasPermission(ctx, "any.node"));
     }
 
     @Test
-    @DisplayName("Non-OP player lacks permission")
-    void hasPermission_nonOpPlayer_returnsFalse() {
-        PermissionContext ctx = PermissionContext.of(UUID.randomUUID(), false);
-        assertFalse(service.hasPermission(ctx, "any.node"));
-    }
-
-    @Test
-    @DisplayName("Source node is always granted regardless of op status")
-    void hasPermission_sourceNode_returnsTrueForNonOp() {
-        PermissionContext ctx = PermissionContext.of(UUID.randomUUID(), false);
-        assertTrue(service.hasPermission(ctx, "everlastingskins.command.skin.source"));
+    @DisplayName("Op level outside 0-4 is rejected")
+    void opLevelOutOfRange_rejected() {
+        assertThrows(IllegalArgumentException.class,
+            () -> PermissionContext.of(UUID.randomUUID(), -1));
+        assertThrows(IllegalArgumentException.class,
+            () -> PermissionContext.of(UUID.randomUUID(), 5));
     }
 }

--- a/src/test/java/levosilimo/everlastingskins/permission/forge/ForgePermissionServiceTest.java
+++ b/src/test/java/levosilimo/everlastingskins/permission/forge/ForgePermissionServiceTest.java
@@ -8,9 +8,11 @@
 package levosilimo.everlastingskins.permission.forge;
 
 import levosilimo.everlastingskins.permission.PermissionContext;
+import levosilimo.everlastingskins.permission.TestConfigSupport;
 import net.minecraftforge.server.ServerLifecycleHooks;
 import net.minecraftforge.server.permission.PermissionAPI;
 import net.minecraftforge.server.permission.events.PermissionGatherEvent;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -36,12 +38,17 @@ class ForgePermissionServiceTest {
     /* ================================================================== */
     private static final UUID TEST_UUID = UUID.fromString("069a79f4-44e9-4726-a5be-fca90e38aaf5");
 
+    @BeforeAll
+    static void loadConfig() {
+        TestConfigSupport.loadDefaults();
+    }
+
     @Test
     @DisplayName("hasPermission returns true when PermissionAPI grants it")
     void hasPermission_granted_returnsTrue() {
         try (MockedStatic<PermissionAPI> api = mockStatic(PermissionAPI.class)) {
             UUID uuid = UUID.randomUUID();
-            PermissionContext ctx = PermissionContext.of(uuid, false);
+            PermissionContext ctx = PermissionContext.of(uuid, 0);
             api.when(() -> PermissionAPI.getOfflinePermission(eq(uuid), eq(ForgePermissionService.SKIN_NODE)))
                .thenReturn(true);
             ForgePermissionService service = new ForgePermissionService();
@@ -54,7 +61,7 @@ class ForgePermissionServiceTest {
     void hasPermission_denied_returnsFalse() {
         try (MockedStatic<PermissionAPI> api = mockStatic(PermissionAPI.class)) {
             UUID uuid = UUID.randomUUID();
-            PermissionContext ctx = PermissionContext.of(uuid, false);
+            PermissionContext ctx = PermissionContext.of(uuid, 0);
             api.when(() -> PermissionAPI.getOfflinePermission(eq(uuid), eq(ForgePermissionService.SKIN_NODE)))
                .thenReturn(false);
             ForgePermissionService service = new ForgePermissionService();
@@ -67,7 +74,7 @@ class ForgePermissionServiceTest {
     void hasPermission_otherNode_mapsCorrectly() {
         try (MockedStatic<PermissionAPI> api = mockStatic(PermissionAPI.class)) {
             UUID uuid = UUID.randomUUID();
-            PermissionContext ctx = PermissionContext.of(uuid, false);
+            PermissionContext ctx = PermissionContext.of(uuid, 0);
             api.when(() -> PermissionAPI.getOfflinePermission(eq(uuid), eq(ForgePermissionService.SKIN_OTHER_NODE)))
                .thenReturn(true);
             ForgePermissionService service = new ForgePermissionService();
@@ -79,12 +86,24 @@ class ForgePermissionServiceTest {
     @DisplayName("hasPermission .skin.source always returns true")
     void hasPermission_sourceNode_returnsTrue() {
         ForgePermissionService service = new ForgePermissionService();
-        PermissionContext ctx = PermissionContext.of(UUID.randomUUID(), false);
+        PermissionContext ctx = PermissionContext.of(UUID.randomUUID(), 0);
         assertTrue(service.hasPermission(ctx, "everlastingskins.command.skin.source"));
     }
 
     @Test
-    @DisplayName("permissionGatherEvent registers all skin and metrics nodes")
+    @DisplayName("hasPermission maps .bypass.cooldown to BYPASS_COOLDOWN_NODE")
+    void hasPermission_bypassNode_mapsCorrectly() {
+        try (MockedStatic<PermissionAPI> api = mockStatic(PermissionAPI.class)) {
+            UUID uuid = UUID.randomUUID();
+            api.when(() -> PermissionAPI.getOfflinePermission(eq(uuid), eq(ForgePermissionService.BYPASS_COOLDOWN_NODE)))
+               .thenReturn(true);
+            ForgePermissionService service = new ForgePermissionService();
+            assertTrue(service.hasPermission(PermissionContext.of(uuid, 0), "everlastingskins.bypass.cooldown"));
+        }
+    }
+
+    @Test
+    @DisplayName("permissionGatherEvent registers all skin, source, bypass and metrics nodes")
     void permissionGatherEvent_registersNodes() {
         PermissionGatherEvent.Nodes event = mock(PermissionGatherEvent.Nodes.class);
         ForgePermissionService.onPermissionGather(event);
@@ -94,18 +113,20 @@ class ForgePermissionServiceTest {
             ForgePermissionService.SKIN_URL_NODE,
             ForgePermissionService.SKIN_CLEAR_NODE,
             ForgePermissionService.METRICS_NODE,
-            ForgePermissionService.METRICS_RESET_NODE
+            ForgePermissionService.METRICS_RESET_NODE,
+            ForgePermissionService.SOURCE_NODE,
+            ForgePermissionService.BYPASS_COOLDOWN_NODE
         );
     }
 
     @Test
-    @DisplayName("hasPermission falls back to context.isOp() when no server context exists")
+    @DisplayName("hasPermission falls back to per-node op levels when no server context exists")
     void hasPermission_noServer_usesContextIsOp() {
         try (MockedStatic<ServerLifecycleHooks> hooks = mockStatic(ServerLifecycleHooks.class)) {
             hooks.when(ServerLifecycleHooks::getCurrentServer).thenReturn(null);
             ForgePermissionService service = new ForgePermissionService();
-            assertTrue(service.hasPermission(PermissionContext.of(TEST_UUID, true), "everlastingskins.command.skin"));
-            assertFalse(service.hasPermission(PermissionContext.of(TEST_UUID, false), "everlastingskins.command.skin"));
+            assertTrue(service.hasPermission(PermissionContext.of(TEST_UUID, 2), "everlastingskins.command.metrics"));
+            assertFalse(service.hasPermission(PermissionContext.of(TEST_UUID, 0), "everlastingskins.command.metrics"));
         }
     }
 
@@ -118,25 +139,25 @@ class ForgePermissionServiceTest {
             api.when(() -> PermissionAPI.getOfflinePermission(eq(TEST_UUID), eq(ForgePermissionService.SKIN_NODE)))
                .thenReturn(false);
             ForgePermissionService service = new ForgePermissionService();
-            assertFalse(service.hasPermission(PermissionContext.of(TEST_UUID, false),
+            assertFalse(service.hasPermission(PermissionContext.of(TEST_UUID, 0),
                     "everlastingskins.command.skin"));
             api.verify(() -> PermissionAPI.getPermission(any(), any()), never());
         }
     }
 
     @Test
-    @DisplayName("hasPermission falls back to context.isOp() when the PermissionAPI lookup throws")
+    @DisplayName("hasPermission falls back to per-node op levels when the PermissionAPI lookup throws")
     void hasPermission_lookupThrows_usesContextIsOp() {
         try (MockedStatic<ServerLifecycleHooks> hooks = mockStatic(ServerLifecycleHooks.class);
              MockedStatic<PermissionAPI> api = mockStatic(PermissionAPI.class)) {
             hooks.when(ServerLifecycleHooks::getCurrentServer).thenReturn(null);
-            api.when(() -> PermissionAPI.getOfflinePermission(eq(TEST_UUID), eq(ForgePermissionService.SKIN_NODE)))
+            api.when(() -> PermissionAPI.getOfflinePermission(eq(TEST_UUID), eq(ForgePermissionService.METRICS_NODE)))
                .thenThrow(new RuntimeException("api unavailable"));
             ForgePermissionService service = new ForgePermissionService();
-            assertTrue(service.hasPermission(PermissionContext.of(TEST_UUID, true),
-                    "everlastingskins.command.skin"));
-            assertFalse(service.hasPermission(PermissionContext.of(TEST_UUID, false),
-                    "everlastingskins.command.skin"));
+            assertTrue(service.hasPermission(PermissionContext.of(TEST_UUID, 2),
+                    "everlastingskins.command.metrics"));
+            assertFalse(service.hasPermission(PermissionContext.of(TEST_UUID, 0),
+                    "everlastingskins.command.metrics"));
         }
     }
 
@@ -161,20 +182,20 @@ class ForgePermissionServiceTest {
     class ExceptionResilience {
 
         @Test
-        @DisplayName("PermissionAPI.getOfflinePermission throws → falls back to isOp")
+        @DisplayName("PermissionAPI.getOfflinePermission throws → falls back to per-node op levels")
         void permissionApi_throws_fallbackToOp() {
             try (MockedStatic<PermissionAPI> api = mockStatic(PermissionAPI.class)) {
                 UUID uuid = UUID.randomUUID();
-                api.when(() -> PermissionAPI.getOfflinePermission(eq(uuid), eq(ForgePermissionService.SKIN_NODE)))
+                api.when(() -> PermissionAPI.getOfflinePermission(eq(uuid), eq(ForgePermissionService.METRICS_NODE)))
                    .thenThrow(new RuntimeException("PermissionAPI unavailable"));
 
                 ForgePermissionService service = new ForgePermissionService();
 
-                PermissionContext opCtx = PermissionContext.of(uuid, true);
-                assertTrue(service.hasPermission(opCtx, "everlastingskins.command.skin"));
+                PermissionContext opCtx = PermissionContext.of(uuid, 2);
+                assertTrue(service.hasPermission(opCtx, "everlastingskins.command.metrics"));
 
-                PermissionContext nonOpCtx = PermissionContext.of(uuid, false);
-                assertFalse(service.hasPermission(nonOpCtx, "everlastingskins.command.skin"));
+                PermissionContext nonOpCtx = PermissionContext.of(uuid, 0);
+                assertFalse(service.hasPermission(nonOpCtx, "everlastingskins.command.metrics"));
             }
         }
 
@@ -188,10 +209,10 @@ class ForgePermissionServiceTest {
 
                 ForgePermissionService service = new ForgePermissionService();
 
-                PermissionContext opCtx = PermissionContext.of(uuid, true);
+                PermissionContext opCtx = PermissionContext.of(uuid, 2);
                 assertTrue(service.hasPermission(opCtx, "everlastingskins.command.skin.other"));
 
-                PermissionContext nonOpCtx = PermissionContext.of(uuid, false);
+                PermissionContext nonOpCtx = PermissionContext.of(uuid, 0);
                 assertFalse(service.hasPermission(nonOpCtx, "everlastingskins.command.skin.other"));
             }
         }
@@ -200,7 +221,7 @@ class ForgePermissionServiceTest {
         @DisplayName(".skin.source always true even if API would throw")
         void sourceNode_alwaysTrue_regardlessOfApi() {
             ForgePermissionService service = new ForgePermissionService();
-            PermissionContext ctx = PermissionContext.of(UUID.randomUUID(), false);
+            PermissionContext ctx = PermissionContext.of(UUID.randomUUID(), 0);
             assertTrue(service.hasPermission(ctx, "everlastingskins.command.skin.source"));
         }
     }

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/SkinCommandPermissionTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/SkinCommandPermissionTest.java
@@ -11,7 +11,9 @@ import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import levosilimo.everlastingskins.permission.PermissionContext;
 import levosilimo.everlastingskins.permission.PermissionServiceManager;
+import levosilimo.everlastingskins.permission.TestConfigSupport;
 import net.minecraft.commands.CommandSourceStack;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -22,6 +24,11 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 class SkinCommandPermissionTest {
+
+    @BeforeAll
+    static void loadConfig() {
+        TestConfigSupport.loadDefaults();
+    }
 
     @Test
     @DisplayName("register builds a command tree without error")
@@ -56,14 +63,14 @@ class SkinCommandPermissionTest {
     @Test
     @DisplayName("canTargetOthers is false for non-op player via PermissionServiceManager")
     void canTargetOthers_nonOp_returnsFalse() {
-        PermissionContext ctx = PermissionContext.of(UUID.randomUUID(), false);
+        PermissionContext ctx = PermissionContext.of(UUID.randomUUID(), 0);
         assertFalse(PermissionServiceManager.hasPermission(ctx, "everlastingskins.command.skin.other"));
     }
 
     @Test
     @DisplayName("canTargetOthers is true for op player")
     void canTargetOthers_op_returnsTrue() {
-        PermissionContext ctx = PermissionContext.of(UUID.randomUUID(), true);
+        PermissionContext ctx = PermissionContext.of(UUID.randomUUID(), 2);
         assertTrue(PermissionServiceManager.hasPermission(ctx, "everlastingskins.command.skin.other"));
     }
 }


### PR DESCRIPTION
lib-49 research. Per-command op level config + bypass permission.

- Config.Permissions: op_level.{mojang,url,clear,random,other,metrics,metrics_reset} (0-4, defaults preserve current behavior)
- PermissionContext widened from boolean isOp to int opLevel (0-4, validated)
- VanillaPermissionService: per-node required op level from Config, unknown nodes default to ALL
- everlastingskins.bypass.cooldown node (OP default) — isRateLimited skips when granted
- everlastingskins.command.skin.source registered as a real node (was hardcoded true)
- Forge/LuckPerms fallback paths delegate to per-node levels

319 tests pass, aislop 100/100.