### PR TITLE
test(1122): MineSkin V1/V2 contract tests + V2 parsing fallback

### DIFF
--- a/src/main/java/levosilimo/everlastingskins/skinchanger/MineSkinApiHttpImpl.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/MineSkinApiHttpImpl.java
@@ -3,7 +3,11 @@
  */
 package levosilimo.everlastingskins.skinchanger;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
 import levosilimo.everlastingskins.Config;
+import levosilimo.everlastingskins.EverlastingSkins;
 import levosilimo.everlastingskins.enums.SkinVariant;
 import levosilimo.everlastingskins.metrics.SkinMetrics;
 import levosilimo.everlastingskins.skinchanger.responses.HttpResponse;
@@ -28,6 +32,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Consumer;
 
 /**
  * Skin generation via the MineSkin API.
@@ -46,6 +51,13 @@ public class MineSkinApiHttpImpl implements MineSkinAPI {
 
     private final HttpClient httpClient;
     private final String apiKey;
+    private boolean apiKeyWarningEmitted;
+
+    /**
+     * Emits MineSkin configuration warnings. Production logs via the mod
+     * logger; tests swap this sink to capture messages without a log backend.
+     */
+    static Consumer<String> warningSink = MineSkinApiHttpImpl::logConfigWarning;
 
     public MineSkinApiHttpImpl() {
         this(new HttpsUrlConnectionHttpClient(), Config.MINESKIN_API_KEY);
@@ -132,24 +144,55 @@ public class MineSkinApiHttpImpl implements MineSkinAPI {
             sleepForRateLimit(response);
             return Optional.empty();
         }
+        if (statusCode == 401 || statusCode == 403 || statusCode == 404) {
+            warnIfMissingApiKey(statusCode);
+            return Optional.empty();
+        }
         if (statusCode == 400 || statusCode == 500) {
             return null;
         }
         return Optional.empty();
     }
 
