### PR TITLE
ci(1.12.2): add aislop quality gate as a required CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,3 +299,22 @@ jobs:
             ${{ env.SERVER_DIR }}/logs/
             ${{ env.HMC_DIR }}/*.log
           if-no-files-found: warn
+
+  # ── aislop quality gate (same scanner as the pre-commit hook) ─
+  aislop-1122:
+    name: aislop (mc1.12.2)
+    runs-on: ubuntu-latest
+    needs: lint-yaml
+    if: |
+      (github.event_name == 'push' && github.ref_name == 'mc1.12.2') ||
+      (github.event_name == 'pull_request' && github.base_ref == 'mc1.12.2')
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
+        with:
+          fetch-depth: 0
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: 20
+      - name: Run aislop gate on PR changes
+        run: npx -y aislop ci --changes --base origin/mc1.12.2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@
 - The hook runs `aislop scan --staged` and surfaces findings (god-files, god-functions, deeply nested branches, swallowed exceptions, narrative comments, hardcoded URLs/IDs, FizzBuzz-Enterprise-style overengineering) at commit time. Warnings do not block commits by default; treat them as review signals.
 - `aislop` is fetched on demand by `bunx` (fallback `npx`). No `package.json` or `node_modules` in the repo. If neither runner is on PATH, the hook logs and exits 0.
 - Use `aislop fix` to auto-apply mechanical fixes (unused imports, narrative comments, formatter drift). Use `aislop rules` for the full rule catalog. Use `git commit --no-verify` only when intentionally bypassing the gate.
+- CI enforces the same gate: job `aislop (mc1.12.2)` in `.github/workflows/ci.yml` runs `npx aislop ci --changes --base origin/mc1.12.2` on every PR and push, failing when the score drops below 100. It is a required check on the `mc1.12.2` branch (branch protection), so the local hook claim and the CI gate use the same scanner.
 
 ## PR Verification Protocol
 


### PR DESCRIPTION
## Summary

Round 8 audit item 3 (mirror of the 1.21 PR): the "100/100 clean" claim was only verifiable from the local `.githooks/pre-commit` hook — CI never ran aislop. This adds an `aislop` job that runs the same scanner on every PR and push, so the same gate blocks local commits and CI merges, and the score is verifiable from CI artifacts.

- New job `aislop (mc1.12.2)` in `.github/workflows/ci.yml`, running in parallel with Build / E2E:
  - `actions/checkout` with `fetch-depth: 0` (so `origin/mc1.12.2` resolves for the diff base)
  - `actions/setup-node` v4 (pinned by SHA per repo convention), node 20
  - `npx -y aislop ci --changes --base origin/mc1.12.2` — fails when the score drops below 100 (verified locally: clean diff exits 0, slop in diff exits 1)
- AGENTS.md documents `aislop (mc1.12.2)` as a required check (branch protection itself stays a manual GitHub UI update per project policy).
- No other CI changes: Build / E2E / YAML Lint untouched. No new dependencies (aislop is fetched on demand via npx, matching the hook's bunx/npx model).

## Related issues

Round 6/7 audit INFO finding — aislop CI gating (Item 3).

## How was this tested?

- `yamllint -c .yamllint.yml .github/workflows/ci.yml` passes (same config the YAML Lint job uses, strict).
- Exact CI invocation simulated locally on the PR diff: `npx -y aislop ci --changes --base origin/mc1.12.2` → score 100/100, exit 0.
- Pre-commit hook (`bunx aislop scan --staged`) ran clean on the commit — no `--no-verify`.
- This PR's own CI run will show the `aislop (mc1.12.2)` check result.

## Checklist

- [x] Tested on the target Minecraft version(s) — CI workflow change only (mc1.12.2)
- [x] No regressions on other supported versions — 1.21 handled in a separate PR
- [x] Code follows project style (no AI-slop patterns, no narrative comments)
- [x] Pre-commit hook (aislop) passes