### PR TITLE
fix(1.12.2): atomic cascade persistence in SkinRefreshTask (R3-3)

### DIFF
--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRefreshTask.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRefreshTask.java
@@ -27,9 +27,11 @@ import net.minecraft.world.WorldServer;
 import java.io.IOException;
 
 /**
- * Server-tick half of a skin change: mutates the GameProfile, forces every
- * viewer to re-read it, and enqueues the async disk flush. Runs on the main
- * thread via {@code addScheduledTask} so packet sends are thread-safe.
+ * Server-tick half of a skin change: enqueues the async disk flush, mutates
+ * the GameProfile, and forces every viewer to re-read it. The flush is
+ * enqueued before the mutation so a failed enqueue leaves the applied
+ * profile untouched (applied and on-disk state stay consistent). Runs on the
+ * main thread via {@code addScheduledTask} so packet sends are thread-safe.
  */
 final class SkinRefreshTask {
 
@@ -73,6 +75,17 @@ final class SkinRefreshTask {
 
     private static void cascade(EntityPlayerMP target, CustomSkinProperty property, long startNanos,
             long fetchNanos) {
+        // Atomicity invariant: the disk flush is enqueued BEFORE the
+        // GameProfile is mutated. saveSkinAsync serializes the property
+        // synchronously, so when the enqueue throws, the applied profile is
+        // left untouched and in-memory and on-disk state still agree — a
+        // mutated profile with no persisted skin would silently revert on the
+        // next server restart. The in-memory map was already updated by the
+        // caller; the flush itself runs off-tick.
+        long saveStartNanos = System.nanoTime();
+        SkinRestorer.getSkinStorage().saveSkinAsync(target.getUniqueID(), property);
+        long saveNanos = System.nanoTime() - saveStartNanos;
+
         // GameProfile mutation is what every client ultimately reads textures from.
         mutateProfile(target, property);
 
@@ -81,11 +94,6 @@ final class SkinRefreshTask {
 
         // Respawn in the same dimension so the target's own view refreshes without an inventory wipe.
         respawnSelf(target);
-
-        // In-memory map already updated by the caller; disk flush is off-tick.
-        long saveStartNanos = System.nanoTime();
-        SkinRestorer.getSkinStorage().saveSkinAsync(target.getUniqueID(), property);
-        long saveNanos = System.nanoTime() - saveStartNanos;
 
         SkinMetrics.INSTANCE.recordRefreshCompleted(
             target.getUniqueID(), startNanos, fetchNanos, saveNanos, broadcastNanos);

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/SkinRefreshTaskTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/SkinRefreshTaskTest.java
@@ -1,0 +1,122 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import com.mojang.authlib.properties.Property;
+import levosilimo.everlastingskins.harness.TestServerContext;
+import levosilimo.everlastingskins.metrics.SkinMetrics;
+import levosilimo.everlastingskins.util.CustomSkinProperty;
+import net.minecraft.entity.player.EntityPlayerMP;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Cascade atomicity invariant (R3): SkinRefreshTask must enqueue the disk
+ * flush BEFORE mutating the GameProfile, so a failed enqueue leaves the
+ * applied profile untouched — applied and on-disk skin stay consistent and
+ * the change cannot silently revert on the next server restart.
+ */
+class SkinRefreshTaskTest {
+
+    private static final Property OLD_PROPERTY = new Property("textures", "oldValue", "oldSignature");
+    private static final CustomSkinProperty NEW_SKIN =
+            new CustomSkinProperty("textures", "newValue", "newSignature", "MojangAPI");
+
+    @TempDir
+    Path tempDir;
+
+    private TestServerContext ctx;
+
+    @BeforeEach
+    void setUp() {
+        ctx = new TestServerContext(tempDir);
+        SkinMetrics.INSTANCE.reset();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        // Undo any failing-storage install so the context closes on the real
+        // storage (flushPending must drain real pending writes, not a mock).
+        setStaticField(SkinRestorer.class, "skinStorage", ctx.storage);
+        ctx.close();
+    }
+
+    private static void setStaticField(Class<?> clazz, String name, Object value) throws Exception {
+        Field field = clazz.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(null, value);
+    }
+
+    private static Collection<Property> texturesOf(EntityPlayerMP player) {
+        return player.getGameProfile().getProperties().get("textures");
+    }
+
+    @Test
+    @DisplayName("saveSkinAsync failure leaves the applied GameProfile textures untouched")
+    void saveSkinAsyncFailure_leavesProfileUntouched() throws Exception {
+        EntityPlayerMP alice = ctx.newPlayer("Alice");
+        alice.getGameProfile().getProperties().put("textures", OLD_PROPERTY);
+        SkinStorage failing = mock(SkinStorage.class);
+        doThrow(new RuntimeException("simulated disk enqueue failure"))
+                .when(failing).saveSkinAsync(any(UUID.class), any(CustomSkinProperty.class));
+        setStaticField(SkinRestorer.class, "skinStorage", failing);
+
+        long failedBefore = SkinMetrics.INSTANCE.snapshot().refreshesFailed();
+        long savesBefore = SkinMetrics.INSTANCE.snapshot().savesSubmitted();
+
+        SkinRefreshTask.task(alice, NEW_SKIN, 0L);
+
+        Collection<Property> textures = texturesOf(alice);
+        assertEquals(1, textures.size(), "a failed save must not mutate the profile");
+        assertEquals(OLD_PROPERTY, textures.iterator().next(),
+                "the applied profile must keep the previous textures when persistence fails");
+        assertEquals(failedBefore + 1, SkinMetrics.INSTANCE.snapshot().refreshesFailed(),
+                "the partial cascade failure must be recorded");
+        assertEquals(savesBefore, SkinMetrics.INSTANCE.snapshot().savesSubmitted(),
+                "a failed enqueue must not count as a submitted save");
+    }
+
+    @Test
+    @DisplayName("successful save applies the stored skin to the GameProfile")
+    void saveSkinAsyncSuccess_appliesStoredSkin() {
+        EntityPlayerMP alice = ctx.newPlayer("Alice");
+        alice.getGameProfile().getProperties().put("textures", OLD_PROPERTY);
+
+        long failedBefore = SkinMetrics.INSTANCE.snapshot().refreshesFailed();
+        long completedBefore = SkinMetrics.INSTANCE.snapshot().refreshesCompleted();
+        long savesBefore = SkinMetrics.INSTANCE.snapshot().savesSubmitted();
+
+        SkinRefreshTask.task(alice, NEW_SKIN, 0L);
+        ctx.storage.flushPending();
+
+        Collection<Property> textures = texturesOf(alice);
+        assertEquals(1, textures.size());
+        assertEquals(NEW_SKIN.getOriginalProperty(), textures.iterator().next(),
+                "the applied profile must match the saved skin value");
+        assertEquals(failedBefore, SkinMetrics.INSTANCE.snapshot().refreshesFailed(),
+                "a successful refresh must not record a failure");
+        assertEquals(completedBefore + 1, SkinMetrics.INSTANCE.snapshot().refreshesCompleted(),
+                "a successful cascade must record a completed refresh");
+        assertEquals(savesBefore + 1, SkinMetrics.INSTANCE.snapshot().savesSubmitted(),
+                "the cascade must enqueue exactly one save");
+    }
+
+}

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/SkinRefreshTaskTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/SkinRefreshTaskTest.java
@@ -119,4 +119,19 @@ class SkinRefreshTaskTest {
                 "the cascade must enqueue exactly one save");
     }
 
+    @Test
+    @DisplayName("restart equivalence: after the cascade the on-disk skin equals the in-memory skin")
+    void afterCascade_ondiskSkinEqualsInMemorySkin() {
+        EntityPlayerMP alice = ctx.newPlayer("Alice");
+
+        SkinRefreshTask.task(alice, NEW_SKIN, 0L);
+        ctx.storage.flushPending();
+
+        CustomSkinProperty fromDisk = ctx.storage.loadSkin(alice.getUniqueID());
+        assertNotNull(fromDisk, "the cascade must have persisted the skin to disk");
+        assertEquals(NEW_SKIN, fromDisk,
+                "the on-disk skin after the cascade must equal the stored in-memory skin");
+        assertEquals(ctx.storage.getSkin(alice.getUniqueID()), fromDisk,
+                "a restart reloading from disk must reproduce the in-memory skin");
+    }
 }


### PR DESCRIPTION
## R3-3: Partial cascade persistence fix — 1.12.2

**Bug**: `SkinRefreshTask.cascade()` mutated the GameProfile (`mutateProfile`) BEFORE enqueuing persistence (`saveSkinAsync`). A `catch (Throwable)` in `task()` swallowed a save failure and only recorded a metric — the in-memory skin then silently reverted on the next server restart.

**Fix**: the disk flush is now enqueued first; the GameProfile is mutated only after the enqueue succeeded. `saveSkinAsync` serializes the property synchronously, so enqueue-first makes the persistence+mutation pair atomic: a failed enqueue leaves the applied profile untouched and applied/on-disk state consistent.

**Commits**:
- `448e27c` fix(1122): persist before mutating the GameProfile in SkinRefreshTask
- `bbcc3c6` test(1122): cascade atomicity rollback and metric tests
- `a2da2f8` test(1122): restart-equivalence test for the cascade

**Verification**: `./gradlew build test` ✓ · aislop 100/100 on every commit (pre-commit hook, no --no-verify)