### PR TITLE
fix(1122): README MineSkin key optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Config file: `config/everlastingskins.cfg` (auto-generated on first run).
 |-----|------|---------|-------------|
 | `Messages.localization` | String | `en` | Language for mod messages |
 | `Messages.display` | Boolean | `true` | Show skin application messages in chat |
-| `Messages.key` | String | (empty) | MineSkin API key (required for `/skin set web`) |
+| `Messages.key` | String | (empty) | MineSkin API key (optional; raises rate limits for `/skin set web`) |
 | `MineSkin.enabled` | Boolean | `false` | Enable MineSkin URL-based skin generation |
 | `Integration.discordsrv_enabled` | Boolean | `false` | Enable DiscordSRV skin change announcements (hybrid servers only) |
 | `Integration.discordsrv_channel_id` | String | (empty) | Discord channel ID for skin change announcements |


### PR DESCRIPTION
lib-40 audit fix (Issue 1): MineSkin API key is optional — it only raises rate limits for `/skin set web`, per MineSkinApiHttpImpl (auth header only added when key non-empty) and OpenAPI spec (apiKey not required).

Issue 2 (TESTING.md labels + 11 test-gaps-closed) was already resolved on mc1.12.2 in #184.