### PR TITLE
fix(1.21): GameTest harness + SkinIO delete race (unblock GameTest required check)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -159,18 +159,67 @@ minecraft {
             // (GameTest job failed with "Reflective setAccessible(true)
             // disabled" / module exports). Applied to the forked GameTest
             // server JVM, not the Gradle daemon.
+            //
+            // ALL-UNNAMED alone is not enough: FG6 dev loads Netty as NAMED
+            // JPMS modules (io.netty.*) inside Forge's SecureModuleClassLoader,
+            // and the JVM refuses "does not open java.nio / export
+            // jdk.internal.misc to module io.netty.common" for those. Open and
+            // export the same packages to each Netty module the dev runtime
+            // loads; flags for modules absent from the layer are ignored.
+            //
+            // NOTE: startup --add-opens cannot reach modules Forge defines in a
+            // runtime module layer (io.netty.common lives in the SECURE-BOOTSTRAP
+            // layer, created after JVM start), so PlatformDependent still cannot
+            // open java.nio reflectively there. tryReflectionSetAccessible=false
+            // makes Netty skip that doomed attempt entirely instead of throwing
+            // and logging InaccessibleObjectException at every boot; the fallback
+            // (heap buffers / no-unsafe paths) is what the current environment
+            // ends up with either way.
             jvmArgs(
                 '--add-opens=java.base/java.lang=ALL-UNNAMED',
                 '--add-opens=java.base/java.nio=ALL-UNNAMED',
                 '--add-opens=java.base/sun.nio.ch=ALL-UNNAMED',
                 '--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED',
-                '-Dio.netty.tryReflectionSetAccessible=true'
+                '--add-opens=java.base/java.nio=io.netty.common',
+                '--add-opens=java.base/java.nio=io.netty.buffer',
+                '--add-opens=java.base/java.nio=io.netty.transport',
+                '--add-opens=java.base/java.nio=io.netty.handler',
+                '--add-opens=java.base/java.nio=io.netty.codec',
+                '--add-opens=java.base/java.nio=io.netty.resolver',
+                '--add-opens=java.base/sun.nio.ch=io.netty.common',
+                '--add-opens=java.base/sun.nio.ch=io.netty.transport',
+                '--add-exports=java.base/jdk.internal.misc=io.netty.common',
+                '--add-exports=java.base/jdk.internal.misc=io.netty.buffer',
+                '--add-exports=java.base/jdk.internal.misc=io.netty.transport',
+                '--add-exports=java.base/jdk.internal.misc=io.netty.handler',
+                '--add-exports=java.base/jdk.internal.misc=io.netty.codec',
+                '--add-exports=java.base/jdk.internal.misc=io.netty.resolver',
+                '-Dio.netty.tryReflectionSetAccessible=false'
             )
             mods {
                 everlastingskins {
                     source sourceSets.main
                     source sourceSets.gametest
                 }
+            }
+        }
+    }
+}
+
+// Minecraft 1.21's Settings loader opens server.properties with no
+// exists() check; a missing file logs NoSuchFileException + ERROR on every
+// GameTest boot. Seed the run directory with a default server.properties so
+// the GameTest server starts clean (vanilla defaults; the server rewrites
+// the file on shutdown anyway).
+tasks.matching { it.name == 'runGameTestServer' }.configureEach {
+    doFirst {
+        def runDir = project.file(project.findProperty('mc.runDir') ?: 'run')
+        runDir.mkdirs()
+        def props = new File(runDir, 'server.properties')
+        if (!props.exists()) {
+            def template = project.file('test-infrastructure/server.properties')
+            if (template.exists()) {
+                props.text = template.text
             }
         }
     }

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinIO.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinIO.java
@@ -100,9 +100,24 @@ public class SkinIO {
         }
     }
 
