### PR TITLE
test(1.21): Discord I18n routing + Mojang cache config + per-player locale

### DIFF
--- a/src/main/java/levosilimo/everlastingskins/integration/discordsrv/DiscordSrvHook.java
+++ b/src/main/java/levosilimo/everlastingskins/integration/discordsrv/DiscordSrvHook.java
@@ -50,8 +50,7 @@ public final class DiscordSrvHook {
                 return;
             }
 
-            String label = skinSource != null ? skinSource : "default";
-            String message = I18nUtils.get("discord_announce", player.getScoreboardName(), label);
+            String message = formatAnnounce(player, skinSource);
 
             Object messageAction = textChannelClass.getMethod("sendMessage", CharSequence.class)
                 .invoke(textChannel, message);
@@ -63,5 +62,17 @@ public final class DiscordSrvHook {
         } catch (NoSuchMethodException | IllegalAccessException | java.lang.reflect.InvocationTargetException e) {
             LOGGER.warn("DiscordSRV reflection chain failed: {}", e.getMessage());
         }
+    }
+
+    /**
+     * Builds the localized announcement text for a player. Routes through the
+     * per-player locale (client language) so non-English players get their own
+     * language in the Discord channel; falls back to Config.LANGUAGE for a
+     * null player. Package-private for direct unit testing.
+     */
+    static String formatAnnounce(ServerPlayer player, String skinSource) {
+        String label = skinSource != null ? skinSource : "default";
+        String name = player != null ? player.getScoreboardName() : "";
+        return I18nUtils.formatMessage("discord_announce", player, name, label);
     }
 }

--- a/src/test/java/levosilimo/everlastingskins/ConfigTest.java
+++ b/src/test/java/levosilimo/everlastingskins/ConfigTest.java
@@ -181,4 +181,59 @@ class ConfigTest {
             }
         }
     }
+
+    /* ================================================================== */
+    /*  Mojang cache config (lib-7 gap: #143 keys untested)                */
+    /* ================================================================== */
+
+    @Nested
+    @DisplayName("Mojang cache config")
+    class MojangCacheConfig {
+
+        @Test
+        @DisplayName("MOJANG_CACHE_ENABLED defaults to true")
+        void mojangCacheEnabledDefault() {
+            assertTrue(Config.MOJANG_CACHE_ENABLED.get());
+        }
+
+        @Test
+        @DisplayName("MOJANG_CACHE_TTL_MS defaults to 1 hour")
+        void mojangCacheTtlDefault() {
+            assertEquals(3600000L, Config.MOJANG_CACHE_TTL_MS.get());
+        }
+
+        @Test
+        @DisplayName("MOJANG_CACHE_MAX_SIZE defaults to 1000")
+        void mojangCacheMaxSizeDefault() {
+            assertEquals(1000, Config.MOJANG_CACHE_MAX_SIZE.get());
+        }
+
+        @Test
+        @DisplayName("TTL can be set to 0 to disable caching")
+        void mojangCacheTtlZeroDisablesCaching() {
+            long orig = Config.MOJANG_CACHE_TTL_MS.get();
+            try {
+                Config.MOJANG_CACHE_TTL_MS.set(0L);
+                assertEquals(0L, Config.MOJANG_CACHE_TTL_MS.get());
+            } finally {
+                Config.MOJANG_CACHE_TTL_MS.set(orig);
+            }
+        }
+
+        @Test
+        @DisplayName("cache keys can be toggled off and read back")
+        void mojangCacheToggledOff() {
+            boolean origEnabled = Config.MOJANG_CACHE_ENABLED.get();
+            long origTtl = Config.MOJANG_CACHE_TTL_MS.get();
+            try {
+                Config.MOJANG_CACHE_ENABLED.set(false);
+                Config.MOJANG_CACHE_TTL_MS.set(0L);
+                assertFalse(Config.MOJANG_CACHE_ENABLED.get());
+                assertEquals(0L, Config.MOJANG_CACHE_TTL_MS.get());
+            } finally {
+                Config.MOJANG_CACHE_ENABLED.set(origEnabled);
+                Config.MOJANG_CACHE_TTL_MS.set(origTtl);
+            }
+        }
+    }
 }

--- a/src/test/java/levosilimo/everlastingskins/integration/discordsrv/DiscordSrvHookTest.java
+++ b/src/test/java/levosilimo/everlastingskins/integration/discordsrv/DiscordSrvHookTest.java
@@ -9,13 +9,16 @@ package levosilimo.everlastingskins.integration.discordsrv;
 
 import github.scarsz.discordsrv.DiscordSRV;
 import github.scarsz.discordsrv.dependencies.jda.api.JDA;
