### PR TITLE
feat(1.12.2): Round 8 — read-latency observability (readDiskLatency histogram, read counters)

### DIFF
--- a/src/main/java/levosilimo/everlastingskins/metrics/MetricsFormat.java
+++ b/src/main/java/levosilimo/everlastingskins/metrics/MetricsFormat.java
@@ -33,6 +33,8 @@ public final class MetricsFormat {
                 .append(" completed, ").append(s.savesCoalesced()).append(" coalesced, ")
                 .append(s.realWrites()).append(" real writes, ").append(s.ioFailures()).append(" failed, ")
                 .append(s.pendingAsyncWrites()).append(" pending\n");
+        sb.append("  reads: ").append(s.readsSubmitted()).append(" submitted, ").append(s.readsCompleted())
+                .append(" completed, ").append(s.readFailures()).append(" failed\n");
         sb.append("  io failures by type: ").append(ioFailures(s.ioFailuresByType())).append('\n');
         sb.append("  network: ").append(bytes(s.netBytesWrittenOut())).append(" out, ")
                 .append(bytes(s.netBytesReadIn())).append(" in (per-connection)\n");
@@ -51,6 +53,7 @@ public final class MetricsFormat {
         sb.append("    fetch:        ").append(percentiles(s.fetchPercentiles())).append('\n');
         sb.append("    save enq:     ").append(percentiles(s.saveEnqueuePercentiles())).append('\n');
         sb.append("    save disk:    ").append(percentiles(s.saveDiskPercentiles())).append('\n');
+        sb.append("    read disk:    ").append(percentiles(s.readDiskPercentiles())).append('\n');
         sb.append("    broadcast:    ").append(percentiles(s.broadcastPercentiles())).append('\n');
         sb.append("    command total:").append(percentiles(s.commandTotalPercentiles())).append('\n');
         sb.append("    task duration:").append(percentiles(s.taskDurationPercentiles())).append('\n');
@@ -77,6 +80,9 @@ public final class MetricsFormat {
                 .append(",\"realWrites\":").append(s.realWrites())
                 .append(",\"ioFailures\":").append(s.ioFailures())
                 .append(",\"pending\":").append(s.pendingAsyncWrites()).append('}');
+        sb.append(",\"reads\":{\"submitted\":").append(s.readsSubmitted())
+                .append(",\"completed\":").append(s.readsCompleted())
+                .append(",\"failed\":").append(s.readFailures()).append('}');
         sb.append(",\"ioFailuresByType\":{");
         boolean firstType = true;
         for (Map.Entry<String, Long> e : s.ioFailuresByType().entrySet()) {
@@ -102,6 +108,7 @@ public final class MetricsFormat {
                 .append("\"fetch\":").append(percentilesJson(s.fetchPercentiles()))
                 .append(",\"saveEnqueue\":").append(percentilesJson(s.saveEnqueuePercentiles()))
                 .append(",\"saveDisk\":").append(percentilesJson(s.saveDiskPercentiles()))
+                .append(",\"readDisk\":").append(percentilesJson(s.readDiskPercentiles()))
                 .append(",\"broadcast\":").append(percentilesJson(s.broadcastPercentiles()))
                 .append(",\"commandTotal\":").append(percentilesJson(s.commandTotalPercentiles()))
                 .append(",\"taskDuration\":").append(percentilesJson(s.taskDurationPercentiles()))

--- a/src/main/java/levosilimo/everlastingskins/metrics/SkinMetrics.java
+++ b/src/main/java/levosilimo/everlastingskins/metrics/SkinMetrics.java
@@ -42,6 +42,9 @@ public final class SkinMetrics {
     private final LongAdder savesCoalesced = new LongAdder();
     private final LongAdder realWrites = new LongAdder();
     private final LongAdder ioFailures = new LongAdder();
+    private final LongAdder readsSubmitted = new LongAdder();
+    private final LongAdder readsCompleted = new LongAdder();
+    private final LongAdder readFailures = new LongAdder();
     private final LongAdder netBytesWrittenOut = new LongAdder();
     private final LongAdder netBytesReadIn = new LongAdder();
     private final LongAdder tickSpikes = new LongAdder();
@@ -61,6 +64,7 @@ public final class SkinMetrics {
     private final LatencyHistogram fetchLatency = new LatencyHistogram();
     private final LatencyHistogram saveEnqueueLatency = new LatencyHistogram();
     private final LatencyHistogram saveDiskLatency = new LatencyHistogram();
+    private final LatencyHistogram readDiskLatency = new LatencyHistogram();
     private final LatencyHistogram broadcastLatency = new LatencyHistogram();
     private final LatencyHistogram commandTotalLatency = new LatencyHistogram();
     private final LatencyHistogram taskDurationLatency = new LatencyHistogram();
@@ -126,6 +130,19 @@ public final class SkinMetrics {
 
     public void recordSaveDiskLatency(long nanos) {
         saveDiskLatency.record(nanos);
+    }
+
+    public void recordReadStart() {
+        readsSubmitted.increment();
+    }
+
+    public void recordReadComplete(long nanos) {
+        readsCompleted.increment();
+        readDiskLatency.record(nanos);
+    }
+
+    public void recordReadFailure() {
+        readFailures.increment();
     }
 
     public void recordBroadcastLatency(long nanos) {
@@ -256,6 +273,9 @@ public final class SkinMetrics {
         savesCoalesced.reset();
         realWrites.reset();
         ioFailures.reset();
+        readsSubmitted.reset();
+        readsCompleted.reset();
+        readFailures.reset();
         netBytesWrittenOut.reset();
         netBytesReadIn.reset();
         tickSpikes.reset();
@@ -273,6 +293,7 @@ public final class SkinMetrics {
         fetchLatency.reset();
         saveEnqueueLatency.reset();
         saveDiskLatency.reset();
+        readDiskLatency.reset();
         broadcastLatency.reset();
         commandTotalLatency.reset();
         taskDurationLatency.reset();
@@ -290,6 +311,7 @@ public final class SkinMetrics {
                 refreshesSkippedStored.sum(), refreshesRateLimited.sum(),
                 broadcastsSent.sum(), bytesWritten.sum(), savesSubmitted.sum(), savesCompleted.sum(),
                 savesCoalesced.sum(), realWrites.sum(),
+                readsSubmitted.sum(), readsCompleted.sum(), readFailures.sum(),
                 ioFailures.sum(), pendingAsyncWrites.get(), onlinePlayers.sum(),
                 System.currentTimeMillis() - startedAtMs.get(),
                 netBytesWrittenOut.sum(), netBytesReadIn.sum(),
@@ -299,7 +321,7 @@ public final class SkinMetrics {
                 providerExceptions.sum(), cacheHits.sum(), cacheMisses.sum(), mineSkinDelayTotalMs.sum(),
                 ioFailuresByType(),
                 fetchLatency.percentiles(), saveEnqueueLatency.percentiles(),
-                saveDiskLatency.percentiles(), broadcastLatency.percentiles(),
+                saveDiskLatency.percentiles(), readDiskLatency.percentiles(), broadcastLatency.percentiles(),
                 commandTotalLatency.percentiles(), taskDurationLatency.percentiles(),
                 tickSpikeLatency.percentiles(),
                 snapshotPerPlayer());

--- a/src/main/java/levosilimo/everlastingskins/metrics/Snapshot.java
+++ b/src/main/java/levosilimo/everlastingskins/metrics/Snapshot.java
@@ -28,6 +28,9 @@ public final class Snapshot {
     private final long savesCompleted;
     private final long savesCoalesced;
     private final long realWrites;
+    private final long readsSubmitted;
+    private final long readsCompleted;
+    private final long readFailures;
     private final long ioFailures;
     private final int pendingAsyncWrites;
     private final long onlinePlayers;
@@ -49,6 +52,7 @@ public final class Snapshot {
     private final Map<String, Long> fetchPercentiles;
     private final Map<String, Long> saveEnqueuePercentiles;
     private final Map<String, Long> saveDiskPercentiles;
+    private final Map<String, Long> readDiskPercentiles;
     private final Map<String, Long> broadcastPercentiles;
     private final Map<String, Long> commandTotalPercentiles;
     private final Map<String, Long> taskDurationPercentiles;
@@ -60,6 +64,7 @@ public final class Snapshot {
                     long refreshesSkippedStored, long refreshesRateLimited,
                     long broadcastsSent, long bytesWritten, long savesSubmitted, long savesCompleted,
                     long savesCoalesced, long realWrites,
+                    long readsSubmitted, long readsCompleted, long readFailures,
                     long ioFailures, int pendingAsyncWrites, long onlinePlayers, long uptimeMs,
                     long netBytesWrittenOut, long netBytesReadIn,
                     long tickSpikes, long tickSpikesBroadcast, long tickSpikesCascade, long tickSpikesSaveEnqueue,
@@ -67,7 +72,8 @@ public final class Snapshot {
                     long providerExceptions, long cacheHits, long cacheMisses, long mineSkinDelayTotalMs,
                     Map<String, Long> ioFailuresByType,
                     Map<String, Long> fetchPercentiles, Map<String, Long> saveEnqueuePercentiles,
-                    Map<String, Long> saveDiskPercentiles, Map<String, Long> broadcastPercentiles,
+                    Map<String, Long> saveDiskPercentiles, Map<String, Long> readDiskPercentiles,
+                    Map<String, Long> broadcastPercentiles,
                     Map<String, Long> commandTotalPercentiles, Map<String, Long> taskDurationPercentiles,
                     Map<String, Long> tickSpikePercentiles,
                     Map<UUID, PlayerSnapshot> perPlayer) {
@@ -85,6 +91,9 @@ public final class Snapshot {
         this.savesCompleted = savesCompleted;
         this.savesCoalesced = savesCoalesced;
         this.realWrites = realWrites;
+        this.readsSubmitted = readsSubmitted;
+        this.readsCompleted = readsCompleted;
+        this.readFailures = readFailures;
         this.ioFailures = ioFailures;
         this.pendingAsyncWrites = pendingAsyncWrites;
         this.onlinePlayers = onlinePlayers;
@@ -106,6 +115,7 @@ public final class Snapshot {
         this.fetchPercentiles = fetchPercentiles;
         this.saveEnqueuePercentiles = saveEnqueuePercentiles;
         this.saveDiskPercentiles = saveDiskPercentiles;
+        this.readDiskPercentiles = readDiskPercentiles;
         this.broadcastPercentiles = broadcastPercentiles;
         this.commandTotalPercentiles = commandTotalPercentiles;
         this.taskDurationPercentiles = taskDurationPercentiles;
@@ -127,6 +137,9 @@ public final class Snapshot {
     public long savesCompleted() { return savesCompleted; }
     public long savesCoalesced() { return savesCoalesced; }
     public long realWrites() { return realWrites; }
+    public long readsSubmitted() { return readsSubmitted; }
+    public long readsCompleted() { return readsCompleted; }
+    public long readFailures() { return readFailures; }
     public long ioFailures() { return ioFailures; }
     public int pendingAsyncWrites() { return pendingAsyncWrites; }
     public long onlinePlayers() { return onlinePlayers; }
@@ -149,6 +162,7 @@ public final class Snapshot {
     public Map<String, Long> fetchPercentiles() { return fetchPercentiles; }
     public Map<String, Long> saveEnqueuePercentiles() { return saveEnqueuePercentiles; }
     public Map<String, Long> saveDiskPercentiles() { return saveDiskPercentiles; }
+    public Map<String, Long> readDiskPercentiles() { return readDiskPercentiles; }
     public Map<String, Long> broadcastPercentiles() { return broadcastPercentiles; }
     public Map<String, Long> commandTotalPercentiles() { return commandTotalPercentiles; }
     public Map<String, Long> taskDurationPercentiles() { return taskDurationPercentiles; }

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinIO.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinIO.java
@@ -245,27 +245,31 @@ public class SkinIO {
     private String readSkinFile(UUID uuid) {
         Path target = savePath.resolve(uuid + FILE_EXTENSION);
         if (!Files.exists(target)) return null;
+        SkinMetrics.INSTANCE.recordReadStart();
+        long start = System.nanoTime();
+        String content;
         try {
-            byte[] bytes = Files.readAllBytes(target);
-            String content = new String(bytes, StandardCharsets.UTF_8);
-            if (!isValidJson(content)) {
-                quarantineFile(uuid);
-                return null;
-            }
-            int status = checksumStatus(content);
-            if (status == CHECKSUM_MISMATCH) {
-                EverlastingSkins.logger.warn("Bit rot detected in skin record {}: checksum mismatch, quarantining", target);
-                quarantineFile(uuid);
-                return null;
-            }
-            if (status == CHECKSUM_ABSENT) {
-                EverlastingSkins.logger.warn(
-                        "Skin record {} has no checksum (legacy format); loaded without integrity verification", target);
-            }
-            return content;
+            content = new String(Files.readAllBytes(target), StandardCharsets.UTF_8);
         } catch (IOException e) {
+            SkinMetrics.INSTANCE.recordReadFailure();
             return null;
         }
+        SkinMetrics.INSTANCE.recordReadComplete(System.nanoTime() - start);
+        if (!isValidJson(content)) {
+            quarantineFile(uuid);
+            return null;
+        }
+        int status = checksumStatus(content);
+        if (status == CHECKSUM_MISMATCH) {
+            EverlastingSkins.logger.warn("Bit rot detected in skin record {}: checksum mismatch, quarantining", target);
+            quarantineFile(uuid);
+            return null;
+        }
+        if (status == CHECKSUM_ABSENT) {
+            EverlastingSkins.logger.warn(
+                    "Skin record {} has no checksum (legacy format); loaded without integrity verification", target);
+        }
+        return content;
     }
 
     /**

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinStorage.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinStorage.java
@@ -73,20 +73,26 @@ public class SkinStorage {
     }
 
     public CustomSkinProperty loadSkin(UUID uuid) {
-        CustomSkinProperty skin = skinIO.loadSkin(uuid);
-        if (skin != null && skin.isEmpty()) {
-            pendingWrites.remove(uuid);
-            try {
-                deleteSkinSerialized(uuid);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new DeleteFailedException("Skin delete of " + uuid + " interrupted", e);
-            } catch (IOException e) {
-                throw new DeleteFailedException("Skin delete of " + uuid + " failed", e);
+        SkinMetrics.INSTANCE.recordReadStart();
+        long start = System.nanoTime();
+        try {
+            CustomSkinProperty skin = skinIO.loadSkin(uuid);
+            if (skin != null && skin.isEmpty()) {
+                pendingWrites.remove(uuid);
+                try {
+                    deleteSkinSerialized(uuid);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new DeleteFailedException("Skin delete of " + uuid + " interrupted", e);
+                } catch (IOException e) {
+                    throw new DeleteFailedException("Skin delete of " + uuid + " failed", e);
+                }
+                return null;
             }
-            return null;
+            return skin;
+        } finally {
+            SkinMetrics.INSTANCE.recordReadComplete(System.nanoTime() - start);
         }
-        return skin;
     }
 
     // Access via SkinRestorer.getSkinStorage().

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/SkinStorageReadLatencyTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/SkinStorageReadLatencyTest.java
@@ -1,0 +1,81 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import levosilimo.everlastingskins.metrics.SkinMetrics;
+import levosilimo.everlastingskins.metrics.Snapshot;
+import levosilimo.everlastingskins.util.CustomSkinProperty;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Read-path observability: a map-miss getSkin aggregates a load-level read
+ * (SkinStorage.loadSkin) plus a disk-level read (SkinIO.readSkinFile), both
+ * recorded into the shared read counters/histogram; a map hit records nothing.
+ * Uses {@link SkinMetrics#INSTANCE} (the production instance the code paths
+ * record into) and resets it per test for isolation.
+ */
+class SkinStorageReadLatencyTest {
+
+    @TempDir
+    Path tempDir;
+
+    private SkinIO skinIO;
+    private SkinStorage storage;
+    private UUID uuid;
+
+    @BeforeEach
+    void setUp() {
+        SkinMetrics.INSTANCE.reset();
+        skinIO = new SkinIO(tempDir);
+        storage = new SkinStorage(skinIO);
+        uuid = UUID.randomUUID();
+    }
+
+    @Test
+    @DisplayName("getSkin on map miss records load and disk read latency")
+    void getSkin_onMapMiss_recordsReadLatency() {
+        CustomSkinProperty persisted = new CustomSkinProperty("cGVyc2lzdGVk", "sig", "disk");
+        skinIO.saveSkin(uuid, persisted);
+
+        CustomSkinProperty result = storage.getSkin(uuid);
+        assertNotNull(result);
+
+        Snapshot s = SkinMetrics.INSTANCE.snapshot();
+        // One load-level read (SkinStorage.loadSkin) + one disk-level read (readSkinFile).
+        assertEquals(2, s.readsSubmitted());
+        assertEquals(2, s.readsCompleted());
+        assertEquals(0, s.readFailures());
+        assertTrue(s.readDiskPercentiles().get("max") > 0, "readDiskLatency must record a positive sample");
+        assertTrue(s.readDiskPercentiles().get("p50") > 0, "readDiskLatency p50 must land in a positive bucket");
+    }
+
+    @Test
+    @DisplayName("getSkin on map hit records no read latency")
+    void getSkin_onMapHit_recordsNothing() {
+        CustomSkinProperty cached = new CustomSkinProperty("Y2FjaGVk", "sig", "cache");
+        storage.setSkin(uuid, cached);
+
+        storage.getSkin(uuid);
+        storage.getSkin(uuid);
+
+        Snapshot s = SkinMetrics.INSTANCE.snapshot();
+        assertEquals(0, s.readsSubmitted());
+        assertEquals(0, s.readsCompleted());
+        assertEquals(0, s.readFailures());
+        assertEquals(0, s.readDiskPercentiles().get("max"));
+    }
+}


### PR DESCRIPTION
## Summary
Mirror of #233 for the 1.12.2 branch (Java 8 line: Snapshot is a separate value class, SkinIO uses Files.readAllBytes).

- **SkinMetrics** + **Snapshot**: new `readDiskLatency` histogram + `readsSubmitted`/`readsCompleted`/`readFailures` counters; accessors `recordReadStart()`/`recordReadComplete(nanos)`/`recordReadFailure()`.
- **SkinIO.readSkinFile**: records disk-level read latency around the read; IOException → readFailures.
- **SkinStorage.loadSkin**: records end-to-end load latency (map-miss → readSkinFile → deserialize); aggregate read count = loads + disk reads; map hits record nothing.
- **MetricsFormat**: reads line + readDisk latency percentiles in human and JSON dump output.
- **Tests**: SkinStorageReadLatencyTest — `getSkin_onMapMiss_recordsReadLatency` and `getSkin_onMapHit_recordsNothing`.

No wire changes, no new dependencies, no public API changes (additive only).

## Verification
- `./gradlew build test` ✅
- aislop 100/100 on every commit (pre-commit hook, no --no-verify)