### PR TITLE
fix(1.21): atomic cascade persistence in SkinRefreshHandler (R3-3)

### DIFF
--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRefreshHandler.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRefreshHandler.java
@@ -7,6 +7,7 @@
 
 package levosilimo.everlastingskins.skinchanger;
 
+import com.mojang.authlib.GameProfile;
 import io.netty.buffer.Unpooled;
 import levosilimo.everlastingskins.Config;
 import levosilimo.everlastingskins.EverlastingSkins;
@@ -55,22 +56,31 @@ public class SkinRefreshHandler {
             // observers re-learn the profile and rebuild the target's own view.
             // Without this, /skin clear with no Mojang profile left the applied
             // profile showing the old texture while storage said "cleared".
-            mutateProfileCleared(player);
+            mutateProfileCleared(player.getGameProfile());
             recordObserverBroadcast(player, null);
             recordCascade(player);
             return;
         }
         long tStart = System.nanoTime();
-        try {
-            mutateProfile(player, skin);
-            recordSaveEnqueue(player);
-            recordObserverBroadcast(player, skin);
-            recordCascade(player);
-        } catch (Throwable t) {
-            // Fail soft: a partial cascade (profile mutated, observers stale)
-            // must not abort scheduled-task execution or the server tick.
-            EverlastingSkins.logger.error("Skin refresh failed for {}", player.getUUID(), t);
-            SkinMetrics.INSTANCE.recordRefreshFailed(player.getUUID());
+        // Atomicity invariant (R3): persistence is enqueued before the
+        // GameProfile is mutated. recordSaveEnqueue captures the stored skin
+        // synchronously (saveSkinAsync serializes the in-memory map entry at
+        // enqueue time), so when the enqueue throws, the applied profile is
+        // left untouched and in-memory and on-disk state still agree — a
+        // mutated profile with no persisted skin would silently revert on the
+        // next server restart. applyAtomicPersistence records the failure
+        // metric itself; broadcast/cascade only run after it succeeded.
+        if (applyAtomicPersistence(player.getUUID(), player.getGameProfile(), skin)) {
+            try {
+                recordObserverBroadcast(player, skin);
+                recordCascade(player);
+            } catch (Throwable t) {
+                // Fail soft: a partial cascade (profile and disk hold the new
+                // skin, observers stale) must not abort scheduled-task
+                // execution or the server tick.
+                EverlastingSkins.logger.error("Skin refresh failed for {}", player.getUUID(), t);
+                SkinMetrics.INSTANCE.recordRefreshFailed(player.getUUID());
+            }
         }
         long totalNanos = System.nanoTime() - tStart;
         if (totalNanos > TICK_SPIKE_THRESHOLD_NANOS) {
@@ -81,24 +91,48 @@ public class SkinRefreshHandler {
         SkinMetrics.INSTANCE.recordTaskDuration(totalNanos);
     }
 
-    private static void mutateProfile(ServerPlayer player, CustomSkinProperty skin) {
-        player.getGameProfile().getProperties().removeAll("textures");
-        player.getGameProfile().getProperties().put("textures", skin.getOriginalProperty());
+    /**
+     * Atomic persistence + profile mutation (R3 invariant): enqueues the disk
+     * flush and only then applies the skin to the GameProfile. The enqueue
+     * captures the stored skin synchronously (saveSkinAsync serializes the
+     * in-memory map entry at enqueue time), so when it throws, the profile is
+     * left untouched: applied and on-disk state stay consistent and the
+     * change cannot silently revert on the next server restart. Any failure
+     * is logged, counted as a partial-cascade failure, and reported via the
+     * return value so the caller can skip the observer broadcast/cascade.
+     * Test-visible: the invariant is exercised directly by
+     * SkinRefreshHandlerTest without a ServerPlayer.
+     */
+    static boolean applyAtomicPersistence(UUID playerId, GameProfile profile, CustomSkinProperty skin) {
+        try {
+            recordSaveEnqueue(playerId);
+        } catch (Throwable t) {
+            EverlastingSkins.logger.error("Skin refresh failed for {}", playerId, t);
+            SkinMetrics.INSTANCE.recordRefreshFailed(playerId);
+            return false;
+        }
+        mutateProfile(profile, skin);
+        return true;
+    }
+
+    private static void mutateProfile(GameProfile profile, CustomSkinProperty skin) {
+        profile.getProperties().removeAll("textures");
+        profile.getProperties().put("textures", skin.getOriginalProperty());
         EverlastingSkins.logger.info("SKIN_REFRESH: profile={}, property={}",
-                player.getGameProfile().getName(),
-                player.getGameProfile().getProperties().get("textures"));
+                profile.getName(),
+                profile.getProperties().get("textures"));
     }
 
-    private static void mutateProfileCleared(ServerPlayer player) {
-        player.getGameProfile().getProperties().removeAll("textures");
+    private static void mutateProfileCleared(GameProfile profile) {
+        profile.getProperties().removeAll("textures");
         EverlastingSkins.logger.info("SKIN_REFRESH: profile={}, property={} (cleared)",
-                player.getGameProfile().getName(),
-                player.getGameProfile().getProperties().get("textures"));
+                profile.getName(),
+                profile.getProperties().get("textures"));
     }
 
-    private static void recordSaveEnqueue(ServerPlayer player) {
+    private static void recordSaveEnqueue(UUID playerId) {
         long start = System.nanoTime();
-        SkinRestorer.getSkinStorage().saveSkinAsync(player.getUUID());
+        SkinRestorer.getSkinStorage().saveSkinAsync(playerId);
         long enqueueNanos = System.nanoTime() - start;
         SkinMetrics.INSTANCE.recordSaveEnqueueLatency(enqueueNanos);
         SkinMetrics.INSTANCE.recordSpikeSaveEnqueue(enqueueNanos);

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/SkinRefreshHandlerTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/SkinRefreshHandlerTest.java
@@ -1,0 +1,144 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import com.mojang.authlib.GameProfile;
+import com.mojang.authlib.properties.Property;
+import levosilimo.everlastingskins.metrics.SkinMetrics;
+import levosilimo.everlastingskins.permission.TestConfigSupport;
+import levosilimo.everlastingskins.util.CustomSkinProperty;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Cascade atomicity invariant (R3): the disk flush must be enqueued BEFORE
+ * the GameProfile is mutated, so a failed enqueue leaves the applied profile
+ * untouched — applied and on-disk skin stay consistent and the change cannot
+ * silently revert on the next server restart. The invariant lives in
+ * {@link SkinRefreshHandler#applyAtomicPersistence} so it is unit-testable
+ * without a ServerPlayer (1.21 entity classes need the FML runtime).
+ */
+class SkinRefreshHandlerTest {
+
+    private static final UUID PLAYER_UUID = UUID.randomUUID();
+    private static final Property OLD_PROPERTY = new Property("textures", "oldValue", "oldSignature");
+    private static final CustomSkinProperty NEW_SKIN =
+            new CustomSkinProperty("textures", "newValue", "newSignature", "MojangAPI");
+
+    @TempDir
+    Path tempDir;
+
+    private SkinIO skinIO;
+    private SkinStorage storage;
+
+    @BeforeAll
+    static void loadConfig() {
+        TestConfigSupport.loadDefaults();
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        Path skinDir = tempDir.resolve("EverlastingSkins");
+        Files.createDirectories(skinDir);
+        skinIO = new SkinIO(skinDir);
+        storage = new SkinStorage(skinIO);
+        setStaticField(SkinRestorer.class, "skinStorage", storage);
+        SkinRestorer.server = null;
+        SkinMetrics.INSTANCE.reset();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        skinIO.flushPending();
+        setStaticField(SkinRestorer.class, "skinStorage", null);
+        SkinRestorer.server = null;
+    }
+
+    private static void setStaticField(Class<?> clazz, String name, Object value) throws Exception {
+        Field field = clazz.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(null, value);
+    }
+
+    private static GameProfile profileWithTextures(Property textures) {
+        GameProfile profile = new GameProfile(PLAYER_UUID, "Alice");
+        profile.getProperties().put("textures", textures);
+        return profile;
+    }
+
+    private static Collection<Property> texturesOf(GameProfile profile) {
+        return profile.getProperties().get("textures");
+    }
+
+    @Test
+    @DisplayName("saveSkinAsync failure leaves the applied GameProfile textures untouched")
+    void saveSkinAsyncFailure_leavesProfileUntouched() throws Exception {
+        GameProfile profile = profileWithTextures(OLD_PROPERTY);
+        SkinStorage failing = mock(SkinStorage.class);
+        when(failing.getSkin(any(UUID.class))).thenReturn(NEW_SKIN);
+        doThrow(new RuntimeException("simulated disk enqueue failure"))
+                .when(failing).saveSkinAsync(any(UUID.class));
+        setStaticField(SkinRestorer.class, "skinStorage", failing);
+
+        long failedBefore = SkinMetrics.INSTANCE.snapshot().refreshesFailed();
+        long savesBefore = SkinMetrics.INSTANCE.snapshot().savesSubmitted();
+
+        boolean persisted = SkinRefreshHandler.applyAtomicPersistence(PLAYER_UUID, profile, NEW_SKIN);
+
+        assertFalse(persisted, "a failed enqueue must report failure");
+        Collection<Property> textures = texturesOf(profile);
+        assertEquals(1, textures.size(), "a failed save must not mutate the profile");
+        assertEquals(OLD_PROPERTY, textures.iterator().next(),
+                "the applied profile must keep the previous textures when persistence fails");
+        assertEquals(failedBefore + 1, SkinMetrics.INSTANCE.snapshot().refreshesFailed(),
+                "the partial cascade failure must be recorded");
+        assertEquals(savesBefore, SkinMetrics.INSTANCE.snapshot().savesSubmitted(),
+                "a failed enqueue must not count as a submitted save");
+    }
+
+    @Test
+    @DisplayName("successful save applies the stored skin to the GameProfile")
+    void saveSkinAsyncSuccess_appliesStoredSkin() throws Exception {
+        GameProfile profile = profileWithTextures(OLD_PROPERTY);
+        storage.setSkin(PLAYER_UUID, NEW_SKIN);
+
+        long failedBefore = SkinMetrics.INSTANCE.snapshot().refreshesFailed();
+        long savesBefore = SkinMetrics.INSTANCE.snapshot().savesSubmitted();
+
+        boolean persisted = SkinRefreshHandler.applyAtomicPersistence(PLAYER_UUID, profile, NEW_SKIN);
+        skinIO.flushPending();
+
+        assertTrue(persisted, "a successful enqueue must report success");
+        Collection<Property> textures = texturesOf(profile);
+        assertEquals(1, textures.size());
+        assertEquals(NEW_SKIN.getOriginalProperty(), textures.iterator().next(),
+                "the applied profile must match the saved skin value");
+        assertEquals(failedBefore, SkinMetrics.INSTANCE.snapshot().refreshesFailed(),
+                "a successful refresh must not record a failure");
+        assertEquals(savesBefore + 1, SkinMetrics.INSTANCE.snapshot().savesSubmitted(),
+                "the cascade must enqueue exactly one save");
+    }
+}

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/SkinRefreshHandlerTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/SkinRefreshHandlerTest.java
@@ -141,4 +141,22 @@ class SkinRefreshHandlerTest {
         assertEquals(savesBefore + 1, SkinMetrics.INSTANCE.snapshot().savesSubmitted(),
                 "the cascade must enqueue exactly one save");
     }
+
+    @Test
+    @DisplayName("restart equivalence: after the cascade the on-disk skin equals the in-memory skin")
+    void afterCascade_ondiskSkinEqualsInMemorySkin() throws Exception {
+        GameProfile profile = new GameProfile(PLAYER_UUID, "Alice");
+        storage.setSkin(PLAYER_UUID, NEW_SKIN);
+
+        boolean persisted = SkinRefreshHandler.applyAtomicPersistence(PLAYER_UUID, profile, NEW_SKIN);
+        skinIO.flushPending();
+
+        assertTrue(persisted, "the cascade must report success");
+        CustomSkinProperty fromDisk = skinIO.loadSkin(PLAYER_UUID);
+        assertNotNull(fromDisk, "the cascade must have persisted the skin to disk");
+        assertEquals(NEW_SKIN, fromDisk,
+                "the on-disk skin after the cascade must equal the stored in-memory skin");
+        assertEquals(storage.getSkin(PLAYER_UUID), fromDisk,
+                "a restart reloading from disk must reproduce the in-memory skin");
+    }
 }


### PR DESCRIPTION
## R3-3: Partial cascade persistence fix — 1.21

**Bug**: `SkinRefreshHandler.task()` mutated the GameProfile (`mutateProfile`) BEFORE enqueuing persistence (`recordSaveEnqueue` → `saveSkinAsync`). A `catch (Throwable)` between the steps swallowed a save failure and only recorded a metric — the in-memory skin then silently reverted on the next server restart.

**Fix**: persistence is now enqueued first; the GameProfile is mutated only after the enqueue succeeded. `saveSkinAsync` captures the stored skin synchronously (serializes the in-memory map entry at enqueue time), so enqueue-first makes the persistence+mutation pair atomic. The atomic pair lives in the test-visible `applyAtomicPersistence(UUID, GameProfile, CustomSkinProperty)` seam (1.21 entity classes need the FML runtime, so the invariant is tested without a `ServerPlayer`).

**Commits**:
- `c9caac5` fix(121): persist before mutating the GameProfile in SkinRefreshHandler
- `6500df5` test(121): cascade atomicity rollback and metric tests
- `157921b` test(121): restart-equivalence test for the cascade

**Verification**: `./gradlew build test` ✓ · `./gradlew runGameTestServer` ✓ (34/34) · aislop 100/100 on every commit (pre-commit hook, no --no-verify)