### PR TITLE
fix(1122): TESTING.md counts

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -3,8 +3,8 @@
 EverlastingSkins uses a three-tier testing pyramid:
 
 ## Tier 1: Pure Java unit tests (JUnit 5)
-- 257 tests on 1.21 branch
-- 252 tests on mc1.12.2 branch
+- 289 unit tests on 1.21 branch
+- 253 tests on mc1.12.2 branch
 - Coverage: provider fallback, HTTP outcomes, persistence atomicity, corruption handling, cache behavior, permission system, command dispatch, integration hooks
 - New in 2.1.0-rc.1: `UrlAllowlistTest`, `DefaultSkinResolverTest`, `PlayerLanguageTest`, `PermissionGateIT`; `PermissionServiceManagerTest`, `VanillaPermissionServiceTest`, `LuckPermsPermissionServiceTest`, `MetricsCommandIT` refreshed/pre-existing (not new)
 - Run: `./gradlew test`


### PR DESCRIPTION
lib-61 audit finding.

- TESTING.md: actual count 253 (246 @Test + 7 @ParameterizedTest)
- TESTING.md: name new test classes (UrlAllowlistTest, DefaultSkinResolverTest, PlayerLanguageTest, PermissionGateIT)
- Sync 1.21 reference count to 289

Aislop clean.