### PR TITLE
test(1.12.2): metamorphic restart-equivalence tests for SkinIO and SkinStorage

### DIFF
--- a/src/test/java/levosilimo/everlastingskins/skinchanger/SkinIOMetamorphicTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/SkinIOMetamorphicTest.java
@@ -1,0 +1,240 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import levosilimo.everlastingskins.EverlastingSkins;
+import levosilimo.everlastingskins.metrics.SkinMetrics;
+import levosilimo.everlastingskins.util.CustomSkinProperty;
+import levosilimo.everlastingskins.util.JsonUtils;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.From;
+import net.jqwik.api.Label;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+import java.util.Comparator;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Metamorphic property tests for {@link SkinIO} restart-equivalence.
+ * <p>
+ * Round 4 takes the Round 1 model-based disk-vs-model checks and adds the
+ * restart framing of Pillai et al. (All File Systems Are Not Created Equal,
+ * OSDI 2014): a fresh reader over the same directory must see exactly the
+ * state the previous writer left behind, with no exception escaping. The
+ * properties encode four invariants:
+ * <ul>
+ *   <li>writeThenRead_equalsPayload: any payload written through saveSkin
+ *       round-trips byte-identical through loadSkin.</li>
+ *   <li>deleteThenRead_returnsNull: a delete shadows the file even when the
+ *       writer goes through the async path; the reader observes null.</li>
+ *   <li>deleteIdempotent: deleting an absent or already-deleted uuid is a
+ *       no-op - the second call must not throw.</li>
+ *   <li>corruptFile_returnsNull: garbage bytes are treated as absent by the
+ *       reader (quarantined, no exception escapes).</li>
+ * </ul>
+ * Every property starts from a fresh temp directory and a reset
+ * {@link SkinMetrics}; assertions use counter deltas where applicable so the
+ * debounce timing stays deterministic under CI load.
+ */
+class SkinIOMetamorphicTest {
+
+    /**
+     * Serializes metric-observing property sections: jqwik may shrink a
+     * failing property on a background thread while the next property's tries
+     * run, so the shared SkinMetrics counters need a mutual-exclusion fence
+     * between property bodies.
+     */
+    private static final Object METRICS_LOCK = new Object();
+
+    @Provide
+    Arbitrary<String> values() {
+        // Valid payloads: loadSkin() rejects values that are not decodable base64.
+        return Arbitraries.strings().withCharRange('a', 'z').ofMinLength(1).ofMaxLength(16)
+                .map(s -> Base64.getEncoder().encodeToString(s.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Provide
+    Arbitrary<String> signatures() {
+        return Arbitraries.strings().withCharRange('a', 'z').ofMinLength(0).ofMaxLength(12);
+    }
+
+    @Provide
+    Arbitrary<String> sources() {
+        return Arbitraries.strings().withCharRange('a', 'z').ofMinLength(1).ofMaxLength(8).injectNull(0.25);
+    }
+
+    /** Small non-JSON byte strings, deterministic garbage for the corrupt-file property. */
+    @Provide
+    Arbitrary<String> garbage() {
+        return Arbitraries.strings().withChars('!', '#', '%', '*', '{', '}', '<', '>')
+                .ofMinLength(1).ofMaxLength(32);
+    }
+
+    private static CustomSkinProperty skin(String value) {
+        return new CustomSkinProperty(value, "signature", "property-test");
+    }
+
+    private static Path newTempDir() {
+        try {
+            return Files.createTempDirectory("skinio-metamorphic-");
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static void deleteRecursively(Path dir) {
+        try (Stream<Path> stream = Files.walk(dir)) {
+            stream.sorted(Comparator.reverseOrder()).forEach(path -> {
+                try {
+                    Files.deleteIfExists(path);
+                } catch (IOException e) {
+                    EverlastingSkins.logger.debug("temp cleanup failed for {}", path, e);
+                }
+            });
+        } catch (IOException e) {
+            EverlastingSkins.logger.debug("temp dir walk failed for {}", dir, e);
+        }
+    }
+
+    /**
+     * writeThenRead_equalsPayload: any payload written through saveSkin must
+     * survive the on-disk serialize/load cycle byte-identical. The serialised
+     * form is the canonical state (Pillai OSDI'14): a reader sees the previous
+     * committed bytes or the new committed bytes, never a partial record. The
+     * equality check goes through JsonUtils.toJson so the assertion stays
+     * stable even if the equals/hashCode contract on CustomSkinProperty is
+     * later relaxed to ignore the original property payload.
+     */
+    @Property(tries = 100)
+    @Label("writeThenRead_equalsPayload: any SkinProperty survives a save/load round-trip")
+    void writeThenRead_equalsPayload(@ForAll @From("values") String value,
+                                     @ForAll @From("signatures") String signature,
+                                     @ForAll @From("sources") String source) throws IOException {
+        synchronized (METRICS_LOCK) {
+            SkinMetrics.INSTANCE.reset();
+            Path dir = newTempDir();
+            try {
+                SkinIO io = new SkinIO(dir);
+                UUID uuid = UUID.randomUUID();
+                CustomSkinProperty original = new CustomSkinProperty(value, signature, source);
+                io.saveSkin(uuid, original);
+                CustomSkinProperty loaded = io.loadSkin(uuid);
+                assertNotNull(loaded, "a freshly written skin must load");
+                assertEquals(JsonUtils.toJson(original), JsonUtils.toJson(loaded),
+                        "loaded payload must be byte-identical to the original");
+                assertEquals(value, loaded.getOriginalProperty().getValue());
+                assertEquals(signature, loaded.getOriginalProperty().getSignature());
+                assertEquals(source, loaded.getSource());
+            } finally {
+                deleteRecursively(dir);
+            }
+        }
+    }
+
+    /**
+     * deleteThenRead_returnsNull: a delete shadows the on-disk file even when
+     * the writer went through the async coalesce path. Tombstone semantics
+     * after the LSM write-buffer (O'Neil et al., Acta Informatica 33, 1996):
+     * the deferred payload is purged from pendingWrites before the file is
+     * removed, so a later drain cannot resurrect the cleared skin. The reader
+     * observes null, never the stale payload.
+     */
+    @Property(tries = 100)
+    @Label("deleteThenRead_returnsNull: a deleted skin is gone after the writer returns")
+    void deleteThenRead_returnsNull(@ForAll @From("values") String value) throws IOException {
+        synchronized (METRICS_LOCK) {
+            SkinMetrics.INSTANCE.reset();
+            Path dir = newTempDir();
+            try {
+                SkinIO io = new SkinIO(dir);
+                UUID uuid = UUID.randomUUID();
+                io.saveSkin(uuid, skin(value));
+                assertNotNull(io.loadSkin(uuid), "freshly written skin must be readable");
+                io.deleteSkin(uuid);
+                assertNull(io.loadSkin(uuid),
+                        "loadSkin must return null after deleteSkin");
+            } finally {
+                deleteRecursively(dir);
+            }
+        }
+    }
+
+    /**
+     * deleteIdempotent: deleting twice yields the same final state with no
+     * exception escaping the second call. A delete on an absent file is a
+     * deleteIfExists no-op; the property is a basic contract callers depend
+     * on (e.g. cascade on logout when a tombstone may already have landed).
+     */
+    @Property(tries = 100)
+    @Label("deleteIdempotent: deleting twice yields the same result, no exception")
+    void deleteIdempotent(@ForAll @From("values") String value) throws IOException {
+        synchronized (METRICS_LOCK) {
+            SkinMetrics.INSTANCE.reset();
+            Path dir = newTempDir();
+            try {
+                SkinIO io = new SkinIO(dir);
+                UUID uuid = UUID.randomUUID();
+                io.saveSkin(uuid, skin(value));
+                io.deleteSkin(uuid);
+                io.deleteSkin(uuid);
+                assertNull(io.loadSkin(uuid),
+                        "delete is idempotent: loadSkin still returns null after the second call");
+                assertTrue(!Files.exists(dir.resolve(uuid + ".json")),
+                        "no skin file after two deletes");
+            } finally {
+                deleteRecursively(dir);
+            }
+        }
+    }
+
+    /**
+     * corruptFile_returnsNull: a file with non-JSON bytes must be treated as
+     * absent by the reader (quarantined to a {@code .corrupt-<epoch>} sibling,
+     * null returned). No exception escapes - the caller never sees a Json
+     * parser failure surfaced. Restart framing of Pillai OSDI'14: the reader
+     * sees either the previous committed bytes or absence, never a partial
+     * record and never an exception from a malformed record.
+     */
+    @Property(tries = 50)
+    @Label("corruptFile_returnsNull: a garbage skin file is treated as absent, no exception escapes")
+    void corruptFile_returnsNull(@ForAll @From("garbage") String garbage) throws IOException {
+        synchronized (METRICS_LOCK) {
+            SkinMetrics.INSTANCE.reset();
+            Path dir = newTempDir();
+            try {
+                SkinIO io = new SkinIO(dir);
+                UUID uuid = UUID.randomUUID();
+                Path target = dir.resolve(uuid + ".json");
+                Files.write(target, garbage.getBytes(StandardCharsets.UTF_8));
+                assertTrue(Files.exists(target), "sanity: garbage file is on disk before loadSkin");
+
+                CustomSkinProperty loaded = io.loadSkin(uuid);
+                assertNull(loaded, "garbage payload must read back as null");
+                // The corrupt file must be moved aside so the reader never sees it again.
+                assertTrue(!Files.exists(target),
+                        "corrupt file must be quarantined after read, not left on disk");
+            } finally {
+                deleteRecursively(dir);
+            }
+        }
+    }
+}

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/SkinStorageMetamorphicTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/SkinStorageMetamorphicTest.java
@@ -1,0 +1,289 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import levosilimo.everlastingskins.EverlastingSkins;
+import levosilimo.everlastingskins.metrics.SkinMetrics;
+import levosilimo.everlastingskins.util.CustomSkinProperty;
+import levosilimo.everlastingskins.util.JsonUtils;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.From;
+import net.jqwik.api.Label;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Metamorphic property tests for {@link SkinStorage} restart-equivalence.
+ * <p>
+ * After Round 1 fixed the write-after-delete race in {@link SkinIO} and
+ * Round 3 made the partial-cascade delete atomic, the mod guarantees that
+ * <pre>
+ *     on-disk loadSkin(uuid) == in-memory getSkin(uuid) == stored skin
+ * </pre>
+ * for every uuid at the time of restart. These properties take the same
+ * model-checking framing as the Round 1 tests (Claessen &amp; Hughes, ICFP
+ * 2000) and apply it at the {@link SkinStorage} layer: a random op script
+ * is run against a reference map, the writes are flushed through the
+ * coalesce path, a fresh {@link SkinStorage} is constructed over the same
+ * directory, and the restarted view must match the reference exactly.
+ * <p>
+ * Encoded invariants:
+ * <ul>
+ *   <li>setSkinAndRestart_equalsInitial: any sequence of saveSkinAsync writes
+ *       must round-trip through a fresh SkinStorage.</li>
+ *   <li>clearAndRestart_skinAbsent: a delete persists; the restarted reader
+ *       sees no file for the tombstoned uuid.</li>
+ *   <li>lastWriteWins: with several saveSkinAsync for one uuid, only the
+ *       last payload survives the restart.</li>
+ *   <li>coalesceTombstone: a saveSkinAsync immediately followed by a delete
+ *       ends up absent after restart - the in-flight write never lands
+ *       (LSM write-buffer tombstone, O'Neil et al., Acta Informatica 33,
+ *       1996).</li>
+ * </ul>
+ */
+class SkinStorageMetamorphicTest {
+
+    /**
+     * Serializes metric-observing property sections: jqwik may shrink a
+     * failing property on a background thread while the next property's tries
+     * run, so the shared SkinMetrics counters need a mutual-exclusion fence
+     * between property bodies.
+     */
+    private static final Object METRICS_LOCK = new Object();
+
+    /** UUID pool small enough that collisions and tombstone races are common. */
+    private static final UUID[] UUID_POOL = {
+            UUID.fromString("00000000-0000-0000-0000-000000000001"),
+            UUID.fromString("00000000-0000-0000-0000-000000000002"),
+            UUID.fromString("00000000-0000-0000-0000-000000000003"),
+            UUID.fromString("00000000-0000-0000-0000-000000000004")
+    };
+
+    @Provide
+    Arbitrary<String> values() {
+        // Valid payloads: loadSkin() rejects values that are not decodable base64.
+        return Arbitraries.strings().withCharRange('a', 'z').ofMinLength(1).ofMaxLength(16)
+                .map(s -> Base64.getEncoder().encodeToString(s.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    /** Ordered value sequences for one uuid; length 2-6 so last-write-wins has something to collapse. */
+    @Provide
+    Arbitrary<List<String>> valueSequences() {
+        return values().list().ofMinSize(2).ofMaxSize(6);
+    }
+
+    /**
+     * Op script: SAVE_ASYNC followed by DELETE for the same uuid. The order
+     * is fixed (write then tombstone) so the property exercises the
+     * coalesce-tombstone path deterministically; the uuid and payload are
+     * generated.
+     */
+    @Provide
+    Arbitrary<SaveThenDelete> saveThenDeleteOps() {
+        return Combinators.combine(Arbitraries.of(UUID_POOL), values()).as(SaveThenDelete::new);
+    }
+
+    private static final class SaveThenDelete {
+        final UUID uuid;
+        final String value;
+
+        SaveThenDelete(UUID uuid, String value) {
+            this.uuid = uuid;
+            this.value = value;
+        }
+    }
+
+    private static CustomSkinProperty skin(String value) {
+        return new CustomSkinProperty(value, "signature", "property-test");
+    }
+
+    private static Path newTempDir() {
+        try {
+            return Files.createTempDirectory("skinstorage-metamorphic-");
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static void deleteRecursively(Path dir) {
+        try (Stream<Path> stream = Files.walk(dir)) {
+            stream.sorted(Comparator.reverseOrder()).forEach(path -> {
+                try {
+                    Files.deleteIfExists(path);
+                } catch (IOException e) {
+                    EverlastingSkins.logger.debug("temp cleanup failed for {}", path, e);
+                }
+            });
+        } catch (IOException e) {
+            EverlastingSkins.logger.debug("temp dir walk failed for {}", dir, e);
+        }
+    }
+
+    private static void assertLoadedEquals(Path dir, UUID uuid, String expected) {
+        SkinStorage restarted = new SkinStorage(new SkinIO(dir));
+        CustomSkinProperty loaded = restarted.loadSkin(uuid);
+        assertNotNull(loaded, "restart must surface the saved skin for " + uuid);
+        assertEquals(JsonUtils.toJson(skin(expected)), JsonUtils.toJson(loaded),
+                "restarted loadSkin must equal the last submitted payload");
+    }
+
+    /**
+     * setSkinAndRestart_equalsInitial: a random saveSkinAsync script over the
+     * uuid pool is run against the reference map (latest-wins) and a fresh
+     * SkinStorage in lockstep. After flush, a new SkinStorage over the same
+     * directory must surface the exact same set of payloads. This is the
+     * property: every skin in the in-memory map at the time of restart is
+     * visible to the restarted reader with byte-identical content.
+     */
+    @Property(tries = 50)
+    @Label("setSkinAndRestart_equalsInitial: the restarted SkinStorage reproduces the in-memory map")
+    void setSkinAndRestart_equalsInitial(@ForAll @From("valueSequences") List<String> sequence) throws IOException {
+        synchronized (METRICS_LOCK) {
+            SkinMetrics.INSTANCE.reset();
+            SkinStorage.resetForTest();
+            Path dir = newTempDir();
+            try {
+                SkinIO io = new SkinIO(dir);
+                SkinStorage storage = new SkinStorage(io);
+                Map<UUID, String> model = new LinkedHashMap<>();
+                for (String value : sequence) {
+                    UUID uuid = UUID.randomUUID();
+                    model.put(uuid, value);
+                    storage.saveSkinAsync(uuid, skin(value));
+                }
+                storage.flushPending();
+                assertEquals(model.size(),
+                        Files.list(dir).filter(p -> p.getFileName().toString().endsWith(".json")).count(),
+                        "flush must land one file per live entry");
+                // Restart: a fresh SkinStorage over the same directory sees the disk state.
+                SkinStorage restarted = new SkinStorage(new SkinIO(dir));
+                for (Map.Entry<UUID, String> entry : model.entrySet()) {
+                    CustomSkinProperty loaded = restarted.loadSkin(entry.getKey());
+                    assertNotNull(loaded,
+                            "restarted SkinStorage must surface the saved skin for " + entry.getKey());
+                    assertEquals(entry.getValue(), loaded.getOriginalProperty().getValue(),
+                            "restarted payload must equal the last submitted payload");
+                }
+            } finally {
+                deleteRecursively(dir);
+            }
+        }
+    }
+
+    /**
+     * clearAndRestart_skinAbsent: a deleteSkin persists across restart; the
+     * restarted reader sees no file for the tombstoned uuid. Tombstone must
+     * survive the harshest reader (Pillai OSDI'14).
+     */
+    @Property(tries = 100)
+    @Label("clearAndRestart_skinAbsent: a deleted skin is absent after restart")
+    void clearAndRestart_skinAbsent(@ForAll @From("values") String value) throws IOException {
+        synchronized (METRICS_LOCK) {
+            SkinMetrics.INSTANCE.reset();
+            SkinStorage.resetForTest();
+            Path dir = newTempDir();
+            try {
+                SkinIO io = new SkinIO(dir);
+                SkinStorage storage = new SkinStorage(io);
+                UUID uuid = UUID.randomUUID();
+                storage.saveSkinAsync(uuid, skin(value));
+                storage.flushPending();
+                storage.removeSkin(uuid);
+
+                SkinStorage restarted = new SkinStorage(new SkinIO(dir));
+                assertNull(restarted.loadSkin(uuid),
+                        "restart must not resurrect a tombstoned skin");
+            } finally {
+                deleteRecursively(dir);
+            }
+        }
+    }
+
+    /**
+     * lastWriteWins: with several saveSkinAsync for one uuid, only the last
+     * payload survives the restart. The intermediate payloads are dropped at
+     * merge time (coalesce drain), so the on-disk file holds only the most
+     * recent value. The restarted SkinStorage's loadSkin must surface that
+     * value, byte-identical.
+     */
+    @Property(tries = 100)
+    @Label("lastWriteWins: after restart the disk holds only the last submitted payload")
+    void lastWriteWins(@ForAll @From("valueSequences") List<String> sequence) throws IOException {
+        synchronized (METRICS_LOCK) {
+            SkinMetrics.INSTANCE.reset();
+            SkinStorage.resetForTest();
+            Path dir = newTempDir();
+            try {
+                SkinIO io = new SkinIO(dir);
+                SkinStorage storage = new SkinStorage(io);
+                UUID uuid = UUID.randomUUID();
+                for (String value : sequence) {
+                    storage.saveSkinAsync(uuid, skin(value));
+                }
+                storage.flushPending();
+                assertLoadedEquals(dir, uuid, sequence.get(sequence.size() - 1));
+            } finally {
+                deleteRecursively(dir);
+            }
+        }
+    }
+
+    /**
+     * coalesceTombstone: a saveSkinAsync immediately followed by a delete
+     * must end up absent after restart - the in-flight write never lands.
+     * The delete purges pendingWrites before the file is removed, so a
+     * drain that has not started yet skips this uuid; an in-flight drain is
+     * serialized through the single writer thread and completes before the
+     * delete runs. LSM write-buffer tombstone semantics (O'Neil et al.,
+     * Acta Informatica 33, 1996).
+     */
+    @Property(tries = 50)
+    @Label("coalesceTombstone: saveSkinAsync then delete must end up absent after restart")
+    void coalesceTombstone(@ForAll @From("saveThenDeleteOps") SaveThenDelete op) throws IOException {
+        synchronized (METRICS_LOCK) {
+            SkinMetrics.INSTANCE.reset();
+            SkinStorage.resetForTest();
+            Path dir = newTempDir();
+            try {
+                SkinIO io = new SkinIO(dir);
+                SkinStorage storage = new SkinStorage(io);
+                storage.saveSkinAsync(op.uuid, skin(op.value));
+                storage.removeSkin(op.uuid);
+                storage.flushPending();
+
+                SkinStorage restarted = new SkinStorage(new SkinIO(dir));
+                assertNull(restarted.loadSkin(op.uuid),
+                        "saveSkinAsync followed by removeSkin must end up absent after restart");
+                assertTrue(!Files.exists(dir.resolve(op.uuid + ".json")),
+                        "no skin file on disk after coalesce-tombstone");
+            } finally {
+                deleteRecursively(dir);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Round 4 mirror: adds the same jqwik metamorphic property tests for SkinIO and SkinStorage on the 1.12.2 branch.

## Properties added

### SkinStorageMetamorphicTest
- setSkinAndRestart_equalsInitial: after a random sequence of saveSkinAsync + restart, the new SkinStorage reproduces the in-memory map byte-identically.
- clearAndRestart_skinAbsent: a deleted skin is absent after restart.
- lastWriteWins: with several saveSkinAsync for one uuid, only the last payload survives restart.
- coalesceTombstone: saveSkinAsync followed by delete must end up absent after restart.

### SkinIOMetamorphicTest
- writeThenRead_equalsPayload: any SkinProperty round-trips save/load byte-identically.
- deleteThenRead_returnsNull: a deleted skin is gone after the writer returns.
- deleteIdempotent: deleting twice yields the same result, no exception.
- corruptFile_returnsNull: a garbage skin file is treated as absent, no exception escapes.

## Test-only PR. No production code touched.

## Verification
- ./gradlew build test passes
- aislop 100/100 clean on every commit