### PR TITLE
docs(1.21): correct aislop gate claim in AGENTS.md (branch protection registration pending)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@
 - The hook runs `aislop scan --staged` and surfaces findings (god-files, god-functions, deeply nested branches, swallowed exceptions, narrative comments, hardcoded URLs/IDs, FizzBuzz-Enterprise-style overengineering) at commit time. Warnings do not block commits by default; treat them as review signals.
 - `aislop` is fetched on demand by `bunx` (fallback `npx`). No `package.json` or `node_modules` in the repo. If neither runner is on PATH, the hook logs and exits 0.
 - Use `aislop fix` to auto-apply mechanical fixes (unused imports, narrative comments, formatter drift). Use `aislop rules` for the full rule catalog. Use `git commit --no-verify` only when intentionally bypassing the gate.
-- CI enforces the same gate: job `aislop (1.21)` in `.github/workflows/ci.yml` runs `npx aislop ci --changes --base origin/1.21` on every PR and push, failing when the score drops below 100. It is a required check on the `1.21` branch (branch protection), so the local hook claim and the CI gate use the same scanner.
+- CI enforces the same gate: job `aislop (1.21)` in `.github/workflows/ci.yml` runs `npx aislop ci --changes --base origin/1.21` on every PR and push, failing when the score drops below 100. Branch protection registration is pending: the gate fails PR CI but is not yet a required check; the local hook and the CI gate use the same scanner.
 
 ## PR Verification Protocol
 


### PR DESCRIPTION
Docs-only fix for the lib-13 audit finding (MEDIUM): AGENTS.md line 47 claimed aislop is "a required check on the `1.21` branch (branch protection)". The aislop (1.21) job runs on every PR and push and fails CI when the score drops below 100, but branch protection required_status_checks on `1.21` list only Build (1.21) / GameTest (1.21) / YAML Lint — aislop is not registered.

Rewrite the line to describe the actual behavior: the gate fails PR CI but branch protection registration is pending (registration stays manual per project policy).

- Single-line change (AGENTS.md line 47 only)
- Pre-commit hook passed (aislop 100/100)