+    private void warnIfMissingApiKey(int statusCode) {
+        if (apiKey != null && !apiKey.isEmpty()) {
+            return;
+        }
+        if (apiKeyWarningEmitted) {
+            return;
+        }
+        apiKeyWarningEmitted = true;
+        warningSink.accept("MineSkin API returned HTTP " + statusCode
+                + " and no API key is configured - set MINESKIN_API_KEY in the mod config");
+    }
+
+    private static void logConfigWarning(String message) {
+        EverlastingSkins.logger.warn(message);
+    }
+
     private static Optional<MineSkinResponse> toSkinResponse(HttpResponse response, @Nullable SkinVariant requestedVariant) {
-        MineSkinUrlResponse urlResponse = response.getBodyAs(MineSkinUrlResponse.class);
+        MineSkinResponse v1 = toV1Response(response.getBodyAs(MineSkinUrlResponse.class), requestedVariant);
+        if (v1 != null) {
+            return Optional.of(v1);
+        }
+        MineSkinResponse v2 = toV2Response(response.body(), requestedVariant);
+        if (v2 != null) {
+            return Optional.of(v2);
+        }
+        return Optional.empty();
+    }
+
+    private static MineSkinResponse toV1Response(MineSkinUrlResponse urlResponse, @Nullable SkinVariant requestedVariant) {
         if (urlResponse == null) {
-            return Optional.empty();
+            return null;
         }
         MineSkinData data = urlResponse.data();
         if (data == null) {
-            return Optional.empty();
+            return null;
         }
         MineSkinTexture texture = data.texture();
         if (texture == null || texture.value() == null || texture.value().isEmpty()) {
-            return Optional.empty();
+            return null;
         }
 
         CustomSkinProperty property = new CustomSkinProperty(
@@ -159,34 +202,111 @@ public class MineSkinApiHttpImpl implements MineSkinAPI {
         );
         String skinId = urlResponse.idStr() != null ? urlResponse.idStr() : String.valueOf(urlResponse.id());
 
-        return Optional.of(new MineSkinResponse(
+        return new MineSkinResponse(
                 property,
                 skinId,
                 requestedVariant,
                 resolveVariant(urlResponse.variant())
-        ));
+        );
+    }
+
+    /**
+     * Parses the V2 success shape (api.mineskin.org/v2: skin.texture.data.
+     * value/signature). Returns null when the body is not a V2 success
+     * response, so empty or unknown bodies still resolve to "no result".
+     */
+    private static MineSkinResponse toV2Response(String body, @Nullable SkinVariant requestedVariant) {
+        JsonObject skin = v2SkinObject(body);
+        if (skin == null) {
+            return null;
+        }
+        JsonObject texture = jsonObject(skin, "texture");
+        JsonObject data = texture != null ? jsonObject(texture, "data") : null;
+        JsonElement valueElement = data != null ? data.get("value") : null;
+        if (valueElement == null || !valueElement.isJsonPrimitive() || valueElement.getAsString().isEmpty()) {
+            return null;
+        }
+
+        String signature = jsonString(data, "signature");
+        String skinId = jsonString(skin, "uuid");
+        String variant = jsonString(skin, "variant");
+
+        CustomSkinProperty property = new CustomSkinProperty(
+                valueElement.getAsString(),
+                signature,
+                SkinAction.SOURCE_MINESKIN
+        );
+        return new MineSkinResponse(property, skinId, requestedVariant, resolveVariant(variant));
+    }
+
+    private static JsonObject v2SkinObject(String body) {
+        try {
+            JsonObject json = JsonUtils.parseJson(body);
+            return jsonObject(json, "skin");
+        } catch (JsonParseException e) {
+            return null;
+        }
+    }
+
+    private static JsonObject jsonObject(JsonObject parent, String member) {
+        JsonElement element = parent.get(member);
+        return element != null && element.isJsonObject() ? element.getAsJsonObject() : null;
+    }
+
+    private static String jsonString(JsonObject parent, String member) {
+        JsonElement element = parent.get(member);
+        return element != null && element.isJsonPrimitive() ? element.getAsString() : null;
     }
 
     private static void sleepForRateLimit(HttpResponse response) {
+        int waitMs = 0;
         MineSkinErrorDelayResponse delay = response.getBodyAs(MineSkinErrorDelayResponse.class);
         if (delay != null) {
-            int waitMs = 0;
             if (delay.nextRequest() != null && delay.nextRequest() > 0) {
                 waitMs = delay.nextRequest();
             } else if (delay.delay() != null && delay.delay() > 0) {
                 waitMs = delay.delay() * 1000;
             }
-            if (waitMs > 0) {
-                // The delay is provider-controlled; cap it so a malicious or
-                // misconfigured response cannot stall the request thread.
-                long capped = Math.min(waitMs, 5000L);
-                SkinMetrics.INSTANCE.recordMineSkinDelay(capped);
-                try {
-                    Thread.sleep(capped);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                }
+        }
+        if (waitMs <= 0) {
+            waitMs = v2RateLimitWaitMs(response.body());
+        }
+        if (waitMs > 0) {
+            // The delay is provider-controlled; cap it so a malicious or
+            // misconfigured response cannot stall the request thread.
+            long capped = Math.min(waitMs, 5000L);
+            SkinMetrics.INSTANCE.recordMineSkinDelay(capped);
+            try {
+                Thread.sleep(capped);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
             }
+        }
+    }
+
+    /**
+     * Extracts the wait time from a V2 rate-limit body: rateLimit.next.
+     * relative is a millisecond delay; absolute is an epoch-millis timestamp.
+     */
+    private static int v2RateLimitWaitMs(String body) {
+        try {
+            JsonObject rateLimit = jsonObject(JsonUtils.parseJson(body), "rateLimit");
+            JsonObject next = rateLimit != null ? jsonObject(rateLimit, "next") : null;
+            if (next == null) {
+                return 0;
+            }
+            JsonElement relative = next.get("relative");
+            if (relative != null && relative.isJsonPrimitive() && relative.getAsLong() > 0) {
+                return (int) Math.min(relative.getAsLong(), Integer.MAX_VALUE);
+            }
+            JsonElement absolute = next.get("absolute");
+            if (absolute != null && absolute.isJsonPrimitive()) {
+                long wait = absolute.getAsLong() - System.currentTimeMillis();
+                return (int) Math.max(0, Math.min(wait, Integer.MAX_VALUE));
+            }
+            return 0;
+        } catch (JsonParseException e) {
+            return 0;
         }
     }
 

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/MineSkinApiHttpImplTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/MineSkinApiHttpImplTest.java
@@ -8,6 +8,7 @@ package levosilimo.everlastingskins.skinchanger;
 
 import levosilimo.everlastingskins.FakeHttpClient;
 import levosilimo.everlastingskins.enums.SkinVariant;
+import levosilimo.everlastingskins.metrics.SkinMetrics;
 import levosilimo.everlastingskins.skinchanger.responses.mineskin.MineSkinResponse;
 import levosilimo.everlastingskins.util.EndpointsConfig;
 import org.junit.jupiter.api.BeforeEach;
@@ -15,6 +16,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.util.Optional;
 
@@ -31,13 +35,19 @@ class MineSkinApiHttpImplTest {
     private static final String VALID_VALUE = "dGV4dHVyZXMgeyBTS0lOIHsgdXJsOiAiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS90ZXN0IiB9IH0=";
     private static final String VALID_SIG = "signature==";
 
+    /** Texture value shared by the V1/V2 fixture files. */
+    private static final String FIXTURE_TEXTURE_VALUE = "eyJ0aW1lc3RhbXAiOjE3MzAwMDAwMDAwMDAsInByb2ZpbGVJZCI6IjU1MGU4NDAwZTI5YjQxZDRhNzE2NDQ2NjU1NDQwMDAwIiwicHJvZmlsZU5hbWUiOiJMZXZvc2lsaW1vIiwic2lnbmF0dXJlUmVxdWlyZWQiOnRydWUsInRleHR1cmVzIjp7IlNLSU4iOnsidXJsIjoiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS9hYmMxMjNkZWY0NTYifX19";
+    private static final String FIXTURE_SIGNATURE = "TQLAykIrTfFeo4eO7uNx0aj4eCy0eR9qAAqXr8CWjZ9NAsDKQitN8V6jh47u43HRqPh4LLR5H2oACpevwJaNn00CwMpCK03xXqOHju7jcdGo+HgstHkfagAKl6/Alo2fTQLAykIrTfFeo4eO7uNx0aj4eCy0eR9qAAqXr8CWjZ9NAsDKQitN8V6jh47u43HRqPh4LLR5H2oACpevwJaNn00CwMpCK03xXqOHju7jcdGo+HgstHkfagAKl6/Alo2fTQLAykIrTfFeo4eO7uNx0aj4eCy0eR9qAAqXr8CWjZ9NAsDKQitN8V6jh47u43HRqPh4LLR5H2oACpevwJaNnw==";
+
     private FakeHttpClient httpClient;
     private MineSkinApiHttpImpl api;
 
     @BeforeEach
     void setUp() {
         httpClient = new FakeHttpClient();
-        api = new MineSkinApiHttpImpl(httpClient, "");
+        // A configured key keeps the retry-classification tests off the
+        // empty-key config-warning path (covered separately in ConfigWarnings).
+        api = new MineSkinApiHttpImpl(httpClient, "test-api-key");
     }
 
     @Nested
@@ -203,8 +213,72 @@ class MineSkinApiHttpImplTest {
     }
 
     /* ================================================================== */
+    /*  Contract fixtures: V1 shape (current /generate/url)                 */
+    /* ================================================================== */
+
+    @Nested
+    @DisplayName("V1 contract fixtures")
+    class V1ContractFixtures {
+
+        @Test
+        @DisplayName("200 OK valid V1 body -> parses texture.value and idStr")
+        void validBody() throws Exception {
+            httpClient.addResponse(MINESKIN_URI, 200, fixture("v1-200-valid.json"));
+
+            Optional<MineSkinResponse> result = api.genSkinInternal(IMAGE_URL, SkinVariant.CLASSIC);
+
+            assertTrue(result.isPresent());
+            assertEquals(FIXTURE_TEXTURE_VALUE, result.get().property().getOriginalProperty().getValue());
+            assertEquals(FIXTURE_SIGNATURE, result.get().property().getOriginalProperty().getSignature());
+            assertEquals("12345", result.get().mineSkinId());
+        }
+
+        @Test
+        @DisplayName("200 OK V1 body with empty texture -> empty (no result, no crash)")
+        void emptyTexture() throws Exception {
+            httpClient.addResponse(MINESKIN_URI, 200, fixture("v1-200-empty-texture.json"));
+
+            Optional<MineSkinResponse> result = api.genSkinInternal(IMAGE_URL, SkinVariant.CLASSIC);
+
+            assertFalse(result.isPresent());
+        }
+
+        @Test
+        @DisplayName("429 V1 delayInfo -> recorded waitMs honors the provider delay")
+        void rateLimitDelay() throws Exception {
+            long before = SkinMetrics.INSTANCE.snapshot().mineSkinDelayTotalMs();
+            httpClient.addResponse(MINESKIN_URI, 429, fixture("v1-429-delay.json"));
+
+            Optional<MineSkinResponse> result = api.genSkinInternal(IMAGE_URL, SkinVariant.CLASSIC);
+
+            assertFalse(result.isPresent());
+            long recorded = SkinMetrics.INSTANCE.snapshot().mineSkinDelayTotalMs() - before;
+            assertEquals(1000, recorded);
+        }
+    }
+
+    /* ================================================================== */
     /*  JSON body helpers                                                  */
     /* ================================================================== */
+
+    /** Reads a contract fixture from src/test/resources/fixtures/mineskin/. */
+    private static String fixture(String name) throws IOException {
+        InputStream in = MineSkinApiHttpImplTest.class.getResourceAsStream("/fixtures/mineskin/" + name);
+        if (in == null) {
+            throw new IOException("missing fixture: " + name);
+        }
+        try {
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            byte[] buffer = new byte[4096];
+            int read;
+            while ((read = in.read(buffer)) != -1) {
+                out.write(buffer, 0, read);
+            }
+            return out.toString("UTF-8");
+        } finally {
+            in.close();
+        }
+    }
 
     private static String validMineSkinJson() {
         return "{\n" +

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/MineSkinApiHttpImplTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/MineSkinApiHttpImplTest.java
@@ -11,6 +11,7 @@ import levosilimo.everlastingskins.enums.SkinVariant;
 import levosilimo.everlastingskins.metrics.SkinMetrics;
 import levosilimo.everlastingskins.skinchanger.responses.mineskin.MineSkinResponse;
 import levosilimo.everlastingskins.util.EndpointsConfig;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -20,7 +21,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -302,6 +306,86 @@ class MineSkinApiHttpImplTest {
             assertFalse(result.isPresent());
             long recorded = SkinMetrics.INSTANCE.snapshot().mineSkinDelayTotalMs() - before;
             assertEquals(250, recorded);
+        }
+    }
+
+    /* ================================================================== */
+    /*  Config warnings: 401/403/404 with an unset MINESKIN_API_KEY         */
+    /* ================================================================== */
+
+    @Nested
+    @DisplayName("Config warnings (MINESKIN_API_KEY)")
+    class ConfigWarnings {
+
+        private final List<String> warnings = new ArrayList<String>();
+        private Consumer<String> originalSink;
+        private MineSkinApiHttpImpl unkeyedApi;
+
+        @BeforeEach
+        void captureWarnings() {
+            originalSink = MineSkinApiHttpImpl.warningSink;
+            MineSkinApiHttpImpl.warningSink = warnings::add;
+            unkeyedApi = new MineSkinApiHttpImpl(httpClient, "");
+        }
+
+        @AfterEach
+        void restoreSink() {
+            MineSkinApiHttpImpl.warningSink = originalSink;
+        }
+
+        @Test
+        @DisplayName("401 with no API key -> warning mentions MINESKIN_API_KEY")
+        void unauthorizedWithoutKey() throws Exception {
+            httpClient.addResponse(MINESKIN_URI, 401, "{\"errorCode\":\"unauthorized\"}");
+
+            unkeyedApi.genSkinInternal(IMAGE_URL, SkinVariant.CLASSIC);
+
+            assertEquals(1, warnings.size());
+            assertTrue(warnings.get(0).contains("MINESKIN_API_KEY"));
+        }
+
+        @Test
+        @DisplayName("403 with no API key -> warning mentions MINESKIN_API_KEY")
+        void forbiddenWithoutKey() throws Exception {
+            httpClient.addResponse(MINESKIN_URI, 403, "{\"errorCode\":\"invalid_api_key\"}");
+
+            unkeyedApi.genSkinInternal(IMAGE_URL, SkinVariant.CLASSIC);
+
+            assertEquals(1, warnings.size());
+            assertTrue(warnings.get(0).contains("MINESKIN_API_KEY"));
+        }
+
+        @Test
+        @DisplayName("404 with no API key -> warning mentions MINESKIN_API_KEY")
+        void missingResourceWithoutKey() throws Exception {
+            httpClient.addResponse(MINESKIN_URI, 404, "{}");
+
+            unkeyedApi.genSkinInternal(IMAGE_URL, SkinVariant.CLASSIC);
+
+            assertEquals(1, warnings.size());
+            assertTrue(warnings.get(0).contains("MINESKIN_API_KEY"));
+        }
+
+        @Test
+        @DisplayName("403 with API key configured -> no config warning")
+        void forbiddenWithKey() throws Exception {
+            MineSkinApiHttpImpl keyedApi = new MineSkinApiHttpImpl(httpClient, "test-api-key");
+            httpClient.addResponse(MINESKIN_URI, 403, "{\"errorCode\":\"invalid_api_key\"}");
+
+            keyedApi.genSkinInternal(IMAGE_URL, SkinVariant.CLASSIC);
+
+            assertTrue(warnings.isEmpty());
+        }
+
+        @Test
+        @DisplayName("Warning emitted at most once per impl instance")
+        void warnedOnce() throws Exception {
+            httpClient.addResponse(MINESKIN_URI, 401, "{}");
+
+            unkeyedApi.genSkinInternal(IMAGE_URL, SkinVariant.CLASSIC);
+            unkeyedApi.genSkinInternal(IMAGE_URL, SkinVariant.CLASSIC);
+
+            assertEquals(1, warnings.size());
         }
     }
 

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/MineSkinApiHttpImplTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/MineSkinApiHttpImplTest.java
@@ -258,6 +258,54 @@ class MineSkinApiHttpImplTest {
     }
 
     /* ================================================================== */
+    /*  Contract fixtures: V2 shape (api.mineskin.org/v2) — F2             */
+    /*  The V2 body nests value/signature under skin.texture.data, which    */
+    /*  the V1 parser (data.texture.value) reads as empty. These tests      */
+    /*  pin that a V2 body must parse or fail loudly — never silent empty.  */
+    /* ================================================================== */
+
+    @Nested
+    @DisplayName("V2 contract fixtures")
+    class V2ContractFixtures {
+
+        @Test
+        @DisplayName("200 OK V2 body -> parses skin.texture.data.value (no silent empty)")
+        void validBody() throws Exception {
+            httpClient.addResponse(MINESKIN_URI, 200, fixture("v2-200-valid.json"));
+
+            Optional<MineSkinResponse> result = api.genSkinInternal(IMAGE_URL, SkinVariant.CLASSIC);
+
+            assertTrue(result.isPresent());
+            assertEquals(FIXTURE_TEXTURE_VALUE, result.get().property().getOriginalProperty().getValue());
+            assertEquals(FIXTURE_SIGNATURE, result.get().property().getOriginalProperty().getSignature());
+            assertEquals("c891dfac-4cd2-47a2-a557-43e7e82ce76f", result.get().mineSkinId());
+        }
+
+        @Test
+        @DisplayName("200 OK V2 body with empty texture -> empty (no result)")
+        void emptyTexture() throws Exception {
+            httpClient.addResponse(MINESKIN_URI, 200, fixture("v2-200-empty-texture.json"));
+
+            Optional<MineSkinResponse> result = api.genSkinInternal(IMAGE_URL, SkinVariant.CLASSIC);
+
+            assertFalse(result.isPresent());
+        }
+
+        @Test
+        @DisplayName("429 V2 rateLimit.next -> recorded waitMs from relative delay")
+        void rateLimit() throws Exception {
+            long before = SkinMetrics.INSTANCE.snapshot().mineSkinDelayTotalMs();
+            httpClient.addResponse(MINESKIN_URI, 429, fixture("v2-429-ratelimit.json"));
+
+            Optional<MineSkinResponse> result = api.genSkinInternal(IMAGE_URL, SkinVariant.CLASSIC);
+
+            assertFalse(result.isPresent());
+            long recorded = SkinMetrics.INSTANCE.snapshot().mineSkinDelayTotalMs() - before;
+            assertEquals(250, recorded);
+        }
+    }
+
+    /* ================================================================== */
     /*  JSON body helpers                                                  */
     /* ================================================================== */
 

--- a/src/test/resources/fixtures/mineskin/v1-200-empty-texture.json
+++ b/src/test/resources/fixtures/mineskin/v1-200-empty-texture.json
@@ -1,0 +1,23 @@
+{
+  "id": 12346,
+  "idStr": "12346",
+  "uuid": "550e8400-e29b-41d4-a716-446655440001",
+  "name": "Test",
+  "variant": "classic",
+  "data": {
+    "uuid": "550e8400-e29b-41d4-a716-446655440001",
+    "texture": {
+      "value": "",
+      "signature": "",
+      "url": ""
+    }
+  },
+  "timestamp": 1234567890,
+  "duration": 100,
+  "account": 1,
+  "server": "server1",
+  "private": false,
+  "views": 0,
+  "nextRequest": 0,
+  "duplicate": false
+}

--- a/src/test/resources/fixtures/mineskin/v1-200-valid.json
+++ b/src/test/resources/fixtures/mineskin/v1-200-valid.json
@@ -1,0 +1,23 @@
+{
+  "id": 12345,
+  "idStr": "12345",
+  "uuid": "550e8400-e29b-41d4-a716-446655440000",
+  "name": "Test",
+  "variant": "classic",
+  "data": {
+    "uuid": "550e8400-e29b-41d4-a716-446655440000",
+    "texture": {
+      "value": "eyJ0aW1lc3RhbXAiOjE3MzAwMDAwMDAwMDAsInByb2ZpbGVJZCI6IjU1MGU4NDAwZTI5YjQxZDRhNzE2NDQ2NjU1NDQwMDAwIiwicHJvZmlsZU5hbWUiOiJMZXZvc2lsaW1vIiwic2lnbmF0dXJlUmVxdWlyZWQiOnRydWUsInRleHR1cmVzIjp7IlNLSU4iOnsidXJsIjoiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS9hYmMxMjNkZWY0NTYifX19",
+      "signature": "TQLAykIrTfFeo4eO7uNx0aj4eCy0eR9qAAqXr8CWjZ9NAsDKQitN8V6jh47u43HRqPh4LLR5H2oACpevwJaNn00CwMpCK03xXqOHju7jcdGo+HgstHkfagAKl6/Alo2fTQLAykIrTfFeo4eO7uNx0aj4eCy0eR9qAAqXr8CWjZ9NAsDKQitN8V6jh47u43HRqPh4LLR5H2oACpevwJaNn00CwMpCK03xXqOHju7jcdGo+HgstHkfagAKl6/Alo2fTQLAykIrTfFeo4eO7uNx0aj4eCy0eR9qAAqXr8CWjZ9NAsDKQitN8V6jh47u43HRqPh4LLR5H2oACpevwJaNnw==",
+      "url": "http://textures.minecraft.net/texture/abc123def456"
+    }
+  },
+  "timestamp": 1234567890,
+  "duration": 100,
+  "account": 1,
+  "server": "server1",
+  "private": false,
+  "views": 0,
+  "nextRequest": 0,
+  "duplicate": false
+}

--- a/src/test/resources/fixtures/mineskin/v1-429-delay.json
+++ b/src/test/resources/fixtures/mineskin/v1-429-delay.json
@@ -1,0 +1,9 @@
+{
+  "error": "rate_limit",
+  "nextRequest": 0,
+  "delay": 1,
+  "delayInfo": {
+    "millis": 1000,
+    "seconds": 1
+  }
+}

--- a/src/test/resources/fixtures/mineskin/v2-200-empty-texture.json
+++ b/src/test/resources/fixtures/mineskin/v2-200-empty-texture.json
@@ -1,0 +1,53 @@
+{
+  "success": true,
+  "skin": {
+    "uuid": "c891dfac-4cd2-47a2-a557-43e7e82ce76f",
+    "name": "Test Skin",
+    "visibility": "public",
+    "variant": "classic",
+    "texture": {
+      "data": {
+        "value": "",
+        "signature": ""
+      },
+      "hash": {
+        "texture": ""
+      },
+      "url": {
+        "skin": ""
+      }
+    },
+    "generator": {
+      "name": "MineSkin",
+      "version": "2.0.0",
+      "build": 1,
+      "javaVersion": 21,
+      "server": "server1",
+      "duration": 100
+    },
+    "views": 1,
+    "duplicate": false
+  },
+  "rateLimit": {
+    "next": {
+      "absolute": 1750000000000,
+      "relative": 250
+    },
+    "delay": {
+      "millis": 1200,
+      "seconds": 1.2
+    },
+    "limit": {
+      "limit": 60,
+      "remaining": 59,
+      "used": 1,
+      "reset": 60
+    }
+  },
+  "messages": [
+    {
+      "code": "ok",
+      "message": "All good!"
+    }
+  ]
+}

--- a/src/test/resources/fixtures/mineskin/v2-200-valid.json
+++ b/src/test/resources/fixtures/mineskin/v2-200-valid.json
@@ -1,0 +1,63 @@
+{
+  "success": true,
+  "skin": {
+    "uuid": "c891dfac-4cd2-47a2-a557-43e7e82ce76f",
+    "name": "Test Skin",
+    "visibility": "public",
+    "variant": "classic",
+    "texture": {
+      "data": {
+        "value": "eyJ0aW1lc3RhbXAiOjE3MzAwMDAwMDAwMDAsInByb2ZpbGVJZCI6IjU1MGU4NDAwZTI5YjQxZDRhNzE2NDQ2NjU1NDQwMDAwIiwicHJvZmlsZU5hbWUiOiJMZXZvc2lsaW1vIiwic2lnbmF0dXJlUmVxdWlyZWQiOnRydWUsInRleHR1cmVzIjp7IlNLSU4iOnsidXJsIjoiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS9hYmMxMjNkZWY0NTYifX19",
+        "signature": "TQLAykIrTfFeo4eO7uNx0aj4eCy0eR9qAAqXr8CWjZ9NAsDKQitN8V6jh47u43HRqPh4LLR5H2oACpevwJaNn00CwMpCK03xXqOHju7jcdGo+HgstHkfagAKl6/Alo2fTQLAykIrTfFeo4eO7uNx0aj4eCy0eR9qAAqXr8CWjZ9NAsDKQitN8V6jh47u43HRqPh4LLR5H2oACpevwJaNn00CwMpCK03xXqOHju7jcdGo+HgstHkfagAKl6/Alo2fTQLAykIrTfFeo4eO7uNx0aj4eCy0eR9qAAqXr8CWjZ9NAsDKQitN8V6jh47u43HRqPh4LLR5H2oACpevwJaNnw=="
+      },
+      "hash": {
+        "texture": "abc123def456"
+      },
+      "url": {
+        "skin": "http://textures.minecraft.net/texture/abc123def456"
+      }
+    },
+    "generator": {
+      "name": "MineSkin",
+      "version": "2.0.0",
+      "build": 1,
+      "javaVersion": 21,
+      "server": "server1",
+      "duration": 100
+    },
+    "views": 1,
+    "duplicate": false
+  },
+  "rateLimit": {
+    "next": {
+      "absolute": 1750000000000,
+      "relative": 250
+    },
+    "delay": {
+      "millis": 1200,
+      "seconds": 1.2
+    },
+    "limit": {
+      "limit": 60,
+      "remaining": 59,
+      "used": 1,
+      "reset": 60
+    }
+  },
+  "usage": {
+    "credits": {
+      "used": 1,
+      "limit": 60
+    },
+    "metered": {
+      "used": 1,
+      "limit": 60
+    }
+  },
+  "messages": [
+    {
+      "code": "ok",
+      "message": "All good!"
+    }
+  ]
+}

--- a/src/test/resources/fixtures/mineskin/v2-429-ratelimit.json
+++ b/src/test/resources/fixtures/mineskin/v2-429-ratelimit.json
@@ -1,0 +1,25 @@
+{
+  "success": false,
+  "errors": [
+    {
+      "code": "rate_limit",
+      "message": "Too many requests"
+    }
+  ],
+  "rateLimit": {
+    "next": {
+      "absolute": 1750000000000,
+      "relative": 250
+    },
+    "delay": {
+      "millis": 1200,
+      "seconds": 1.2
+    },
+    "limit": {
+      "limit": 60,
+      "remaining": 0,
+      "used": 60,
+      "reset": 60
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Contract tests for the MineSkin integration on the mc1.12.2 branch, plus the V2 parsing fallback that makes the V2 fixtures pass. Mirrors the 1.21 PR.

## What the tests cover

- **V1 fixtures parse** — legacy MineSkin V1 API responses decode correctly.
- **V2 fixtures parse via Gson JsonObject fallback** — V2 API responses are parsed with the Gson `JsonObject` fallback path.
- **V2 429 waitMs** — parsed from `rateLimit.next.relative` / `rateLimit.next.absolute`.
- **Config-warning tests** — 401 / 403 / 404 with an empty key produce the expected config-warning result.

## RED-on-old evidence

- V2 200 valid response -> empty result (pre-fix behavior).
- V2 429 -> `waitMs` 0 (pre-fix behavior).

## Results (mc1.12.2)

- **398 tests = 387 + 11 new**, all green.
- 0 relaxed tests.
- aislop **100/100**.