### PR TITLE
fix(1122): complete parent-directory fsync durability (Tier-1)

### DIFF
--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinIO.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinIO.java
@@ -138,11 +138,23 @@ public class SkinIO {
      * only the rename entry may not survive a crash.
      */
     private void fsyncDirectory() {
-        try (FileChannel dir = FileChannel.open(savePath, StandardOpenOption.READ)) {
+        try (FileChannel dir = openDirectoryChannel(savePath)) {
             dir.force(true);
+        } catch (UnsupportedOperationException ignored) {
+            // Some filesystems (e.g. FAT) don't support dir fsync; tolerate silently.
         } catch (IOException e) {
             EverlastingSkins.logger.warn("Failed to fsync skin directory {}", savePath, e);
         }
+    }
+
+    /**
+     * Opens the save directory read-only so it can be fsynced. Package-private
+     * so tests can substitute the channel and assert the durability barrier
+     * runs after the rename (Mockito cannot intercept static
+     * {@code FileChannel.open} on the Java 8 line).
+     */
+    FileChannel openDirectoryChannel(Path dir) throws IOException {
+        return FileChannel.open(dir, StandardOpenOption.READ);
     }
 
     @Nullable

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/SkinIOPowerLossTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/SkinIOPowerLossTest.java
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import levosilimo.everlastingskins.util.CustomSkinProperty;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Power-loss durability of {@link SkinIO} writes: the file content is
+ * fsynced before the atomic rename, and the parent directory must be
+ * fsynced after the rename so the directory entry itself survives a crash
+ * (Pillai OSDI'14 safe file flush). No real power-loss simulation is
+ * required — the fsync barrier is verified by intercepting the channel.
+ */
+class SkinIOPowerLossTest {
+
+    @TempDir
+    Path tempDir;
+
+    private SkinIO skinIO;
+
+    @BeforeEach
+    void setUp() {
+        skinIO = new SkinIO(tempDir);
+    }
+
+    @Test
+    @DisplayName("saveSkin forces the parent directory after the atomic rename")
+    void writeSkinFile_fsyncsParentDirectory_afterAtomicMove() throws Exception {
+        FileChannel dirChannel = mock(FileChannel.class);
+        SkinIO spy = spy(skinIO);
+        doReturn(dirChannel).when(spy).openDirectoryChannel(tempDir);
+
+        UUID uuid = UUID.randomUUID();
+        spy.saveSkin(uuid, new CustomSkinProperty("value", "sig", "source"));
+
+        // The durability barrier must run on the save directory, and the
+        // returned channel must be forced so the rename entry is durable.
+        verify(spy, atLeastOnce()).openDirectoryChannel(tempDir);
+        verify(dirChannel, atLeastOnce()).force(true);
+        assertTrue(Files.exists(tempDir.resolve(uuid + ".json")), "skin must still be saved");
+    }
+}


### PR DESCRIPTION
## What
Mirror of #221 (1.21). The parent-directory fsync after the rename already landed in `ede35b6`; this PR closes the remaining Tier-1 gaps:
1. `fsyncDirectory()` only caught `IOException` — filesystems that reject opening a directory for READ throw `UnsupportedOperationException`, which would escape and fail the save. Now tolerated silently (content already durable).
2. New `SkinIOPowerLossTest.writeSkinFile_fsyncsParentDirectory_afterAtomicMove` pinning that `saveSkin` calls `force(true)` on the parent directory at least once.

## Changes
- `SkinIO.fsyncDirectory()`: adds `UnsupportedOperationException` tolerance; delegates to new package-private `openDirectoryChannel(Path)` seam
- `SkinIO.openDirectoryChannel(Path)`: package-private so tests can substitute the channel (Mockito 2.28.2 on Java 8 has no `mockStatic`; no new dependencies)
- New `SkinIOPowerLossTest` — mirror of the 1.21 test

## Verification
- `./gradlew build test` — BUILD SUCCESSFUL, all tests green incl. new `SkinIOPowerLossTest` (1 test, 0 failures)
- aislop 100/100 clean on both commits; pre-commit hook ran on every commit (no --no-verify)

## Notes
- No new dependencies, no public API changes (package-private seam only)