### PR TITLE
docs(1122): CHANGELOG backfill + TESTING.md + AGENTS.md + README locale claim

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@
 
 - Current configuration targets Minecraft `1.12.2`, Forge `14.23.5.2847`, Java 8 (Corretto `1.8.0_472-amzn` via SDKMAN), Gradle `4.10.3`, ForgeGradle `2.3`, MCP mappings `snapshot_20171003`. No Mixin annotation processor is configured (the leftover `mixin/server/MixinCommandManager.java` stub is excluded from the jar).
 - Build with the repository wrapper. The current `gradlew` is LF-encoded and executable. Build with `./gradlew build`.
-- CI runs on every push to `1.21` and `mc1.12.2` branches: lint (yamllint) + build + unit tests (JUnit 5) + E2E (HeadlessMC + HMCSpecifics + Forge + WireMock).
+- CI runs on every push to `1.21` and `mc1.12.2` branches: lint (yamllint) + build + unit tests (JUnit 5). 1.21 additionally runs GameTest (31 tests via `runGameTestServer`, mock-player + real packet assertions); mc1.12.2 additionally runs a bash server-log smoke E2E (`run-e2e.sh` + `assert-skin-property.sh`, Mojang endpoints stubbed with WireMock — no HeadlessMC scenarios).
 - `gradle.properties` contains stale metadata (`minecraft_version_range`, `curse_versions`, placeholder description, broad loader/Forge ranges). Treat executable dependency coordinates in `build.gradle` as authoritative until metadata is reconciled.
 - The local Qartez index currently points at another workspace. If Qartez returns paths such as `neodeal/` or `ik_llama.cpp`, stop and re-index this repository rather than trusting impact or dependency results.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,13 @@
 - **Per-command op level config** (#153): 7 `op_level.*` keys (same defaults as 1.21).
 - **`everlastingskins.bypass.cooldown` permission node** (#153): `DefaultPermissionLevel.OP`. 8 total nodes registered (added `.source` + `bypass.cooldown`).
 - **PermissionContext widened** (#153): Java 8-compatible class with opLevel 0-4 validation.
+- **MojangProfileCache config wired** (#160): `mojangProfileCache*` keys now read from `Config.load()` (were compiled-in defaults).
+- **i18n infrastructure overhaul** (#162): 22 message keys with per-server config defaults + per-locale overrides via I18nUtils (en/ru/uk + 8 more resource files, 11 locales total); per-player locale via `PlayerLanguage`.
 - **Resource lang files**: `src/main/resources/assets/everlastingskins/lang/{en,ru,uk}.properties` shipped with the mod (not just runtime-writeable config dir).
 
 ### Fixed
 - All lib-17 + lib-49 fixes ported from 1.21.
+- **Translation drift** (#167): `ru`/`uk` properties realigned with the 1.21 canonical translations.
 
 ### Tests added
 - `UrlAllowlistTest` (8 cases)
@@ -21,6 +24,11 @@
 - `PlayerLanguageTest` (3 cases)
 - `PermissionServiceManagerTest` + `VanillaPermissionServiceTest` + `LuckPermsPermissionServiceTest` (refreshed)
 - `PermissionGateIT` (integration test)
+- **Test gaps closed** (#170): Discord I18n routing tests + `ConfigTest` defaults tests + per-player locale tests (11 tests)
+
+### Docs
+- README — fix Forge version (51.0.8 in branches table), add per-player locale + languages sections (#164)
+- CHANGELOG/TESTING cleanup (#166)
 
 ## 2.1.0 (2026-08-02)
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Config file: `config/everlastingskins.cfg` (auto-generated on first run).
 | `Permissions.op_level.metrics` | Integer | `2` | Required op level for `/skin metrics` |
 | `Permissions.op_level.metrics_reset` | Integer | `2` | Required op level for `/skin metrics cleanup/reset` |
 
-> **Per-player locale** (1.12.2 only): when a message has no custom default, the mod resolves the player's client language (`en_us`, etc.) via `PlayerLanguage` (AT-exposed `EntityPlayerMP.language` field, `META-INF/everlastingskins_at.cfg`) and falls back to `Messages.localization` if the field is unavailable.
+> **Per-player locale**: when a message has no custom default, the mod resolves the player's client language (`en_us`, etc.) via `PlayerLanguage` (AT-exposed `EntityPlayerMP.language` field, `META-INF/everlastingskins_at.cfg`) and falls back to `Messages.localization` if the field is unavailable. The 1.21 branch provides the same behavior via `ServerPlayer.clientInformation().language()`.
 
 ## 🌐 Languages
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -3,8 +3,8 @@
 EverlastingSkins uses a three-tier testing pyramid:
 
 ## Tier 1: Pure Java unit tests (JUnit 5)
-- 324 unit tests on 1.21 branch
-- 314 tests on mc1.12.2 branch
+- 335 unit tests on 1.21 branch
+- 325 tests on mc1.12.2 branch
 - Coverage: provider fallback, HTTP outcomes, persistence atomicity, corruption handling, cache behavior, permission system, command dispatch, integration hooks
 - New in 2.1.0-rc.1: `UrlAllowlistTest`, `DefaultSkinResolverTest`, `PlayerLanguageTest`, `PermissionGateIT`; `PermissionServiceManagerTest`, `VanillaPermissionServiceTest`, `LuckPermsPermissionServiceTest`, `MetricsCommandIT` refreshed/pre-existing (not new)
 - Run: `./gradlew test`


### PR DESCRIPTION
lib-12 audit gap fix.