### PR TITLE
feat(Tier 2): per-record SHA-256 checksum + startup sweep (Pillai safe-state)

### DIFF
--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinIO.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinIO.java
@@ -55,6 +55,13 @@ public class SkinIO {
      */
     private static final String CHECKSUM_FIELD = "checksum";
 
+    /** {@link #checksumStatus(String)} result: canonical record matches its marker. */
+    private static final int CHECKSUM_VALID = 0;
+    /** {@link #checksumStatus(String)} result: record is malformed or its marker no longer matches. */
+    private static final int CHECKSUM_MISMATCH = 1;
+    /** {@link #checksumStatus(String)} result: record carries no marker (legacy format). */
+    private static final int CHECKSUM_ABSENT = 2;
+
     /**
      * Single-thread writer so per-UUID writes are serialized; latest payload
      * per UUID wins (coalescing). Daemon thread so it never blocks shutdown.
@@ -361,10 +368,53 @@ public class SkinIO {
                 quarantineFile(uuid);
                 return null;
             }
+            int status = checksumStatus(content);
+            if (status == CHECKSUM_MISMATCH) {
+                EverlastingSkins.logger.warn("Bit rot detected in skin record {}: checksum mismatch, quarantining", target);
+                quarantineFile(uuid);
+                return null;
+            }
+            if (status == CHECKSUM_ABSENT) {
+                EverlastingSkins.logger.warn(
+                        "Skin record {} has no checksum (legacy format); loaded without integrity verification", target);
+            }
             return content;
         } catch (IOException e) {
             return null;
         }
+    }
+
+    /**
+     * Recomputed the in-band SHA-256 of a parsed record and compares it to
+     * the stored marker. The canonical form (record minus the marker member,
+     * re-serialized through the same Gson) is byte-identical to the bytes
+     * that were hashed on write, so a single flipped byte in the value,
+     * signature or any other member fails the comparison — the silent
+     * failure mode that {@code isValidJson} cannot see (bit rot that still
+     * parses as valid JSON). Returns {@link #CHECKSUM_VALID} on a match,
+     * {@link #CHECKSUM_MISMATCH} on malformed JSON or a digest mismatch and
+     * {@link #CHECKSUM_ABSENT} for legacy records without a marker.
+     */
+    private static int checksumStatus(String content) {
+        JsonElement element;
+        try {
+            element = JsonParser.parseString(content);
+        } catch (JsonParseException e) {
+            return CHECKSUM_MISMATCH;
+        }
+        if (!element.isJsonObject()) {
+            // Array-shaped records predate the marker; nothing to verify.
+            return CHECKSUM_ABSENT;
+        }
+        JsonObject obj = element.getAsJsonObject();
+        if (!obj.has(CHECKSUM_FIELD) || obj.get(CHECKSUM_FIELD).isJsonNull()) {
+            return CHECKSUM_ABSENT;
+        }
+        String expected = obj.get(CHECKSUM_FIELD).getAsString();
+        obj.remove(CHECKSUM_FIELD);
+        String canonical = JsonUtils.toJson(obj);
+        boolean matches = sha256Hex(canonical.getBytes(StandardCharsets.UTF_8)).equals(expected);
+        return matches ? CHECKSUM_VALID : CHECKSUM_MISMATCH;
     }
 
     private static boolean isValidJson(String content) {
@@ -378,10 +428,18 @@ public class SkinIO {
     }
 
     private void quarantineFile(UUID uuid) {
-        Path target = savePath.resolve(uuid + FILE_EXTENSION);
+        quarantineFile(savePath.resolve(uuid + FILE_EXTENSION));
+    }
+
+    /**
+     * Renames a corrupt record to {@code <name>.corrupt-<ts>} so it is never
+     * re-read. Called for malformed JSON and checksum mismatches alike; a
+     * mismatched record that still parses as JSON is quarantined identically.
+     */
+    private void quarantineFile(Path target) {
         if (!Files.exists(target)) return;
         String timestamp = String.valueOf(Instant.now().toEpochMilli());
-        Path quarantine = savePath.resolve(uuid + FILE_EXTENSION + CORRUPT_PREFIX + timestamp);
+        Path quarantine = target.resolveSibling(target.getFileName() + CORRUPT_PREFIX + timestamp);
         try {
             Files.move(target, quarantine, StandardCopyOption.REPLACE_EXISTING);
         } catch (IOException ignored) {

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinIO.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinIO.java
@@ -20,21 +20,21 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.util.UUID;
-import java.util.stream.Stream;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
 
 public class SkinIO {
 
@@ -385,7 +385,7 @@ public class SkinIO {
     }
 
     /**
-     * Recomputed the in-band SHA-256 of a parsed record and compares it to
+     * Recomputes the in-band SHA-256 of a parsed record and compares it to
      * the stored marker. The canonical form (record minus the marker member,
      * re-serialized through the same Gson) is byte-identical to the bytes
      * that were hashed on write, so a single flipped byte in the value,

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinIO.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinIO.java
@@ -20,12 +20,15 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.time.Instant;
 import java.util.UUID;
+import java.util.stream.Stream;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
@@ -38,6 +41,19 @@ public class SkinIO {
     private static final String FILE_EXTENSION = ".json";
     private static final String TEMP_SUFFIX = ".tmp";
     private static final String CORRUPT_PREFIX = ".corrupt-";
+
+    /**
+     * In-band per-record integrity marker (Tier 2): hex SHA-256 of the
+     * canonical record bytes, stored as a JSON member of the record itself.
+     * Record and marker therefore move together in one atomic rename, so a
+     * crash can never leave a torn record/checksum pair on disk (a sidecar
+     * file has an unavoidable two-file window). This mirrors the in-band
+     * checksum placement of ARIES (per-log-page checksums) and RocksDB
+     * (per-block trailers) and the committed-state framing of Pillai et al.
+     * (OSDI 2014): a reader sees either the previous committed record or the
+     * new one, never a record whose integrity cannot be checked.
+     */
+    private static final String CHECKSUM_FIELD = "checksum";
 
     /**
      * Single-thread writer so per-UUID writes are serialized; latest payload
@@ -235,7 +251,7 @@ public class SkinIO {
             Files.createDirectories(savePath);
             Files.deleteIfExists(temp);
 
-            Files.write(temp, payload, StandardOpenOption.CREATE, StandardOpenOption.WRITE,
+            Files.write(temp, withChecksum(payload), StandardOpenOption.CREATE, StandardOpenOption.WRITE,
                     StandardOpenOption.TRUNCATE_EXISTING);
 
             try (FileChannel channel = FileChannel.open(temp, StandardOpenOption.WRITE)) {
@@ -258,6 +274,54 @@ public class SkinIO {
                     }
                 }
             }
+        }
+    }
+
+    /**
+     * Wraps a raw record payload in the checksum envelope: strips any stale
+     * {@value #CHECKSUM_FIELD} member, hashes the canonical record bytes and
+     * appends the hex SHA-256 digest as the {@value #CHECKSUM_FIELD} member.
+     * The canonical record is the payload re-serialized through the same Gson
+     * used by {@link JsonUtils} (deterministic field order and pretty
+     * printing), so the write path and the verify path derive identical
+     * bytes: a single flipped byte anywhere in the canonical record changes
+     * the digest. This is the tier-2 barrier that closes the silent bit-rot
+     * gap — a flipped byte inside the base64 value or signature still parses
+     * as valid JSON, and the {@code isValidJson} check alone cannot see it
+     * (cf. ARIES page checksums and RocksDB block trailers, which store the
+     * integrity marker in-band with the data it protects).
+     * <p>
+     * Backwards compatibility: a payload that is not a JSON object (e.g.
+     * the raw byte payloads written by the durability tests, or any
+     * hand-crafted legacy record) is written verbatim without a marker;
+     * such files load with a warning, never a quarantine.
+     */
+    private static byte[] withChecksum(byte[] payload) {
+        try {
+            JsonObject obj = JsonParser.parseString(new String(payload, StandardCharsets.UTF_8)).getAsJsonObject();
+            obj.remove(CHECKSUM_FIELD);
+            String canonical = JsonUtils.toJson(obj);
+            obj.addProperty(CHECKSUM_FIELD, sha256Hex(canonical.getBytes(StandardCharsets.UTF_8)));
+            return JsonUtils.toJson(obj).getBytes(StandardCharsets.UTF_8);
+        } catch (JsonParseException | IllegalStateException e) {
+            // Not a JSON object: write verbatim (legacy format, no marker).
+            return payload;
+        }
+    }
+
+    /** Hex SHA-256 of the given bytes. Built-in {@link MessageDigest}: no new dependency. */
+    private static String sha256Hex(byte[] data) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(data);
+            StringBuilder hex = new StringBuilder(hash.length * 2);
+            for (byte b : hash) {
+                hex.append(Character.forDigit((b >> 4) & 0xF, 16));
+                hex.append(Character.forDigit(b & 0xF, 16));
+            }
+            return hex.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is required but unavailable", e);
         }
     }
 

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinIO.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinIO.java
@@ -445,4 +445,62 @@ public class SkinIO {
         } catch (IOException ignored) {
         }
     }
+
+    /**
+     * Startup integrity sweep: scans every {@code *.json} record in the save
+     * directory, recomputes the in-band SHA-256 and quarantines any record
+     * whose marker no longer matches (bit rot detected before any player
+     * logs in, so a silently corrupt skin can never be applied). Legacy
+     * records without a marker pass through, as do {@code .tmp} and
+     * {@code .corrupt-*} files. Logs a summary line with the counts; the
+     * result is returned so tests (and the summary) can assert the sweep
+     * outcome. One hash per record: negligible at startup scale.
+     */
+    public SweepResult validateAllFiles() {
+        if (!Files.isDirectory(savePath)) {
+            EverlastingSkins.logger.info("SkinIO sweep: no skin directory at {}, nothing to validate", savePath);
+            return new SweepResult(0, 0, 0);
+        }
+        int checked = 0;
+        int corrupt = 0;
+        int legacy = 0;
+        try (Stream<Path> files = Files.list(savePath)) {
+            for (Path file : (Iterable<Path>) files::iterator) {
+                String name = file.getFileName().toString();
+                if (!name.endsWith(FILE_EXTENSION)) continue;
+                checked++;
+                try {
+                    String content = Files.readString(file, StandardCharsets.UTF_8);
+                    int status = checksumStatus(content);
+                    if (status == CHECKSUM_MISMATCH) {
+                        EverlastingSkins.logger.warn("Bit rot detected in {} during startup sweep; quarantining", file);
+                        quarantineFile(file);
+                        corrupt++;
+                    } else if (status == CHECKSUM_ABSENT) {
+                        legacy++;
+                    }
+                } catch (IOException e) {
+                    EverlastingSkins.logger.warn("SkinIO sweep could not read {}; leaving it in place", file, e);
+                }
+            }
+        } catch (IOException e) {
+            EverlastingSkins.logger.warn("SkinIO sweep failed to list {}", savePath, e);
+        }
+        EverlastingSkins.logger.info("SkinIO sweep: {} files checked, {} corrupt quarantined, {} legacy without checksum",
+                checked, corrupt, legacy);
+        return new SweepResult(checked, corrupt, legacy);
+    }
+
+    /** Outcome of {@link #validateAllFiles()}. */
+    public static final class SweepResult {
+        public final int filesChecked;
+        public final int corruptFound;
+        public final int legacyFound;
+
+        SweepResult(int filesChecked, int corruptFound, int legacyFound) {
+            this.filesChecked = filesChecked;
+            this.corruptFound = corruptFound;
+            this.legacyFound = legacyFound;
+        }
+    }
 }

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRestorer.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRestorer.java
@@ -57,6 +57,9 @@ public class SkinRestorer {
             throw new RuntimeException(e);
         }
         skinIO = new SkinIO(path);
+        // Startup integrity sweep: quarantine bit-rotten records before the
+        // first player logs in, so SkinStorage only ever sees verified files.
+        skinIO.validateAllFiles();
         skinStorage = new SkinStorage(skinIO);
     }
 

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/SkinIOCRCTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/SkinIOCRCTest.java
@@ -67,12 +67,12 @@ class SkinIOCRCTest {
     @DisplayName("valid record with matching checksum loads successfully")
     void readSkinFile_verifiesChecksum_pass() {
         UUID uuid = UUID.randomUUID();
-        CustomSkinProperty original = skin("value1");
-        skinIO.saveSkin(uuid, original);
+        String value = base64("value1");
+        skinIO.saveSkin(uuid, skin(value));
 
         CustomSkinProperty loaded = skinIO.loadSkin(uuid);
         assertNotNull(loaded, "a record whose checksum matches must load");
-        assertEquals("value1", loaded.getOriginalProperty().value());
+        assertEquals(value, loaded.getOriginalProperty().value());
         assertEquals("sig1", loaded.getOriginalProperty().signature());
     }
 
@@ -105,11 +105,12 @@ class SkinIOCRCTest {
     void readSkinFile_noChecksum_backwardCompat() throws IOException {
         UUID uuid = UUID.randomUUID();
         // Legacy files were written as bare JsonUtils.toJson(skin) — no marker.
-        Files.writeString(tempDir.resolve(uuid + ".json"), JsonUtils.toJson(skin("legacy")), StandardCharsets.UTF_8);
+        String value = base64("legacy");
+        Files.writeString(tempDir.resolve(uuid + ".json"), JsonUtils.toJson(skin(value)), StandardCharsets.UTF_8);
 
         CustomSkinProperty loaded = skinIO.loadSkin(uuid);
         assertNotNull(loaded, "a markerless legacy record must still load");
-        assertEquals("legacy", loaded.getOriginalProperty().value());
+        assertEquals(value, loaded.getOriginalProperty().value());
         assertTrue(Files.exists(tempDir.resolve(uuid + ".json")),
                 "a legacy record must never be quarantined for lacking a checksum");
     }
@@ -120,7 +121,7 @@ class SkinIOCRCTest {
         List<UUID> valid = new ArrayList<>();
         for (int i = 0; i < 3; i++) {
             UUID u = UUID.randomUUID();
-            skinIO.saveSkin(u, skin("ok-" + i));
+            skinIO.saveSkin(u, skin(base64("ok-" + i)));
             valid.add(u);
         }
         UUID corrupt = UUID.randomUUID();
@@ -152,7 +153,7 @@ class SkinIOCRCTest {
         List<UUID> uuids = new ArrayList<>();
         for (int i = 0; i < count; i++) {
             UUID u = UUID.randomUUID();
-            skinIO.saveSkin(u, skin("perf-" + i));
+            skinIO.saveSkin(u, skin(base64("perf-" + i)));
             uuids.add(u);
         }
 

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/SkinIOCRCTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/SkinIOCRCTest.java
@@ -1,0 +1,190 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
+package levosilimo.everlastingskins.skinchanger;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import levosilimo.everlastingskins.util.CustomSkinProperty;
+import levosilimo.everlastingskins.util.JsonUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Per-record CRC (Tier 2): the in-band SHA-256 checksum envelope of
+ * {@link SkinIO} closes the silent bit-rot gap — a flipped byte inside the
+ * base64 value or signature still parses as valid JSON, and the
+ * {@code isValidJson} check alone cannot see it. These tests pin the
+ * write-side marker, the read-side verification and quarantine, backward
+ * compatibility with markerless legacy records, the startup sweep, and the
+ * per-load hash cost.
+ */
+class SkinIOCRCTest {
+
+    @TempDir
+    Path tempDir;
+
+    private SkinIO skinIO;
+
+    @BeforeEach
+    void setUp() {
+        skinIO = new SkinIO(tempDir);
+    }
+
+    @Test
+    @DisplayName("saveSkin writes an in-band SHA-256 checksum member")
+    void writeSkinFile_includesChecksum() throws IOException {
+        UUID uuid = UUID.randomUUID();
+        skinIO.saveSkin(uuid, skin("val"));
+
+        Path target = tempDir.resolve(uuid + ".json");
+        assertTrue(Files.exists(target), "target file must exist after save");
+        JsonObject envelope = JsonParser.parseString(Files.readString(target, StandardCharsets.UTF_8)).getAsJsonObject();
+        assertTrue(envelope.has("checksum"), "persisted record must carry a checksum member");
+        String checksum = envelope.get("checksum").getAsString();
+        assertEquals(64, checksum.length(), "SHA-256 hex digest must be 64 chars");
+        assertTrue(checksum.matches("[0-9a-f]{64}"), "checksum must be lowercase hex: " + checksum);
+    }
+
+    @Test
+    @DisplayName("valid record with matching checksum loads successfully")
+    void readSkinFile_verifiesChecksum_pass() {
+        UUID uuid = UUID.randomUUID();
+        CustomSkinProperty original = skin("value1");
+        skinIO.saveSkin(uuid, original);
+
+        CustomSkinProperty loaded = skinIO.loadSkin(uuid);
+        assertNotNull(loaded, "a record whose checksum matches must load");
+        assertEquals("value1", loaded.getOriginalProperty().value());
+        assertEquals("sig1", loaded.getOriginalProperty().signature());
+    }
+
+    @Test
+    @DisplayName("flipped byte in the base64 value → checksum mismatch, quarantined, null returned")
+    void readSkinFile_verifiesChecksum_fail_quarantines() throws IOException {
+        UUID uuid = UUID.randomUUID();
+        skinIO.saveSkin(uuid, skin(base64("flip-me")));
+
+        // Simulate bit rot: flip one base64 alphabet char in the value. The
+        // result is still valid JSON AND still decodes as base64, so the old
+        // isValidJson-only path would have silently loaded it — only the
+        // in-band checksum can see this corruption.
+        Path target = tempDir.resolve(uuid + ".json");
+        JsonObject envelope = JsonParser.parseString(Files.readString(target, StandardCharsets.UTF_8)).getAsJsonObject();
+        JsonObject record = envelope.getAsJsonObject("originalProperty");
+        String value = record.get("value").getAsString();
+        char flipped = value.charAt(0) == 'Z' ? 'Y' : 'Z';
+        record.addProperty("value", flipped + value.substring(1));
+        Files.writeString(target, JsonUtils.toJson(envelope), StandardCharsets.UTF_8);
+
+        CustomSkinProperty loaded = skinIO.loadSkin(uuid);
+        assertNull(loaded, "a record with a flipped byte must not load");
+        assertFalse(Files.exists(target), "corrupt record must be moved out of the storage path");
+        assertCorruptFileExists(uuid);
+    }
+
+    @Test
+    @DisplayName("record without checksum (legacy format) loads with a warning, not quarantined")
+    void readSkinFile_noChecksum_backwardCompat() throws IOException {
+        UUID uuid = UUID.randomUUID();
+        // Legacy files were written as bare JsonUtils.toJson(skin) — no marker.
+        Files.writeString(tempDir.resolve(uuid + ".json"), JsonUtils.toJson(skin("legacy")), StandardCharsets.UTF_8);
+
+        CustomSkinProperty loaded = skinIO.loadSkin(uuid);
+        assertNotNull(loaded, "a markerless legacy record must still load");
+        assertEquals("legacy", loaded.getOriginalProperty().value());
+        assertTrue(Files.exists(tempDir.resolve(uuid + ".json")),
+                "a legacy record must never be quarantined for lacking a checksum");
+    }
+
+    @Test
+    @DisplayName("startup sweep quarantines exactly the corrupt records")
+    void validateAllFiles_sweepsCorrupt() throws IOException {
+        List<UUID> valid = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            UUID u = UUID.randomUUID();
+            skinIO.saveSkin(u, skin("ok-" + i));
+            valid.add(u);
+        }
+        UUID corrupt = UUID.randomUUID();
+        skinIO.saveSkin(corrupt, skin(base64("rot")));
+        Path corruptTarget = tempDir.resolve(corrupt + ".json");
+        JsonObject envelope = JsonParser.parseString(Files.readString(corruptTarget, StandardCharsets.UTF_8)).getAsJsonObject();
+        JsonObject record = envelope.getAsJsonObject("originalProperty");
+        String value = record.get("value").getAsString();
+        char flipped = value.charAt(0) == 'Z' ? 'Y' : 'Z';
+        record.addProperty("value", flipped + value.substring(1));
+        Files.writeString(corruptTarget, JsonUtils.toJson(envelope), StandardCharsets.UTF_8);
+
+        SkinIO.SweepResult result = skinIO.validateAllFiles();
+
+        assertEquals(4, result.filesChecked, "sweep must check all four records");
+        assertEquals(1, result.corruptFound, "sweep must find the one bit-rotten record");
+        assertEquals(0, result.legacyFound, "all four records carry markers");
+        assertFalse(Files.exists(corruptTarget), "corrupt record must be quarantined");
+        assertCorruptFileExists(corrupt);
+        for (UUID u : valid) {
+            assertTrue(Files.exists(tempDir.resolve(u + ".json")), "valid record must survive the sweep");
+        }
+    }
+
+    @Test
+    @DisplayName("1000 load cycles with verification stay under 100ms")
+    void crcPerformanceOverhead_acceptable() {
+        int count = 1000;
+        List<UUID> uuids = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            UUID u = UUID.randomUUID();
+            skinIO.saveSkin(u, skin("perf-" + i));
+            uuids.add(u);
+        }
+
+        // Timed region: the full read + verify + parse load cycle only; the
+        // disk-write setup is intentionally outside the budget.
+        long start = System.nanoTime();
+        for (UUID u : uuids) {
+            assertNotNull(skinIO.loadSkin(u), "every record must load during the perf probe");
+        }
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+        assertTrue(elapsedMs < 100,
+                count + " load+verify cycles took " + elapsedMs + "ms, expected < 100ms");
+    }
+
+    /* ================================================================== */
+    /*  Helpers                                                            */
+    /* ================================================================== */
+
+    private static CustomSkinProperty skin(String value) {
+        return new CustomSkinProperty(value, "sig1", "crc-test");
+    }
+
+    private static String base64(String text) {
+        return Base64.getEncoder().encodeToString(text.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private void assertCorruptFileExists(UUID uuid) {
+        try (var files = Files.list(tempDir)) {
+            boolean found = files.anyMatch(p -> p.getFileName().toString().startsWith(uuid + ".json.corrupt-"));
+            assertTrue(found, "Expected a .corrupt-* quarantine file");
+        } catch (IOException e) {
+            fail("Failed to list temp dir for corrupt file check", e);
+        }
+    }
+}

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/SkinIOPropertyTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/SkinIOPropertyTest.java
@@ -6,6 +6,7 @@
 
 package levosilimo.everlastingskins.skinchanger;
 
+import com.google.gson.JsonObject;
 import levosilimo.everlastingskins.EverlastingSkins;
 import levosilimo.everlastingskins.metrics.SkinMetrics;
 import levosilimo.everlastingskins.util.CustomSkinProperty;
@@ -195,7 +196,18 @@ class SkinIOPropertyTest {
         Path target = dir.resolve(uuid + ".json");
         assertTrue(Files.exists(target), "missing skin file: " + target);
         String content = new String(Files.readAllBytes(target), StandardCharsets.UTF_8);
-        assertEquals(JsonUtils.toJson(skin(expected)), content, "disk payload must be the latest submitted payload");
+        assertEquals(JsonUtils.toJson(skin(expected)), stripChecksum(content),
+                "disk payload must be the latest submitted payload");
+    }
+
+    /**
+     * The persisted record is the payload wrapped in the in-band checksum
+     * envelope (see SkinIO Tier 2); strip the marker before comparing bytes.
+     */
+    private static String stripChecksum(String envelope) {
+        JsonObject obj = JsonUtils.parseJson(envelope);
+        obj.remove("checksum");
+        return JsonUtils.toJson(obj);
     }
 
     private static void sleepUnchecked(long millis) {
@@ -255,7 +267,7 @@ class SkinIOPropertyTest {
         for (Map.Entry<UUID, String> entry : model.entrySet()) {
             String content = byName.get(entry.getKey().toString());
             assertTrue(content != null, "model uuid missing on disk: " + entry.getKey());
-            assertEquals(JsonUtils.toJson(skin(entry.getValue())), content,
+            assertEquals(JsonUtils.toJson(skin(entry.getValue())), stripChecksum(content),
                     "disk payload must match the model for " + entry.getKey());
         }
     }
@@ -412,7 +424,10 @@ class SkinIOPropertyTest {
                     io.saveSkin(uuid, skin);
                     String serialized = JsonUtils.toJson(skin);
                     String onDisk = new String(Files.readAllBytes(dir.resolve(uuid + ".json")), StandardCharsets.UTF_8);
-                    assertEquals(serialized, onDisk, "file bytes must equal the serialized payload");
+                    assertTrue(JsonUtils.parseJson(onDisk).has("checksum"),
+                            "persisted record must carry the in-band checksum marker");
+                    assertEquals(serialized, stripChecksum(onDisk),
+                            "file must hold the serialized payload inside the checksum envelope");
                     CustomSkinProperty loaded = storage.loadSkin(uuid);
                     assertNotNull(loaded, "a valid payload must load");
                     assertEquals(serialized, JsonUtils.toJson(loaded),


### PR DESCRIPTION
## Summary

Tier 2 CRC: per-record SHA-256 checksum envelope + startup integrity sweep over all persisted skin records.

### In-band SHA-256 envelope — single-file atomicity

Each record is persisted as a single self-contained envelope: the `originalProperty` payload plus an in-band `checksum` member (SHA-256 hex digest of the payload), written in one atomic file write. The record and its checksum cannot be torn apart — a crash either yields the previous committed record or the complete new envelope; there is no window in which a record exists without its checksum (no torn record/checksum pair).

### Design citations

- **ARIES** (Mohan et al., SIGMOD '92) per-log-page checksums and **RocksDB** per-block trailers — checksum placement precedent for write-ahead data.
- **Pillai et al., "All File Systems Are Not Created Equal: On the Complexity of Crafting Crash-Consistent Applications", OSDI '14** — committed-state framing: a reader sees either the previous committed record or the new one, never a torn pair.

### Backwards compatibility

Markerless legacy records (written before the checksum envelope) still load normally — they are never quarantined for lacking a checksum, and are transparently re-written with a checksum on the next write. No migration pass required.

### Tests — 6 new SkinIOCRCTest cases

1. `writeSkinFile_includesChecksum` — persisted record carries a 64-char lowercase-hex SHA-256 member
2. `readSkinFile_verifiesChecksum_pass` — matching checksum loads successfully
3. `readSkinFile_verifiesChecksum_fail_quarantines` — flipped byte (still valid JSON and base64) → mismatch → quarantined as `.corrupt-*`, null returned
4. `readSkinFile_noChecksum_backwardCompat` — legacy markerless record loads with a warning, never quarantined
5. `validateAllFiles_sweepsCorrupt` — startup sweep checks all records and quarantines exactly the corrupt ones
6. `crcPerformanceOverhead_acceptable` — 1000 load+verify cycles stay under 100ms