### PR TITLE
fix(1122): SkinIO write-after-delete race + directory fsync durability

### DIFF
--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinIO.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinIO.java
@@ -100,20 +100,47 @@ public class SkinIO {
                 channel.force(true);
             }
 
-            Files.move(temp, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+            moveIntoPlace(uuid, temp, target);
         } catch (IOException e) {
             SkinMetrics.INSTANCE.recordIoFailure(e);
             EverlastingSkins.logger.error("Failed to save skin for player {}", uuid, e);
-            if (Files.exists(temp)) {
-                try {
-                    Files.move(temp, target, StandardCopyOption.REPLACE_EXISTING);
-                } catch (IOException ex) {
-                    try {
-                        Files.deleteIfExists(temp);
-                    } catch (IOException ignored) {
-                    }
-                }
+            try {
+                Files.deleteIfExists(temp);
+            } catch (IOException ignored) {
             }
+        }
+    }
+
+    /**
+     * Renames the fsync'd temp file over the target. Filesystems without
+     * atomic renames throw from ATOMIC_MOVE; we then downgrade to a plain
+     * move, but surface the loss of crash-consistency instead of swallowing
+     * it. Either way the parent directory is fsync'd afterwards: file fsync
+     * does not flush the rename's directory entry, so without this the write
+     * can vanish on power loss (Pillai OSDI'14).
+     */
+    private void moveIntoPlace(UUID uuid, Path temp, Path target) throws IOException {
+        try {
+            Files.move(temp, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException e) {
+            SkinMetrics.INSTANCE.recordIoFailure(e);
+            EverlastingSkins.logger.warn("Atomic rename unsupported for {}, downgrading to non-atomic move", uuid, e);
+            Files.move(temp, target, StandardCopyOption.REPLACE_EXISTING);
+        }
+        fsyncDirectory();
+    }
+
+    /**
+     * fsyncs the save directory. Java 8 cannot open directories for READ on
+     * every platform (Windows throws AccessDeniedException), so a failure is
+     * logged but does not fail the save: the file content is already durable,
+     * only the rename entry may not survive a crash.
+     */
+    private void fsyncDirectory() {
+        try (FileChannel dir = FileChannel.open(savePath, StandardOpenOption.READ)) {
+            dir.force(true);
+        } catch (IOException e) {
+            EverlastingSkins.logger.warn("Failed to fsync skin directory {}", savePath, e);
         }
     }
 

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinIO.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinIO.java
@@ -68,14 +68,15 @@ public class SkinIO {
         }
     }
 
