### PR TITLE
fix(ci): add timeout to gametest-121, remove duplicated build-1122

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
   gametest-121:
     name: GameTest (1.21)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: lint-yaml
     if: |
       (github.event_name == 'push' && github.ref_name == '1.21') ||
@@ -106,38 +107,3 @@ jobs:
             --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
             --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED
             -Dio.netty.tryReflectionSetAccessible=true"
-
-  # ── Build & test on mc1.12.2 (Java 8) ─────────────────────────
-  build-1122:
-    name: Build (mc1.12.2)
-    runs-on: ubuntu-latest
-    needs: lint-yaml
-    if: |
-      (github.event_name == 'push' && github.ref_name == 'mc1.12.2') ||
-      (github.event_name == 'pull_request' && github.base_ref == 'mc1.12.2')
-    steps:
-      - uses: actions/checkout@v5
-      - name: Set up JDK 8
-        uses: actions/setup-java@v5
-        with:
-          java-version: 8
-          distribution: temurin
-      - name: Cache Gradle wrapper and caches
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.gradle/wrapper/dists
-            ~/.gradle/caches
-          key: gradle-${{ runner.os }}-mc1.12.2-${{ hashFiles('**/gradle-wrapper.properties') }}
-          restore-keys: |
-            gradle-${{ runner.os }}-mc1.12.2-
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-      - name: Build and test
-        run: ./gradlew build test --no-daemon --stacktrace
-      - name: Upload built jar
-        uses: actions/upload-artifact@v5
-        with:
-          name: mod-1122
-          path: build/libs/*.jar
-          if-no-files-found: error


### PR DESCRIPTION
lib-27 audit gap fix.

- gametest-121: added job-level `timeout-minutes: 15` (previously only the GameTest step had a timeout; setup/cache/gradle steps were unbounded)
- build-1122: removed from 1.21 ci.yml — duplicates logic in mc1.12.2/ci.yml and is not referenced by publish.yml (publish checks out the mc1.12.2 ref directly)