### PR TITLE
fix(1.21): README MineSkin optional + config-key casing + Permissions + TESTING

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,72 +57,82 @@ Config file: `world/serverconfig/everlastingskins-server.toml` (auto-generated o
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `messages.localization` | String | `en` | Language for mod messages |
-| `messages.display` | Boolean | `true` | Show skin application messages in chat |
-| `messages.key` | String | (empty) | MineSkin API key (required for `/skin set web`) |
-| `integration.discordsrv_enabled` | Boolean | `false` | Enable DiscordSRV skin change announcements |
-| `integration.discordsrv_channel_id` | String | (empty) | Discord channel ID for announcements |
-| `ratelimit.cooldown_seconds` | Integer | `3` | Cooldown between `/skin` commands (seconds) |
-| `ratelimit.rate_limit_enabled` | Boolean | `true` | Enable `/skin` rate limiting |
-| `ratelimit.max_commands_per_minute` | Integer | `5` | Max `/skin` commands per minute (per player) |
-| `broadcast.dimension_scoped_broadcast` | Boolean | `false` | Restrict refresh broadcasts to the target's dimension |
-| `broadcast.broadcast_use_bundle` | Boolean | `false` | Send REMOVE + ADD_PLAYER broadcast as one bundle packet |
-| `broadcast.debounce_millis` | Integer | `100` | Per-player refresh debounce window (milliseconds) |
-| `broadcast.refresh_via_entity_tracker` | Boolean | `true` | Untrack/re-track the target entity so observers re-fetch the updated profile (fixes stale skin renders on remote clients) |
-| `metrics.metrics_enabled` | Boolean | `true` | Enable in-process metrics and periodic `metrics.json` dump |
-| `metrics.metrics_dump_interval_seconds` | Integer | `60` | Interval between `metrics.json` dumps (0 disables the dump) |
-| `http.http_client_version` | String | `HTTP_2` | JDK HTTP client version (`HTTP_2` or `HTTP_1_1`) |
-| `http.http_connect_timeout_seconds` | Integer | `5` | Connection timeout for provider requests (seconds) |
-| `mojang_cache.mojang_profile_cache_enabled` | Boolean | `true` | Enable the in-process Mojang profile cache |
-| `mojang_cache.mojang_profile_cache_ttl_ms` | Long | `3600000` | Mojang profile cache entry lifetime (milliseconds; `0` disables caching) |
-| `mojang_cache.mojang_profile_cache_max_size` | Integer | `1000` | Max Mojang profile cache entries (oldest evicted first) |
-| `default_skins.enabled` | Boolean | `false` | Apply a default skin from `list` to players without a saved custom skin |
-| `default_skins.applyForPremium` | Boolean | `false` | Also apply the default skin to players WITH a saved custom skin (display-only override; their stored custom skin is preserved) |
-| `default_skins.list` | String[] | `Steve, <random>` | Default skins list: Mojang usernames or the literal `<random>` token (random Mojang username on each login) |
-| `security.urlAllowlistEnabled` | Boolean | `false` | Enable URL domain allowlist for `/skin set web` (empty list = deny all) |
-| `security.urlAllowlistDomains` | String[] | 9 default domains | Domains allowed for `/skin set web` (eTLD+1 suffix match; one entry covers all subdomains) |
-| `permissions.op_level.mojang` | Integer | `0` | Required op level for `/skin set <mojang>` |
-| `permissions.op_level.url` | Integer | `2` | Required op level for `/skin set web` |
-| `permissions.op_level.clear` | Integer | `0` | Required op level for `/skin clear` |
-| `permissions.op_level.random` | Integer | `0` | Required op level for `/skin set random` |
-| `permissions.op_level.other` | Integer | `2` | Required op level for changing another player's skin |
-| `permissions.op_level.metrics` | Integer | `2` | Required op level for `/skin metrics` |
-| `permissions.op_level.metrics_reset` | Integer | `2` | Required op level for `/skin metrics cleanup/reset` |
+| `Messages.localization` | String | `en` | Language for mod messages |
+| `Messages.display` | Boolean | `true` | Show skin application messages in chat |
+| `Messages.key` | String | (empty) | MineSkin API key (optional; raises rate limits for `/skin set web`) |
+| `Integration.discordsrv_enabled` | Boolean | `false` | Enable DiscordSRV skin change announcements |
+| `Integration.discordsrv_channel_id` | String | (empty) | Discord channel ID for announcements |
+| `RateLimit.cooldown_seconds` | Integer | `3` | Cooldown between `/skin` commands (seconds) |
+| `RateLimit.rate_limit_enabled` | Boolean | `true` | Enable `/skin` rate limiting |
+| `RateLimit.max_commands_per_minute` | Integer | `5` | Max `/skin` commands per minute (per player) |
+| `Broadcast.dimension_scoped_broadcast` | Boolean | `false` | Restrict refresh broadcasts to the target's dimension |
+| `Broadcast.broadcast_use_bundle` | Boolean | `false` | Send REMOVE + ADD_PLAYER broadcast as one bundle packet |
+| `Broadcast.debounce_millis` | Integer | `100` | Per-player refresh debounce window (milliseconds) |
+| `Broadcast.refresh_via_entity_tracker` | Boolean | `true` | Untrack/re-track the target entity so observers re-fetch the updated profile (fixes stale skin renders on remote clients) |
+| `Metrics.metrics_enabled` | Boolean | `true` | Enable in-process metrics and periodic `metrics.json` dump |
+| `Metrics.metrics_dump_interval_seconds` | Integer | `60` | Interval between `metrics.json` dumps (0 disables the dump) |
+| `Http.http_client_version` | String | `HTTP_2` | JDK HTTP client version (`HTTP_2` or `HTTP_1_1`) |
+| `Http.http_connect_timeout_seconds` | Integer | `5` | Connection timeout for provider requests (seconds) |
+| `MojangCache.mojang_profile_cache_enabled` | Boolean | `true` | Enable the in-process Mojang profile cache |
+| `MojangCache.mojang_profile_cache_ttl_ms` | Long | `3600000` | Mojang profile cache entry lifetime (milliseconds; `0` disables caching) |
+| `MojangCache.mojang_profile_cache_max_size` | Integer | `1000` | Max Mojang profile cache entries (oldest evicted first) |
+| `DefaultSkins.enabled` | Boolean | `false` | Apply a default skin from `list` to players without a saved custom skin |
+| `DefaultSkins.applyForPremium` | Boolean | `false` | Also apply the default skin to players WITH a saved custom skin (display-only override; their stored custom skin is preserved) |
+| `DefaultSkins.list` | String[] | `Steve, <random>` | Default skins list: Mojang usernames or the literal `<random>` token (random Mojang username on each login) |
+| `Security.urlAllowlistEnabled` | Boolean | `false` | Enable URL domain allowlist for `/skin set web` (empty list = deny all) |
+| `Security.urlAllowlistDomains` | String[] | 9 default domains | Domains allowed for `/skin set web` (eTLD+1 suffix match; one entry covers all subdomains) |
+| `Permissions.op_level.mojang` | Integer | `0` | Required op level for `/skin set <mojang>` |
+| `Permissions.op_level.url` | Integer | `2` | Required op level for `/skin set web` |
+| `Permissions.op_level.clear` | Integer | `0` | Required op level for `/skin clear` |
+| `Permissions.op_level.random` | Integer | `0` | Required op level for `/skin set random` |
+| `Permissions.op_level.other` | Integer | `2` | Required op level for changing another player's skin |
+| `Permissions.op_level.metrics` | Integer | `2` | Required op level for `/skin metrics` |
+| `Permissions.op_level.metrics_reset` | Integer | `2` | Required op level for `/skin metrics cleanup/reset` |
 
 All message strings are customizable. Defaults (keys under the `Messages` section):
 
 | Key | Default |
 |-----|---------|
-| `messages.messages_change` | `Skin change queued` |
-| `messages.messages_fulfilled` | `Skin has been applied.` |
-| `messages.messages_timeout` | `Skin fetch timed out.` |
-| `messages.messages_error` | `Skin fetch failed.` |
-| `messages.messages_restored_from` | `Skin restored from %s` |
-| `messages.messages_cleared_no_profile` | `Skin cleared (no Mojang profile found)` |
-| `messages.messages_no_source` | `No source available` |
-| `messages.messages_player_only` | `Player only command` |
-| `messages.messages_permission_denied` | `Permission denied` |
-| `messages.messages_cooldown` | `Please wait %ds before using /skin again` |
-| `messages.messages_rate_limited` | `Too many /skin commands. Try again later.` |
-| `messages.messages_no_skin_found` | `No skin found for "%s"` |
-| `messages.messages_no_skin_found_plain` | `No skin found` |
-| `messages.messages_mineskin_rejected` | `MineSkin rejected the URL` |
-| `messages.messages_no_random_username` | `No random username available` |
-| `messages.messages_provider_no_result` | `Provider returned no result` |
-| `messages.messages_metrics_top_players` | `Top players by refresh count:` |
-| `messages.messages_metrics_refreshes` | ` refreshes` |
-| `messages.messages_metrics_no_refreshes` | `(no refreshes recorded)` |
-| `messages.messages_metrics_cleanup` | `Metrics cleanup: pruned %d stale player entries` |
-| `messages.messages_metrics_reset` | `Metrics reset` |
-| `messages.messages_discord_announce` | `**%s** changed their skin to: \`%s\`` |
+| `Messages.messages_change` | `Skin change queued` |
+| `Messages.messages_fulfilled` | `Skin has been applied.` |
+| `Messages.messages_timeout` | `Skin fetch timed out.` |
+| `Messages.messages_error` | `Skin fetch failed.` |
+| `Messages.messages_restored_from` | `Skin restored from %s` |
+| `Messages.messages_cleared_no_profile` | `Skin cleared (no Mojang profile found)` |
+| `Messages.messages_no_source` | `No source available` |
+| `Messages.messages_player_only` | `Player only command` |
+| `Messages.messages_permission_denied` | `Permission denied` |
+| `Messages.messages_cooldown` | `Please wait %ds before using /skin again` |
+| `Messages.messages_rate_limited` | `Too many /skin commands. Try again later.` |
+| `Messages.messages_no_skin_found` | `No skin found for "%s"` |
+| `Messages.messages_no_skin_found_plain` | `No skin found` |
+| `Messages.messages_mineskin_rejected` | `MineSkin rejected the URL` |
+| `Messages.messages_no_random_username` | `No random username available` |
+| `Messages.messages_provider_no_result` | `Provider returned no result` |
+| `Messages.messages_metrics_top_players` | `Top players by refresh count:` |
+| `Messages.messages_metrics_refreshes` | ` refreshes` |
+| `Messages.messages_metrics_no_refreshes` | `(no refreshes recorded)` |
+| `Messages.messages_metrics_cleanup` | `Metrics cleanup: pruned %d stale player entries` |
+| `Messages.messages_metrics_reset` | `Metrics reset` |
+| `Messages.messages_discord_announce` | `**%s** changed their skin to: \`%s\`` |
 
 Message keys are configurable per-locale via I18nUtils. The Custom messages tree (#144) added 22 keys with per-server config defaults — see [CHANGELOG.md](CHANGELOG.md) for the full list.
 
 ### Permissions
 
-The 8 registered permission nodes. Permission nodes use Forge's
-PermissionAPI; players without a node (e.g., vanilla clients) fall
-back to the per-command `op_level.*` config values.
+The 8 registered permission nodes. EverlastingSkins uses a
+multi-plugin abstraction layer:
+
+1. **LuckPerms** (soft-detected): if installed and loaded, its nodes
+   take priority.
+2. **Forge PermissionAPI**: registered nodes use Forge's defaults.
+3. **Vanilla fallback** (via VanillaPermissionService): reads the
+   per-command `Permissions.op_level.*` config values when no
+   backend is available.
+
+Permission nodes are listed below with their **Forge PermissionAPI
+default** (ALL = true, OP = false) and the **vanilla op level
+fallback** if Forge isn't present.
 
 - `everlastingskins.command.skin` (default ALL)
 - `everlastingskins.command.skin.other` (default OP)
@@ -135,7 +145,7 @@ back to the per-command `op_level.*` config values.
 
 ## 🌐 Languages
 
-Built-in locales (11 total) — set `messages.localization` to one of:
+Built-in locales (11 total) — set `Messages.localization` to one of:
 
 | Locale | Language |
 |--------|----------|
@@ -153,7 +163,7 @@ Built-in locales (11 total) — set `messages.localization` to one of:
 
 ### Per-Player Locale
 
-Each player sees mod messages in their own Minecraft client language (e.g., a player with French `fr_fr` sees French translations). The locale is read automatically from `clientInformation().language()` and normalized (`en_us` -> `en`); locales not among the 11 built-ins fall back to `messages.localization` (default `en`).
+Each player sees mod messages in their own Minecraft client language (e.g., a player with French `fr_fr` sees French translations). The locale is read automatically from `clientInformation().language()` and normalized (`en_us` -> `en`); locales not among the 11 built-ins fall back to `Messages.localization` (default `en`).
 
 Configurable in `world/serverconfig/everlastingskins-server.toml` under the `Messages` section.
 
@@ -162,7 +172,7 @@ Configurable in `world/serverconfig/everlastingskins-server.toml` under the `Mes
 | Service | Required | Used For |
 |---------|----------|----------|
 | Mojang Session Server | No (offline-mode supported) | Resolving usernames to skin data |
-| MineSkin API | No | Converting image URLs to skin textures |
+| MineSkin API | No (key optional; raises rate limits) | Converting image URLs to skin textures |
 
 ## 💾 Storage
 
@@ -189,8 +199,8 @@ To enable PlaceholderAPI on a hybrid server:
 
 To enable DiscordSRV announcements:
 1. Install DiscordSRV on the Bukkit side
-2. Configure the channel ID in the mod config: `integration.discordsrv_channel_id = "123456789"`
-3. Set `integration.discordsrv_enabled = true` in the mod config
+2. Configure the channel ID in the mod config: `Integration.discordsrv_channel_id = "123456789"`
+3. Set `Integration.discordsrv_enabled = true` in the mod config
 4. Skin changes will be announced to the configured Discord channel
 
 ## 🔨 Building from Source

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,7 +6,8 @@ EverlastingSkins uses a three-tier testing pyramid:
 - 336 unit tests + 32 GameTest = 368 total on 1.21 branch
 - 325 tests on mc1.12.2 branch
 - Coverage: provider fallback, HTTP outcomes, persistence atomicity, corruption handling, cache behavior, permission system, command dispatch, integration hooks
-- New in 2.1.0-rc.1: `MojangProfileCacheTest`, `UrlAllowlistTest`, `DefaultSkinResolverTest`, `PermissionServiceManagerTest`, `VanillaPermissionServiceTest`, `LuckPermsPermissionServiceTest`
+- New in 2.1.0-rc.1: `MojangProfileCacheTest`, `UrlAllowlistTest`, `DefaultSkinResolverTest`; `PermissionServiceManagerTest`, `VanillaPermissionServiceTest`, `LuckPermsPermissionServiceTest` refreshed with `opLevel` (were pre-existing)
+- **Test gaps closed (#169)**: 11 new tests covering Discord i18n routing, MojangProfileCache config, per-player locale behavior
 - Run: `./gradlew test`
 
 ## Tier 2: Forge server integration (manual smoke test)


### PR DESCRIPTION
lib-38 + lib-40 audit gap fixes (Issues 1-4): MineSkin key optional, config key casing matches Config.java (TOML case-sensitive), Permissions section reflects VanillaPermissionService, TESTING.md labels + #169 test gaps