### PR TITLE
fix(1.21): gate persistence behind refresh debounce in SkinActionCommand

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@
 
 - Current configuration targets Minecraft `1.21`, Forge `51.0.8`, Java 21, Gradle 8.8, ForgeGradle 6, official mappings, and Mixin `0.8.5` annotation processing.
 - Build with the repository wrapper. The current `gradlew` is LF-encoded and executable. Build with `./gradlew build`.
-- CI runs on every push to `1.21` and `mc1.12.2` branches: lint (yamllint) + build + unit tests (JUnit 5). 1.21 additionally runs GameTest (33 tests via `runGameTestServer`, mock-player + real packet assertions); mc1.12.2 additionally runs a bash server-log smoke E2E (`run-e2e.sh` + `assert-skin-property.sh`, Mojang endpoints stubbed with WireMock — no HeadlessMC scenarios).
+- CI runs on every push to `1.21` and `mc1.12.2` branches: lint (yamllint) + build + unit tests (JUnit 5). 1.21 additionally runs GameTest (34 tests via `runGameTestServer`, mock-player + real packet assertions); mc1.12.2 additionally runs a bash server-log smoke E2E (`run-e2e.sh` + `assert-skin-property.sh`, Mojang endpoints stubbed with WireMock — no HeadlessMC scenarios).
 - `gradle.properties` contains stale metadata (`minecraft_version_range`, `curse_versions`, placeholder description, broad loader/Forge ranges). Treat executable dependency coordinates in `build.gradle` as authoritative until metadata is reconciled.
 - The local Qartez index currently points at another workspace. If Qartez returns paths such as `neodeal/` or `ik_llama.cpp`, stop and re-index this repository rather than trusting impact or dependency results.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@
 
 - Current configuration targets Minecraft `1.21`, Forge `51.0.8`, Java 21, Gradle 8.8, ForgeGradle 6, official mappings, and Mixin `0.8.5` annotation processing.
 - Build with the repository wrapper. The current `gradlew` is LF-encoded and executable. Build with `./gradlew build`.
-- CI runs on every push to `1.21` and `mc1.12.2` branches: lint (yamllint) + build + unit tests (JUnit 5). 1.21 additionally runs GameTest (32 tests via `runGameTestServer`, mock-player + real packet assertions); mc1.12.2 additionally runs a bash server-log smoke E2E (`run-e2e.sh` + `assert-skin-property.sh`, Mojang endpoints stubbed with WireMock — no HeadlessMC scenarios).
+- CI runs on every push to `1.21` and `mc1.12.2` branches: lint (yamllint) + build + unit tests (JUnit 5). 1.21 additionally runs GameTest (33 tests via `runGameTestServer`, mock-player + real packet assertions); mc1.12.2 additionally runs a bash server-log smoke E2E (`run-e2e.sh` + `assert-skin-property.sh`, Mojang endpoints stubbed with WireMock — no HeadlessMC scenarios).
 - `gradle.properties` contains stale metadata (`minecraft_version_range`, `curse_versions`, placeholder description, broad loader/Forge ranges). Treat executable dependency coordinates in `build.gradle` as authoritative until metadata is reconciled.
 - The local Qartez index currently points at another workspace. If Qartez returns paths such as `neodeal/` or `ik_llama.cpp`, stop and re-index this repository rather than trusting impact or dependency results.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,11 @@
 
 ### Changed
 - Default permission posture: `/skin set mojang/clear/random` are now open to all players (op_level=0); `/skin set web` and `/skin set/clear <other>` still require op-2; `/skin metrics` and `/skin metrics reset` still require op-2.
