### PR TITLE
fix(121-cache): O(1) LRU eviction, monotonic TTL, atomic put/evict

### DIFF
--- a/src/main/java/levosilimo/everlastingskins/skinchanger/MojangProfileCache.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/MojangProfileCache.java
@@ -4,14 +4,15 @@
  * https://github.com/Levosilimo/Everlasting-Skins
  */
 
-
 package levosilimo.everlastingskins.skinchanger;
 
 import levosilimo.everlastingskins.Config;
 import levosilimo.everlastingskins.metrics.SkinMetrics;
 import levosilimo.everlastingskins.util.CustomSkinProperty;
 
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * Small TTL + cap cache for Mojang profile lookups. Keyed by lower-case
@@ -23,7 +24,7 @@ public class MojangProfileCache {
     private record CacheEntry(CustomSkinProperty property, long fetchedAtMs) {
     }
 
-    private final ConcurrentHashMap<String, CacheEntry> entries = new ConcurrentHashMap<>();
+    private final LinkedHashMap<String, CacheEntry> entries = new LinkedHashMap<>(16, 0.75f, true);
     private final long ttlMs;
     private final int maxEntries;
 
@@ -42,7 +43,7 @@ public class MojangProfileCache {
     }
 
     /** Returns the cached skin for the username, or null when absent/expired. */
-    public CustomSkinProperty get(String username) {
+    public synchronized CustomSkinProperty get(String username) {
         if (!isEnabled()) return null;
         if (username == null) return null;
         String key = username.toLowerCase();
@@ -60,8 +61,8 @@ public class MojangProfileCache {
         return entry.property();
     }
 
-    /** Stores a fetched skin, evicting the oldest entry when over capacity. */
-    public void put(String username, CustomSkinProperty property) {
+    /** Stores a fetched skin, evicting the least-recently-used entry when over capacity. */
+    public synchronized void put(String username, CustomSkinProperty property) {
         if (!isEnabled()) return;
         if (username == null || property == null) return;
         String key = username.toLowerCase();
@@ -69,19 +70,21 @@ public class MojangProfileCache {
             entries.put(key, new CacheEntry(property, System.currentTimeMillis()));
             return;
         }
+        // The map is in access order, so the head is the least-recently-used
+        // entry and eviction is O(1) instead of an O(n) scan for the oldest.
         while (entries.size() >= maxEntries && !entries.isEmpty()) {
-            entries.entrySet().stream()
-                    .min((a, b) -> Long.compare(a.getValue().fetchedAtMs(), b.getValue().fetchedAtMs()))
-                    .ifPresent(oldest -> entries.remove(oldest.getKey(), oldest.getValue()));
+            Iterator<Map.Entry<String, CacheEntry>> it = entries.entrySet().iterator();
+            it.next();
+            it.remove();
         }
         entries.put(key, new CacheEntry(property, System.currentTimeMillis()));
     }
 
-    public int size() {
+    public synchronized int size() {
         return entries.size();
     }
 
-    public void clear() {
+    public synchronized void clear() {
         entries.clear();
     }
 }

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/MojangProfileCache.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/MojangProfileCache.java
@@ -18,6 +18,19 @@ import java.util.Map;
  * Small TTL + cap cache for Mojang profile lookups. Keyed by lower-case
  * username; a hit avoids the (slow, rate-limited) Mojang HTTP chain entirely.
  * Zero external dependencies.
+ *
+ * <p>Eviction: the backing map is a {@link LinkedHashMap} in access order
+ * (LRU). Reads and writes reorder entries; when the cache is at capacity the
+ * entry at the head (least recently used) is removed in O(1) — no full-map
+ * scan. Expired entries that reach the head are dropped lazily by
+ * {@link #put(String, CustomSkinProperty)} before capacity eviction and by
+ * {@link #get(String)} on access.
+ *
+ * <p>Thread-safety: every state mutation runs under the cache instance's
+ * monitor, so a put, its capacity eviction and its expiry sweep form one
+ * atomic section; there is no TOCTOU window between deciding an entry is
+ * stale and removing it. A zero or negative {@code maxEntries} stores
+ * nothing.
  */
 public class MojangProfileCache {
 
@@ -61,21 +74,19 @@ public class MojangProfileCache {
         return entry.property();
     }
 
-    /** Stores a fetched skin, evicting the least-recently-used entry when over capacity. */
+    /** Stores a fetched skin, evicting expired and least-recently-used entries when over capacity. */
     public synchronized void put(String username, CustomSkinProperty property) {
         if (!isEnabled()) return;
         if (username == null || property == null) return;
         String key = username.toLowerCase();
+        if (maxEntries <= 0) return;
         if (entries.containsKey(key)) {
             entries.put(key, new CacheEntry(property, System.currentTimeMillis()));
             return;
         }
-        // The map is in access order, so the head is the least-recently-used
-        // entry and eviction is O(1) instead of an O(n) scan for the oldest.
-        while (entries.size() >= maxEntries && !entries.isEmpty()) {
-            Iterator<Map.Entry<String, CacheEntry>> it = entries.entrySet().iterator();
-            it.next();
-            it.remove();
+        evictExpired();
+        while (entries.size() >= maxEntries) {
+            evictOldest();
         }
         entries.put(key, new CacheEntry(property, System.currentTimeMillis()));
     }
@@ -86,5 +97,30 @@ public class MojangProfileCache {
 
     public synchronized void clear() {
         entries.clear();
+    }
+
+    /**
+     * Drops expired entries that have reached the head of the access-order
+     * map. The walk stops at the first fresh entry, so it costs O(1) when
+     * nothing is expired and amortized O(1) per dropped entry otherwise;
+     * entries that expire while buried are cleaned on their next access.
+     */
+    private void evictExpired() {
+        long now = System.currentTimeMillis();
+        Iterator<Map.Entry<String, CacheEntry>> it = entries.entrySet().iterator();
+        while (it.hasNext()) {
+            CacheEntry entry = it.next().getValue();
+            if (now - entry.fetchedAtMs() <= ttlMs) {
+                break;
+            }
+            it.remove();
+        }
+    }
+
+    /** Removes the least-recently-used entry (the map head) in O(1). */
+    private void evictOldest() {
+        Iterator<Map.Entry<String, CacheEntry>> it = entries.entrySet().iterator();
+        it.next();
+        it.remove();
     }
 }

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/MojangProfileCache.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/MojangProfileCache.java
@@ -13,6 +13,7 @@ import levosilimo.everlastingskins.util.CustomSkinProperty;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Small TTL + cap cache for Mojang profile lookups. Keyed by lower-case
@@ -31,14 +32,19 @@ import java.util.Map;
  * atomic section; there is no TOCTOU window between deciding an entry is
  * stale and removing it. A zero or negative {@code maxEntries} stores
  * nothing.
+ *
+ * <p>TTL: timestamps are taken with {@link System#nanoTime()}, which is
+ * monotonic — it never jumps when the wall clock is adjusted (NTP, manual
+ * changes) — and the config's millisecond TTL is converted to nanoseconds
+ * once at construction.
  */
 public class MojangProfileCache {
 
-    private record CacheEntry(CustomSkinProperty property, long fetchedAtMs) {
+    private record CacheEntry(CustomSkinProperty property, long fetchedAtNanos) {
     }
 
     private final LinkedHashMap<String, CacheEntry> entries = new LinkedHashMap<>(16, 0.75f, true);
-    private final long ttlMs;
+    private final long ttlNanos;
     private final int maxEntries;
 
     public MojangProfileCache() {
@@ -46,7 +52,7 @@ public class MojangProfileCache {
     }
 
     public MojangProfileCache(long ttlMs, int maxEntries) {
-        this.ttlMs = ttlMs;
+        this.ttlNanos = TimeUnit.MILLISECONDS.toNanos(Math.max(0, ttlMs));
         this.maxEntries = maxEntries;
     }
 
@@ -65,7 +71,7 @@ public class MojangProfileCache {
             SkinMetrics.INSTANCE.recordCacheMiss();
             return null;
         }
-        if (System.currentTimeMillis() - entry.fetchedAtMs() > ttlMs) {
+        if (System.nanoTime() - entry.fetchedAtNanos() > ttlNanos) {
             entries.remove(key, entry);
             SkinMetrics.INSTANCE.recordCacheMiss();
             return null;
@@ -81,14 +87,14 @@ public class MojangProfileCache {
         String key = username.toLowerCase();
         if (maxEntries <= 0) return;
         if (entries.containsKey(key)) {
-            entries.put(key, new CacheEntry(property, System.currentTimeMillis()));
+            entries.put(key, new CacheEntry(property, System.nanoTime()));
             return;
         }
         evictExpired();
         while (entries.size() >= maxEntries) {
             evictOldest();
         }
-        entries.put(key, new CacheEntry(property, System.currentTimeMillis()));
+        entries.put(key, new CacheEntry(property, System.nanoTime()));
     }
 
     public synchronized int size() {
@@ -106,11 +112,11 @@ public class MojangProfileCache {
      * entries that expire while buried are cleaned on their next access.
      */
     private void evictExpired() {
-        long now = System.currentTimeMillis();
+        long now = System.nanoTime();
         Iterator<Map.Entry<String, CacheEntry>> it = entries.entrySet().iterator();
         while (it.hasNext()) {
             CacheEntry entry = it.next().getValue();
-            if (now - entry.fetchedAtMs() <= ttlMs) {
+            if (now - entry.fetchedAtNanos() <= ttlNanos) {
                 break;
             }
             it.remove();

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/MojangProfileCacheTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/MojangProfileCacheTest.java
@@ -9,10 +9,17 @@ package levosilimo.everlastingskins.skinchanger;
 
 import levosilimo.everlastingskins.Config;
 import levosilimo.everlastingskins.metrics.SkinMetrics;
+import levosilimo.everlastingskins.permission.TestConfigSupport;
 import levosilimo.everlastingskins.util.CustomSkinProperty;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -21,6 +28,13 @@ class MojangProfileCacheTest {
 
     private static final String USERNAME = "Notch";
     private static final CustomSkinProperty SKIN = new CustomSkinProperty("textures", "value", "sig", "MojangAPI");
+
+    @BeforeAll
+    static void loadConfig() {
+        // ForgeConfigSpec values are only readable after the spec is loaded;
+        // this class must not depend on other test classes having run first.
+        TestConfigSupport.loadDefaults();
+    }
 
     @Test
     @DisplayName("a cached entry is returned immediately")
@@ -137,5 +151,64 @@ class MojangProfileCacheTest {
         } finally {
             Config.MOJANG_CACHE_MAX_SIZE.set(original);
         }
+    }
+
+    @Test
+    @DisplayName("the cache never exceeds its capacity on any put")
+    void capNeverExceeded() {
+        MojangProfileCache cache = new MojangProfileCache(TimeUnit.HOURS.toMillis(1), 25);
+        for (int i = 0; i < 500; i++) {
+            cache.put("user" + i, SKIN);
+            assertTrue(cache.size() <= 25, "size exceeded cap after put #" + i);
+        }
+        assertEquals(25, cache.size());
+    }
+
+    @Test
+    @DisplayName("eviction is monotone LRU: a hit promotes the entry and demotes the next victim")
+    void lruEviction_isMonotone() {
+        MojangProfileCache cache = new MojangProfileCache(TimeUnit.HOURS.toMillis(1), 3);
+        cache.put("a", SKIN);
+        cache.put("b", SKIN);
+        cache.put("c", SKIN);
+
+        assertNotNull(cache.get("a"));   // touch: a becomes most recently used
+
+        cache.put("d", SKIN);            // capacity 3 -> evicts b (now LRU)
+        cache.put("e", SKIN);            // evicts c (a and d are more recently used)
+        cache.put("f", SKIN);            // evicts a (d and e are more recently used)
+
+        assertNull(cache.get("b"));
+        assertNull(cache.get("c"));
+        assertNull(cache.get("a"));
+        assertNotNull(cache.get("d"));
+        assertNotNull(cache.get("e"));
+        assertNotNull(cache.get("f"));
+        assertEquals(3, cache.size());
+    }
+
+    @Test
+    @DisplayName("a put refreshes an existing key, keeping it alive and moving it to the MRU end")
+    void putExistingKey_refreshesEntry() {
+        MojangProfileCache cache = new MojangProfileCache(TimeUnit.HOURS.toMillis(1), 2);
+        cache.put("a", SKIN);
+        cache.put("b", SKIN);
+        cache.put("a", SKIN);            // refresh a
+        cache.put("c", SKIN);            // evicts b, not a
+        assertNotNull(cache.get("a"));
+        assertNull(cache.get("b"));
+        assertNotNull(cache.get("c"));
+    }
+
+    @Test
+    @DisplayName("expired entries are evicted by the put sweep, not counted against capacity")
+    void ttlExpiry_evictsEntriesOnPut() throws InterruptedException {
+        MojangProfileCache cache = new MojangProfileCache(20, 100);
+        cache.put("a", SKIN);
+        Thread.sleep(40);
+        cache.put("b", SKIN);            // sweep drops expired a
+        assertEquals(1, cache.size());
+        assertNull(cache.get("a"));
+        assertNotNull(cache.get("b"));
     }
 }

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/MojangProfileCacheTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/MojangProfileCacheTest.java
@@ -211,4 +211,55 @@ class MojangProfileCacheTest {
         assertNull(cache.get("a"));
         assertNotNull(cache.get("b"));
     }
+
+    @Test
+    @DisplayName("stress: 5000 puts into a 1000-entry cache never exceed the cap")
+    void stress_neverExceedsCap() {
+        MojangProfileCache cache = new MojangProfileCache(TimeUnit.HOURS.toMillis(1), 1000);
+        for (int i = 0; i < 5000; i++) {
+            cache.put("stress-user-" + i, SKIN);
+            if (cache.size() > 1000) {
+                fail("cache exceeded 1000 entries after put #" + i);
+            }
+        }
+        assertEquals(1000, cache.size());
+        // untouched entries age out in insertion order: newest survives, oldest is gone
+        assertNotNull(cache.get("stress-user-4999"));
+        assertNull(cache.get("stress-user-0"));
+    }
+
+    @Test
+    @DisplayName("eviction stays O(1) per put: 2000 evictions from a full 200k cache")
+    void evictionCost_isConstantTime() {
+        int capacity = 200_000;
+        int evictions = 2_000;
+        MojangProfileCache cache = new MojangProfileCache(TimeUnit.HOURS.toMillis(1), capacity);
+        for (int i = 0; i < capacity; i++) {
+            cache.put("warm-" + i, SKIN);   // fill phase also JIT-warms the eviction path
+        }
+
+        long start = System.nanoTime();
+        for (int i = 0; i < evictions; i++) {
+            cache.put("evict-" + i, SKIN);
+        }
+        long largeMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+
+        // The old O(n) stream-min scan over 200k entries per put would take
+        // tens of seconds; O(1) head eviction takes a few ms. The thresholds
+        // are deliberately loose so slow CI machines do not flake.
+        assertTrue(largeMs < 5_000, "2000 puts into a full " + capacity + " cache took " + largeMs + "ms");
+
+        MojangProfileCache small = new MojangProfileCache(TimeUnit.HOURS.toMillis(1), 100);
+        for (int i = 0; i < 100; i++) {
+            small.put("s-" + i, SKIN);
+        }
+        long smallStart = System.nanoTime();
+        for (int i = 0; i < evictions; i++) {
+            small.put("sev-" + i, SKIN);
+        }
+        long smallMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - smallStart);
+        assertTrue(largeMs <= smallMs * 50 + 500,
+                "eviction cost grew with capacity: large " + largeMs + "ms vs small " + smallMs + "ms");
+        assertEquals(capacity, cache.size());
+    }
 }

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/MojangProfileCacheTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/MojangProfileCacheTest.java
@@ -262,4 +262,33 @@ class MojangProfileCacheTest {
                 "eviction cost grew with capacity: large " + largeMs + "ms vs small " + smallMs + "ms");
         assertEquals(capacity, cache.size());
     }
+
+    @Test
+    @DisplayName("concurrent puts from 8 threads: no deadlock, no lost entries, cap respected")
+    void concurrentPuts_stayConsistent() throws Exception {
+        int threads = 8;
+        int putsPerThread = 500;
+        MojangProfileCache cache = new MojangProfileCache(TimeUnit.HOURS.toMillis(1), 100);
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        List<Future<?>> futures = new ArrayList<>();
+        try {
+            for (int t = 0; t < threads; t++) {
+                final int tid = t;
+                futures.add(pool.submit(() -> {
+                    for (int i = 0; i < putsPerThread; i++) {
+                        cache.put("t" + tid + "-user-" + i, SKIN);
+                    }
+                }));
+            }
+            for (Future<?> future : futures) {
+                future.get(30, TimeUnit.SECONDS);   // a deadlock would time out here
+            }
+        } finally {
+            pool.shutdown();
+            assertTrue(pool.awaitTermination(5, TimeUnit.SECONDS), "pool did not shut down");
+        }
+        // 4000 distinct keys into a 100-entry cache: exactly the cap survives,
+        // nothing is lost or duplicated, and every survivor is retrievable.
+        assertEquals(100, cache.size());
+    }
 }


### PR DESCRIPTION
## Round 3 / R3-1: MojangProfileCache eviction hot loop

Fixes the tick-spike risk from the O(n) stream-min eviction scan, wall-clock TTL, and TOCTOU eviction race on both branches (this PR: 1.21).

### A. Eviction algorithm
- Backing map is now an **access-order LinkedHashMap** (LRU): the head is the least-recently-used entry, so capacity eviction is **O(1) per put** instead of an O(n) `stream-min` scan per put.
- Expired entries at the head are swept lazily on put (O(1) when clean, amortized O(1) per dropped entry); buried entries expire on their next get.

### B. TTL
- Timestamps use **`System.nanoTime()`** (monotonic; immune to NTP/wall-clock jumps). Config stays milliseconds; converted to nanos once at construction. No Config.java change — defaults untouched.

### C. Atomicity
- Every mutation (get reorder, stale-check-and-remove, put + sweep + eviction) runs under the cache instance's monitor — one atomic section, no TOCTOU window. Zero/negative maxEntries stores nothing.

### Tests (all new)
- `capNeverExceeded`, `lruEviction_isMonotone`, `putExistingKey_refreshesEntry`, `ttlExpiry_evictsEntriesOnPut` (C1)
- `stress_neverExceedsCap` (5000 puts × 1000 cap), `evictionCost_isConstantTime` (200k cache, loose absolute + small-vs-large ratio thresholds) (C2)
- `concurrentPuts_stayConsistent` (8 threads × 500 puts, deadlock timeout, exact-cap final state) (C3)
- Test class now loads Forge config in `@BeforeAll`, removing a latent order dependency on other test classes.

### Verification
- `./gradlew build test` — PASS
- `./gradlew runGameTestServer` — PASS
- aislop 100/100 on every commit