-import net.minecraft.server.level.ServerPlayer;
+import levosilimo.everlastingskins.Config;
+import levosilimo.everlastingskins.util.I18nUtils;
 
+import com.electronwill.nightconfig.core.InMemoryCommentedFormat;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 /**
@@ -33,6 +36,51 @@ import static org.mockito.Mockito.*;
  * method's declared return type is the relocated JDA type.
  */
 class DiscordSrvHookTest {
+
+    @BeforeAll
+    static void init() {
+        // Serve Config defaults so the null-player fallback (Config.LANGUAGE) works.
+        Config.COMMON_CONFIG.setConfig(
+                InMemoryCommentedFormat.defaultInstance().createConfig(java.util.HashMap::new));
+        // Load classpath locale resources for per-player announce assertions.
+        I18nUtils.loadAll();
+    }
+
+    @Test
+    @DisplayName("announce text uses the player's client language (lib-7 disc-i18n)")
+    void discI18n_discordAnnounce_usesLocalizedMessage() {
+        // ServerPlayer cannot be mocked in the unit JVM (its supertype static
+        // initializers require a bootstrapped Minecraft runtime), so the
+        // per-player routing formatAnnounce delegates to is asserted through
+        // the locale API directly: the German file must carry the announce key.
+        String german = I18nUtils.getLocalizedString("discord_announce", "de_de");
+        assertTrue(german.contains("geändert"), "expected German text, got: " + german);
+        assertNotEquals("discord_announce", german);
+    }
+
+    @Test
+    @DisplayName("unsupported client language falls back to English (lib-7 disc-i18n)")
+    void discI18n_discordAnnounce_fallbackToEnglishWhenLanguageUnsupported() {
+        String result = I18nUtils.getLocalizedString("discord_announce", "zz_zz");
+        assertTrue(result.contains("changed their skin"), "expected English fallback, got: " + result);
+        assertFalse(result.contains("geändert"));
+    }
+
+    @Test
+    @DisplayName("null player falls back to the global locale (lib-7 disc-i18n)")
+    void discI18n_discordAnnounce_nullPlayerUsesGlobalLocale() {
+        String result = DiscordSrvHook.formatAnnounce(null, "Notch");
+        assertTrue(result.contains("changed their skin"), "expected global-locale text, got: " + result);
+    }
+
+    @Test
+    @DisplayName("null skin source uses the 'default' label (lib-7 disc-i18n)")
+    void discI18n_discordAnnounce_nullSourceDefaultsLabel() {
+        String result = DiscordSrvHook.formatAnnounce(null, null);
+        assertTrue(result.contains("`default`"), "expected default label, got: " + result);
+        String withSource = DiscordSrvHook.formatAnnounce(null, "Notch");
+        assertTrue(withSource.contains("`Notch`"), "expected source label, got: " + withSource);
+    }
 
     @Test
     @DisplayName("null DiscordSRV plugin instance is handled gracefully (DSRV-2)")

--- a/src/test/java/levosilimo/everlastingskins/util/I18nUtilsTest.java
+++ b/src/test/java/levosilimo/everlastingskins/util/I18nUtilsTest.java
@@ -229,5 +229,22 @@ class I18nUtilsTest {
             assertEquals("Skin change queued",
                     I18nUtils.getLocalizedComponent("change", (net.minecraft.server.level.ServerPlayer) null).getString());
         }
+
+        @Test
+        @DisplayName("Per-player locale resolution: de_de client language drives the translation (lib-7 gap)")
+        void perPlayerLocaleResolution_deDe() {
+            // ServerPlayer cannot be mocked in the unit JVM (its supertype static
+            // initializers need a bootstrapped Minecraft runtime); the player
+            // overload is a null-safe wrapper over this locale-API path.
+            assertEquals("Skin für \"%s\" nicht gefunden", I18nUtils.getLocalizedString("no_skin_found", "de_de"));
+            assertEquals("Skin-Wechsel eingereiht", I18nUtils.getLocalizedString("change", "de_de"));
+        }
+
+        @Test
+        @DisplayName("Per-player locale resolution: unsupported language falls back to English")
+        void perPlayerLocaleResolution_unsupported() {
+            assertEquals("Skin change queued", I18nUtils.getLocalizedString("change", "zz_zz"));
+            assertEquals("No skin found", I18nUtils.getLocalizedString("no_skin_found_plain", "zz_zz"));
+        }
     }
 }


### PR DESCRIPTION
lib-7 audit gap fix.

- formatAnnounce extracted for testability (per-player locale routing, global fallback, default label)
- Mojang cache config defaults + toggle coverage
- Per-player locale resolution tests (locale-API path; ServerPlayer unmockable in unit JVM — supertype static init)
- 335 tests pass