### PR TITLE
feat(1.21): broadcast broker seam — extract SkinBroadcaster for REMOVE+ADD/tracker abstraction

### DIFF
--- a/src/main/java/levosilimo/everlastingskins/broadcast/SkinBroadcaster.java
+++ b/src/main/java/levosilimo/everlastingskins/broadcast/SkinBroadcaster.java
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.broadcast;
+
+import com.mojang.authlib.GameProfile;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Entity;
+
+/**
+ * Abstraction over the per-viewer packet fan-out for a skin change. The
+ * refresh pipeline builds a fresh GameProfile, then asks the broadcaster
+ * to deliver the tab-list REMOVE+ADD pair (or one bundled REMOVE+ADD in
+ * 1.21) and to drive the entity-tracker untrack/retrack so observers
+ * re-fetch the profile.
+ *
+ * <p>{@link VanillaSkinBroadcaster} is the production implementation; it
+ * reads {@code BROADCAST_USE_BUNDLE}, {@code DIMENSION_SCOPED_BROADCAST}
+ * and {@code REFRESH_VIA_ENTITY_TRACKER} from {@link
+ * levosilimo.everlastingskins.Config} and emits the vanilla packets.
+ * Tests inject a recording fake so the handler's call shape can be
+ * asserted without re-implementing the REMOVE+ADD+cascade pipeline.
+ */
+public interface SkinBroadcaster {
+
+    /**
+     * Broadcast the REMOVE+ADD (or one bundled REMOVE+ADD) tab-list pair
+     * for {@code target}. The implementation is responsible for honoring
+     * {@code BROADCAST_USE_BUNDLE} and {@code DIMENSION_SCOPED_BROADCAST}.
+     */
+    void broadcastProfileChange(GameProfile newProfile, ServerPlayer target);
+
+    /**
+     * Broadcast the REMOVE+ADD (or one bundled REMOVE+ADD) tab-list pair
+     * for {@code target} to an explicit observer set. Used when the
+     * caller has already filtered by dimension or other criteria and
+     * wants to bypass the broadcast-all helper.
+     */
+    void broadcastProfileChange(GameProfile newProfile, ServerPlayer target, ServerPlayer[] observers);
+
+    /**
+     * Untrack/re-track {@code entity} on its server level's entity
+     * tracker. The implementation reads {@code REFRESH_VIA_ENTITY_TRACKER}
+     * and is a no-op when disabled. Forced re-track is what makes remote
+     * clients destroy+re-spawn the entity so their cached playerInfo
+     * re-fetches the new profile entry.
+     */
+    void trackerUntrackRetrack(Entity entity);
+}

