### PR TITLE
fix(1.21): fsync parent directory after skin rename (Tier-1 durability)

### DIFF
--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinIO.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinIO.java
@@ -224,6 +224,8 @@ public class SkinIO {
     /**
      * Atomic write: temp file + force + ATOMIC_MOVE, with a fallback move on
      * failure. Preserved from the original synchronous implementation.
+     * After the rename the parent directory is fsynced so the directory
+     * entry itself survives a power loss (Pillai OSDI'14 safe file flush).
      */
     private void writeSkinFile(UUID uuid, byte[] payload) {
         Path target = savePath.resolve(uuid + FILE_EXTENSION);
@@ -241,12 +243,14 @@ public class SkinIO {
             }
 
             Files.move(temp, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+            fsyncDirectory();
         } catch (IOException e) {
             SkinMetrics.INSTANCE.recordIoFailure(e);
             EverlastingSkins.logger.error("Failed to save skin for player {}", uuid, e);
             if (Files.exists(temp)) {
                 try {
                     Files.move(temp, target, StandardCopyOption.REPLACE_EXISTING);
+                    fsyncDirectory();
                 } catch (IOException ex) {
                     try {
                         Files.deleteIfExists(temp);
@@ -255,6 +259,32 @@ public class SkinIO {
                 }
             }
         }
+    }
+
+    /**
+     * Durability barrier: fsync the parent directory after the rename.
+     * File fsync alone does not flush the rename's directory entry, so
+     * without this a power loss can lose the write even though the content
+     * was already durable. Best-effort: the content is already fsynced, so
+     * a directory fsync failure is logged, never propagated.
+     */
+    private void fsyncDirectory() {
+        try (FileChannel dirChannel = openDirectoryChannel(savePath)) {
+            dirChannel.force(true);
+        } catch (UnsupportedOperationException ignored) {
+            // Some filesystems (e.g. FAT) don't support dir fsync; tolerate silently.
+        } catch (IOException e) {
+            EverlastingSkins.logger.warn("Failed to fsync skin directory {}", savePath, e);
+        }
+    }
+
+    /**
+     * Opens the save directory read-only so it can be fsynced. Package-private
+     * so tests can substitute the channel and assert the durability barrier
+     * runs after the rename.
+     */
+    FileChannel openDirectoryChannel(Path dir) throws IOException {
+        return FileChannel.open(dir, StandardOpenOption.READ);
     }
 
     @Nullable

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/SkinIOPowerLossTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/SkinIOPowerLossTest.java
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import levosilimo.everlastingskins.util.CustomSkinProperty;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Power-loss durability of {@link SkinIO} writes: the file content is
+ * fsynced before the atomic rename, and the parent directory must be
+ * fsynced after the rename so the directory entry itself survives a crash
+ * (Pillai OSDI'14 safe file flush). No real power-loss simulation is
+ * required — the fsync barrier is verified by intercepting the channel.
+ */
+class SkinIOPowerLossTest {
+
+    @TempDir
+    Path tempDir;
+
+    private SkinIO skinIO;
+
+    @BeforeEach
+    void setUp() {
+        skinIO = new SkinIO(tempDir);
+    }
+
+    @Test
+    @DisplayName("saveSkin forces the parent directory after the atomic rename")
+    void writeSkinFile_fsyncsParentDirectory_afterAtomicMove() throws Exception {
+        FileChannel dirChannel = mock(FileChannel.class);
+        SkinIO spy = spy(skinIO);
+        doReturn(dirChannel).when(spy).openDirectoryChannel(tempDir);
+
+        UUID uuid = UUID.randomUUID();
+        spy.saveSkin(uuid, new CustomSkinProperty("value", "sig", "source"));
+
+        // The durability barrier must run on the save directory, and the
+        // returned channel must be forced so the rename entry is durable.
+        verify(spy, atLeastOnce()).openDirectoryChannel(tempDir);
+        verify(dirChannel, atLeastOnce()).force(true);
+        assertTrue(Files.exists(tempDir.resolve(uuid + ".json")), "skin must still be saved");
+    }
+}


### PR DESCRIPTION
## What
Closes the last Tier-1 durability gap: after `ATOMIC_MOVE` (and the non-atomic fallback), the save directory is now fsynced so the rename's directory entry itself survives power loss (Pillai OSDI'14 safe file flush). Previously the file content was durable but the rename could be lost.

## Changes
- `SkinIO.writeSkinFile`: calls `fsyncDirectory()` after both the atomic move and the fallback move
- `fsyncDirectory()`: opens the parent dir read-only via `FileChannel` and `force(true)`; best-effort — `UnsupportedOperationException` (e.g. FAT) tolerated silently, `IOException` logged, never fails the write (content already durable)
- `openDirectoryChannel(Path)`: package-private seam so tests can intercept the channel (no public API change)
- New `SkinIOPowerLossTest.writeSkinFile_fsyncsParentDirectory_afterAtomicMove` verifying `force(true)` on the parent directory at least once via Mockito

## Verification
- `./gradlew build test` — BUILD SUCCESSFUL, all tests green incl. new `SkinIOPowerLossTest` (1 test, 0 failures)
- `./gradlew runGameTestServer` — "All 34 required tests passed" (34/34, same as round-4 baseline)
- aislop 100/100 clean on both commits; pre-commit hook ran on every commit (no --no-verify)

## Notes
- No new dependencies, no public API changes
- 1.12.2 mirror: fix/1122-tier1-fsync (dir fsync already present there; adds the missing UnsupportedOperationException tolerance + the same test)