+- **Discord announce fires only when a refresh actually runs** (#195): previously `/skin` announced every target to DiscordSRV regardless of outcome — including provider failures, unchanged-skin skips and debounced requests. Announcements now require a completed refresh, matching mc1.12.2 after #194.
 
 ### Fixed
+- **Stored/applied divergence across the refresh debounce** (#195): a second `/skin` request inside the per-player debounce window previously overwrote the stored source/skin and sent a fulfilment message while the applied GameProfile still showed the earlier skin. The debounce now gates persistence, messaging and the Discord announce as well as the refresh: a debounced request is a completion no-op — the dispatch-time "Skin change queued" feedback is unchanged.
+- **`/skin clear` with no Mojang profile kept the old texture applied** (#195): storage was cleared but the applied GameProfile retained the previous textures until the next refresh (the legacy mc1.12.2 port scheduled a refresh task that was a no-op). The clear now drops the textures property from the applied profile and re-broadcasts, so stored (null) and applied stay consistent.
 - Login-time 3-provider HTTP chain offloaded to executor (no more 30s server freeze per login)
 - Multi-target `/skin clear` per-target restores from Mojang
 - `SkinRefreshHandler.task()` wrapped in try/catch (no partial cascade on exception)

--- a/TESTING.md
+++ b/TESTING.md
@@ -3,7 +3,7 @@
 EverlastingSkins uses a three-tier testing pyramid:
 
 ## Tier 1: Pure Java unit tests (JUnit 5)
-- 336 unit tests + 32 GameTest = 368 total on 1.21 branch
+- 336 unit tests + 33 GameTest = 369 total on 1.21 branch
 - 325 tests on mc1.12.2 branch
 - Coverage: provider fallback, HTTP outcomes, persistence atomicity, corruption handling, cache behavior, permission system, command dispatch, integration hooks
 - New in 2.1.0-rc.1: `MojangProfileCacheTest`, `UrlAllowlistTest`, `DefaultSkinResolverTest`; `PermissionServiceManagerTest`, `VanillaPermissionServiceTest`, `LuckPermsPermissionServiceTest` refreshed with `opLevel` (were pre-existing)
@@ -20,7 +20,7 @@ EverlastingSkins uses a three-tier testing pyramid:
 
 ### 1.21: GameTest (automated)
 
-The 1.21 branch uses Minecraft's GameTest framework for automated integration testing. The `gametest-121` CI job runs 32 tests covering the /skin command pipeline via mock players + EmbeddedChannel packet assertions.
+The 1.21 branch uses Minecraft's GameTest framework for automated integration testing. The `gametest-121` CI job runs 33 tests covering the /skin command pipeline via mock players + EmbeddedChannel packet assertions.
 
 Components:
 - `src/gametest/java/` — GameTest methods (skin-set, skin-clear, persistence, refresh)

--- a/TESTING.md
+++ b/TESTING.md
@@ -3,7 +3,7 @@
 EverlastingSkins uses a three-tier testing pyramid:
 
 ## Tier 1: Pure Java unit tests (JUnit 5)
-- 336 unit tests + 33 GameTest = 369 total on 1.21 branch
+- 336 unit tests + 34 GameTest = 370 total on 1.21 branch
 - 325 tests on mc1.12.2 branch
 - Coverage: provider fallback, HTTP outcomes, persistence atomicity, corruption handling, cache behavior, permission system, command dispatch, integration hooks
 - New in 2.1.0-rc.1: `MojangProfileCacheTest`, `UrlAllowlistTest`, `DefaultSkinResolverTest`; `PermissionServiceManagerTest`, `VanillaPermissionServiceTest`, `LuckPermsPermissionServiceTest` refreshed with `opLevel` (were pre-existing)
@@ -20,7 +20,9 @@ EverlastingSkins uses a three-tier testing pyramid:
 
 ### 1.21: GameTest (automated)
 
-The 1.21 branch uses Minecraft's GameTest framework for automated integration testing. The `gametest-121` CI job runs 33 tests covering the /skin command pipeline via mock players + EmbeddedChannel packet assertions.
+The 1.21 branch uses Minecraft's GameTest framework for automated integration testing. The `gametest-121` CI job runs 34 tests covering the /skin command pipeline via mock players + EmbeddedChannel packet assertions.
+
+Count note: `grep -c "@GameTest"` in `SkinVisibilityTest.java` reports 35 matches — 34 method-level `@GameTest(` tests plus the class-level `@GameTestHolder` annotation, which contains `@GameTest` as a substring. The `runGameTestServer` summary ("34 GAME TESTS COMPLETE") is authoritative.
 
 Components:
 - `src/gametest/java/` — GameTest methods (skin-set, skin-clear, persistence, refresh)

--- a/src/gametest/java/levosilimo/everlastingskins/gametest/SkinVisibilityTest.java
+++ b/src/gametest/java/levosilimo/everlastingskins/gametest/SkinVisibilityTest.java
@@ -929,6 +929,182 @@ public class SkinVisibilityTest {
         }
     }
 
+    @GameTest(template = "everlastingskins:empty", timeoutTicks = 200, batch = "everlastingskins:debounce_consistency")
+    public void debouncedRequest_keepsStoredEqualToApplied(GameTestHelper helper) {
+        FakeMojangAPI fake = installFakeMojangAPI(true);
+        SkinStorage storage = ensureStorage(helper);
+        MinecraftServer server = helper.getLevel().getServer();
+        ServerPlayer playerA = mockPlayer(helper, "DebConsistA");
+        makeOp(playerA);
+        UUID uuidA = playerA.getUUID();
+        try {
+            placePlayer(helper, playerA);
+            SkinRefreshHandler.resetRefreshTaskCount();
+            SkinActionCommand.resetSkinCompletionsProcessed();
+            SkinActionCommand.getLastRefreshByPlayer().remove(uuidA);
+            fake.fail = false;
+
+            int first = dispatch(server, "skin set mojang Notch", playerA.createCommandSourceStack(), helper);
+            helper.assertTrue(first == 1, "first dispatch must be accepted, got " + first);
+
+            // Two phases inside succeedWhen: the test method's finally block runs
+            // before the callback, so every mutable bit of state the second
+            // dispatch depends on (debounce window, rate limit, varyValue) is
+            // re-applied here. The first refresh must land (storage + applied
+            // profile), then a DIFFERENT skin is dispatched inside the debounce
+            // window: the debounced completion must leave both the stored
+            // source/skin and the applied GameProfile untouched and must not
+            // claim fulfilment.
+            final boolean[] phase = {false};
+            final String[] firstTextureValue = new String[1];
+            helper.succeedWhen(() -> {
+                if (!phase[0]) {
+                    SkinActionCommand.debounceMillis = 60_000;
+                    Config.RATE_LIMIT_ENABLED.set(false);
+                    fake.varyValue = true;
+                    CustomSkinProperty stored = storage.getSkin(uuidA);
+                    if (stored == null || !"Notch".equals(stored.getSource())) {
+                        throw new GameTestAssertException("waiting for first dispatch to store source=Notch");
+                    }
+                    if (SkinRefreshHandler.getRefreshTaskCount() != 1) {
+                        throw new GameTestAssertException("waiting for first task() to run, count="
+                                + SkinRefreshHandler.getRefreshTaskCount());
+                    }
+                    firstTextureValue[0] = stored.getOriginalProperty().value();
+                    SkinActionCommand.getLastRefreshByPlayer().put(uuidA, System.currentTimeMillis());
+                    drain(playerA);
+                    int second = dispatch(server, "skin set mojang Jeb_", playerA.createCommandSourceStack(), helper);
+                    if (second != 1) {
+                        throw new GameTestAssertException("second dispatch must be accepted, got " + second);
+                    }
+                    phase[0] = true;
+                    throw new GameTestAssertException("entering second-phase wait");
+                }
+                if (SkinActionCommand.getSkinCompletionsProcessed() < 2) {
+                    throw new GameTestAssertException("waiting for second completion to be processed");
+                }
+                if (SkinRefreshHandler.getRefreshTaskCount() != 1) {
+                    throw new GameTestAssertException("second dispatch inside debounce window must not run a refresh; count="
+                            + SkinRefreshHandler.getRefreshTaskCount());
+                }
+                CustomSkinProperty stored = storage.getSkin(uuidA);
+                if (stored == null || !"Notch".equals(stored.getSource())) {
+                    throw new GameTestAssertException("debounced request must not overwrite the stored source (got "
+                            + (stored == null ? "null" : stored.getSource()) + ")");
+                }
+                if (!firstTextureValue[0].equals(stored.getOriginalProperty().value())) {
+                    throw new GameTestAssertException("debounced request must not overwrite the stored skin");
+                }
+                boolean applied = playerA.getGameProfile().getProperties().get("textures").stream()
+                        .anyMatch(p -> firstTextureValue[0].equals(p.value()));
+                if (!applied) {
+                    throw new GameTestAssertException("debounced request must not change the applied GameProfile");
+                }
+                boolean claimedFulfilment = drain(playerA).stream()
+                        .filter(ClientboundSystemChatPacket.class::isInstance)
+                        .map(ClientboundSystemChatPacket.class::cast)
+                        .anyMatch(p -> p.content().getString().contains("applied"));
+                if (claimedFulfilment) {
+                    throw new GameTestAssertException("debounced request must not claim fulfilment");
+                }
+                removeQuietly(server, playerA);
+            });
+        } finally {
+            SkinActionCommand.debounceMillis = 100;
+            SkinActionCommand.getLastRefreshByPlayer().remove(uuidA);
+            Config.RATE_LIMIT_ENABLED.set(true);
+            fake.slow = false;
+            fake.varyValue = false;
+            removeQuietly(server, playerA);
+        }
+    }
+
+    @GameTest(template = "everlastingskins:empty", timeoutTicks = 200, batch = "everlastingskins:debounce_consistency_expired")
+    public void expiredDebounceWindow_appliesNormally(GameTestHelper helper) {
+        FakeMojangAPI fake = installFakeMojangAPI(true);
+        SkinStorage storage = ensureStorage(helper);
+        MinecraftServer server = helper.getLevel().getServer();
+        ServerPlayer playerA = mockPlayer(helper, "DebConsistB");
+        makeOp(playerA);
+        UUID uuidA = playerA.getUUID();
+        try {
+            placePlayer(helper, playerA);
+            SkinRefreshHandler.resetRefreshTaskCount();
+            SkinActionCommand.resetSkinCompletionsProcessed();
+            SkinActionCommand.getLastRefreshByPlayer().remove(uuidA);
+            fake.fail = false;
+
+            int first = dispatch(server, "skin set mojang Notch", playerA.createCommandSourceStack(), helper);
+            helper.assertTrue(first == 1, "first dispatch must be accepted, got " + first);
+
+            // Two phases inside succeedWhen (the method finally runs first, so
+            // the window/rate-limit/varyValue state is re-applied here). After
+            // the first refresh, the last-refresh timestamp is backdated far
+            // beyond the 100ms window, then a DIFFERENT skin is dispatched: it
+            // must store, refresh and apply as before (no lockout from the
+            // debounce gate).
+            final boolean[] phase = {false};
+            final long[] debouncedBefore = new long[1];
+            final long[] completedBefore = new long[1];
+            helper.succeedWhen(() -> {
+                if (!phase[0]) {
+                    SkinActionCommand.debounceMillis = 100;
+                    Config.RATE_LIMIT_ENABLED.set(false);
+                    fake.varyValue = true;
+                    CustomSkinProperty stored = storage.getSkin(uuidA);
+                    if (stored == null || !"Notch".equals(stored.getSource())) {
+                        throw new GameTestAssertException("waiting for first dispatch to store source=Notch");
+                    }
+                    if (SkinRefreshHandler.getRefreshTaskCount() != 1) {
+                        throw new GameTestAssertException("waiting for first task() to run, count="
+                                + SkinRefreshHandler.getRefreshTaskCount());
+                    }
+                    SkinActionCommand.getLastRefreshByPlayer().put(uuidA, System.currentTimeMillis() - 10_000);
+                    debouncedBefore[0] = SkinMetrics.INSTANCE.snapshot().refreshesDebounced();
+                    completedBefore[0] = SkinMetrics.INSTANCE.snapshot().refreshesCompleted();
+                    int second = dispatch(server, "skin set mojang Jeb_", playerA.createCommandSourceStack(), helper);
+                    if (second != 1) {
+                        throw new GameTestAssertException("second dispatch must be accepted, got " + second);
+                    }
+                    phase[0] = true;
+                    throw new GameTestAssertException("entering second-phase wait");
+                }
+                if (SkinActionCommand.getSkinCompletionsProcessed() < 2) {
+                    throw new GameTestAssertException("waiting for second completion to be processed");
+                }
+                CustomSkinProperty stored = storage.getSkin(uuidA);
+                if (stored == null || !"Jeb_".equals(stored.getSource())) {
+                    throw new GameTestAssertException("request after the window must store the new skin (got "
+                            + (stored == null ? "null" : stored.getSource()) + ")");
+                }
+                if (SkinRefreshHandler.getRefreshTaskCount() != 2) {
+                    throw new GameTestAssertException("request after the window must run a profile refresh; count="
+                            + SkinRefreshHandler.getRefreshTaskCount());
+                }
+                String jebValue = stored.getOriginalProperty().value();
+                boolean applied = playerA.getGameProfile().getProperties().get("textures").stream()
+                        .anyMatch(p -> jebValue.equals(p.value()));
+                if (!applied) {
+                    throw new GameTestAssertException("request after the window must apply the new skin to the GameProfile");
+                }
+                if (SkinMetrics.INSTANCE.snapshot().refreshesDebounced() != debouncedBefore[0]) {
+                    throw new GameTestAssertException("request after the window must not be recorded as debounced");
+                }
+                if (SkinMetrics.INSTANCE.snapshot().refreshesCompleted() <= completedBefore[0]) {
+                    throw new GameTestAssertException("request after the window must record a completed refresh");
+                }
+                removeQuietly(server, playerA);
+            });
+        } finally {
+            SkinActionCommand.debounceMillis = 100;
+            SkinActionCommand.getLastRefreshByPlayer().remove(uuidA);
+            Config.RATE_LIMIT_ENABLED.set(true);
+            fake.slow = false;
+            fake.varyValue = false;
+            removeQuietly(server, playerA);
+        }
+    }
+
     @GameTest(template = "everlastingskins:empty", timeoutTicks = 200, batch = "everlastingskins:r8_ratelimit")
     public void rateLimitAfterCooldown(GameTestHelper helper) {
         installFakeMojangAPI(true);

--- a/src/gametest/java/levosilimo/everlastingskins/gametest/SkinVisibilityTest.java
+++ b/src/gametest/java/levosilimo/everlastingskins/gametest/SkinVisibilityTest.java
@@ -1060,6 +1060,11 @@ public class SkinVisibilityTest {
                                 + SkinRefreshHandler.getRefreshTaskCount());
                     }
                     SkinActionCommand.getLastRefreshByPlayer().put(uuidA, System.currentTimeMillis() - 10_000);
+                    // GameTestRunner executes batches strictly sequentially (the
+                    // runtime log shows one "Running test batch" at a time and
+                    // this batch holds a single test), so no other test touches
+                    // the global metric counters between this snapshot and the
+                    // phase-2 read: the debounced delta must be exactly 0.
                     debouncedBefore[0] = SkinMetrics.INSTANCE.snapshot().refreshesDebounced();
                     completedBefore[0] = SkinMetrics.INSTANCE.snapshot().refreshesCompleted();
                     int second = dispatch(server, "skin set mojang Jeb_", playerA.createCommandSourceStack(), helper);
@@ -1102,6 +1107,77 @@ public class SkinVisibilityTest {
             fake.slow = false;
             fake.varyValue = false;
             removeQuietly(server, playerA);
+        }
+    }
+
+    @GameTest(template = "everlastingskins:empty", timeoutTicks = 200, batch = "everlastingskins:clear_no_profile")
+    public void skinClear_noProfile_clearsAppliedProfile(GameTestHelper helper) {
+        FakeMojangAPI fake = installFakeMojangAPI(true);
+        SkinStorage storage = ensureStorage(helper);
+        MinecraftServer server = helper.getLevel().getServer();
+        ServerPlayer playerA = mockPlayer(helper, "ClearConsistA");
+        ServerPlayer observer = mockPlayer(helper, "ClearObsA");
+        makeOp(playerA);
+        UUID uuidA = playerA.getUUID();
+        try {
+            placePlayer(helper, playerA);
+            placePlayer(helper, observer);
+            drain(observer);
+            fake.fail = false;
+
+            int first = dispatch(server, "skin set mojang Notch", playerA.createCommandSourceStack(), helper);
+            helper.assertTrue(first == 1, "first dispatch must be accepted, got " + first);
+
+            // Two phases inside succeedWhen (the method finally runs first): wait
+            // for the skin to be stored AND applied, then clear with a failing
+            // provider (no Mojang profile to restore). The clear must remove the
+            // stored skin AND drop the applied textures property so stored
+            // (null) stays equal to the applied GameProfile.
+            final boolean[] phase = {false};
+            final String[] appliedValue = new String[1];
+            helper.succeedWhen(() -> {
+                if (!phase[0]) {
+                    Config.RATE_LIMIT_ENABLED.set(false);
+                    CustomSkinProperty stored = storage.getSkin(uuidA);
+                    if (stored == null || !"Notch".equals(stored.getSource())) {
+                        throw new GameTestAssertException("waiting for first dispatch to store source=Notch");
+                    }
+                    appliedValue[0] = stored.getOriginalProperty().value();
+                    boolean applied = playerA.getGameProfile().getProperties().get("textures").stream()
+                            .anyMatch(p -> appliedValue[0].equals(p.value()));
+                    if (!applied) {
+                        throw new GameTestAssertException("waiting for the first skin to be applied to the GameProfile");
+                    }
+                    drain(observer);
+                    SkinActionCommand.resetSkinCompletionsProcessed();
+                    fake.fail = true;
+                    int second = dispatch(server, "skin clear", playerA.createCommandSourceStack(), helper);
+                    if (second != 1) {
+                        throw new GameTestAssertException("clear dispatch must be accepted, got " + second);
+                    }
+                    phase[0] = true;
+                    throw new GameTestAssertException("entering second-phase wait");
+                }
+                if (SkinActionCommand.getSkinCompletionsProcessed() < 1) {
+                    throw new GameTestAssertException("waiting for clear completion to be processed");
+                }
+                if (storage.getSkin(uuidA) != null) {
+                    throw new GameTestAssertException("waiting for /skin clear to remove the stored skin");
+                }
+                if (!playerA.getGameProfile().getProperties().get("textures").isEmpty()) {
+                    throw new GameTestAssertException("clear with no Mojang profile must drop the applied textures property");
+                }
+                if (findTexturesFor(drain(observer), uuidA) != null) {
+                    throw new GameTestAssertException("clear must not broadcast stale textures to observers");
+                }
+                removeQuietly(server, playerA);
+                removeQuietly(server, observer);
+            });
+        } finally {
+            fake.slow = false;
+            Config.RATE_LIMIT_ENABLED.set(true);
+            removeQuietly(server, playerA);
+            removeQuietly(server, observer);
         }
     }
 

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRefreshHandler.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRefreshHandler.java
@@ -50,6 +50,14 @@ public class SkinRefreshHandler {
         refreshTaskCount++;
         CustomSkinProperty skin = SkinRestorer.getSkinStorage().getSkin(player.getUUID());
         if (skin == null || skin.isEmpty()) {
+            // Stored skin is cleared (or never set): drop the applied textures
+            // property so the applied GameProfile matches storage, then let
+            // observers re-learn the profile and rebuild the target's own view.
+            // Without this, /skin clear with no Mojang profile left the applied
+            // profile showing the old texture while storage said "cleared".
+            mutateProfileCleared(player);
+            recordObserverBroadcast(player, null);
+            recordCascade(player);
             return;
         }
         long tStart = System.nanoTime();
@@ -77,6 +85,13 @@ public class SkinRefreshHandler {
         player.getGameProfile().getProperties().removeAll("textures");
         player.getGameProfile().getProperties().put("textures", skin.getOriginalProperty());
         EverlastingSkins.logger.info("SKIN_REFRESH: profile={}, property={}",
+                player.getGameProfile().getName(),
+                player.getGameProfile().getProperties().get("textures"));
+    }
+
+    private static void mutateProfileCleared(ServerPlayer player) {
+        player.getGameProfile().getProperties().removeAll("textures");
+        EverlastingSkins.logger.info("SKIN_REFRESH: profile={}, property={} (cleared)",
                 player.getGameProfile().getName(),
                 player.getGameProfile().getProperties().get("textures"));
     }

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/command/SkinActionCommand.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/command/SkinActionCommand.java
@@ -255,6 +255,11 @@ public final class SkinActionCommand {
                 if (Config.TOGGLE.get()) {
                     player.sendSystemMessage(Component.literal(FEEDBACK_PREFIX + " " + I18nUtils.formatMessage("cleared_no_profile", player)));
                 }
+                // Clear the applied GameProfile too, not just storage: the
+                // refresh task drops the textures property and re-broadcasts, so
+                // stored (null) and applied stay consistent. Mirrors the legacy
+                // mc1.12.2 scheduling; 1.21's task() actually performs the clear.
+                SkinRestorer.server.execute(() -> SkinRefreshHandler.task(player));
                 continue;
             }
             boolean isRestore = isClear && skinProperty != null;

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/command/SkinActionCommand.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/command/SkinActionCommand.java
@@ -263,6 +263,18 @@ public final class SkinActionCommand {
                 SkinMetrics.INSTANCE.recordRefreshSkipped(uuid);
                 continue;
             }
+            // The debounce gates persistence as well as the profile refresh:
+            // storing a skin whose refresh was skipped would leave the stored
+            // source/skin different from the applied GameProfile.
+            long now = System.currentTimeMillis();
+            Long last = lastRefreshByPlayer.get(uuid);
+            long window = debounceMillis > 0 ? debounceMillis : Config.DEBOUNCE_MILLIS.get();
+            if (last != null && now - last < window) {
+                EverlastingSkins.logger.debug("SKIN_REFRESH debounced for {}", uuid);
+                SkinMetrics.INSTANCE.recordRefreshDebounced(uuid);
+                continue;
+            }
+            lastRefreshByPlayer.put(uuid, now);
             SkinRestorer.getSkinStorage().setSkin(uuid, skinProperty);
             if (Config.TOGGLE.get()) {
                 String msg = isRestore
@@ -274,19 +286,8 @@ public final class SkinActionCommand {
                     player.sendSystemMessage(Component.literal(FEEDBACK_PREFIX + " " + msg));
                 }
             }
-            long now = System.currentTimeMillis();
-            Long last = lastRefreshByPlayer.get(uuid);
-            long window = debounceMillis > 0 ? debounceMillis : Config.DEBOUNCE_MILLIS.get();
-            if (last != null && now - last < window) {
-                EverlastingSkins.logger.debug("SKIN_REFRESH debounced for {}", uuid);
-                SkinMetrics.INSTANCE.recordRefreshDebounced(uuid);
-                continue;
-            }
-            lastRefreshByPlayer.put(uuid, now);
             SkinMetrics.INSTANCE.recordRefreshCompleted(uuid, t0, fetchNanos, 0, 0);
             SkinRestorer.server.execute(() -> SkinRefreshHandler.task(player));
-        }
-        for (ServerPlayer player : targets) {
             try {
                 DiscordSrvHook.announceSkinChange(player, customSource);
             } catch (Exception e) {


### PR DESCRIPTION
## Summary

Port of mc1.12.2 PR #194 (`659ce07` + `2409630`) to 1.21, plus the re-audit fixes: the same stored/applied debounce divergence in `SkinActionCommand.handleCompletion`, and a second stored/applied divergence in the `/skin clear` no-profile path.

## Fix 1 — debounce gates persistence (port of #194)

`handleCompletion` persisted the fetched skin and sent the fulfil message **before** checking the per-player debounce window. A fast second request could therefore store source/skin X while the GameProfile still showed the previously applied skin Y: stored state diverged from the applied profile, and a restart would apply a skin the session never showed.

The debounce check now runs **before** `setSkin`/fulfil message/profile refresh. A debounced request is a **completion no-op** — no storage write, no profile refresh, no fulfilment message, no Discord announce. The dispatch-time "Skin change queued" feedback is unchanged: the user sees the queued message immediately and simply never gets a completion for a debounced request (this is not a silent drop like a cooldown rejection — the command is accepted and queued; only the completion side is skipped).

## Fix 2 — `/skin clear` with no Mojang profile clears the applied profile

The clear-no-profile path (`isClear && skinProperty == null`) removed the stored skin but never touched the applied GameProfile, which kept the old textures property until the next refresh — the same stored/applied divergence, for clears.

**Legacy comparison**: mc1.12.2 schedules `SkinRefreshTask.task(p, null)` after `setSkin(null)`, but its `task()` early-returns on a null property, so legacy also left the profile stale. The 1.21 fix makes the scheduled task actually perform the clear: `SkinRefreshHandler.task()` on a null/empty stored skin now drops the textures property from the applied profile, re-broadcasts REMOVE+ADD so observers re-learn the profile, and runs the respawn cascade so the target's own view reverts. The null branch is only reachable from the command pipeline (A5-skip guarantees a stored skin; login applies inline), so skin-less logins are unaffected.

## Behavior compatibility (parity with PR #194)

- **Discord announce**: previously fired for every target of every `/skin` command after the completion loop — including provider **failures**, **unchanged-skip** targets, **debounced** requests, and **clear-no-profile** targets. It now fires only for targets whose refresh/restore path reaches the announce call — a completed refresh or a restore-clear — and never for provider-failed, unchanged, debounced, or clear-no-profile targets, matching mc1.12.2 post-#194.
- All other semantics preserved: A5 stored-source skip, unchanged-skin skip, per-minute rate limit, metrics counters, per-target clear restore, timeout handling. The test-tunable `debounceMillis` and per-target loop shape of the 1.21 branch are kept.

## Tests (34 GameTests, +3)

`SkinVisibilityTest` (established suite pattern, one batch per test):

- `debouncedRequest_keepsStoredEqualToApplied` — a request inside the debounce window must not overwrite the stored source/skin, must not run a profile refresh, must not change the applied GameProfile, must not claim fulfilment. **Fails on the old ordering** with `debounced request must not overwrite the stored source (got Jeb_)` (red run verified).
- `expiredDebounceWindow_appliesNormally` — window-expired control: same request stores, refreshes and applies as before (no lockout).
- `skinClear_noProfile_clearsAppliedProfile` — applies a skin, then clears with a failing provider; asserts storage becomes null **and** the applied profile loses its textures property, with no stale-texture broadcast to observers. **Fails on the old ordering** with `clear with no Mojang profile must drop the applied textures property` (red run verified); the pre-existing `skinCommand_clear_removesTexture` test is the unchanged control.

All tests re-apply mutable state (debounce window, rate limit, varyValue) inside the `succeedWhen` callback because the GameTest method-level `finally` runs before the callback — the pre-existing suite tests share this shape.

## Metric isolation in the expired-window test

The `refreshesDebounced`/`refreshesCompleted` assertions use exact before/after deltas captured around the second dispatch. This is race-free: GameTestRunner executes batches strictly sequentially (runtime log shows one "Running test batch" at a time; each of these tests is the only test in its batch), so no other test touches the global counters between the snapshot and the read.

## GameTest count reconciliation

The audit's "34 @GameTest methods" vs docs/CI "33" was a counting artifact, now documented in TESTING.md: `grep -c "@GameTest"` reports **35** matches = **34** method-level `@GameTest(` tests + the class-level `@GameTestHolder` annotation (which contains `@GameTest` as a substring). Runtime registration always matched the method count — with this PR the `runGameTestServer` summary is `34 GAME TESTS COMPLETE` (31 prior + 3 new), so static count, docs and runtime now all agree.

## Verification

- Red runs (pre-fix code): debounce test failed with `got Jeb_` (1/33); clear test failed with `must drop the applied textures property` (1/34); all other tests passed including both controls.
- Green run (fixed): 34/34 passed (`All 34 required tests passed`), locally and on CI.
- `./gradlew build` + unit tests: 336 passed, 0 failures.
- aislop: 100/100 (staged hooks on all commits + full-repo scan).