--- a/src/main/java/levosilimo/everlastingskins/broadcast/VanillaSkinBroadcaster.java
+++ b/src/main/java/levosilimo/everlastingskins/broadcast/VanillaSkinBroadcaster.java
@@ -1,0 +1,156 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.broadcast;
+
+import com.mojang.authlib.GameProfile;
+import io.netty.buffer.Unpooled;
+import levosilimo.everlastingskins.Config;
+import levosilimo.everlastingskins.EverlastingSkins;
+import levosilimo.everlastingskins.metrics.NetworkMetricsHandler;
+import levosilimo.everlastingskins.metrics.SkinMetrics;
+import levosilimo.everlastingskins.skinchanger.SkinRestorer;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.ClientGamePacketListener;
+import net.minecraft.network.protocol.game.ClientboundBundlePacket;
+import net.minecraft.network.protocol.game.ClientboundPlayerInfoRemovePacket;
+import net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.players.PlayerList;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.Level;
+
+import java.util.List;
+
+/**
+ * Production {@link SkinBroadcaster} for Minecraft 1.21. Builds the
+ * REMOVE+ADD (or one bundled REMOVE+ADD) tab-list pair and delivers it
+ * via the live {@link PlayerList} or, when {@code BROADCAST_USE_BUNDLE}
+ * is enabled, directly to each filtered observer's connection. Also
+ * drives the chunk-source remove/add pair that re-tracks the target on
+ * observers' entity trackers when {@code REFRESH_VIA_ENTITY_TRACKER}
+ * is enabled.
+ *
+ * <p>UPDATE_DISPLAY_NAME does not serialize the GameProfile, so
+ * observers never received new textures; REMOVE+ADD_PLAYER forces
+ * clients to re-learn the profile. Dimension-scoped only when
+ * {@code DIMENSION_SCOPED_BROADCAST} is enabled.
+ */
+public final class VanillaSkinBroadcaster implements SkinBroadcaster {
+
+    @Override
+    public void broadcastProfileChange(GameProfile newProfile, ServerPlayer target) {
+        broadcastInternal(target, null);
+    }
+
+    @Override
+    public void broadcastProfileChange(GameProfile newProfile, ServerPlayer target, ServerPlayer[] observers) {
+        broadcastInternal(target, observers);
+    }
+
+    private void broadcastInternal(ServerPlayer target, ServerPlayer[] explicitObservers) {
+        PlayerList playerlist = target.server.getPlayerList();
+        ServerLevel serverLevel = target.serverLevel();
+        ResourceKey<Level> dimension = serverLevel.dimension();
+        Packet<ClientGamePacketListener> removePacket =
+            new ClientboundPlayerInfoRemovePacket(List.of(target.getUUID()));
+        Packet<ClientGamePacketListener> addPacket =
+            new ClientboundPlayerInfoUpdatePacket(ClientboundPlayerInfoUpdatePacket.Action.ADD_PLAYER, target);
+
+        NetworkMetricsHandler netHandler = NetworkMetricsHandler.getOrAttach(target.connection.getConnection());
+        long outBefore = netHandler != null ? netHandler.outboundBytes() : 0;
+        long inBefore = netHandler != null ? netHandler.inboundBytes() : 0;
+        long start = System.nanoTime();
+
+        if (Config.BROADCAST_USE_BUNDLE.get()) {
+            ClientboundBundlePacket bundle = new ClientboundBundlePacket(List.of(removePacket, addPacket));
+            if (explicitObservers != null) {
+                for (ServerPlayer observer : explicitObservers) {
+                    if (Config.DIMENSION_SCOPED_BROADCAST.get()
+                            && !observer.serverLevel().dimension().equals(dimension)) {
+                        continue;
+                    }
+                    observer.connection.send(bundle);
+                }
+            } else if (Config.DIMENSION_SCOPED_BROADCAST.get()) {
+                playerlist.broadcastAll(bundle, dimension);
+            } else {
+                playerlist.broadcastAll(bundle);
+            }
+        } else if (explicitObservers != null) {
+            for (ServerPlayer observer : explicitObservers) {
+                if (Config.DIMENSION_SCOPED_BROADCAST.get()
+                        && !observer.serverLevel().dimension().equals(dimension)) {
+                    continue;
+                }
+                observer.connection.send(removePacket);
+                observer.connection.send(addPacket);
+            }
+        } else if (Config.DIMENSION_SCOPED_BROADCAST.get()) {
+            playerlist.broadcastAll(removePacket, dimension);
+            playerlist.broadcastAll(addPacket, dimension);
+        } else {
+            playerlist.broadcastAll(removePacket);
+            playerlist.broadcastAll(addPacket);
+        }
+
+        long broadcastNanos = System.nanoTime() - start;
+        SkinMetrics.INSTANCE.recordBroadcastLatency(broadcastNanos);
+        SkinMetrics.INSTANCE.recordSpikeBroadcast(broadcastNanos);
+        SkinMetrics.INSTANCE.recordBroadcast(wireSize(removePacket) + wireSize(addPacket));
+        if (netHandler != null) {
+            SkinMetrics.INSTANCE.recordNetworkDelta(
+                netHandler.outboundBytes() - outBefore,
+                netHandler.inboundBytes() - inBefore);
+        }
+    }
+
+    @Override
+    public void trackerUntrackRetrack(Entity entity) {
+        if (!Config.REFRESH_VIA_ENTITY_TRACKER.get()) {
+            return;
+        }
+        if (!(entity instanceof ServerPlayer player)) {
+            return;
+        }
+        // Per-viewer entity re-render via the tracker: untrack/track forces
+        // remote clients to destroy+re-spawn the entity, so their cached
+        // playerInfo re-fetches the new profile entry. Without this step
+        // observers keep rendering the stale skin even after the tab-list
+        // REMOVE+ADD (PR #121 dropped this step; lib-13 research: regression).
+        ServerLevel level = (ServerLevel) player.level();
+        level.getChunkSource().removeEntity(player);
+        level.getChunkSource().addEntity(player);
+    }
+
+    /** Serialized byte size of the packets, measured with their stream codecs. */
+    private static int wireSize(Packet<?> packet) {
+        try {
+            if (packet instanceof ClientboundPlayerInfoRemovePacket remove) {
+                return encodeSize(remove, ClientboundPlayerInfoRemovePacket.STREAM_CODEC);
+            }
+            if (packet instanceof ClientboundPlayerInfoUpdatePacket update) {
+                return encodeSize(update, ClientboundPlayerInfoUpdatePacket.STREAM_CODEC);
+            }
+        } catch (Exception e) {
+            EverlastingSkins.logger.debug("Failed to measure packet wire size", e);
+        }
+        return 0;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> int encodeSize(T packet, net.minecraft.network.codec.StreamCodec<?, T> codec) {
+        RegistryFriendlyByteBuf buf = new RegistryFriendlyByteBuf(Unpooled.buffer(),
+            SkinRestorer.server.registryAccess());
+        ((net.minecraft.network.codec.StreamCodec<RegistryFriendlyByteBuf, T>) codec).encode(buf, packet);
+        int size = buf.readableBytes();
+        buf.release();
+        return size;
+    }
+}

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRefreshHandler.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRefreshHandler.java
@@ -11,15 +11,15 @@ import com.mojang.authlib.GameProfile;
 import io.netty.buffer.Unpooled;
 import levosilimo.everlastingskins.Config;
 import levosilimo.everlastingskins.EverlastingSkins;
+import levosilimo.everlastingskins.broadcast.SkinBroadcaster;
+import levosilimo.everlastingskins.broadcast.VanillaSkinBroadcaster;
 import levosilimo.everlastingskins.enums.SkinActionType;
-import levosilimo.everlastingskins.metrics.NetworkMetricsHandler;
 import levosilimo.everlastingskins.metrics.SkinMetrics;
 import levosilimo.everlastingskins.skinchanger.responses.mojang.MojangSkinDataResult;
 import levosilimo.everlastingskins.util.CustomSkinProperty;
 import levosilimo.everlastingskins.util.I18nUtils;
 import levosilimo.everlastingskins.util.EverlastingHelpers;
 import net.minecraft.network.RegistryFriendlyByteBuf;
-import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.*;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
@@ -27,13 +27,32 @@ import net.minecraft.server.players.PlayerList;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
-import java.util.List;
 import java.util.UUID;
 
 public class SkinRefreshHandler {
 
     /** Test-visible counter of task() invocations (see gametest assertions). */
     public static volatile long refreshTaskCount = 0;
+
+    /**
+     * Seam for the per-viewer packet fan-out. Production uses
+     * {@link VanillaSkinBroadcaster}; tests inject a recording fake to
+     * assert call shape without re-implementing the REMOVE+ADD+cascade
+     * pipeline. Static so the {@code task} entry point stays
+     * signature-compatible with all existing callers (R3 invariant:
+     * public API unchanged).
+     */
+    private static volatile SkinBroadcaster broadcaster = new VanillaSkinBroadcaster();
+
+    /** Test seam: replace the broadcaster. */
+    public static void setBroadcaster(SkinBroadcaster newBroadcaster) {
+        broadcaster = newBroadcaster;
+    }
+
+    /** Current broadcaster (mainly for tests asserting the wiring). */
+    public static SkinBroadcaster getBroadcaster() {
+        return broadcaster;
+    }
 
     public static void resetRefreshTaskCount() {
         refreshTaskCount = 0;
@@ -142,54 +161,15 @@ public class SkinRefreshHandler {
      * UPDATE_DISPLAY_NAME does not serialize the GameProfile, so observers never
      * received new textures; REMOVE + ADD_PLAYER forces clients to re-learn the
      * profile. Dimension-scoped only when DIMENSION_SCOPED_BROADCAST is enabled.
+     *
+     * <p>Per-viewer packet fan-out is delegated to the injected
+     * {@link SkinBroadcaster}; the call shape is broadcaster-agnostic so
+     * config-flag tests can swap in a recording fake without rebuilding
+     * the REMOVE+ADD+cascade pipeline.
      */
     private static void recordObserverBroadcast(ServerPlayer player, CustomSkinProperty skin) {
-        PlayerList playerlist = player.server.getPlayerList();
-        ServerLevel serverLevel = player.serverLevel();
-        var dimension = serverLevel.dimension();
-        Packet<ClientGamePacketListener> removePacket = new ClientboundPlayerInfoRemovePacket(List.of(player.getUUID()));
-        Packet<ClientGamePacketListener> addPacket = new ClientboundPlayerInfoUpdatePacket(ClientboundPlayerInfoUpdatePacket.Action.ADD_PLAYER, player);
-
-        NetworkMetricsHandler netHandler = NetworkMetricsHandler.getOrAttach(player.connection.getConnection());
-        long outBefore = netHandler != null ? netHandler.outboundBytes() : 0;
-        long inBefore = netHandler != null ? netHandler.inboundBytes() : 0;
-        long start = System.nanoTime();
-
-        if (Config.BROADCAST_USE_BUNDLE.get()) {
-            ClientboundBundlePacket bundle = new ClientboundBundlePacket(List.of(removePacket, addPacket));
-            for (ServerPlayer online : playerlist.getPlayers()) {
-                if (Config.DIMENSION_SCOPED_BROADCAST.get() && !online.serverLevel().dimension().equals(dimension)) {
-                    continue;
-                }
-                online.connection.send(bundle);
-            }
-        } else if (Config.DIMENSION_SCOPED_BROADCAST.get()) {
-            playerlist.broadcastAll(removePacket, dimension);
-            playerlist.broadcastAll(addPacket, dimension);
-        } else {
-            playerlist.broadcastAll(removePacket);
-            playerlist.broadcastAll(addPacket);
-        }
-
-        long broadcastNanos = System.nanoTime() - start;
-        SkinMetrics.INSTANCE.recordBroadcastLatency(broadcastNanos);
-        SkinMetrics.INSTANCE.recordSpikeBroadcast(broadcastNanos);
-        SkinMetrics.INSTANCE.recordBroadcast(wireSize(removePacket) + wireSize(addPacket));
-        if (netHandler != null) {
-            SkinMetrics.INSTANCE.recordNetworkDelta(
-                    netHandler.outboundBytes() - outBefore,
-                    netHandler.inboundBytes() - inBefore);
-        }
-
-        // Per-viewer entity re-render via the tracker: untrack/track forces
-        // remote clients to destroy+re-spawn the entity, so their cached
-        // playerInfo re-fetches the new profile entry. Without this step
-        // observers keep rendering the stale skin even after the tab-list
-        // REMOVE+ADD (PR #121 dropped this step; lib-13 research: regression).
-        if (Config.REFRESH_VIA_ENTITY_TRACKER.get()) {
-            ((ServerLevel) player.level()).getChunkSource().removeEntity(player);
-            ((ServerLevel) player.level()).getChunkSource().addEntity(player);
-        }
+        broadcaster.broadcastProfileChange(player.getGameProfile(), player);
+        broadcaster.trackerUntrackRetrack(player);
     }
 
     /**
@@ -232,15 +212,9 @@ public class SkinRefreshHandler {
 
     private static final long TICK_SPIKE_THRESHOLD_NANOS = 50_000_000;
 
-    /** Serialized byte size of the packets, measured with their stream codecs. */
+    /** Serialized byte size of the cascade packets, measured with their stream codecs. */
     private static int wireSize(net.minecraft.network.protocol.Packet<?> packet) {
         try {
-            if (packet instanceof ClientboundPlayerInfoRemovePacket remove) {
-                return encodeSize(remove, ClientboundPlayerInfoRemovePacket.STREAM_CODEC);
-            }
-            if (packet instanceof ClientboundPlayerInfoUpdatePacket update) {
-                return encodeSize(update, ClientboundPlayerInfoUpdatePacket.STREAM_CODEC);
-            }
             if (packet instanceof ClientboundPlayerPositionPacket position) {
                 return encodeSize(position, ClientboundPlayerPositionPacket.STREAM_CODEC);
             }

--- a/src/test/java/levosilimo/everlastingskins/broadcast/FakeSkinBroadcaster.java
+++ b/src/test/java/levosilimo/everlastingskins/broadcast/FakeSkinBroadcaster.java
@@ -1,0 +1,55 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.broadcast;
+
+import com.mojang.authlib.GameProfile;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Entity;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Recording fake of {@link SkinBroadcaster} for tests that want to assert
+ * the handler's call shape (broadcast then tracker) without rebuilding the
+ * REMOVE+ADD+cascade pipeline. Records every call into observable lists so
+ * tests can pin order and arguments.
+ */
+public final class FakeSkinBroadcaster implements SkinBroadcaster {
+
+    public record BroadcastCall(GameProfile profile, ServerPlayer target, List<ServerPlayer> observers) {
+        BroadcastCall(GameProfile profile, ServerPlayer target, ServerPlayer[] observers) {
+            this(profile, target,
+                observers == null ? Collections.emptyList() : Arrays.asList(observers));
+        }
+    }
+
+    public final List<BroadcastCall> broadcastCalls = new ArrayList<>();
+    public final List<Entity> trackerCalls = new ArrayList<>();
+
+    @Override
+    public void broadcastProfileChange(GameProfile newProfile, ServerPlayer target) {
+        broadcastCalls.add(new BroadcastCall(newProfile, target, (ServerPlayer[]) null));
+    }
+
+    @Override
+    public void broadcastProfileChange(GameProfile newProfile, ServerPlayer target, ServerPlayer[] observers) {
+        broadcastCalls.add(new BroadcastCall(newProfile, target, observers));
+    }
+
+    @Override
+    public void trackerUntrackRetrack(Entity entity) {
+        trackerCalls.add(entity);
+    }
+
+    public void reset() {
+        broadcastCalls.clear();
+        trackerCalls.clear();
+    }
+}

--- a/src/test/java/levosilimo/everlastingskins/broadcast/FakeSkinBroadcaster.java
+++ b/src/test/java/levosilimo/everlastingskins/broadcast/FakeSkinBroadcaster.java
@@ -21,7 +21,7 @@ import java.util.List;
  * REMOVE+ADD+cascade pipeline. Records every call into observable lists so
  * tests can pin order and arguments.
  */
-public final class FakeSkinBroadcaster implements SkinBroadcaster {
+public class FakeSkinBroadcaster implements SkinBroadcaster {
 
     public record BroadcastCall(GameProfile profile, ServerPlayer target, List<ServerPlayer> observers) {
         BroadcastCall(GameProfile profile, ServerPlayer target, ServerPlayer[] observers) {

--- a/src/test/java/levosilimo/everlastingskins/broadcast/VanillaSkinBroadcasterTest.java
+++ b/src/test/java/levosilimo/everlastingskins/broadcast/VanillaSkinBroadcasterTest.java
@@ -1,0 +1,396 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.broadcast;
+
+import com.electronwill.nightconfig.core.InMemoryCommentedFormat;
+import com.mojang.authlib.GameProfile;
+import com.mojang.authlib.properties.Property;
+import levosilimo.everlastingskins.Config;
+import levosilimo.everlastingskins.permission.TestConfigSupport;
+import levosilimo.everlastingskins.skinchanger.SkinRestorer;
+import net.minecraft.core.Holder;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.ClientboundBundlePacket;
+import net.minecraft.network.protocol.game.ClientboundPlayerInfoRemovePacket;
+import net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerChunkCache;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import net.minecraft.server.players.PlayerList;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.GameType;
+import net.minecraft.world.level.Level;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Direct test of the production {@link VanillaSkinBroadcaster}: pins the
+ * packet sequence the broadcaster emits for each combination of
+ * {@code BROADCAST_USE_BUNDLE}, {@code DIMENSION_SCOPED_BROADCAST} and
+ * the explicit-observer vs broadcast-all variants. These contract
+ * guarantees are what {@link
+ * levosilimo.everlastingskins.skinchanger.SkinRefreshHandler#task}
+ * inherits by calling the broadcaster; the handler test asserts the
+ * call shape, this one asserts the packets.
+ */
+class VanillaSkinBroadcasterTest {
+
+    private static final String TEXTURE_VALUE = "cGF5bG9hZA==";
+    private static final String TEXTURE_SIGNATURE = "c2lnbmF0dXJl";
+    private static final ResourceKey<Level> OVERWORLD = Level.OVERWORLD;
+    private static final ResourceKey<Level> NETHER = Level.NETHER;
+
+    private MinecraftServer server;
+    private PlayerList playerlist;
+    private ServerLevel overworldLevel;
+    private ServerLevel netherLevel;
+    private ServerChunkCache chunkSource;
+
+    private ServerPlayer target;
+    private ServerPlayer observer1;
+    private ServerPlayer netherObserver;
+
+    private final List<Object> targetStream = new ArrayList<>();
+    private final List<Object> observer1Stream = new ArrayList<>();
+    private final List<Object> netherStream = new ArrayList<>();
+    private final List<Packet<?>> globalSink = new ArrayList<>();
+    private final List<String> chunkTrace = new ArrayList<>();
+
+    private VanillaSkinBroadcaster broadcaster;
+
+    @BeforeAll
+    static void loadConfig() {
+        TestConfigSupport.loadDefaults();
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        Config.COMMON_CONFIG.setConfig(
+                InMemoryCommentedFormat.defaultInstance().createConfig(HashMap::new));
+        Config.BROADCAST_USE_BUNDLE.set(false);
+        Config.DIMENSION_SCOPED_BROADCAST.set(false);
+        Config.REFRESH_VIA_ENTITY_TRACKER.set(true);
+
+        overworldLevel = levelMock(OVERWORLD);
+        netherLevel = levelMock(NETHER);
+        chunkSource = mock(ServerChunkCache.class);
+        doAnswer(inv -> { chunkTrace.add("removeEntity"); return null; })
+            .when(chunkSource).removeEntity(any(Entity.class));
+        doAnswer(inv -> { chunkTrace.add("addEntity"); return null; })
+            .when(chunkSource).addEntity(any(Entity.class));
+        when(overworldLevel.getChunkSource()).thenReturn(chunkSource);
+        when(netherLevel.getChunkSource()).thenReturn(chunkSource);
+
+        playerlist = mock(PlayerList.class);
+        server = mock(MinecraftServer.class);
+        when(server.getPlayerList()).thenReturn(playerlist);
+        SkinRestorer.server = server;
+
+        target = newPlayer("Target", overworldLevel);
+        observer1 = newPlayer("ObserverOne", overworldLevel);
+        netherObserver = newPlayer("NetherObserver", netherLevel);
+
+        List<ServerPlayer> online = List.of(target, observer1, netherObserver);
+        when(playerlist.getPlayers()).thenReturn(online);
+
+        attachStream(target, targetStream);
+        attachStream(observer1, observer1Stream);
+        attachStream(netherObserver, netherStream);
+
+        doAnswer(inv -> {
+            Packet<?> packet = inv.getArgument(0);
+            globalSink.add(packet);
+            for (ServerPlayer onlinePlayer : online) {
+                streamFor(onlinePlayer).add(packet);
+            }
+            return null;
+        }).when(playerlist).broadcastAll(any(Packet.class));
+
+        doAnswer(inv -> {
+            Packet<?> packet = inv.getArgument(0);
+            ResourceKey<Level> dim = inv.getArgument(1);
+            globalSink.add(packet);
+            for (ServerPlayer onlinePlayer : online) {
+                if (onlinePlayer.serverLevel().dimension().equals(dim)) {
+                    streamFor(onlinePlayer).add(packet);
+                }
+            }
+            return null;
+        }).when(playerlist).broadcastAll(any(Packet.class), any(ResourceKey.class));
+
+        broadcaster = new VanillaSkinBroadcaster();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        Config.BROADCAST_USE_BUNDLE.set(false);
+        Config.DIMENSION_SCOPED_BROADCAST.set(false);
+        Config.REFRESH_VIA_ENTITY_TRACKER.set(true);
+        SkinRestorer.server = null;
+    }
+
+    /* ================================================================== */
+    /*  Packet sequence contract                                          */
+    /* ================================================================== */
+
+    @Test
+    @DisplayName("REMOVE is emitted strictly before ADD in non-bundle mode")
+    void removeStrictlyBeforeAdd_nonBundle() {
+        broadcaster.broadcastProfileChange(target.getGameProfile(), target);
+
+        assertEquals(2, globalSink.size(), "exactly one REMOVE + one ADD");
+        assertTrue(globalSink.get(0) instanceof ClientboundPlayerInfoRemovePacket,
+            "first broadcast must be REMOVE; sink=" + globalSink);
+        assertTrue(globalSink.get(1) instanceof ClientboundPlayerInfoUpdatePacket,
+            "second broadcast must be ADD; sink=" + globalSink);
+        int removeIdx = indexOfType(targetStream, ClientboundPlayerInfoRemovePacket.class);
+        int addIdx = indexOfType(targetStream, ClientboundPlayerInfoUpdatePacket.class);
+        assertTrue(removeIdx >= 0 && addIdx == removeIdx + 1,
+            "REMOVE+ADD must be neighbors in the captured stream; stream=" + targetStream);
+    }
+
+    @Test
+    @DisplayName("Bundle mode: REMOVE+ADD travel inside one ClientboundBundlePacket (atomicity)")
+    void bundleAtomicity_removeAddInSingleBundle() {
+        Config.BROADCAST_USE_BUNDLE.set(true);
+        broadcaster.broadcastProfileChange(target.getGameProfile(), target);
+
+        List<ClientboundBundlePacket> bundles = filterType(targetStream, ClientboundBundlePacket.class);
+        assertEquals(1, bundles.size(), "exactly one bundle expected; stream=" + targetStream);
+        List<Packet<?>> inner = new ArrayList<>();
+        bundles.get(0).subPackets().forEach(inner::add);
+        assertEquals(2, inner.size(), "bundle must contain exactly REMOVE+ADD; inner=" + inner);
+        assertTrue(inner.get(0) instanceof ClientboundPlayerInfoRemovePacket,
+            "bundle[0] must be REMOVE; inner=" + inner);
+        assertTrue(inner.get(1) instanceof ClientboundPlayerInfoUpdatePacket,
+            "bundle[1] must be ADD; inner=" + inner);
+        assertEquals(0, countOfType(targetStream, ClientboundPlayerInfoRemovePacket.class),
+            "no standalone REMOVE outside the bundle");
+        assertEquals(0, countOfType(targetStream, ClientboundPlayerInfoUpdatePacket.class),
+            "no standalone ADD outside the bundle");
+    }
+
+    @Test
+    @DisplayName("Explicit-observer variant sends REMOVE+ADD only to the given observers")
+    void explicitObserver_variantReachesOnlyGivenSet() {
+        ServerPlayer[] onlyOverworld = new ServerPlayer[]{target, observer1};
+        broadcaster.broadcastProfileChange(target.getGameProfile(), target, onlyOverworld);
+
+        assertTrue(!observer1Stream.isEmpty(),
+            "observer1 must receive the broadcast; stream=" + observer1Stream);
+        assertEquals(0, netherStream.size(),
+            "nether observer must receive nothing when not in the explicit set; stream=" + netherStream);
+    }
+
+    @Test
+    @DisplayName("Explicit-observer variant with DIMENSION_SCOPED_BROADCAST still excludes other dimensions")
+    void explicitObserver_dimScoped_excludesCrossDim() {
+        Config.DIMENSION_SCOPED_BROADCAST.set(true);
+        ServerPlayer[] allPlayers = new ServerPlayer[]{target, observer1, netherObserver};
+        broadcaster.broadcastProfileChange(target.getGameProfile(), target, allPlayers);
+
+        assertEquals(0, netherStream.size(),
+            "nether observer must receive nothing when dim scoping is on; stream=" + netherStream);
+        assertTrue(!observer1Stream.isEmpty(),
+            "same-dim observer must receive the broadcast; stream=" + observer1Stream);
+    }
+
+    @Test
+    @DisplayName("DIMENSION_SCOPED_BROADCAST=true excludes nether observer in broadcast-all mode")
+    void dimScoped_broadcastAll_excludesCrossDim() {
+        Config.DIMENSION_SCOPED_BROADCAST.set(true);
+        broadcaster.broadcastProfileChange(target.getGameProfile(), target);
+
+        assertEquals(0, netherStream.size(),
+            "nether observer must receive nothing; stream=" + netherStream);
+        assertTrue(!observer1Stream.isEmpty(),
+            "same-dim observer must receive the broadcast; stream=" + observer1Stream);
+    }
+
+    @Test
+    @DisplayName("DIMENSION_SCOPED_BROADCAST=false delivers to all online players including nether")
+    void dimScoped_false_deliversEverywhere() {
+        Config.DIMENSION_SCOPED_BROADCAST.set(false);
+        broadcaster.broadcastProfileChange(target.getGameProfile(), target);
+
+        assertTrue(!netherStream.isEmpty(),
+            "nether observer must receive the broadcast when not dim scoped; stream=" + netherStream);
+        assertTrue(!observer1Stream.isEmpty(),
+            "observer1 must receive the broadcast; stream=" + observer1Stream);
+    }
+
+    @Test
+    @DisplayName("Bundle + DIMENSION_SCOPED_BROADCAST=true delivers the bundle only to same-dim observers")
+    void bundleAndDimScoped_onlySameDimObservers() {
+        Config.BROADCAST_USE_BUNDLE.set(true);
+        Config.DIMENSION_SCOPED_BROADCAST.set(true);
+        broadcaster.broadcastProfileChange(target.getGameProfile(), target);
+
+        assertEquals(0, netherStream.size(),
+            "nether observer must receive nothing; stream=" + netherStream);
+        assertEquals(1, countOfType(observer1Stream, ClientboundBundlePacket.class),
+            "observer1 must receive the bundle; stream=" + observer1Stream);
+    }
+
+    /* ================================================================== */
+    /*  Tracker untrack/retrack                                           */
+    /* ================================================================== */
+
+    @Test
+    @DisplayName("trackerUntrackRetrack drives removeEntity then addEntity when flag is on")
+    void trackerUntrackRetrack_runsWhenEnabled() {
+        broadcaster.trackerUntrackRetrack(target);
+
+        assertEquals(List.of("removeEntity", "addEntity"), chunkTrace,
+            "chunk-source untrack must precede retrack");
+    }
+
+    @Test
+    @DisplayName("trackerUntrackRetrack is a no-op when REFRESH_VIA_ENTITY_TRACKER is off")
+    void trackerUntrackRetrack_skippedWhenDisabled() {
+        Config.REFRESH_VIA_ENTITY_TRACKER.set(false);
+        broadcaster.trackerUntrackRetrack(target);
+
+        assertEquals(Collections.emptyList(), chunkTrace,
+            "no chunk-source interaction expected");
+        verify(chunkSource, never()).removeEntity(any(Entity.class));
+        verify(chunkSource, never()).addEntity(any(Entity.class));
+    }
+
+    @Test
+    @DisplayName("trackerUntrackRetrack ignores non-ServerPlayer entities")
+    void trackerUntrackRetrack_ignoresNonServerPlayer() {
+        Entity other = mock(Entity.class);
+        broadcaster.trackerUntrackRetrack(other);
+
+        assertEquals(Collections.emptyList(), chunkTrace,
+            "non-ServerPlayer entities must not be untracked");
+    }
+
+    /* ================================================================== */
+    /*  ADD packet payload                                                 */
+    /* ================================================================== */
+
+    @Test
+    @DisplayName("ADD packet carries the player's GameProfile")
+    void addPacket_carriesTargetProfile() {
+        // Add a textures property to the target's profile so the assertion
+        // is non-trivial.
+        target.getGameProfile().getProperties().put("textures",
+            new Property("textures", TEXTURE_VALUE, TEXTURE_SIGNATURE));
+        broadcaster.broadcastProfileChange(target.getGameProfile(), target);
+
+        ClientboundPlayerInfoUpdatePacket add = filterType(targetStream, ClientboundPlayerInfoUpdatePacket.class)
+            .stream()
+            .filter(p -> p.actions().contains(ClientboundPlayerInfoUpdatePacket.Action.ADD_PLAYER))
+            .findFirst()
+            .orElse(null);
+        assertNotNull(add, "ADD packet missing from stream=" + targetStream);
+        boolean hasTexture = add.entries().stream()
+            .anyMatch(e -> e.profile() != null
+                && e.profile().getProperties().get("textures").stream()
+                    .anyMatch(prop -> TEXTURE_VALUE.equals(prop.value())));
+        assertTrue(hasTexture, "ADD packet must carry the textures property");
+    }
+
+    /* ================================================================== */
+    /*  Helpers                                                            */
+    /* ================================================================== */
+
+    private ServerPlayer newPlayer(String name, ServerLevel level) {
+        UUID uuid = UUID.randomUUID();
+        ServerPlayer player = mock(ServerPlayer.class);
+        when(player.getUUID()).thenReturn(uuid);
+        when(player.getGameProfile()).thenReturn(new GameProfile(uuid, name));
+        when(player.serverLevel()).thenReturn(level);
+        when(player.level()).thenReturn(level);
+        when(player.getTabListDisplayName()).thenReturn(null);
+        when(player.getChatSession()).thenReturn(null);
+        ServerGamePacketListenerImpl connection = mock(ServerGamePacketListenerImpl.class);
+        setField(player, "connection", connection);
+        setField(player, "server", server);
+        return player;
+    }
+
+    private List<Object> streamFor(ServerPlayer player) {
+        if (player == target) return targetStream;
+        if (player == observer1) return observer1Stream;
+        if (player == netherObserver) return netherStream;
+        throw new IllegalArgumentException("unknown player: " + player);
+    }
+
+    private void attachStream(ServerPlayer player, List<Object> stream) {
+        doAnswer(inv -> {
+            stream.add(inv.getArgument(0));
+            return null;
+        }).when(player.connection).send(any(Packet.class));
+    }
+
+    private static ServerLevel levelMock(ResourceKey<Level> dimension) {
+        ServerLevel level = mock(ServerLevel.class);
+        when(level.dimension()).thenReturn(dimension);
+        return level;
+    }
+
+    private static int indexOfType(List<?> events, Class<?> type) {
+        for (int i = 0; i < events.size(); i++) {
+            if (type.isInstance(events.get(i))) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static long countOfType(List<?> events, Class<?> type) {
+        return events.stream().filter(type::isInstance).count();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> List<T> filterType(List<?> events, Class<T> type) {
+        List<T> result = new ArrayList<>();
+        for (Object event : events) {
+            if (type.isInstance(event)) {
+                result.add((T) event);
+            }
+        }
+        return result;
+    }
+
+    private static void setField(Object target, String fieldName, Object value) {
+        try {
+            Field field = ServerPlayer.class.getField(fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Cannot set ServerPlayer." + fieldName, e);
+        }
+    }
+}

--- a/src/test/java/levosilimo/everlastingskins/broadcast/VanillaSkinBroadcasterTest.java
+++ b/src/test/java/levosilimo/everlastingskins/broadcast/VanillaSkinBroadcasterTest.java
@@ -18,10 +18,12 @@ import net.minecraft.network.protocol.game.ClientboundBundlePacket;
 import net.minecraft.network.protocol.game.ClientboundPlayerInfoRemovePacket;
 import net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.Bootstrap;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerChunkCache;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.level.ServerPlayerGameMode;
 import net.minecraft.server.network.ServerGamePacketListenerImpl;
 import net.minecraft.server.players.PlayerList;
 import net.minecraft.world.entity.Entity;
@@ -62,6 +64,24 @@ import static org.mockito.Mockito.when;
  * call shape, this one asserts the packets.
  */
 class VanillaSkinBroadcasterTest {
+
+    /**
+     * The unit-test JVM has no running server, so vanilla's
+     * BuiltInRegistries &lt;clinit&gt; would throw "Not bootstrapped" the moment
+     * a registry-touching class (ServerLevel) is mocked. Flag the bootstrap
+     * as done directly: calling {@link Bootstrap#bootStrap()} would also run
+     * Forge's patched GameData.vanillaSnapshot(), which needs the FML
+     * runtime this JVM does not have.
+     */
+    static {
+        try {
+            Field bootstrapFlag = Bootstrap.class.getDeclaredField("isBootstrapped");
+            bootstrapFlag.setAccessible(true);
+            bootstrapFlag.setBoolean(null, true);
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
 
     private static final String TEXTURE_VALUE = "cGF5bG9hZA==";
     private static final String TEXTURE_SIGNATURE = "c2lnbmF0dXJl";
@@ -337,6 +357,12 @@ class VanillaSkinBroadcasterTest {
         ServerGamePacketListenerImpl connection = mock(ServerGamePacketListenerImpl.class);
         setField(player, "connection", connection);
         setField(player, "server", server);
+        // ClientboundPlayerInfoUpdatePacket's Entry constructor reads
+        // p_252094_.gameMode.getGameModeForPlayer(); field-back it with a
+        // mock that returns SURVIVAL.
+        ServerPlayerGameMode gameMode = mock(ServerPlayerGameMode.class);
+        when(gameMode.getGameModeForPlayer()).thenReturn(GameType.SURVIVAL);
+        setField(player, "gameMode", gameMode);
         return player;
     }
 

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/SkinRefreshHandlerTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/SkinRefreshHandlerTest.java
@@ -25,6 +25,7 @@ import net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket;
 import net.minecraft.network.protocol.game.ClientboundPlayerPositionPacket;
 import net.minecraft.network.protocol.game.ClientboundRespawnPacket;
 import net.minecraft.network.protocol.game.CommonPlayerSpawnInfo;
+import net.minecraft.core.Holder;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.Bootstrap;
 import net.minecraft.server.MinecraftServer;
@@ -249,15 +250,19 @@ class SkinRefreshHandlerTest {
     }
 
     @Test
-    @DisplayName("handler invokes broadcastProfileChange and skips trackerUntrackRetrack when flag disabled")
-    void handlerCalls_broadcastOnly_whenTrackerDisabled() {
+    @DisplayName("handler always invokes trackerUntrackRetrack; flag check lives in the broadcaster")
+    void handlerCalls_trackerEvenWhenFlagDisabled() {
+        // The handler unconditionally delegates to broadcaster.trackerUntrackRetrack;
+        // the broadcaster reads REFRESH_VIA_ENTITY_TRACKER and is a no-op when off.
+        // VanillaSkinBroadcasterTest pins that no-op; here we only assert the
+        // call shape from the handler.
         Config.REFRESH_VIA_ENTITY_TRACKER.set(false);
         refresh();
 
         assertEquals(1, fakeBroadcaster.broadcastCalls.size(),
             "broadcast still runs; calls=" + fakeBroadcaster.broadcastCalls);
-        assertEquals(Collections.emptyList(), fakeBroadcaster.trackerCalls,
-            "tracker must be skipped when flag is disabled");
+        assertEquals(1, fakeBroadcaster.trackerCalls.size(),
+            "handler still calls broadcaster.trackerUntrackRetrack; the flag is the broadcaster's concern");
     }
 
     @Test
@@ -274,8 +279,11 @@ class SkinRefreshHandlerTest {
                     String combo = "bundle=" + bundle + ", scoped=" + scoped + ", tracker=" + tracker;
                     assertEquals(1, fakeBroadcaster.broadcastCalls.size(),
                         combo + ": exactly one broadcast");
-                    assertEquals(tracker ? 1 : 0, fakeBroadcaster.trackerCalls.size(),
-                        combo + ": tracker contract");
+                    // The handler always invokes trackerUntrackRetrack; the
+                    // broadcaster reads REFRESH_VIA_ENTITY_TRACKER and may
+                    // skip the work (pinned in VanillaSkinBroadcasterTest).
+                    assertEquals(1, fakeBroadcaster.trackerCalls.size(),
+                        combo + ": handler always delegates tracker call");
                 }
             }
         }

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/SkinRefreshHandlerTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/SkinRefreshHandlerTest.java
@@ -10,10 +10,11 @@ import com.electronwill.nightconfig.core.InMemoryCommentedFormat;
 import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
 import levosilimo.everlastingskins.Config;
+import levosilimo.everlastingskins.broadcast.FakeSkinBroadcaster;
+import levosilimo.everlastingskins.broadcast.VanillaSkinBroadcaster;
 import levosilimo.everlastingskins.metrics.SkinMetrics;
 import levosilimo.everlastingskins.permission.TestConfigSupport;
 import levosilimo.everlastingskins.util.CustomSkinProperty;
-import net.minecraft.core.Holder;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientboundBundlePacket;
 import net.minecraft.network.protocol.game.ClientboundChangeDifficultyPacket;
@@ -65,38 +66,34 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
  * Broadcast/cascade ordering contract of the 1.21 refresh pipeline
  * ({@link SkinRefreshHandler#task}). Pure Mockito unit test: players,
- * server, player list and level are mocks; the packet stream is captured
- * per connection in send order and PlayerList helpers are replaced by
- * faithful seams that emit the vanilla packet they would send
- * (difficulty via sendLevelInfo, permission-level via
- * sendPlayerPermissionLevel).
+ * server, player list and level are mocks; the per-connection packet
+ * stream (cascade respawn/position/difficulty/permission/abilities only)
+ * is captured, and the broadcaster seam is exercised via
+ * {@link FakeSkinBroadcaster} which records call shape without
+ * re-implementing the REMOVE+ADD+cascade pipeline.
  *
  * <p>Contract pinned here:
  * <ul>
- *   <li>REMOVE is sent strictly before ADD; in non-bundle mode they are
- *       neighbors in the captured stream, in bundle mode they travel inside
- *       one ClientboundBundlePacket (atomicity).</li>
+ *   <li>The handler invokes {@code broadcastProfileChange} once per refresh
+ *       and then {@code trackerUntrackRetrack} when
+ *       {@code REFRESH_VIA_ENTITY_TRACKER} is enabled, in that order.</li>
  *   <li>Cascade order on the target connection:
- *       REMOVE, ADD, respawn, position, difficulty, permission, abilities —
- *       each packet type exactly once per refresh.</li>
- *   <li>Tracker untrack/retrack (chunk-source removeEntity/addEntity) runs
- *       before the respawn packet, and only when
- *       REFRESH_VIA_ENTITY_TRACKER is enabled.</li>
- *   <li>The full cascade order holds under every combination of
+ *       respawn, position, difficulty, permission, abilities — each packet
+ *       type exactly once per refresh.</li>
+ *   <li>Cascade order holds under every combination of
  *       BROADCAST_USE_BUNDLE x DIMENSION_SCOPED_BROADCAST x
  *       REFRESH_VIA_ENTITY_TRACKER.</li>
- *   <li>Self-reception and multi-observer delivery, with cross-dimension
- *       observers excluded when DIMENSION_SCOPED_BROADCAST is enabled.</li>
  * </ul>
+ *
+ * <p>The packet-level REMOVE-before-ADD and bundle-atomicity guarantees
+ * are pinned by {@link VanillaSkinBroadcasterTest} on the production
+ * broadcaster itself; this test only asserts the handler's call shape.
  *
  * <p>Cascade atomicity invariant (R3): the disk flush must be enqueued BEFORE
  * the GameProfile is mutated, so a failed enqueue leaves the applied profile
@@ -128,7 +125,6 @@ class SkinRefreshHandlerTest {
     private static final String TEXTURE_VALUE = "cGF5bG9hZA==";
     private static final String TEXTURE_SIGNATURE = "c2lnbmF0dXJl";
     private static final ResourceKey<Level> OVERWORLD = Level.OVERWORLD;
-    private static final ResourceKey<Level> NETHER = Level.NETHER;
 
     private static final UUID PLAYER_UUID = UUID.randomUUID();
     private static final Property OLD_PROPERTY = new Property("textures", "oldValue", "oldSignature");
@@ -144,23 +140,14 @@ class SkinRefreshHandlerTest {
     private MinecraftServer server;
     private PlayerList playerlist;
     private ServerLevel overworldLevel;
-    private ServerLevel netherLevel;
     private ServerChunkCache chunkSource;
 
     private ServerPlayer target;
-    private ServerPlayer observer1;
-    private ServerPlayer observer2;
-    private ServerPlayer netherObserver;
-    private UUID targetUuid;
 
-    /** Ordered per-connection streams (packets + PlayerList-seam markers). */
+    private FakeSkinBroadcaster fakeBroadcaster;
+
     private final Map<ServerPlayer, List<Object>> playerStreams = new HashMap<>();
     private List<Object> targetStream;
-    private List<Object> observer1Stream;
-    private List<Object> observer2Stream;
-    private List<Object> netherStream;
-    private List<Packet<?>> globalSink;
-    private List<String> chunkTrace;
 
     @BeforeAll
     static void loadConfig() {
@@ -186,18 +173,10 @@ class SkinRefreshHandlerTest {
         SkinMetrics.INSTANCE.reset();
 
         playerStreams.clear();
-        globalSink = new ArrayList<>();
-        chunkTrace = new ArrayList<>();
 
         overworldLevel = levelMock(OVERWORLD);
-        netherLevel = levelMock(NETHER);
         chunkSource = mock(ServerChunkCache.class);
-        doAnswer(inv -> { chunkTrace.add("removeEntity"); return null; })
-            .when(chunkSource).removeEntity(any(Entity.class));
-        doAnswer(inv -> { chunkTrace.add("addEntity"); return null; })
-            .when(chunkSource).addEntity(any(Entity.class));
         when(overworldLevel.getChunkSource()).thenReturn(chunkSource);
-        when(netherLevel.getChunkSource()).thenReturn(chunkSource);
 
         playerlist = mock(PlayerList.class);
         server = mock(MinecraftServer.class);
@@ -205,42 +184,8 @@ class SkinRefreshHandlerTest {
         SkinRestorer.server = server;
 
         target = newPlayer("Target", overworldLevel);
-        observer1 = newPlayer("ObserverOne", overworldLevel);
-        observer2 = newPlayer("ObserverTwo", overworldLevel);
-        netherObserver = newPlayer("NetherObserver", netherLevel);
-        targetUuid = target.getUUID();
-
-        List<ServerPlayer> online = List.of(target, observer1, observer2, netherObserver);
-        when(playerlist.getPlayers()).thenReturn(online);
 
         targetStream = streamFor(target);
-        observer1Stream = streamFor(observer1);
-        observer2Stream = streamFor(observer2);
-        netherStream = streamFor(netherObserver);
-
-        // Non-bundle broadcast: records into the global sink and delivers to
-        // every online player's connection (vanilla PlayerList.broadcastAll).
-        doAnswer(inv -> {
-            Packet<?> packet = inv.getArgument(0);
-            globalSink.add(packet);
-            for (ServerPlayer onlinePlayer : online) {
-                streamFor(onlinePlayer).add(packet);
-            }
-            return null;
-        }).when(playerlist).broadcastAll(any(Packet.class));
-
-        // Dimension-scoped broadcast: same, filtered by the player's level.
-        doAnswer(inv -> {
-            Packet<?> packet = inv.getArgument(0);
-            ResourceKey<Level> dim = inv.getArgument(1);
-            globalSink.add(packet);
-            for (ServerPlayer onlinePlayer : online) {
-                if (onlinePlayer.serverLevel().dimension().equals(dim)) {
-                    streamFor(onlinePlayer).add(packet);
-                }
-            }
-            return null;
-        }).when(playerlist).broadcastAll(any(Packet.class), any(ResourceKey.class));
 
         // Faithful PlayerList seams: emit the packet vanilla would send at
         // this call site into the recipient's stream.
@@ -263,7 +208,11 @@ class SkinRefreshHandlerTest {
             return null;
         }).when(playerlist).sendActivePlayerEffects(any(ServerPlayer.class));
 
-        storage.setSkin(targetUuid,
+        // Inject the recording fake; assertions read its call lists.
+        fakeBroadcaster = new FakeSkinBroadcaster();
+        SkinRefreshHandler.setBroadcaster(fakeBroadcaster);
+
+        storage.setSkin(target.getUUID(),
                 new CustomSkinProperty("textures", TEXTURE_VALUE, TEXTURE_SIGNATURE, "Notch"));
     }
 
@@ -275,64 +224,69 @@ class SkinRefreshHandlerTest {
         skinIO.flushPending();
         setStaticField(SkinRestorer.class, "skinStorage", null);
         SkinRestorer.server = null;
+        // Restore the production broadcaster so a later test in the same JVM
+        // does not see the fake.
+        SkinRefreshHandler.setBroadcaster(new VanillaSkinBroadcaster());
     }
 
     /* ================================================================== */
-    /*  A. Packet sequence contract                                       */
+    /*  A. Broadcaster call shape                                          */
     /* ================================================================== */
 
     @Test
-    @DisplayName("REMOVE is sent strictly before ADD (non-bundle broadcast)")
-    void removeStrictlyBeforeAdd() {
+    @DisplayName("handler invokes broadcastProfileChange then trackerUntrackRetrack (tracker flag enabled)")
+    void handlerCalls_broadcastThenTracker() {
         refresh();
 
-        assertEquals(2, globalSink.size(), "exactly one REMOVE + one ADD broadcast expected");
-        assertTrue(globalSink.get(0) instanceof ClientboundPlayerInfoRemovePacket,
-            "first broadcast must be REMOVE; sink=" + globalSink);
-        assertTrue(globalSink.get(1) instanceof ClientboundPlayerInfoUpdatePacket,
-            "second broadcast must be ADD; sink=" + globalSink);
-
-        int removeIdx = indexOfType(targetStream, ClientboundPlayerInfoRemovePacket.class);
-        int addIdx = indexOfType(targetStream, ClientboundPlayerInfoUpdatePacket.class);
-        assertTrue(removeIdx >= 0 && addIdx > removeIdx,
-            "REMOVE must strictly precede ADD; stream=" + targetStream);
+        assertEquals(1, fakeBroadcaster.broadcastCalls.size(),
+            "exactly one broadcastProfileChange per refresh; calls=" + fakeBroadcaster.broadcastCalls);
+        assertEquals(1, fakeBroadcaster.trackerCalls.size(),
+            "exactly one trackerUntrackRetrack per refresh; calls=" + fakeBroadcaster.trackerCalls);
+        assertEquals(target, fakeBroadcaster.broadcastCalls.get(0).target(),
+            "broadcast target must be the refreshed player");
+        assertEquals(target, fakeBroadcaster.trackerCalls.get(0),
+            "tracker call must target the refreshed player");
     }
 
     @Test
-    @DisplayName("REMOVE+ADD are neighbors in the captured stream (non-bundle)")
-    void removeAddAreNeighbors() {
+    @DisplayName("handler invokes broadcastProfileChange and skips trackerUntrackRetrack when flag disabled")
+    void handlerCalls_broadcastOnly_whenTrackerDisabled() {
+        Config.REFRESH_VIA_ENTITY_TRACKER.set(false);
         refresh();
 
-        int removeIdx = indexOfType(targetStream, ClientboundPlayerInfoRemovePacket.class);
-        int addIdx = indexOfType(targetStream, ClientboundPlayerInfoUpdatePacket.class);
-        assertEquals(removeIdx + 1, addIdx,
-            "no packet may sit between REMOVE and ADD; stream=" + targetStream);
+        assertEquals(1, fakeBroadcaster.broadcastCalls.size(),
+            "broadcast still runs; calls=" + fakeBroadcaster.broadcastCalls);
+        assertEquals(Collections.emptyList(), fakeBroadcaster.trackerCalls,
+            "tracker must be skipped when flag is disabled");
     }
 
     @Test
-    @DisplayName("Bundle mode: REMOVE+ADD travel inside one ClientboundBundlePacket (atomicity)")
-    void bundleAtomicity_removeAddInSingleBundle() {
-        Config.BROADCAST_USE_BUNDLE.set(true);
-        refresh();
+    @DisplayName("broadcaster is invoked once per refresh across the 8-flag matrix")
+    void configMatrix_handlerInvokesBroadcasterOnce() {
+        for (boolean bundle : new boolean[]{false, true}) {
+            for (boolean scoped : new boolean[]{false, true}) {
+                for (boolean tracker : new boolean[]{false, true}) {
+                    Config.BROADCAST_USE_BUNDLE.set(bundle);
+                    Config.DIMENSION_SCOPED_BROADCAST.set(scoped);
+                    Config.REFRESH_VIA_ENTITY_TRACKER.set(tracker);
+                    refresh();
 
-        List<ClientboundBundlePacket> bundles = filterType(targetStream, ClientboundBundlePacket.class);
-        assertEquals(1, bundles.size(), "exactly one bundle expected; stream=" + targetStream);
-        List<Packet<?>> inner = new ArrayList<>();
-        bundles.get(0).subPackets().forEach(inner::add);
-        assertEquals(2, inner.size(), "bundle must contain exactly REMOVE+ADD; inner=" + inner);
-        assertTrue(inner.get(0) instanceof ClientboundPlayerInfoRemovePacket,
-            "bundle[0] must be REMOVE; inner=" + inner);
-        assertTrue(inner.get(1) instanceof ClientboundPlayerInfoUpdatePacket,
-            "bundle[1] must be ADD; inner=" + inner);
-        // Atomicity: no standalone info packets outside the bundle.
-        assertEquals(0, countOfType(targetStream, ClientboundPlayerInfoRemovePacket.class),
-            "no standalone REMOVE outside the bundle");
-        assertEquals(0, countOfType(targetStream, ClientboundPlayerInfoUpdatePacket.class),
-            "no standalone ADD outside the bundle");
+                    String combo = "bundle=" + bundle + ", scoped=" + scoped + ", tracker=" + tracker;
+                    assertEquals(1, fakeBroadcaster.broadcastCalls.size(),
+                        combo + ": exactly one broadcast");
+                    assertEquals(tracker ? 1 : 0, fakeBroadcaster.trackerCalls.size(),
+                        combo + ": tracker contract");
+                }
+            }
+        }
     }
 
+    /* ================================================================== */
+    /*  B. Cascade order on the target connection                          */
+    /* ================================================================== */
+
     @Test
-    @DisplayName("Cascade order: REMOVE, ADD, respawn, position, difficulty, permission, abilities")
+    @DisplayName("Cascade order: respawn, position, difficulty, permission, abilities")
     void cascadeOrderFullStream() {
         refresh();
 
@@ -340,7 +294,7 @@ class SkinRefreshHandlerTest {
     }
 
     @Test
-    @DisplayName("Each packet type is sent exactly once per refresh")
+    @DisplayName("Each cascade packet type is sent exactly once per refresh")
     void eachPacketTypeExactlyOnce() {
         // refresh() clears between runs, so drive task() directly to
         // accumulate two refreshes in one captured stream.
@@ -348,10 +302,8 @@ class SkinRefreshHandlerTest {
         SkinRefreshHandler.task(target);
         SkinRefreshHandler.task(target);
 
-        // Two refreshes: every type appears exactly twice total (lib-22
-        // matcher-bugfix guard: no duplicate sends).
-        assertEquals(2, countOfType(targetStream, ClientboundPlayerInfoRemovePacket.class));
-        assertEquals(2, countOfType(targetStream, ClientboundPlayerInfoUpdatePacket.class));
+        // Two refreshes: every cascade type appears exactly twice total
+        // (lib-22 matcher-bugfix guard: no duplicate sends).
         assertEquals(2, countOfType(targetStream, ClientboundRespawnPacket.class));
         assertEquals(2, countOfType(targetStream, ClientboundPlayerPositionPacket.class));
         assertEquals(2, countOfType(targetStream, ClientboundChangeDifficultyPacket.class));
@@ -360,37 +312,26 @@ class SkinRefreshHandlerTest {
     }
 
     @Test
-    @DisplayName("Tracker untrack/retrack runs before the respawn packet")
+    @DisplayName("Tracker untrack/retrack runs before the respawn packet (handler-side ordering)")
     void trackerUntrackRetrack_beforeRespawn() {
+        // Use a tracking broadcaster to capture the call moment so we can
+        // compare it against the respawn index on the captured stream.
+        FakeSkinBroadcaster spyBroadcaster = new FakeSkinBroadcaster() {
+            @Override
+            public void trackerUntrackRetrack(Entity entity) {
+                targetStream.add("trackerUntrackRetrack");
+                super.trackerUntrackRetrack(entity);
+            }
+        };
+        SkinRefreshHandler.setBroadcaster(spyBroadcaster);
+
         refresh();
 
-        assertEquals(List.of("removeEntity", "addEntity"), chunkTrace,
-            "chunk-source untrack must precede retrack");
-        // The tracker step is part of recordObserverBroadcast, which runs
-        // before recordCascade: removeEntity, addEntity, then the respawn
-        // send on the connection.
-        org.mockito.InOrder order = inOrder(chunkSource, target.connection);
-        order.verify(chunkSource).removeEntity(target);
-        order.verify(chunkSource).addEntity(target);
-        order.verify(target.connection).send(any(ClientboundRespawnPacket.class));
+        int tracker = indexOfType(targetStream, "trackerUntrackRetrack", String.class);
+        int respawn = indexOfType(targetStream, ClientboundRespawnPacket.class);
+        assertTrue(tracker >= 0 && respawn > tracker,
+            "tracker must precede respawn; stream=" + targetStream);
     }
-
-    @Test
-    @DisplayName("Tracker is never touched when REFRESH_VIA_ENTITY_TRACKER is disabled")
-    void trackerSkipped_whenDisabled() {
-        Config.REFRESH_VIA_ENTITY_TRACKER.set(false);
-        refresh();
-
-        assertEquals(Collections.emptyList(), chunkTrace, "no chunk-source interaction expected");
-        verify(chunkSource, never()).removeEntity(target);
-        verify(chunkSource, never()).addEntity(target);
-        // The cascade itself must be unaffected.
-        assertCascadeOrder(targetStream);
-    }
-
-    /* ================================================================== */
-    /*  B. Config flag matrix                                             */
-    /* ================================================================== */
 
     @Test
     @DisplayName("Cascade order holds for all 8 BROADCAST_USE_BUNDLE x DIMENSION_SCOPED_BROADCAST x REFRESH_VIA_ENTITY_TRACKER combos")
@@ -405,106 +346,15 @@ class SkinRefreshHandlerTest {
 
                     String combo = "bundle=" + bundle + ", scoped=" + scoped + ", tracker=" + tracker;
                     assertCascadeOrder(targetStream, combo);
-                    if (bundle) {
-                        assertEquals(1, countOfType(targetStream, ClientboundBundlePacket.class),
-                            combo + ": exactly one bundle");
-                    } else {
-                        assertEquals(1, countOfType(targetStream, ClientboundPlayerInfoRemovePacket.class),
-                            combo + ": exactly one REMOVE");
-                        assertEquals(1, countOfType(targetStream, ClientboundPlayerInfoUpdatePacket.class),
-                            combo + ": exactly one ADD");
-                    }
-                    assertEquals(tracker ? List.of("removeEntity", "addEntity") : Collections.emptyList(),
-                        chunkTrace, combo + ": tracker contract");
+                    assertEquals(1, fakeBroadcaster.broadcastCalls.size(),
+                        combo + ": exactly one broadcast call");
                 }
             }
         }
     }
 
-    @Test
-    @DisplayName("DIMENSION_SCOPED_BROADCAST=true: cross-dimension observers receive nothing (bundle and non-bundle)")
-    void dimensionScoped_netherObserverExcluded() {
-        Config.DIMENSION_SCOPED_BROADCAST.set(true);
-        for (boolean bundle : new boolean[]{false, true}) {
-            Config.BROADCAST_USE_BUNDLE.set(bundle);
-            refresh();
-
-            assertTrue(netherStream.isEmpty(),
-                "bundle=" + bundle + ": nether observer must receive nothing; stream=" + netherStream);
-            // Same-dimension observers still receive.
-            if (bundle) {
-                assertEquals(1, countOfType(observer1Stream, ClientboundBundlePacket.class),
-                    "bundle=" + bundle + ": same-dimension observer must get the bundle");
-            } else {
-                assertEquals(1, countOfType(observer1Stream, ClientboundPlayerInfoRemovePacket.class),
-                    "bundle=" + bundle + ": same-dimension observer must get REMOVE");
-                assertEquals(1, countOfType(observer1Stream, ClientboundPlayerInfoUpdatePacket.class),
-                    "bundle=" + bundle + ": same-dimension observer must get ADD");
-            }
-        }
-    }
-
-    @Test
-    @DisplayName("DIMENSION_SCOPED_BROADCAST=false: cross-dimension observers receive (bundle and non-bundle)")
-    void dimensionScoped_netherObserverReceives() {
-        Config.DIMENSION_SCOPED_BROADCAST.set(false);
-        for (boolean bundle : new boolean[]{false, true}) {
-            Config.BROADCAST_USE_BUNDLE.set(bundle);
-            refresh();
-
-            if (bundle) {
-                assertEquals(1, countOfType(netherStream, ClientboundBundlePacket.class),
-                    "bundle=" + bundle + ": nether observer must get the bundle");
-            } else {
-                assertEquals(1, countOfType(netherStream, ClientboundPlayerInfoRemovePacket.class),
-                    "bundle=" + bundle + ": nether observer must get REMOVE");
-                assertEquals(1, countOfType(netherStream, ClientboundPlayerInfoUpdatePacket.class),
-                    "bundle=" + bundle + ": nether observer must get ADD");
-            }
-        }
-    }
-
     /* ================================================================== */
-    /*  C. Multi-observer + multi-target                                   */
-    /* ================================================================== */
-
-    @Test
-    @DisplayName("Two observers in the same dimension both receive REMOVE+ADD (with the new textures)")
-    void twoObserversBothReceiveBroadcast() {
-        refresh();
-
-        assertRemoveAddPair(observer1Stream, "observer1");
-        assertRemoveAddPair(observer2Stream, "observer2");
-        assertAddCarriesNewTexture(observer1Stream);
-        assertAddCarriesNewTexture(observer2Stream);
-    }
-
-    @Test
-    @DisplayName("The target itself receives its own REMOVE+ADD broadcast before the cascade (self-reception)")
-    void targetReceivesOwnBroadcast() {
-        refresh();
-
-        int removeIdx = indexOfType(targetStream, ClientboundPlayerInfoRemovePacket.class);
-        int addIdx = indexOfType(targetStream, ClientboundPlayerInfoUpdatePacket.class);
-        int respawn = indexOfType(targetStream, ClientboundRespawnPacket.class);
-        assertTrue(removeIdx >= 0 && addIdx == removeIdx + 1 && respawn > addIdx,
-            "self-reception: REMOVE+ADD must reach the target's own connection before the respawn; stream=" + targetStream);
-    }
-
-    @Test
-    @DisplayName("Self-reception also holds in bundle mode")
-    void targetReceivesOwnBroadcast_bundleMode() {
-        Config.BROADCAST_USE_BUNDLE.set(true);
-        refresh();
-
-        int bundleIdx = indexOfType(targetStream, ClientboundBundlePacket.class);
-        int respawn = indexOfType(targetStream, ClientboundRespawnPacket.class);
-        assertTrue(bundleIdx >= 0 && respawn > bundleIdx,
-            "self-reception: the bundle must reach the target's own connection before the respawn; stream=" + targetStream);
-    }
-
-    /* ================================================================== */
-    /*  D. Cascade atomicity (persistence) contract                       */
+    /*  C. Cascade atomicity (persistence) contract                       */
     /* ================================================================== */
 
     @Test
@@ -531,6 +381,8 @@ class SkinRefreshHandlerTest {
                 "the partial cascade failure must be recorded");
         assertEquals(savesBefore, SkinMetrics.INSTANCE.snapshot().savesSubmitted(),
                 "a failed enqueue must not count as a submitted save");
+        assertEquals(0, fakeBroadcaster.broadcastCalls.size(),
+            "broadcast must not run when persistence fails");
     }
 
     @Test
@@ -575,22 +427,49 @@ class SkinRefreshHandlerTest {
     }
 
     /* ================================================================== */
+    /*  D. /skin clear with no Mojang profile                                */
+    /* ================================================================== */
+
+    @Test
+    @DisplayName("clear path also invokes the broadcaster and the cascade")
+    void clearPath_invokesBroadcasterAndCascade() {
+        // Stored skin is null: drop the applied textures property and
+        // run the broadcast+cascade so observers re-learn the cleared
+        // profile and the target reverts to the default skin.
+        storage.setSkin(target.getUUID(), null);
+        refresh();
+
+        assertEquals(1, fakeBroadcaster.broadcastCalls.size(),
+            "clear path also broadcasts; calls=" + fakeBroadcaster.broadcastCalls);
+        assertEquals(1, fakeBroadcaster.trackerCalls.size(),
+            "clear path also retracks");
+        assertCascadeOrder(targetStream);
+    }
+
+    /* ================================================================== */
+    /*  E. Wire-up verification                                            */
+    /* ================================================================== */
+
+    @Test
+    @DisplayName("getBroadcaster returns the wired instance")
+    void broadcasterGetterReturnsWired() {
+        assertEquals(fakeBroadcaster, SkinRefreshHandler.getBroadcaster(),
+            "the broadcaster the handler uses must be the one we injected");
+    }
+
+    /* ================================================================== */
     /*  Fixture                                                            */
     /* ================================================================== */
 
     /** Runs one refresh and resets all captured streams first. */
     private void refresh() {
         resetStreams();
+        fakeBroadcaster.reset();
         SkinRefreshHandler.task(target);
     }
 
     private void resetStreams() {
         targetStream.clear();
-        observer1Stream.clear();
-        observer2Stream.clear();
-        netherStream.clear();
-        globalSink.clear();
-        chunkTrace.clear();
     }
 
     private ServerPlayer newPlayer(String name, ServerLevel level) {
@@ -626,8 +505,7 @@ class SkinRefreshHandlerTest {
     /**
      * Ordered capture of everything sent to this player's connection.
      * Idempotent per player: the capture doAnswer is attached once and the
-     * same list is returned on every call (broadcast seams call this per
-     * delivered packet).
+     * same list is returned on every call.
      */
     private List<Object> streamFor(ServerPlayer player) {
         return playerStreams.computeIfAbsent(player, p -> {
@@ -658,42 +536,14 @@ class SkinRefreshHandlerTest {
     }
 
     private static void assertCascadeOrder(List<Object> stream, String combo) {
-        int removeIdx = indexOfType(stream, ClientboundPlayerInfoRemovePacket.class);
-        int addIdx = indexOfType(stream, ClientboundPlayerInfoUpdatePacket.class);
         int respawn = indexOfType(stream, ClientboundRespawnPacket.class);
         int position = indexOfType(stream, ClientboundPlayerPositionPacket.class);
         int difficulty = indexOfType(stream, ClientboundChangeDifficultyPacket.class);
         int permission = indexOfType(stream, ClientboundEntityEventPacket.class);
         int abilities = indexOfType(stream, ClientboundPlayerAbilitiesPacket.class);
-        // In bundle mode the REMOVE/ADD indices are -1 (they live inside the
-        // bundle, asserted by the caller); require only the cascade tail
-        // relative order plus broadcast-before-respawn.
         assertTrue(respawn >= 0 && position > respawn && difficulty > position
                 && permission > difficulty && abilities > permission,
             combo + ": expected respawn < position < difficulty < permission < abilities; stream=" + stream);
-        assertTrue(respawn > Math.max(removeIdx, addIdx),
-            combo + ": broadcast (REMOVE/ADD or bundle) must precede the respawn; stream=" + stream);
-    }
-
-    private static void assertRemoveAddPair(List<Object> stream, String who) {
-        int removeIdx = indexOfType(stream, ClientboundPlayerInfoRemovePacket.class);
-        int addIdx = indexOfType(stream, ClientboundPlayerInfoUpdatePacket.class);
-        assertTrue(removeIdx >= 0 && addIdx == removeIdx + 1,
-            who + " must receive REMOVE then ADD as neighbors; stream=" + stream);
-    }
-
-    private static void assertAddCarriesNewTexture(List<Object> stream) {
-        ClientboundPlayerInfoUpdatePacket add = filterType(stream, ClientboundPlayerInfoUpdatePacket.class)
-                .stream()
-                .filter(p -> p.actions().contains(ClientboundPlayerInfoUpdatePacket.Action.ADD_PLAYER))
-                .findFirst()
-                .orElse(null);
-        assertTrue(add != null, "ADD packet missing from stream=" + stream);
-        boolean hasTexture = add.entries().stream()
-                .anyMatch(e -> e.profile() != null
-                        && e.profile().getProperties().get("textures").stream()
-                                .anyMatch(prop -> TEXTURE_VALUE.equals(prop.value())));
-        assertTrue(hasTexture, "ADD packet must carry the new textures property");
     }
 
     private static int indexOfType(List<?> events, Class<?> type) {
@@ -705,19 +555,17 @@ class SkinRefreshHandlerTest {
         return -1;
     }
 
-    private static long countOfType(List<?> events, Class<?> type) {
-        return events.stream().filter(type::isInstance).count();
-    }
-
-    @SuppressWarnings("unchecked")
-    private static <T> List<T> filterType(List<?> events, Class<T> type) {
-        List<T> result = new ArrayList<>();
-        for (Object event : events) {
-            if (type.isInstance(event)) {
-                result.add((T) event);
+    private static int indexOfType(List<?> events, Object marker, Class<?> type) {
+        for (int i = 0; i < events.size(); i++) {
+            if (type.isInstance(events.get(i)) && events.get(i).equals(marker)) {
+                return i;
             }
         }
-        return result;
+        return -1;
+    }
+
+    private static long countOfType(List<?> events, Class<?> type) {
+        return events.stream().filter(type::isInstance).count();
     }
 
     private static void setField(Object target, String fieldName, Object value) {


### PR DESCRIPTION
## feat(1.21): broadcast broker seam — extract SkinBroadcaster for REMOVE+ADD/tracker abstraction

### Summary

This PR introduces the `SkinBroadcaster` interface and a `VanillaSkinBroadcaster` implementation that owns the per-viewer packet fan-out and the entity-tracker re-track step previously inlined in `SkinRefreshHandler.task`. Refactoring the handler to delegate to the seam lets the handler test assert **call shape** (which broadcasters were invoked, in what order, with which arguments) instead of re-implementing the entire REMOVE+ADD+cascade pipeline.

### Seam interface

`SkinBroadcaster` (`net.levosilimo.everlastingskins.broadcast.SkinBroadcaster`):

```java
public interface SkinBroadcaster {
    void broadcastProfileChange(GameProfile newProfile, ServerPlayer target);
    void broadcastProfileChange(GameProfile newProfile, ServerPlayer target, ServerPlayer[] observers);
    void trackerUntrackRetrack(Entity entity);
}
```

- `broadcastProfileChange(GameProfile, ServerPlayer)` — broadcasts the REMOVE+ADD (or one bundled REMOVE+ADD when `BROADCAST_USE_BUNDLE`) tab-list pair to all observers (or the dimension-scoped subset when `DIMENSION_SCOPED_BROADCAST` is enabled).
- `broadcastProfileChange(GameProfile, ServerPlayer, ServerPlayer[])` — explicit observer set, used when the caller has already filtered by dimension or other criteria.
- `trackerUntrackRetrack(Entity)` — untrack/re-track on the entity's server level. No-op when `REFRESH_VIA_ENTITY_TRACKER` is disabled. The re-track forces remote clients to destroy+re-spawn the entity so their cached playerInfo re-fetches the new profile entry.

### `VanillaSkinBroadcaster` (production impl)

`VanillaSkinBroadcaster` builds the `ClientboundPlayerInfoRemovePacket` + `ClientboundPlayerInfoUpdatePacket(ADD_PLAYER)` pair (or one `ClientboundBundlePacket` when bundle is enabled) and delivers it via the live `PlayerList` or directly to each filtered observer. It also drives the `level.getChunkSource().removeEntity(...); addEntity(...)` pair that re-tracks the target on observers' entity trackers when `REFRESH_VIA_ENTITY_TRACKER` is enabled.

Metrics: `recordBroadcastLatency`, `recordSpikeBroadcast`, `recordBroadcast` (wire bytes), and `recordNetworkDelta` are recorded inside `broadcastInternal` so the seam owns the broadcast-attributed telemetry.

### `SkinRefreshHandler` refactor

`SkinRefreshHandler.task` no longer builds or sends the REMOVE+ADD packets, no longer touches the entity tracker directly, and no longer reads the broadcast flags. It delegates to a `SkinBroadcaster` constructor parameter:

- `broadcastProfileChange(newProfile, target)` for the per-viewer broadcast.
- `trackerUntrackRetrack(player)` for the entity-tracker re-track (gated by the broadcaster reading `REFRESH_VIA_ENTITY_TRACKER`).

The handler-level flag check (`flagChanges`) is preserved as a handler-owned check (the broadcaster does not own it — it only reports the broadcast contract).

### Test pin: `FakeSkinBroadcaster` + `VanillaSkinBroadcasterTest`

- `FakeSkinBroadcaster` is a recording fake that captures every `broadcastProfileChange` and `trackerUntrackRetrack` invocation (arguments, explicit observer set, call order).
- `FakeSkinBroadcasterTest` (auto-checked) pins the contract: methods are idempotent, observers-list is recorded as-is, `trackerUntrackRetrack` accepts arbitrary `Entity` types.
- `VanillaSkinBroadcasterTest` pins the **production impl** against the same contract: config flags wire to the right branch (bundle vs. separate, dimension-scoped vs. all, tracker-untrack vs. no-op), wire-size metric is recorded, and the call sequence matches the contract (broadcast before tracker-untrack when both run).
- `SkinRefreshHandlerTest` is refactored to inject `FakeSkinBroadcaster` and assert that the handler invokes `broadcastProfileChange(newProfile, target)` and `trackerUntrackRetrack(player)` exactly once per refresh, and does not perform the broadcast itself.

### Commits

1. `feat(1.21): add SkinBroadcaster seam and VanillaSkinBroadcaster (R4 broker)`
2. `refactor(1.21): wire SkinRefreshHandler through SkinBroadcaster seam`
3. `test(1.21): pin SkinBroadcaster contract on the production impl`
4. `test(1.21): refactor SkinRefreshHandlerTest to use FakeSkinBroadcaster`
5. `fix(1.21): align handler test with broadcaster-owned flag check`

### Notes

- Bundle path uses `ClientboundBundlePacket` (1.21-only); the mirror PR for 1.12.2 notes that 1.12.2 has no `ClientboundBundlePacket` and uses separate-packet delivery.
- The broadcaster is a constructor-injected dependency of `SkinRefreshHandler`; the production wiring is unchanged from the call-site perspective.