-    public void deleteSkin(UUID uuid) {
+    /**
+     * Deletes the skin file. Failures propagate so the caller can keep the
+     * in-memory state in lockstep with the disk instead of dropping the map
+     * entry while the file survives (later reload resurrects the skin).
+     */
+    public void deleteSkin(UUID uuid) throws IOException {
         Path target = savePath.resolve(uuid + FILE_EXTENSION);
-        try {
-            if (Files.deleteIfExists(target)) {
-                EverlastingSkins.logger.info("Deleted skin file for {}", uuid);
-            }
-        } catch (IOException e) {
-            EverlastingSkins.logger.warn("Failed to delete skin file for {}", uuid, e);
+        if (Files.deleteIfExists(target)) {
+            EverlastingSkins.logger.info("Deleted skin file for {}", uuid);
         }
     }
 

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinStorage.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinStorage.java
@@ -174,9 +174,14 @@ public class SkinStorage {
     }
 
     public CustomSkinProperty removeSkin(UUID uuid) {
-        pendingWrites.remove(uuid); // purge deferred drain; it must not resurrect a deleted skin
-        skinMap.remove(uuid);
+        // Purge the deferred payload so a drain that has not started yet skips
+        // this UUID, then delete the file before dropping the map entry:
+        // getSkin() reloads from disk on a map miss, so removing the entry
+        // before the file is gone would let a concurrent read resurrect the
+        // cleared skin into the map.
+        pendingWrites.remove(uuid);
         deleteSkinSerialized(uuid);
+        skinMap.remove(uuid);
         return null;
     }
 

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinStorage.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinStorage.java
@@ -76,7 +76,14 @@ public class SkinStorage {
         CustomSkinProperty skin = skinIO.loadSkin(uuid);
         if (skin != null && skin.isEmpty()) {
             pendingWrites.remove(uuid);
-            deleteSkinSerialized(uuid);
+            try {
+                deleteSkinSerialized(uuid);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new DeleteFailedException("Skin delete of " + uuid + " interrupted", e);
+            } catch (IOException e) {
+                throw new DeleteFailedException("Skin delete of " + uuid + " failed", e);
+            }
             return null;
         }
         return skin;
@@ -190,14 +197,35 @@ public class SkinStorage {
         }
     }
 
+    /**
+     * Raised when a serialized skin delete cannot be confirmed to have landed
+     * (timeout, writer failure, or interrupted wait). The in-memory map entry
+     * and the on-disk file must move together, so callers propagate this
+     * instead of silently dropping the entry while the file survives.
+     */
+    public static class DeleteFailedException extends RuntimeException {
+
+        DeleteFailedException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+
     public CustomSkinProperty removeSkin(UUID uuid) {
         // Purge the deferred payload so a drain that has not started yet skips
         // this UUID, then delete the file before dropping the map entry:
         // getSkin() reloads from disk on a map miss, so removing the entry
         // before the file is gone would let a concurrent read resurrect the
-        // cleared skin into the map.
+        // cleared skin into the map. A failed delete propagates instead of
+        // dropping the entry: the file and the map must move together.
         pendingWrites.remove(uuid);
-        deleteSkinSerialized(uuid);
+        try {
+            deleteSkinSerialized(uuid);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new DeleteFailedException("Skin delete of " + uuid + " interrupted", e);
+        } catch (IOException e) {
+            throw new DeleteFailedException("Skin delete of " + uuid + " failed", e);
+        }
         skinMap.remove(uuid);
         return null;
     }
@@ -208,14 +236,33 @@ public class SkinStorage {
      * in-flight drain that already pulled this payload completes its write
      * before the delete runs, so no stale write can land after the delete
      * (write-after-delete race).
+     *
+     * <p>Failure is raised, never swallowed: the caller must not drop the
+     * in-memory entry while the file may still exist, or a later getSkin()
+     * reload resurrects the cleared skin. InterruptedException is re-thrown
+     * as-is; a timeout or writer failure surfaces as
+     * {@link DeleteFailedException}.
      */
-    private void deleteSkinSerialized(UUID uuid) {
+    private void deleteSkinSerialized(UUID uuid) throws InterruptedException, IOException {
         try {
-            SAVE_EXECUTOR.submit(() -> skinIO.deleteSkin(uuid)).get(5, TimeUnit.SECONDS);
+            SAVE_EXECUTOR.submit(() -> {
+                skinIO.deleteSkin(uuid);
+                return null;
+            }).get(5, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-        } catch (ExecutionException | TimeoutException e) {
-            EverlastingSkins.logger.warn("Skin delete did not complete in time for {}", uuid, e);
+            throw e;
+        } catch (TimeoutException e) {
+            EverlastingSkins.logger.warn("Skin delete of {} timed out after 5s", uuid);
+            throw new DeleteFailedException("Skin delete of " + uuid + " timed out after 5s", e);
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof IOException) {
+                EverlastingSkins.logger.warn("Failed to delete skin file for {}", uuid, cause);
+                throw (IOException) cause;
+            }
+            EverlastingSkins.logger.warn("Skin delete of {} failed", uuid, cause);
+            throw new DeleteFailedException("Skin delete of " + uuid + " failed", cause);
         }
     }
 

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinStorage.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinStorage.java
@@ -76,7 +76,7 @@ public class SkinStorage {
         CustomSkinProperty skin = skinIO.loadSkin(uuid);
         if (skin != null && skin.isEmpty()) {
             pendingWrites.remove(uuid);
-            skinIO.deleteSkin(uuid);
+            deleteSkinSerialized(uuid);
             return null;
         }
         return skin;
@@ -176,8 +176,25 @@ public class SkinStorage {
     public CustomSkinProperty removeSkin(UUID uuid) {
         pendingWrites.remove(uuid); // purge deferred drain; it must not resurrect a deleted skin
         skinMap.remove(uuid);
-        skinIO.deleteSkin(uuid);
+        deleteSkinSerialized(uuid);
         return null;
+    }
+
+    /**
+     * Runs the file deletion on the single writer thread so it is serialized
+     * against drain writes, and blocks until the delete has landed. An
+     * in-flight drain that already pulled this payload completes its write
+     * before the delete runs, so no stale write can land after the delete
+     * (write-after-delete race).
+     */
+    private void deleteSkinSerialized(UUID uuid) {
+        try {
+            SAVE_EXECUTOR.submit(() -> skinIO.deleteSkin(uuid)).get(5, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (ExecutionException | TimeoutException e) {
+            EverlastingSkins.logger.warn("Skin delete did not complete in time for {}", uuid, e);
+        }
     }
 
     public CustomSkinProperty setSkin(UUID uuid, @Nullable CustomSkinProperty skin) {

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinStorage.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinStorage.java
@@ -104,10 +104,27 @@ public class SkinStorage {
         return loaded.getSource();
     }
 
+    /**
+     * Strict last-write-wins save: the in-memory value is written through the
+     * single writer thread and this call blocks until the write has landed.
+     * Submitting through SAVE_EXECUTOR (FIFO) orders the sync save after any
+     * in-flight drain write for the same UUID; purging the pending payload
+     * first keeps a not-yet-drained async write from overwriting it. Without
+     * the serialization the async drain could land a stale payload after the
+     * sync save (sync/async inversion).
+     */
     public void saveSkin(UUID uuid) {
         CustomSkinProperty skinProperty = skinMap.get(uuid);
-        if (skinProperty != null) {
-            skinIO.saveSkin(uuid, skinProperty);
+        if (skinProperty == null) return;
+        pendingWrites.remove(uuid);
+        byte[] payload = JsonUtils.toJson(skinProperty).getBytes(StandardCharsets.UTF_8);
+        try {
+            SAVE_EXECUTOR.submit(() -> skinIO.saveSkin(uuid, payload)).get(5, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            EverlastingSkins.logger.warn("Sync skin save of {} interrupted", uuid, e);
+        } catch (ExecutionException | TimeoutException e) {
+            EverlastingSkins.logger.warn("Sync skin save of {} did not complete in 5s", uuid, e);
         }
     }
 

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/SkinDeleteFailureTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/SkinDeleteFailureTest.java
@@ -1,0 +1,108 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import levosilimo.everlastingskins.skinchanger.SkinStorage.DeleteFailedException;
+import levosilimo.everlastingskins.util.CustomSkinProperty;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Failure semantics of the serialized delete: when the delete cannot be
+ * confirmed to have landed, the exception must propagate so the in-memory
+ * map entry survives — file and map move together, or a later getSkin()
+ * reload resurrects the cleared skin.
+ */
+class SkinDeleteFailureTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    @DisplayName("failed delete propagates and keeps the map entry and the file")
+    void failedDeletePropagatesAndKeepsMapEntry() throws Exception {
+        IOException injected = new IOException("injected delete failure");
+        SkinStorage failingStorage = new SkinStorage(new FailingDeleteSkinIO(tempDir, injected));
+        UUID u = UUID.randomUUID();
+        Path target = tempDir.resolve(u + ".json");
+        failingStorage.setSkin(u, skin("persisted"));
+        failingStorage.saveSkin(u);
+        assertTrue(Files.exists(target));
+
+        DeleteFailedException ex = assertThrows(DeleteFailedException.class, () -> failingStorage.removeSkin(u));
+
+        assertTrue(hasCause(ex, IOException.class, "injected delete failure"),
+                "the delete failure must surface with its original cause");
+        assertNotNull(failingStorage.getSkin(u), "the map entry must survive a failed delete");
+        assertTrue(Files.exists(target), "the file must survive a failed delete");
+    }
+
+    @Test
+    @DisplayName("setSkin(null) on a failing delete propagates instead of clearing")
+    void setSkinNullOnFailingDeletePropagates() throws Exception {
+        SkinStorage failingStorage = new SkinStorage(new FailingDeleteSkinIO(tempDir, new IOException("injected delete failure")));
+        UUID u = UUID.randomUUID();
+        failingStorage.setSkin(u, skin("persisted"));
+
+        assertThrows(DeleteFailedException.class, () -> failingStorage.setSkin(u, null));
+        assertNotNull(failingStorage.getSkin(u), "the map entry must survive a failed clear");
+    }
+
+    @Test
+    @DisplayName("writer crash on delete surfaces as DeleteFailedException, not a silent drop")
+    void writerCrashOnDeletePropagates() throws Exception {
+        SkinStorage failingStorage = new SkinStorage(new FailingDeleteSkinIO(tempDir, new IllegalStateException("writer crashed")));
+        UUID u = UUID.randomUUID();
+        failingStorage.setSkin(u, skin("persisted"));
+
+        assertThrows(DeleteFailedException.class, () -> failingStorage.removeSkin(u));
+        assertNotNull(failingStorage.getSkin(u));
+    }
+
+    private static boolean hasCause(Throwable t, Class<? extends Throwable> type, String messagePart) {
+        for (Throwable c = t; c != null; c = c.getCause()) {
+            if (type.isInstance(c) && String.valueOf(c.getMessage()).contains(messagePart)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static CustomSkinProperty skin(String value) {
+        return new CustomSkinProperty(value, "sig", "src");
+    }
+
+    /** SkinIO whose delete always fails with the injected exception. */
+    private static final class FailingDeleteSkinIO extends SkinIO {
+
+        private final Throwable failure;
+
+        FailingDeleteSkinIO(Path savePath, Throwable failure) {
+            super(savePath);
+            this.failure = failure;
+        }
+
+        @Override
+        public void deleteSkin(UUID uuid) throws IOException {
+            if (failure instanceof IOException) {
+                throw (IOException) failure;
+            }
+            if (failure instanceof RuntimeException) {
+                throw (RuntimeException) failure;
+            }
+            throw new IOException(failure);
+        }
+    }
+}

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/SkinIODeleteRaceTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/SkinIODeleteRaceTest.java
@@ -9,11 +9,15 @@ package levosilimo.everlastingskins.skinchanger;
 import levosilimo.everlastingskins.util.CustomSkinProperty;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.RepetitionInfo;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -83,8 +87,82 @@ class SkinIODeleteRaceTest {
         }
     }
 
+    @RepeatedTest(20)
+    @DisplayName("randomized save/delete/flush sequences never resurrect a deleted file")
+    void randomizedSequencesNeverResurrectDeletedFile(RepetitionInfo repetition) throws Exception {
+        UUID u = UUID.randomUUID();
+        Path target = tempDir.resolve(u + ".json");
+        Random rnd = new Random(0x5eedL + repetition.getCurrentRepetition() * 7919L);
+        String lastPayload = null;
+        Op lastOp = null;
+
+        for (int i = 0; i < 15; i++) {
+            switch (rnd.nextInt(3)) {
+                case 0:
+                    lastPayload = "payload-" + rnd.nextInt(100000);
+                    storage.saveSkinAsync(u, skin(lastPayload));
+                    lastOp = Op.SAVE;
+                    break;
+                case 1:
+                    storage.removeSkin(u);
+                    lastOp = Op.DELETE;
+                    break;
+                default:
+                    storage.flushPending();
+            }
+            Thread.sleep(rnd.nextInt(3));
+        }
+        storage.flushPending();
+
+        if (lastOp == Op.DELETE) {
+            assertFalse(Files.exists(target),
+                    "repetition " + repetition.getCurrentRepetition() + ": stale write resurrected a deleted skin");
+        } else if (lastOp == Op.SAVE) {
+            assertTrue(Files.exists(target),
+                    "repetition " + repetition.getCurrentRepetition() + ": last save was lost");
+            String content = new String(Files.readAllBytes(target), StandardCharsets.UTF_8);
+            assertTrue(content.contains(lastPayload),
+                    "repetition " + repetition.getCurrentRepetition() + ": stale payload won over the last save");
+        }
+    }
+
+    @Test
+    @DisplayName("delete then restart: fresh storage must not reload the cleared skin")
+    void restartAfterDeleteKeepsFileAbsent() throws Exception {
+        storage.setSkin(uuid, skin("persisted"));
+        storage.saveSkin(uuid);
+        Path target = tempDir.resolve(uuid + ".json");
+        assertTrue(Files.exists(target));
+
+        storage.removeSkin(uuid);
+        SkinStorage.resetForTest();
+        SkinStorage restarted = new SkinStorage(skinIO);
+
+        assertNull(restarted.getSkin(uuid));
+        assertFalse(Files.exists(target));
+    }
+
+    @Test
+    @DisplayName("removeSkin deletes the file before dropping the map entry")
+    void removeSkinFileThenMap() throws Exception {
+        storage.setSkin(uuid, skin("persisted"));
+        storage.saveSkin(uuid);
+        assertNotNull(storage.getSkin(uuid));
+
+        storage.removeSkin(uuid);
+
+        assertNull(storage.getSkin(uuid));
+        assertNull(storage.getSource(uuid));
+        assertTrue(storage.hasDefaultSkin(uuid));
+        assertFalse(Files.exists(tempDir.resolve(uuid + ".json")));
+    }
+
     private static CustomSkinProperty skin(String value) {
         return new CustomSkinProperty(value, "sig", "src");
+    }
+
+    private enum Op {
+        SAVE, DELETE
     }
 
     /** SkinIO whose drain write blocks until the test releases it. */

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/SkinIODeleteRaceTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/SkinIODeleteRaceTest.java
@@ -1,0 +1,114 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import levosilimo.everlastingskins.util.CustomSkinProperty;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Write-after-delete regression tests for the coalescing async writer:
+ * a drain that already pulled a payload must land its write BEFORE a
+ * delete of the same skin, never after it (resurrecting the file).
+ */
+class SkinIODeleteRaceTest {
+
+    @TempDir
+    Path tempDir;
+
+    private SkinIO skinIO;
+    private SkinStorage storage;
+    private UUID uuid;
+
+    @BeforeEach
+    void setUp() {
+        skinIO = new SkinIO(tempDir);
+        storage = new SkinStorage(skinIO);
+        uuid = UUID.randomUUID();
+    }
+
+    @Test
+    @DisplayName("delete serialized after an in-flight drain write: no write-after-delete resurrection")
+    void deleteSerializedAgainstInFlightDrain() throws Exception {
+        BlockingSkinIO blockingIO = new BlockingSkinIO(tempDir);
+        SkinStorage blockingStorage = new SkinStorage(blockingIO);
+        UUID u = UUID.randomUUID();
+        Path target = tempDir.resolve(u + ".json");
+
+        blockingStorage.saveSkinAsync(u, skin("stale"));
+        assertTrue(blockingIO.writeStarted.await(5, TimeUnit.SECONDS),
+                "drain must reach the file write before the delete");
+
+        CountDownLatch removeDone = new CountDownLatch(1);
+        ExecutorService remover = Executors.newSingleThreadExecutor();
+        try {
+            Future<?> delete = remover.submit(() -> {
+                blockingStorage.removeSkin(u);
+                removeDone.countDown();
+            });
+            // Unfixed code returns here immediately: the delete runs on the
+            // remover thread while the drain is still blocked, so the drain's
+            // write lands after the delete and resurrects the file. Fixed code
+            // blocks until the serialized delete has run on the writer thread,
+            // which can only happen after the blocked drain write completes.
+            boolean removedWhileDrainBlocked = removeDone.await(2, TimeUnit.SECONDS);
+            blockingIO.releaseWrite.countDown();
+            delete.get(5, TimeUnit.SECONDS);
+            // Barrier on the writer thread: the drain write is async, so wait
+            // for it to land before asserting on the file state.
+            blockingStorage.flushPending();
+
+            assertFalse(Files.exists(target),
+                    "stale drain write resurrected the deleted file (removedWhileDrainBlocked="
+                            + removedWhileDrainBlocked + ")");
+        } finally {
+            remover.shutdownNow();
+        }
+    }
+
+    private static CustomSkinProperty skin(String value) {
+        return new CustomSkinProperty(value, "sig", "src");
+    }
+
+    /** SkinIO whose drain write blocks until the test releases it. */
+    private static final class BlockingSkinIO extends SkinIO {
+
+        final CountDownLatch writeStarted = new CountDownLatch(1);
+        final CountDownLatch releaseWrite = new CountDownLatch(1);
+
+        BlockingSkinIO(Path savePath) {
+            super(savePath);
+        }
+
+        @Override
+        void saveSkin(UUID uuid, byte[] payload) {
+            writeStarted.countDown();
+            try {
+                if (!releaseWrite.await(5, TimeUnit.SECONDS)) {
+                    throw new IllegalStateException("test latch not released in time");
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("interrupted while waiting for test latch", e);
+            }
+            super.saveSkin(uuid, payload);
+        }
+    }
+}

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/SkinIODurabilityTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/SkinIODurabilityTest.java
@@ -1,0 +1,72 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import levosilimo.everlastingskins.metrics.SkinMetrics;
+import levosilimo.everlastingskins.metrics.Snapshot;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Durability guarantees of {@link SkinIO} writes: the rename must not be
+ * silently downgraded, and every failure path must surface in metrics and
+ * leave no half-written state behind.
+ */
+class SkinIODurabilityTest {
+
+    @TempDir
+    Path tempDir;
+
+    private SkinIO skinIO;
+
+    @BeforeEach
+    void setUp() {
+        skinIO = new SkinIO(tempDir);
+        SkinMetrics.INSTANCE.reset();
+    }
+
+    @Test
+    @DisplayName("save survives a simulated crash: temp file plus target rename")
+    void saveIsAtomicAndDurable() throws Exception {
+        UUID u = UUID.randomUUID();
+        Path target = tempDir.resolve(u + ".json");
+
+        skinIO.saveSkin(u, "payload".getBytes(StandardCharsets.UTF_8));
+
+        assertTrue(Files.exists(target));
+        assertEquals("payload", new String(Files.readAllBytes(target), StandardCharsets.UTF_8));
+        assertFalse(Files.exists(tempDir.resolve(u + ".json.tmp")), "temp file must be gone after the move");
+        assertEquals(0, SkinMetrics.INSTANCE.snapshot().ioFailures(), "clean save must not record I/O failures");
+    }
+
+    @Test
+    @DisplayName("rename failure is recorded, logged and cleaned up, never silently swallowed")
+    void renameFailureIsSurfacedNotSwallowed() throws Exception {
+        UUID u = UUID.randomUUID();
+        Path target = tempDir.resolve(u + ".json");
+        Files.createDirectories(target);
+        Files.write(target.resolve("occupied"), new byte[]{1}); // non-empty dir: rename cannot replace it
+
+        skinIO.saveSkin(u, "payload".getBytes(StandardCharsets.UTF_8));
+
+        assertTrue(Files.isDirectory(target), "target directory must be untouched");
+        assertTrue(Files.exists(target.resolve("occupied")), "target contents must survive");
+        assertFalse(Files.exists(tempDir.resolve(u + ".json.tmp")), "temp file must be cleaned up");
+        Snapshot snap = SkinMetrics.INSTANCE.snapshot();
+        assertTrue(snap.ioFailures() >= 1, "rename failure must increment the I/O failure metric");
+        assertFalse(snap.ioFailuresByType().isEmpty(), "failure type must be recorded, not swallowed");
+    }
+}

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/SkinSyncAsyncOrderTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/SkinSyncAsyncOrderTest.java
@@ -1,0 +1,134 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import levosilimo.everlastingskins.util.CustomSkinProperty;
+import levosilimo.everlastingskins.util.JsonUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Sync/async ordering regression tests: the drain-coalesce writer is
+ * asynchronous, but a sync saveSkin(UUID) is a strict last-write-wins save
+ * and must land on disk AFTER any async write for the same UUID — queued
+ * (purged so the drain skips it) or in-flight (FIFO on the writer thread).
+ */
+class SkinSyncAsyncOrderTest {
+
+    @TempDir
+    Path tempDir;
+
+    private SkinStorage storage;
+
+    @BeforeEach
+    void setUp() {
+        storage = new SkinStorage(new SkinIO(tempDir));
+    }
+
+    @Test
+    @DisplayName("sync save after a queued async save: latest value wins on disk")
+    void syncSaveAfterQueuedAsyncSave_lastWriteWins() throws Exception {
+        UUID u = UUID.randomUUID();
+        storage.setSkin(u, skin("Yg==")); // v2 = latest, in the in-memory map
+        storage.saveSkinAsync(u, skin("YQ==")); // v1 = stale payload, queued for the debounced drain
+        storage.saveSkin(u); // sync: must purge the queued v1 and land v2
+        storage.flushPending();
+
+        String disk = new String(Files.readAllBytes(tempDir.resolve(u + ".json")), StandardCharsets.UTF_8);
+        assertEquals("Yg==", valueOnDisk(disk),
+                "disk holds YQ== (stale async payload) but model expects Yg== (latest sync save)");
+    }
+
+    @Test
+    @DisplayName("sync save blocks until an in-flight drain write for the same UUID has landed")
+    void syncSaveWaitsForInFlightDrainWrite() throws Exception {
+        BlockingSkinIO blockingIO = new BlockingSkinIO(tempDir);
+        SkinStorage blockingStorage = new SkinStorage(blockingIO);
+        UUID u = UUID.randomUUID();
+        Path target = tempDir.resolve(u + ".json");
+
+        blockingStorage.setSkin(u, skin("Yg=="));
+        blockingStorage.saveSkinAsync(u, skin("YQ=="));
+        assertTrue(blockingIO.writeStarted.await(5, TimeUnit.SECONDS),
+                "drain must reach the file write before the sync save");
+
+        CountDownLatch syncDone = new CountDownLatch(1);
+        ExecutorService saver = Executors.newSingleThreadExecutor();
+        try {
+            Future<?> sync = saver.submit(() -> {
+                blockingStorage.saveSkin(u);
+                syncDone.countDown();
+            });
+            // Unfixed code writes v2 directly on the caller thread while the
+            // drain is blocked, so the sync save returns immediately and the
+            // drain's stale v1 lands last. Fixed code submits through the
+            // single writer thread (FIFO), so the sync save cannot complete
+            // until the blocked drain write has landed.
+            boolean completedWhileDrainBlocked = syncDone.await(2, TimeUnit.SECONDS);
+            blockingIO.releaseWrite.countDown();
+            sync.get(5, TimeUnit.SECONDS);
+            blockingStorage.flushPending();
+
+            String disk = new String(Files.readAllBytes(target), StandardCharsets.UTF_8);
+            assertEquals("Yg==", valueOnDisk(disk),
+                    "disk holds YQ== (stale async payload) but model expects Yg== (latest sync save)"
+                            + " (completedWhileDrainBlocked=" + completedWhileDrainBlocked + ")");
+        } finally {
+            saver.shutdownNow();
+        }
+    }
+
+    private static CustomSkinProperty skin(String value) {
+        return new CustomSkinProperty(value, "sig", "src");
+    }
+
+    /** Parses the serialized value field off disk (Gson escapes '=' as \\u003d). */
+    private static String valueOnDisk(String diskJson) {
+        return JsonUtils.parseJson(diskJson)
+                .get("originalProperty").getAsJsonObject()
+                .get("value").getAsString();
+    }
+
+    /** SkinIO whose drain write blocks until the test releases it. */
+    private static final class BlockingSkinIO extends SkinIO {
+
+        final CountDownLatch writeStarted = new CountDownLatch(1);
+        final CountDownLatch releaseWrite = new CountDownLatch(1);
+
+        BlockingSkinIO(Path savePath) {
+            super(savePath);
+        }
+
+        @Override
+        void saveSkin(UUID uuid, byte[] payload) {
+            writeStarted.countDown();
+            try {
+                if (!releaseWrite.await(5, TimeUnit.SECONDS)) {
+                    throw new IllegalStateException("test latch not released in time");
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("interrupted while waiting for test latch", e);
+            }
+            super.saveSkin(uuid, payload);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Ports the 1.21 write-after-delete fix (#199, 6910411) to mc1.12.2 with
adapted APIs, and closes the directory-fsync durability gap on top.

### Findings (cross-version asymmetry, memory #1214)
1. `SkinIO.deleteSkin` did not serialize through the single writer thread —
   `pendingWrites.remove` then `file.delete` could be inverted by a drain in
   flight, resurrecting the file after the delete.
2. `SkinStorage.removeSkin` did map-remove before file-delete, so
   `getSkin` → `loadSkin` could re-read the still-existing file and
   re-populate the cleared skin into the map.
3. `SkinIO.writeSkinFile` fsync'd the temp file but never the parent
   directory after `ATOMIC_MOVE`; the non-atomic fallback silently dropped
   atomicity on filesystems without atomic rename.

### Changes
- **A1 (692b3f4)** `SkinStorage.deleteSkinSerialized`: file deletion now runs
  on the single writer thread (`SAVE_EXECUTOR.submit(...).get(5s)`), purging
  the deferred payload first; `InterruptedException` is never swallowed.
  mc1.12.2's writer lives in SkinStorage (static final daemon executor, never
  shut down) so there is no lazy-recreate hazard to manage.
- **A2 (0f4affb)** `removeSkin`: file-then-map — the file is gone before the
  map entry drops, closing the getSkin reload-resurrection window.
- **A3 (ede35b6)** `SkinIO`: directory fsync after the rename via the Java 8
  canonical `FileChannel.open(parent, READ).force(true)`; the ATOMIC_MOVE
  fallback is kept but the downgrade is surfaced (distinct warn log + I/O
  failure metric) instead of the old error-log + silent fallback; the fsync
  covers the fallback path too. Unsupported platforms (Windows dir-open)
  degrade to a warn log, not a failed save.
- **B1 (884dd11)** deterministic interleaving test: saveAsync → drain latched
  inside the write → removeSkin while blocked → release → assert file absent.
  Red on the old code (`stale drain write resurrected the deleted file`),
  green after A1+A2.
- **B2 (a1376f7)** `@RepeatedTest(20)` randomized save/delete/flush property
  test, restart-after-delete test, file-then-map regression test.
- **B3 (ccae7c8)** durability tests: clean-save regression guard + rename
  failure surfaced in the metric with temp cleanup.

## Verification
- `./gradlew build test` (Java 8): 369 tests, 0 failures.
- Race test red on base, green on branch (repro log excerpt below).
- aislop scan clean (0 findings), pre-commit gate passed on every commit.

### Race repro (branch base, before fix)
```
deleteSerializedAgainstInFlightDrain() FAILED
AssertionFailedError: stale drain write resurrected the deleted file
(removedWhileDrainBlocked=true) ==> expected: <false> but was: <true>
```
After the fix the same test passes (file stays deleted; drain write lands
before the serialized delete).