-    public void deleteSkin(UUID uuid) {
-        // A deferred drain must not resurrect a deleted skin from a stale payload.
+        public void deleteSkin(UUID uuid) {
+        // Drop any deferred payload first so a drain that has not started yet
+        // skips this UUID, then perform the file deletion ON the writer thread.
+        // An in-flight drain that already pulled this payload completes its
+        // write before our delete runs (single writer thread), so a cleared
+        // skin can never be resurrected by a stale write landing after the
+        // delete (write-after-delete race).
         pendingWrites.remove(uuid);
+        try {
+            writer().submit(() -> deleteSkinFile(uuid)).get(5, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (Exception e) {
+            EverlastingSkins.logger.warn("SkinIO delete did not complete in time for {}", uuid, e);
+        }
+    }
+
+    private void deleteSkinFile(UUID uuid) {
         Path target = savePath.resolve(uuid + FILE_EXTENSION);
         try {
             if (Files.deleteIfExists(target)) {

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinStorage.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinStorage.java
@@ -88,8 +88,12 @@ public class SkinStorage {
     }
 
     public CustomSkinProperty removeSkin(UUID uuid) {
-        skinMap.remove(uuid);
+        // Delete the file first (blocking, serialized through the SkinIO writer
+        // thread) and only then drop the map entry: getSkin() reloads from disk
+        // on a map miss, so removing the entry before the file is gone would let
+        // a concurrent read resurrect the cleared skin into the map.
         skinIO.deleteSkin(uuid);
+        skinMap.remove(uuid);
         return null;
     }
 

--- a/test-infrastructure/server.properties
+++ b/test-infrastructure/server.properties
@@ -1,0 +1,66 @@
+#Minecraft server properties
+#Default template for the Forge 1.21 GameTest server (see build.gradle
+#runGameTestServer task). The GameTest server overwrites this file on
+#shutdown; it only needs to exist so the 1.21 Settings loader does not
+#log NoSuchFileException at boot.
+accepts-transfers=false
+allow-flight=false
+allow-nether=true
+broadcast-console-to-ops=true
+broadcast-rcon-to-ops=true
+bug-report-link=
+difficulty=easy
+enable-command-block=false
+enable-jmx-monitoring=false
+enable-query=false
+enable-rcon=false
+enable-status=true
+enforce-secure-profile=false
+enforce-whitelist=false
+entity-broadcast-range-percentage=100
+force-gamemode=false
+function-permission-level=2
+gamemode=survival
+generate-structures=true
+generator-settings={}
+hardcore=false
+hide-online-players=false
+initial-disabled-packs=
+initial-enabled-packs=vanilla
+level-name=world
+level-seed=
+level-type=minecraft\:normal
+log-ips=true
+max-chained-neighbor-updates=1000000
+max-players=20
+max-tick-time=60000
+max-world-size=29999984
+motd=A Minecraft Server
+network-compression-threshold=256
+online-mode=false
+op-permission-level=4
+player-idle-timeout=0
+prevent-proxy-connections=false
+pvp=true
+query.port=25565
+rate-limit=0
+rcon.password=
+rcon.port=25575
+region-file-compression=deflate
+require-resource-pack=false
+resource-pack=
+resource-pack-id=
+resource-pack-prompt=
+resource-pack-sha1=
+server-ip=
+server-port=25565
+simulation-distance=10
+spawn-animals=true
+spawn-monsters=true
+spawn-npcs=true
+spawn-protection=16
+sync-chunk-writes=true
+text-filtering-config=
+use-native-transport=true
+view-distance=10
+white-list=false


### PR DESCRIPTION
## Summary

Fixes the two pre-existing `runGameTestServer` failures that have been failing the **GameTest (1.21)** required check on every PR against `1.21` (e.g. PR #197, run 30863898854):

1. **SkinIO write-after-delete race (root cause of the flaky test failures)** — `src/main/java/.../SkinIO.java`
   The coalescing async writer could land a file write *after* `deleteSkin` removed the file. A drain already in flight pulled the payload out of `pendingWrites`, the delete then removed the file, and the drain's fsync'd write re-created it. Because `SkinStorage.getSkin` reloads from disk on a map miss (`computeIfAbsent → loadSkin`), the cleared skin was **resurrected into the in-memory map** — `/skin clear` appeared to never remove the skin, failing `skincommand_clear_removestexture` and `skinrefresh_runcommandsuccesspath` (CI evidence: `Deleted skin file` logged, then an immediate non-cleared `SKIN_REFRESH`).
   Fix: perform the file deletion on the single writer thread (after dropping the deferred payload), so any in-flight drain write completes before the delete and no stale write can follow it.

2. **Netty `InaccessibleObjectException` at boot** — `build.gradle`
   FG6 dev loads Netty as *named* JPMS modules (`io.netty.common` etc.) inside Forge's SecureModuleClassLoader, so `--add-opens=...=ALL-UNNAMED` doesn't cover it. Startup `--add-opens` cannot target modules Forge defines in a runtime layer, so `-Dio.netty.tryReflectionSetAccessible=false` makes Netty skip the doomed reflective attempt (same fallback it ends up with anyway) instead of throwing on every boot. Per-module `--add-opens`/`--add-exports` retained for the layers the JVM can reach.

3. **`NoSuchFileException: server.properties` at boot** — `build.gradle` + `test-infrastructure/server.properties`
   1.21's `Settings.load` opens `server.properties` without an exists() check. The `runGameTestServer` task now seeds the run dir from a checked-in template before the fork starts.

## Verification

- 4 consecutive local `./gradlew runGameTestServer --rerun-tasks` runs (JDK 21.0.2-tem): **34/34 tests pass**, **zero** `InaccessibleObjectException`, **zero** `NoSuchFileException`.
- `./gradlew build test`: green.
- Pre-commit aislop hook: passed (no `--no-verify`).

## Anti-duplication

1.21 only. Does not touch PR #197 or its branch; PR #197's required check goes green after this lands and its branch is updated.