### PR TITLE
fix(ci): mc1.12.2 client-E2E boundary is boot smoke + real client join (drop dead WireMock)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,8 +216,24 @@ jobs:
             --command "launch forge:1.12.2 -lwjgl -offline --uid 14.23.5.2860 --jvm -Djava.awt.headless=true" \
             --game-args "--server=127.0.0.1 --port=25565 --username TestPlayer" > "${{ env.HMC_DIR }}/hmc-output.log" 2>&1 &
           CLIENT_PID=$!
-          CLIENT_PGID=$(ps -o pgid= -p "$CLIENT_PID" 2>/dev/null | tr -d ' ' || true)
           OWN_PGID=$(ps -o pgid= -p $$ | tr -d ' ' || true)
+          # A one-shot ps right after & can read the child's pre-setsid
+          # group (the runner's own PGID) and silently degrade cleanup to a
+          # wrapper-only kill, orphaning the Java client. Poll until the
+          # tracked PGID leaves our own group, the process exits, or a
+          # bounded budget runs out, then decide group-kill vs PID-kill.
+          CLIENT_PGID=""
+          for _ in $(seq 1 50); do
+            if ! kill -0 "$CLIENT_PID" 2>/dev/null; then
+              break
+            fi
+            CANDIDATE=$(ps -o pgid= -p "$CLIENT_PID" 2>/dev/null | tr -d ' ' || true)
+            if [ -n "$CANDIDATE" ] && [ "$CANDIDATE" != "$OWN_PGID" ]; then
+              CLIENT_PGID="$CANDIDATE"
+              break
+            fi
+            sleep 0.1
+          done
           JOINED=0
           for _ in $(seq 1 90); do
             if grep -q " joined the game" "${{ env.SERVER_DIR }}/logs/latest.log" 2>/dev/null; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,10 @@ jobs:
   # JSONs cannot run here. This job is a server boot smoke test plus a
   # real headless client join assertion.
   e2e-test-1122:
-    name: Boot Smoke (mc1.12.2)
+    # Display name kept as `E2E (mc1.12.2)` for branch-protection
+    # compatibility (required status check context); the job itself is a
+    # boot smoke test.
+    name: E2E (mc1.12.2)
     runs-on: ubuntu-latest
     needs: build-1122
     if: github.event_name == 'push' && github.ref_name == 'mc1.12.2'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,34 +69,23 @@ jobs:
           path: build/libs/*.jar
           if-no-files-found: error
 
-  # ── E2E test on mc1.12.2 ──────────────────────────────────────
+  # ── Boot smoke test on mc1.12.2 ───────────────────────────────
+  # The vanilla 1.12.2 client has no console/stdin bridge: HMCSpecifics
+  # (the only console provider) crashes the client at boot, so HeadlessMC
+  # cannot drive commands and scenario JSONs cannot run here. This job is
+  # a server boot smoke test plus a real headless client join assertion.
   e2e-test-1122:
-    name: E2E (mc1.12.2)
+    name: Boot Smoke (mc1.12.2)
     runs-on: ubuntu-latest
     needs: build-1122
     if: github.event_name == 'push' && github.ref_name == 'mc1.12.2'
     timeout-minutes: 20
-    services:
-      wiremock:
-        image: wiremock/wiremock:3.13.2
-        ports:
-          - 8080:8080
-        volumes:
-          - ${{ github.workspace }}/test-infrastructure/wiremock/fixtures/mappings:/home/wiremock/mappings
-        options: >-
-          --health-cmd "curl -sf http://localhost:8080/__admin/health || exit 1"
-          --health-interval 5s
-          --health-timeout 10s
-          --health-retries 12
-          --health-start-period 15s
     env:
       HMC_DIR: ${{ github.workspace }}/HeadlessMC
       SERVER_DIR: ${{ github.workspace }}/test-server
       MODS_DIR: ${{ github.workspace }}/test-server/mods
       HMC_VERSION: "2.10.0"
     steps:
-      - name: Clean WireMock artifacts (EACCES workaround)
-        run: sudo rm -rf ${{ github.workspace }}/test-infrastructure/wiremock || true
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
       - name: Set up JDK 8
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961  # v5
@@ -164,31 +153,34 @@ jobs:
             ls -la
             exit 1
           fi
-          java -Xmx1G -Xms512M \
-            -Deverlastingskins.allowHttp=true \
-            -Deverlastingskins.endpoint.uuid.eclipse="http://localhost:8080/uuid/eclipse/%playerName%" \
-            -Deverlastingskins.endpoint.uuid.mojang="http://localhost:8080/uuid/mojang/%playerName%" \
-            -Deverlastingskins.endpoint.uuid.minetools="http://localhost:8080/uuid/minetools/%playerName%" \
-            -Deverlastingskins.endpoint.profile.eclipse="http://localhost:8080/profile/eclipse/%uuid%" \
-            -Deverlastingskins.endpoint.profile.mojang="http://localhost:8080/profile/mojang/%uuid%" \
-            -Deverlastingskins.endpoint.profile.minetools="http://localhost:8080/profile/minetools/%uuid%" \
-            -jar "$SERVER_JAR" nogui > "${{ env.SERVER_DIR }}/logs/server-stdout.log" 2>&1 &
+          java -Xmx1G -Xms512M -jar "$SERVER_JAR" nogui > "${{ env.SERVER_DIR }}/logs/server-stdout.log" 2>&1 &
           SERVER_PID=$!
           echo "server_pid=$SERVER_PID" >> $GITHUB_OUTPUT
-      - name: Wait for server ready
+      - name: Wait for server ready and assert mod discovery
         run: |
+          SERVER_PID="${{ steps.start-server.outputs.server_pid }}"
           for i in $(seq 1 120); do
+            if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+              echo "ERROR: server process exited during startup"
+              tail -200 "${{ env.SERVER_DIR }}/logs/latest.log" 2>/dev/null || true
+              exit 1
+            fi
             if grep -q 'For help, type "help"' "${{ env.SERVER_DIR }}/logs/latest.log" 2>/dev/null; then
               echo "Server ready after ${i} attempts"
-              exit 0
+              break
             fi
-            if [ $i -eq 120 ]; then
+            if [ "$i" -eq 120 ]; then
               echo "ERROR: Server did not start within 10 minutes"
               tail -200 "${{ env.SERVER_DIR }}/logs/latest.log" 2>/dev/null || true
               exit 1
             fi
             sleep 5
           done
+          grep -q "everlastingskins" "${{ env.SERVER_DIR }}/logs/latest.log" || {
+            echo "FAIL: mod not discovered in server log"
+            tail -100 "${{ env.SERVER_DIR }}/logs/latest.log"
+            exit 1
+          }
       - name: Download HeadlessMC launcher
         run: |
           mkdir -p "${{ env.HMC_DIR }}"
@@ -197,6 +189,9 @@ jobs:
       - name: Configure HeadlessMC
         run: |
           {
+            echo "# Vanilla 1.12.2 has no console/stdin bridge: HMCSpecifics"
+            echo "# crashes the client at boot, so no hmc.test.filename scenario"
+            echo "# can run. Smoke test only: server boot + real client join."
             echo "hmc.java.versions=$JAVA_HOME/bin/java"
             echo "hmc.gamedir=${{ github.workspace }}/headlessmc-run"
             echo "hmc.mcdir=$HOME/.minecraft"
@@ -208,8 +203,9 @@ jobs:
             echo "hmc.always.lwjgl.flag=true"
             echo "hmc.jline.enabled=false"
             echo "hmc.auto.download.specifics=false"
+            echo "hmc.crash.report.watcher=true"
           } > "${{ env.HMC_DIR }}/config.properties"
-      - name: Launch client and assert server log
+      - name: Launch real client and assert join on server log
         run: |
           set -euo pipefail
           cd "${{ env.HMC_DIR }}"
@@ -218,36 +214,25 @@ jobs:
             --game-args "--server=127.0.0.1 --port=25565 --username TestPlayer" > "${{ env.HMC_DIR }}/hmc-output.log" 2>&1 &
           CLIENT_PID=$!
           JOINED=0
-          for i in $(seq 1 90); do
+          for _ in $(seq 1 90); do
             if grep -q " joined the game" "${{ env.SERVER_DIR }}/logs/latest.log" 2>/dev/null; then
               JOINED=1
               break
             fi
             if ! kill -0 "$CLIENT_PID" 2>/dev/null; then
-              echo "ERROR: client process exited early"
+              echo "ERROR: client process exited early (see hmc-output.log)"
+              tail -50 "${{ env.HMC_DIR }}/hmc-output.log"
               break
             fi
             sleep 2
           done
           kill "$CLIENT_PID" 2>/dev/null || true
           wait "$CLIENT_PID" 2>/dev/null || true
-          grep -q 'For help, type "help"' "${{ env.SERVER_DIR }}/logs/latest.log" || { echo "FAIL: server did not boot"; tail -100 "${{ env.SERVER_DIR }}/logs/latest.log"; exit 1; }
-          grep -q "everlastingskins" "${{ env.SERVER_DIR }}/logs/latest.log" || { echo "FAIL: mod not discovered"; tail -100 "${{ env.SERVER_DIR }}/logs/latest.log"; exit 1; }
           if [ "$JOINED" -ne 1 ]; then
-            echo "FAIL: client did not connect"
+            echo "FAIL: client did not connect to the server"
             tail -100 "${{ env.SERVER_DIR }}/logs/latest.log"
             tail -50 "${{ env.HMC_DIR }}/hmc-output.log"
             exit 1
-          fi
-      - name: Verify WireMock requests
-        if: always()
-        run: |
-          REQUESTS=$(curl -s http://localhost:8080/__admin/requests 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print(len(d.get('requests',[])))" 2>/dev/null || echo "0")
-          echo "WireMock requests served: $REQUESTS"
-          if [ "$REQUESTS" -ge "1" ]; then
-            echo "WireMock: received requests ✅"
-          else
-            echo "WireMock: NO requests received ❌"
           fi
       - name: Kill server
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,10 +70,10 @@ jobs:
           if-no-files-found: error
 
   # ── Boot smoke test on mc1.12.2 ───────────────────────────────
-  # The vanilla 1.12.2 client has no console/stdin bridge: HMCSpecifics
-  # (the only console provider) crashes the client at boot, so HeadlessMC
-  # cannot drive commands and scenario JSONs cannot run here. This job is
-  # a server boot smoke test plus a real headless client join assertion.
+  # The vanilla 1.12.2 client has no console/stdin bridge, so HeadlessMC
+  # SEND/ENDS_WITH/CONTAINS scenario steps cannot drive it and scenario
+  # JSONs cannot run here. This job is a server boot smoke test plus a
+  # real headless client join assertion.
   e2e-test-1122:
     name: Boot Smoke (mc1.12.2)
     runs-on: ubuntu-latest
@@ -189,9 +189,10 @@ jobs:
       - name: Configure HeadlessMC
         run: |
           {
-            echo "# Vanilla 1.12.2 has no console/stdin bridge: HMCSpecifics"
-            echo "# crashes the client at boot, so no hmc.test.filename scenario"
-            echo "# can run. Smoke test only: server boot + real client join."
+            echo "# Vanilla 1.12.2 has no console/stdin bridge, so HeadlessMC"
+            echo "# SEND/ENDS_WITH/CONTAINS steps cannot drive it: no"
+            echo "# hmc.test.filename scenario can run. Smoke test only:"
+            echo "# server boot + real client join."
             echo "hmc.java.versions=$JAVA_HOME/bin/java"
             echo "hmc.gamedir=${{ github.workspace }}/headlessmc-run"
             echo "hmc.mcdir=$HOME/.minecraft"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,22 +261,24 @@ jobs:
             kill "$CLIENT_PID" 2>/dev/null || true
           fi
           wait "$CLIENT_PID" 2>/dev/null || true
-          # Mod presence: Forge 1.12.2 names the mod id at INFO only in the
-          # FML mod-list handshake lines written when the client joins (the
-          # headless client carries no mods, so the server reports its mod
-          # list as 'missing mods [..., everlastingskins]'). Assert on that
-          # handshake signal after the join attempt - never at server-ready,
-          # before any client exists.
-          if ! grep -Eq 'Attempting connection with missing mods \[[^]]*everlastingskins' "${{ env.SERVER_DIR }}/logs/latest.log" \
-            && ! grep -Eq 'Client attempting to join with [0-9]+ mods : [^ ]*everlastingskins' "${{ env.SERVER_DIR }}/logs/latest.log"; then
-            echo "FAIL: mod id not found in FML handshake mod-list line"
-            tail -100 "${{ env.SERVER_DIR }}/logs/latest.log"
-            exit 1
-          fi
+          # Report the join outcome before the mod-presence assertion: a
+          # failed connect is the root cause, and a handshake-line failure
+          # checked first would mask it with a secondary error.
           if [ "$JOINED" -ne 1 ]; then
             echo "FAIL: client did not connect to the server"
             tail -100 "${{ env.SERVER_DIR }}/logs/latest.log"
             tail -50 "${{ env.HMC_DIR }}/hmc-output.log"
+            exit 1
+          fi
+          # Mod presence: Forge 1.12.2 names the mod id at INFO in the FML
+          # mod-list lines - the server logs 'missing mods [.., everlastingskins]
+          # at CLIENT' when the client joins, and names the full mod list at
+          # startup too. Assert after the join attempt; the pattern keys on
+          # the mod id in the bracket list, so either line matches.
+          if ! grep -Eq 'Attempting connection with missing mods \[[^]]*everlastingskins' "${{ env.SERVER_DIR }}/logs/latest.log" \
+            && ! grep -Eq 'Client attempting to join with [0-9]+ mods : [^ ]*everlastingskins' "${{ env.SERVER_DIR }}/logs/latest.log"; then
+            echo "FAIL: mod id not found in FML handshake mod-list line"
+            tail -100 "${{ env.SERVER_DIR }}/logs/latest.log"
             exit 1
           fi
       - name: Kill server

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
           java -Xmx1G -Xms512M -jar "$SERVER_JAR" nogui > "${{ env.SERVER_DIR }}/logs/server-stdout.log" 2>&1 &
           SERVER_PID=$!
           echo "server_pid=$SERVER_PID" >> $GITHUB_OUTPUT
-      - name: Wait for server ready and assert mod discovery
+      - name: Wait for server ready
         run: |
           SERVER_PID="${{ steps.start-server.outputs.server_pid }}"
           for i in $(seq 1 120); do
@@ -176,11 +176,6 @@ jobs:
             fi
             sleep 5
           done
-          grep -q "everlastingskins" "${{ env.SERVER_DIR }}/logs/latest.log" || {
-            echo "FAIL: mod not discovered in server log"
-            tail -100 "${{ env.SERVER_DIR }}/logs/latest.log"
-            exit 1
-          }
       - name: Download HeadlessMC launcher
         run: |
           mkdir -p "${{ env.HMC_DIR }}"
@@ -206,7 +201,7 @@ jobs:
             echo "hmc.auto.download.specifics=false"
             echo "hmc.crash.report.watcher=true"
           } > "${{ env.HMC_DIR }}/config.properties"
-      - name: Launch real client and assert join on server log
+      - name: Launch real client; assert FML mod handshake and join
         run: |
           set -euo pipefail
           cd "${{ env.HMC_DIR }}"
@@ -229,6 +224,18 @@ jobs:
           done
           kill "$CLIENT_PID" 2>/dev/null || true
           wait "$CLIENT_PID" 2>/dev/null || true
+          # Mod presence: Forge 1.12.2 names the mod id at INFO only in the
+          # FML mod-list handshake lines written when the client joins (the
+          # headless client carries no mods, so the server reports its mod
+          # list as 'missing mods [..., everlastingskins]'). Assert on that
+          # handshake signal after the join attempt - never at server-ready,
+          # before any client exists.
+          if ! grep -Eq 'Attempting connection with missing mods \[[^]]*everlastingskins' "${{ env.SERVER_DIR }}/logs/latest.log" \
+            && ! grep -Eq 'Client attempting to join with [0-9]+ mods : [^ ]*everlastingskins' "${{ env.SERVER_DIR }}/logs/latest.log"; then
+            echo "FAIL: mod id not found in FML handshake mod-list line"
+            tail -100 "${{ env.SERVER_DIR }}/logs/latest.log"
+            exit 1
+          fi
           if [ "$JOINED" -ne 1 ]; then
             echo "FAIL: client did not connect to the server"
             tail -100 "${{ env.SERVER_DIR }}/logs/latest.log"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,10 +205,19 @@ jobs:
         run: |
           set -euo pipefail
           cd "${{ env.HMC_DIR }}"
-          timeout --kill-after=10 300 xvfb-run -a java -jar "headlessmc-launcher-wrapper-${{ env.HMC_VERSION }}.jar" \
+          # Run the whole client pipeline (timeout -> xvfb-run -> Xvfb + MC
+          # java) in its own session/process group so cleanup can terminate
+          # the entire tree. Killing only the timeout/xvfb wrapper PID would
+          # orphan the Java client on self-hosted runners; pkill is banned by
+          # project policy. setsid execs directly when it is not a process
+          # group leader (the GHA/WSL non-interactive case), so the tracked
+          # PGID is the PID of the timeout process itself.
+          setsid timeout --kill-after=10 300 xvfb-run -a java -jar "headlessmc-launcher-wrapper-${{ env.HMC_VERSION }}.jar" \
             --command "launch forge:1.12.2 -lwjgl -offline --uid 14.23.5.2860 --jvm -Djava.awt.headless=true" \
             --game-args "--server=127.0.0.1 --port=25565 --username TestPlayer" > "${{ env.HMC_DIR }}/hmc-output.log" 2>&1 &
           CLIENT_PID=$!
+          CLIENT_PGID=$(ps -o pgid= -p "$CLIENT_PID" 2>/dev/null | tr -d ' ' || true)
+          OWN_PGID=$(ps -o pgid= -p $$ | tr -d ' ' || true)
           JOINED=0
           for _ in $(seq 1 90); do
             if grep -q " joined the game" "${{ env.SERVER_DIR }}/logs/latest.log" 2>/dev/null; then
@@ -222,7 +231,19 @@ jobs:
             fi
             sleep 2
           done
-          kill "$CLIENT_PID" 2>/dev/null || true
+          # Cleanup: TERM the tracked process group, escalate to KILL after a
+          # grace period, then reap. Fall back to a plain PID kill if the
+          # group could not be tracked (setsid forked or already gone).
+          if [ -n "$CLIENT_PGID" ] && [ "$CLIENT_PGID" != "$OWN_PGID" ]; then
+            kill -TERM -- "-$CLIENT_PGID" 2>/dev/null || true
+            for _ in $(seq 1 10); do
+              kill -0 -- "-$CLIENT_PGID" 2>/dev/null || break
+              sleep 1
+            done
+            kill -KILL -- "-$CLIENT_PGID" 2>/dev/null || true
+          else
+            kill "$CLIENT_PID" 2>/dev/null || true
+          fi
           wait "$CLIENT_PID" 2>/dev/null || true
           # Mod presence: Forge 1.12.2 names the mod id at INFO only in the
           # FML mod-list handshake lines written when the client joins (the

--- a/test-infrastructure/README.md
+++ b/test-infrastructure/README.md
@@ -48,6 +48,8 @@ curl -L -o test-infrastructure/headlessmc/headlessmc-launcher-wrapper.jar \
 ## CI integration
 
 `.github/workflows/ci.yml` (job `e2e-test-1122`) runs the same flow:
-start the Forge server with WireMock-backed endpoints, launch the headless
-client, and assert on `$SERVER_DIR/logs/latest.log`. Client crashes are
-visible because launch steps run under `set -euo pipefail`.
+start the Forge server, launch the headless client, and assert on
+`$SERVER_DIR/logs/latest.log`. The mod's skin API endpoints are never
+exercised here — without a console bridge no `/skin` command can be sent
+— so the job uses no WireMock service and no endpoint overrides. Client
+crashes are visible because launch steps run under `set -euo pipefail`.

--- a/test-infrastructure/README.md
+++ b/test-infrastructure/README.md
@@ -48,8 +48,6 @@ curl -L -o test-infrastructure/headlessmc/headlessmc-launcher-wrapper.jar \
 ## CI integration
 
 `.github/workflows/ci.yml` (job `e2e-test-1122`) runs the same flow:
-start the Forge server, launch the headless client, and assert on
-`$SERVER_DIR/logs/latest.log`. The mod's skin API endpoints are never
-exercised here — without a console bridge no `/skin` command can be sent
-— so the job uses no WireMock service and no endpoint overrides. Client
-crashes are visible because launch steps run under `set -euo pipefail`.
+start the Forge server with WireMock-backed endpoints, launch the headless
+client, and assert on `$SERVER_DIR/logs/latest.log`. Client crashes are
+visible because launch steps run under `set -euo pipefail`.

--- a/test-infrastructure/run-e2e.sh
+++ b/test-infrastructure/run-e2e.sh
@@ -113,11 +113,16 @@ echo "  Server PID: $SERVER_PID"
 
 echo "  Waiting for server to start..."
 for i in $(seq 1 60); do
+    if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+        echo "ERROR: server process exited during startup"
+        cat "$SERVER_DIR/logs/latest.log" 2>/dev/null || true
+        exit 1
+    fi
     if grep -q 'For help, type "help"' "$SERVER_DIR/logs/latest.log" 2>/dev/null; then
         echo "  Server ready after ${i}s"
         break
     fi
-    if [ $i -eq 60 ]; then
+    if [ "$i" -eq 60 ]; then
         echo "ERROR: Server did not start within 5 minutes"
         cat "$SERVER_DIR/logs/latest.log" 2>/dev/null || true
         kill "$SERVER_PID" 2>/dev/null || true
@@ -149,6 +154,7 @@ hmc.rethrow.launch.exceptions=true
 hmc.exit.on.failed.command=true
 hmc.assets.dummy=true
 hmc.always.lwjgl.flag=true
+hmc.jline.enabled=false
 hmc.auto.download.specifics=false
 hmc.crash.report.watcher=true
 CONFIG

--- a/test-infrastructure/run-e2e.sh
+++ b/test-infrastructure/run-e2e.sh
@@ -174,8 +174,24 @@ setsid timeout --kill-after=10 300 xvfb-run -a java -jar "$HMC_DIR/headlessmc-la
     --command "launch forge:$MC_VERSION -lwjgl -offline --uid $CLIENT_UID --jvm -Djava.awt.headless=true" \
     --game-args "--server=127.0.0.1 --port=25565 --username TestPlayer" > "$HMC_DIR/client.log" 2>&1 &
 CLIENT_PID=$!
-CLIENT_PGID=$(ps -o pgid= -p "$CLIENT_PID" 2>/dev/null | tr -d ' ' || true)
 OWN_PGID=$(ps -o pgid= -p $$ | tr -d ' ' || true)
+# A one-shot ps right after & can read the child's pre-setsid group (the
+# parent's own PGID) and silently degrade cleanup to a wrapper-only kill,
+# orphaning the Java client. Poll until the tracked PGID leaves our own
+# group, the process exits, or a bounded budget runs out, then decide
+# group-kill vs PID-kill fallback.
+CLIENT_PGID=""
+for _ in $(seq 1 50); do
+    if ! kill -0 "$CLIENT_PID" 2>/dev/null; then
+        break
+    fi
+    CANDIDATE=$(ps -o pgid= -p "$CLIENT_PID" 2>/dev/null | tr -d ' ' || true)
+    if [ -n "$CANDIDATE" ] && [ "$CANDIDATE" != "$OWN_PGID" ]; then
+        CLIENT_PGID="$CANDIDATE"
+        break
+    fi
+    sleep 0.1
+done
 
 JOINED=0
 for i in $(seq 1 90); do

--- a/test-infrastructure/run-e2e.sh
+++ b/test-infrastructure/run-e2e.sh
@@ -229,19 +229,21 @@ else
     echo "FAIL: server did not boot"
     FAILED=1
 fi
-# Forge 1.12.2 names the mod id at INFO only in the FML mod-list handshake
-# lines written when the client joins; assert on that signal after the join.
+if [ "$JOINED" -eq 1 ]; then
+    echo "PASS: client connected"
+else
+    echo "FAIL: client did not connect"
+    FAILED=1
+fi
+# Forge 1.12.2 names the mod id at INFO in the FML mod-list lines: the
+# server logs 'missing mods [... at CLIENT]' at join and names the full
+# mod list at startup too. Report the connect outcome first so a failed
+# join is not masked by this secondary assertion.
 if grep -Eq 'Attempting connection with missing mods \[[^]]*everlastingskins' "$SERVER_DIR/logs/latest.log" \
     || grep -Eq 'Client attempting to join with [0-9]+ mods : [^ ]*everlastingskins' "$SERVER_DIR/logs/latest.log"; then
     echo "PASS: mod discovered (FML handshake mod-list line)"
 else
     echo "FAIL: mod id not found in FML handshake mod-list line"
-    FAILED=1
-fi
-if [ "$JOINED" -eq 1 ]; then
-    echo "PASS: client connected"
-else
-    echo "FAIL: client did not connect"
     FAILED=1
 fi
 

--- a/test-infrastructure/run-e2e.sh
+++ b/test-infrastructure/run-e2e.sh
@@ -165,10 +165,17 @@ cd "$PROJECT_DIR"
 # Client profile was installed with the 2860 installer, so the uid must
 # match that profile even though the server runs the canonical 2847 build.
 CLIENT_UID="14.23.5.2860"
-timeout --kill-after=10 300 xvfb-run -a java -jar "$HMC_DIR/headlessmc-launcher-wrapper.jar" \
+# Run the client pipeline (timeout -> xvfb-run -> Xvfb + MC java) in its own
+# session/process group so cleanup can kill the whole tree: killing only the
+# timeout/xvfb wrapper PID would orphan the Java client (no pkill by project
+# policy). setsid execs directly when it is not a process group leader (the
+# non-interactive case), so the tracked PGID is the timeout process itself.
+setsid timeout --kill-after=10 300 xvfb-run -a java -jar "$HMC_DIR/headlessmc-launcher-wrapper.jar" \
     --command "launch forge:$MC_VERSION -lwjgl -offline --uid $CLIENT_UID --jvm -Djava.awt.headless=true" \
     --game-args "--server=127.0.0.1 --port=25565 --username TestPlayer" > "$HMC_DIR/client.log" 2>&1 &
 CLIENT_PID=$!
+CLIENT_PGID=$(ps -o pgid= -p "$CLIENT_PID" 2>/dev/null | tr -d ' ' || true)
+OWN_PGID=$(ps -o pgid= -p $$ | tr -d ' ' || true)
 
 JOINED=0
 for i in $(seq 1 90); do
@@ -183,7 +190,19 @@ for i in $(seq 1 90); do
     sleep 2
 done
 
-kill "$CLIENT_PID" 2>/dev/null || true
+# Cleanup: TERM the tracked process group, escalate to KILL after a grace
+# period, then reap. Fall back to a plain PID kill if the group could not
+# be tracked (setsid forked or already gone).
+if [ -n "$CLIENT_PGID" ] && [ "$CLIENT_PGID" != "$OWN_PGID" ]; then
+    kill -TERM -- "-$CLIENT_PGID" 2>/dev/null || true
+    for _ in $(seq 1 10); do
+        kill -0 -- "-$CLIENT_PGID" 2>/dev/null || break
+        sleep 1
+    done
+    kill -KILL -- "-$CLIENT_PGID" 2>/dev/null || true
+else
+    kill "$CLIENT_PID" 2>/dev/null || true
+fi
 wait "$CLIENT_PID" 2>/dev/null || true
 
 echo "=== E2E Assertions ==="

--- a/test-infrastructure/run-e2e.sh
+++ b/test-infrastructure/run-e2e.sh
@@ -194,10 +194,13 @@ else
     echo "FAIL: server did not boot"
     FAILED=1
 fi
-if grep -q "everlastingskins" "$SERVER_DIR/logs/latest.log"; then
-    echo "PASS: mod discovered"
+# Forge 1.12.2 names the mod id at INFO only in the FML mod-list handshake
+# lines written when the client joins; assert on that signal after the join.
+if grep -Eq 'Attempting connection with missing mods \[[^]]*everlastingskins' "$SERVER_DIR/logs/latest.log" \
+    || grep -Eq 'Client attempting to join with [0-9]+ mods : [^ ]*everlastingskins' "$SERVER_DIR/logs/latest.log"; then
+    echo "PASS: mod discovered (FML handshake mod-list line)"
 else
-    echo "FAIL: mod not discovered"
+    echo "FAIL: mod id not found in FML handshake mod-list line"
     FAILED=1
 fi
 if [ "$JOINED" -eq 1 ]; then


### PR DESCRIPTION
## What

Makes the mc1.12.2 client-E2E boundary truthful: the CI job is a **server boot smoke test with a real headless client join** — not a command-driven scenario run.

The vanilla 1.12.2 client has no console/stdin bridge, so HeadlessMC `SEND`/`ENDS_WITH`/`CONTAINS` scenario steps cannot drive it and scenario JSONs cannot run on this branch. The real-client mechanism that *does* work — launch the actual Forge 1.12.2 client headless under xvfb and observe the join in the server log — is preserved and kept as a hard assertion.

This revision addresses the librarian audit of the previous PR state plus the re-audit residuals:

- **Blocker — mod-discovery assertion ran before any client existed.** The old assertion grepped `everlastingskins` right after server-ready, but the mod id appears at INFO inside the FML mod-list lines only once a client's mod list is exchanged. The join-time line in the server log is `Attempting connection with missing mods [everlastingskins] at CLIENT` (verified verbatim in the last green push run's log, immediately before `Server side modded connection established`); the same message with the full mod list is also logged `at CLIENT` **and** `at SERVER` during the server's startup self-check. The assertion now runs **after** the join attempt and matches the mod id in the bracket list on any of those lines.
- **LOW — wrapper-PID kill could orphan Java on self-hosted runners.** The client cleanup killed only the `timeout`/`xvfb-run` wrapper PID, orphaning the MC Java client and Xvfb. The client pipeline now starts under `setsid` in its own session/process group; cleanup TERMs the tracked group with a KILL escalation after a grace period, then reaps. No `pkill` (project policy); safe on GHA ubuntu-latest and WSL.
- **Re-audit — PGID capture micro-race.** A one-shot `ps` read right after `&` can observe the child's pre-`setsid` process group (the runner's own PGID), silently falling back to wrapper-only kill. The tracked PGID is now polled until it leaves the runner's own group, the client exits, or a bounded 5s budget expires — then group-kill vs PID-kill is decided. Stress-tested, see Verification.

## Changes

**`.github/workflows/ci.yml` (job `e2e-test-1122`)**
- Removed the dead WireMock service + fixture volume mount: the mc1.12.2 clone ships no wiremock fixtures, the smoke test never issues a `/skin` command, and CI logs showed `WireMock requests served: 0` while the verify step printed ❌ and still passed.
- Removed the `-Deverlastingskins.endpoint.*`/`allowHttp` overrides and the `Verify WireMock requests` step that pointed at it.
- Job display name is **`E2E (mc1.12.2)`** — the exact required branch-protection status-check context — while the job itself remains a server boot smoke + real headless client join (job id `e2e-test-1122` kept for stable references). A workflow comment documents that the display name is retained for branch-protection compatibility; all boot-smoke semantics/assertions are unchanged.
- **Mod-presence assertion moved out of the ready-wait step** (which is a pure server-ready wait again) **into the client step, after the join attempt**, matching the FML mod-list lines — the deterministic signal per the audit.
- **Join outcome is reported before the mod-presence assertion** — a failed connect now fails the step with its own message instead of being masked by a secondary handshake-line failure.
- Client launch runs under `setsid`; cleanup kills the tracked process group (TERM → KILL escalation → reap) instead of the wrapper PID.
- **Tracked PGID is captured by polling** until it differs from the runner's own PGID or the client exits (bounded budget, PID-kill fallback) — closes the setsid capture race.
- Added server liveness check to the ready-wait loop (fail fast instead of a 10-minute burn on a dead server).
- Added `hmc.crash.report.watcher=true` (parity with the local runner) and a config comment documenting why no `hmc.test.filename` scenario can run.
- Client-early-exit now prints the HMC output tail immediately.

**`test-infrastructure/run-e2e.sh`**
- Same fixes for local parity: mod-presence assertion on the FML mod-list line (after join), join outcome reported first, `setsid` + tracked process-group cleanup, and polling PGID capture.
- `hmc.jline.enabled=false` in the generated HMC config (parity with CI).
- Server liveness check in the ready-wait loop.

**`test-infrastructure/README.md`** — no longer touched by this PR; README/CI-docs reconciliation belongs to the docs lane (#191).

## Merge order

**Merge #192 before #191.** PR #191's docs changes (`AGENTS.md`, `TESTING.md`, `test-infrastructure/README.md`) describe the post-#192 workflow — the real headless client join + FML mod-list boot-smoke flow this PR implements. Landing #191 first would document a workflow that does not exist on `mc1.12.2` yet.

## Verification

**Status disclosure (important):** job `e2e-test-1122` is push-only (`push` + `ref_name == 'mc1.12.2'`) and therefore **has never run on this PR's head** — it cannot run on a pull_request event. The last green push runs on `mc1.12.2` (e.g. run 30826717173, commit 7900c19) executed the *previous* workflow revision (WireMock, different assertion placement) and **do not cover these changes**. This PR must not be considered E2E-green until an mc1.12.2 branch-push-equivalent run of the changed workflow passes.

What has been validated on this head (plus one observed CI run on the PR head, run 30843309161):

- CI run 30843309161 (pull_request event on this head): YAML Lint **pass**, Build (mc1.12.2) **pass**; `E2E (mc1.12.2)` **skipped** — push-only by design, confirming the disclosure above.

- `yamllint -c .yamllint.yml` on ci.yml: clean.
- `actionlint` v1.7.12 on ci.yml: only pre-existing shellcheck findings in untouched steps (Find mod JAR, Start Forge server) remain.
- `bash -n` + `shellcheck` on run-e2e.sh: only pre-existing `ls | grep` jar-discovery warnings remain.
- aislop scan: clean (100/100).
- Handshake pattern positive/negative controls against the real log from run 30826717173 (artifact `e2e-logs-1122-7900c198…`): join-time line `Attempting connection with missing mods [everlastingskins] at CLIENT` **matches**; startup self-check lines with the full mod list, `… at CLIENT` and `… at SERVER`, **both match** (pattern keys on the mod id in the bracket list); the mod-less lines (`[minecraft, mcp, FML, forge]`, from the client log) **do not match**.
- PGID-capture race stress test (local, 60 iterations × 3 scenarios): the old one-shot capture reads the pre-`setsid` group **60/60** times when the child is delayed before `setsid` (widened 0.3s race window); the polling capture has **0 fallbacks** in the same scenario and **0 fallbacks** on normal spawns; group TERM→KILL→reap left **0 orphaned** processes across all 180 iterations; the immediate-exit scenario exercises the PID-kill fallback with no orphans.
- Connect-first ordering control: with `JOINED=0` and a matching handshake line present (the previously-masked case), the step now reports `FAIL: client did not connect to the server` first and skips the handshake assert; with `JOINED=1` and no handshake line, the mod-line failure is reported.
- **Local branch-push-equivalent harness run (this machine, real Forge 1.12.2 server + real headless client under xvfb, this revision's runner): E2E PASSED** — `PASS: server booted`, `PASS: client connected`, `PASS: mod discovered (FML handshake mod-list line)`; join-time line reproduced verbatim (`… missing mods [everlastingskins] at CLIENT`); no orphaned java/xvfb processes after cleanup.

## Follow-up for the docs lane (NOT edited here)

- `TESTING.md` lines 29/52 describe the `e2e-test-1122` job as "boot the server with WireMock-stubbed Mojang endpoints" — no longer true; job display name is `E2E (mc1.12.2)` (retained for branch-protection compatibility; the job is a boot smoke).
- `AGENTS.md` (CI paragraph) claims the mc1.12.2 smoke E2E uses "Mojang endpoints stubbed with WireMock" and runs via `run-e2e.sh` + `assert-skin-property.sh`; the workflow runs inline steps and now uses no WireMock. Pre-existing drift, needs docs-lane reconciliation.
- `test-infrastructure/README.md` CI-integration section still describes the WireMock flow; left to the docs lane (#191) per lane ownership.

