### PR TITLE
fix(1122): wire mojangProfileCache* into Config.load()

### DIFF
--- a/src/main/java/levosilimo/everlastingskins/Config.java
+++ b/src/main/java/levosilimo/everlastingskins/Config.java
@@ -103,6 +103,12 @@ public final class Config {
                 "Enable URL domain allowlist for /skin set web (empty list = deny all)");
             urlAllowlistDomains = cfg.getStringList("urlAllowlistDomains", "Security", urlAllowlistDomains,
                 "Domains allowed for /skin set web (eTLD+1 suffix match; one entry covers all subdomains)");
+            mojangProfileCacheEnabled = cfg.getBoolean("mojangProfileCacheEnabled", "MojangCache", true,
+                "Enable Mojang profile cache (recommended for production servers; reduces Mojang API hits)");
+            mojangProfileCacheTtlMs = cfg.getInt("mojangProfileCacheTtlMs", "MojangCache", 3600000, 0, 604800000,
+                "Mojang profile cache TTL in milliseconds (default 1h, max 7 days)");
+            mojangProfileCacheMaxSize = cfg.getInt("mojangProfileCacheMaxSize", "MojangCache", 1000, 0, 1000000,
+                "Mojang profile cache max entries (default 1000, max 1M)");
         } catch (Exception e) {
             EverlastingSkins.logger.error("Failed to load config", e);
         } finally {

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/MojangProfileCache.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/MojangProfileCache.java
@@ -6,12 +6,11 @@
 
 package levosilimo.everlastingskins.skinchanger;
 
+import levosilimo.everlastingskins.Config;
 import levosilimo.everlastingskins.metrics.SkinMetrics;
 import levosilimo.everlastingskins.util.CustomSkinProperty;
 
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
-
 /**
  * Small TTL + cap cache for Mojang profile lookups. Keyed by lower-case
  * username; a hit avoids the (slow, rate-limited) Mojang HTTP chain entirely.
@@ -34,7 +33,7 @@ public class MojangProfileCache {
     private final int maxEntries;
 
     public MojangProfileCache() {
-        this(TimeUnit.HOURS.toMillis(1), 1000);
+        this(Config.mojangProfileCacheTtlMs, Config.mojangProfileCacheMaxSize);
     }
 
     public MojangProfileCache(long ttlMs, int maxEntries) {

--- a/src/test/java/levosilimo/everlastingskins/ConfigTest.java
+++ b/src/test/java/levosilimo/everlastingskins/ConfigTest.java
@@ -1,0 +1,51 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class ConfigTest {
+
+    @Test
+    @DisplayName("load() reads the MojangCache keys from the .cfg file")
+    void load_readsMojangCacheKeys() throws Exception {
+        File cfg = File.createTempFile("everlastingskins-config-test", ".cfg");
+        cfg.deleteOnExit();
+        String content = String.join("\n",
+            "MojangCache {",
+            "    # Mojang profile cache TTL in milliseconds (default 1h, max 7 days)",
+            "    I:mojangProfileCacheTtlMs=5000",
+            "    # Mojang profile cache max entries (default 1000, max 1M)",
+            "    I:mojangProfileCacheMaxSize=50",
+            "    # Enable Mojang profile cache (recommended for production servers; reduces Mojang API hits)",
+            "    B:mojangProfileCacheEnabled=false",
+            "}");
+        Files.write(cfg.toPath(), content.getBytes());
+
+        boolean origEnabled = Config.mojangProfileCacheEnabled;
+        long origTtl = Config.mojangProfileCacheTtlMs;
+        int origMax = Config.mojangProfileCacheMaxSize;
+        try {
+            Config.load(cfg);
+
+            assertFalse(Config.mojangProfileCacheEnabled);
+            assertEquals(5000, Config.mojangProfileCacheTtlMs);
+            assertEquals(50, Config.mojangProfileCacheMaxSize);
+        } finally {
+            Config.mojangProfileCacheEnabled = origEnabled;
+            Config.mojangProfileCacheTtlMs = origTtl;
+            Config.mojangProfileCacheMaxSize = origMax;
+        }
+    }
+}


### PR DESCRIPTION
Closes the audit finding from PR #157. Adds the 3 missing cfg.get calls so the keys are actually user-configurable, and wires the MojangProfileCache default constructor to the Config fields (mirrors 1.21). New ConfigTest verifies the .cfg read.