### PR TITLE
fix(1122): README MojangCache category + TESTING test-gaps line

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ Config file: `config/everlastingskins.cfg` (auto-generated on first run).
 | `everlastingskins.cooldown_seconds` | Integer | `3` | Cooldown between `/skin` commands (seconds) |
 | `everlastingskins.max_commands_per_minute` | Integer | `5` | Max `/skin` commands per minute (per player) |
 | `everlastingskins.debounce_millis` | Integer | `100` | Per-player refresh debounce window (milliseconds) |
-| `everlastingskins.mojangProfileCacheEnabled` | Boolean | `true` | Enable the in-process Mojang profile cache |
-| `everlastingskins.mojangProfileCacheTtlMs` | Long | `3600000` | Mojang profile cache entry lifetime (milliseconds; `0` disables caching) |
-| `everlastingskins.mojangProfileCacheMaxSize` | Integer | `1000` | Max Mojang profile cache entries (oldest evicted first) |
+| `MojangCache.mojangProfileCacheEnabled` | Boolean | `true` | Enable the in-process Mojang profile cache |
+| `MojangCache.mojangProfileCacheTtlMs` | Long | `3600000` | Mojang profile cache entry lifetime (milliseconds; `0` disables caching) |
+| `MojangCache.mojangProfileCacheMaxSize` | Integer | `1000` | Max Mojang profile cache entries (oldest evicted first) |
 | `DefaultSkins.enabled` | Boolean | `false` | Apply a default skin from `list` to players without a saved custom skin |
 | `DefaultSkins.applyForPremium` | Boolean | `false` | Also apply the default skin to players WITH a saved custom skin (display-only override) |
 | `DefaultSkins.list` | String[] | `Steve, <random>` | Default skins list: Mojang usernames or the literal `<random>` token |
@@ -132,7 +132,7 @@ Built-in locales (11 total) — set `Messages.localization` to one of:
 
 Skins are stored as one JSON file per player in `world/EverlastingSkins/<uuid>.json`. Writes are atomic (drain-coalesce async writer with a 50ms debounce). Files with corrupt JSON are quarantined as `.corrupt-<timestamp>` and a fresh entry is created on next save.
 
-Mojang profile lookups are cached in-memory (MojangProfileCache, TTL 1h, cap 1000) to avoid rate limits; the cache is not persisted. Its behavior is controlled by the `everlastingskins.mojangProfileCache*` keys (see Configuration above), which are read from `Config.load()` since #160.
+Mojang profile lookups are cached in-memory (MojangProfileCache, TTL 1h, cap 1000) to avoid rate limits; the cache is not persisted. Its behavior is controlled by the `MojangCache.mojangProfileCache*` keys (see Configuration above), which are read from `Config.load()` since #160.
 
 ## ⚠️ Compatibility
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -7,6 +7,7 @@ EverlastingSkins uses a three-tier testing pyramid:
 - 325 tests on mc1.12.2 branch
 - Coverage: provider fallback, HTTP outcomes, persistence atomicity, corruption handling, cache behavior, permission system, command dispatch, integration hooks
 - New in 2.1.0-rc.1: `UrlAllowlistTest`, `DefaultSkinResolverTest`, `PlayerLanguageTest`, `PermissionGateIT`; `PermissionServiceManagerTest`, `VanillaPermissionServiceTest`, `LuckPermsPermissionServiceTest`, `MetricsCommandIT` refreshed/pre-existing (not new)
+- **Test gaps closed (#170)**: 11 new tests covering Discord i18n routing, MojangProfileCache config, per-player locale behavior
 - Run: `./gradlew test`
 
 ## Tier 2: Forge server integration (manual smoke test)


### PR DESCRIPTION
lib-42 + lib-44 audit gap fixes (Issues 1, 2)

- README.md: move 3 mojangProfileCache* keys from 'everlastingskins.*' to 'MojangCache.*' category (matches Config.java 'MojangCache' category)
- README.md Storage prose: corrected key reference
- TESTING.md: added 'Test gaps closed (#170)' line