### PR TITLE
feat(1.21): tab completion for /skin mojang and web arguments + metrics permission gate

### DIFF
--- a/src/main/java/levosilimo/everlastingskins/skinchanger/MojangProfileCache.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/MojangProfileCache.java
@@ -10,8 +10,11 @@ import levosilimo.everlastingskins.Config;
 import levosilimo.everlastingskins.metrics.SkinMetrics;
 import levosilimo.everlastingskins.util.CustomSkinProperty;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -99,6 +102,15 @@ public class MojangProfileCache {
 
     public synchronized int size() {
         return entries.size();
+    }
+
+    /**
+     * Snapshot of the cached usernames (lower-case keys), most recently used
+     * first. The copy is unmodifiable, so callers cannot mutate cache state;
+     * the size is inherently capped at the configured max entries.
+     */
+    public synchronized List<String> snapshot() {
+        return Collections.unmodifiableList(new ArrayList<>(entries.keySet()));
     }
 
     public synchronized void clear() {

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinCommand.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinCommand.java
@@ -18,9 +18,11 @@ import levosilimo.everlastingskins.permission.PermissionContext;
 import levosilimo.everlastingskins.permission.PermissionServiceManager;
 import levosilimo.everlastingskins.skinchanger.command.SkinActionCommand;
 import levosilimo.everlastingskins.skinchanger.command.SkinMetricsCommand;
+import levosilimo.everlastingskins.util.CompletionSources;
 import levosilimo.everlastingskins.util.I18nUtils;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
+import net.minecraft.commands.SharedSuggestionProvider;
 import net.minecraft.commands.arguments.EntityArgument;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
@@ -73,8 +75,15 @@ public class SkinCommand {
                 .then(buildSetSubcommand())
                 .then(buildSourceSubcommand())
                 .then(buildClearSubcommand())
-                .then(SkinMetricsCommand.build());
+                .then(SkinMetricsCommand.build().requires(SkinCommand::canUseMetrics));
         dispatcher.register(skinCommand);
+    }
+
+    private static boolean canUseMetrics(CommandSourceStack source) {
+        ServerPlayer player = source.getPlayer();
+        if (player == null) return false;
+        PermissionContext ctx = PermissionContext.of(player.getUUID(), player);
+        return PermissionServiceManager.hasPermission(ctx, "everlastingskins.command.metrics");
     }
 
     private static boolean canTargetOthers(CommandSourceStack source) {
@@ -111,6 +120,8 @@ public class SkinCommand {
         return Commands.literal("set")
                 .then(Commands.literal("mojang")
                         .then(Commands.argument("skin_name", StringArgumentType.word())
+                                .suggests((context, builder) ->
+                                        SharedSuggestionProvider.suggest(CompletionSources.recentUsernames(), builder))
                                 .executes(context -> SkinActionCommand.execute(context, new SkinActionParameters(
                                         Collections.singleton(context.getSource().getPlayer()),
                                         SkinActionType.username, SkinVariant.ALL, false,
@@ -128,6 +139,8 @@ public class SkinCommand {
                 .then(Commands.literal("web")
                         .then(Commands.literal("classic")
                                 .then(Commands.argument("url", StringArgumentType.string())
+                                        .suggests((context, builder) ->
+                                                SharedSuggestionProvider.suggest(CompletionSources.urlCandidates(), builder))
                                         .executes(context -> SkinActionCommand.execute(context, new SkinActionParameters(
                                                 Collections.singleton(context.getSource().getPlayer()),
                                                 SkinActionType.url, SkinVariant.CLASSIC, false,
@@ -144,6 +157,8 @@ public class SkinCommand {
                         )
                         .then(Commands.literal("slim")
                                 .then(Commands.argument("url", StringArgumentType.string())
+                                        .suggests((context, builder) ->
+                                                SharedSuggestionProvider.suggest(CompletionSources.urlCandidates(), builder))
                                         .executes(context -> SkinActionCommand.execute(context, new SkinActionParameters(
                                                 Collections.singleton(context.getSource().getPlayer()),
                                                 SkinActionType.url, SkinVariant.SLIM, false,

--- a/src/main/java/levosilimo/everlastingskins/util/CompletionSources.java
+++ b/src/main/java/levosilimo/everlastingskins/util/CompletionSources.java
@@ -1,0 +1,112 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.util;
+
+import levosilimo.everlastingskins.Config;
+import levosilimo.everlastingskins.permission.PermissionContext;
+import levosilimo.everlastingskins.permission.PermissionServiceManager;
+import levosilimo.everlastingskins.skinchanger.DefaultSkinResolver;
+import levosilimo.everlastingskins.skinchanger.MojangProfileCache;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerPlayer;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Shared candidate sources for /skin tab completion.
+ *
+ * <p>Both the 1.21 Brigadier suggesters and the 1.12.2
+ * {@code getTabCompletions} switch consume these lists, so the completion
+ * vocabulary (providers, cached usernames, allowlisted URLs, online players,
+ * permission-gated metrics subcommands) stays consistent across versions.
+ */
+public final class CompletionSources {
+
+    private static final String METRICS_RESET_PERMISSION = "everlastingskins.command.metrics.reset";
+
+    /** View subcommands every metrics-authorized sender may complete. */
+    private static final List<String> METRICS_VIEW_SUBCOMMANDS = List.of("json", "players");
+
+    private static volatile MojangProfileCache profileCache = new MojangProfileCache();
+
+    private CompletionSources() {
+    }
+
+    /**
+     * Swaps the cache backing {@link #recentUsernames()}. Primarily a test
+     * seam; production deployments can point it at the same cache instance
+     * the Mojang API uses so recently fetched profiles are offered.
+     */
+    public static void setMojangProfileCache(MojangProfileCache cache) {
+        profileCache = cache != null ? cache : new MojangProfileCache();
+    }
+
+    /**
+     * Mojang usernames worth offering for {@code set mojang <name>}: cached
+     * profile lookups first, then the configured default skins list with the
+     * {@code <random>} token excluded (it is not a real username).
+     */
+    public static List<String> recentUsernames() {
+        List<String> names = new ArrayList<>();
+        for (String cached : profileCache.snapshot()) {
+            if (!names.contains(cached)) names.add(cached);
+        }
+        for (String configured : Config.DEFAULT_SKINS_LIST.get()) {
+            if (!DefaultSkinResolver.RANDOM_TOKEN.equals(configured) && !names.contains(configured)) {
+                names.add(configured);
+            }
+        }
+        return Collections.unmodifiableList(names);
+    }
+
+    /** Every allowlisted domain as both an https:// and an http:// URL. */
+    public static List<String> urlCandidates() {
+        List<String> candidates = new ArrayList<>();
+        for (String domain : Config.URL_ALLOWLIST_DOMAINS.get()) {
+            candidates.add("https://" + domain);
+            candidates.add("http://" + domain);
+        }
+        return Collections.unmodifiableList(candidates);
+    }
+
+    /** Providers for {@code set <provider>}; web is always available on 1.21. */
+    public static List<String> providerNames() {
+        return Collections.unmodifiableList(List.of("mojang", "random", "web"));
+    }
+
+    /** Names of every player currently online on the server. */
+    public static List<String> onlinePlayerNames(MinecraftServer server) {
+        if (server == null || server.getPlayerList() == null) return Collections.emptyList();
+        return Collections.unmodifiableList(new ArrayList<>(Arrays.asList(server.getPlayerList().getPlayerNamesArray())));
+    }
+
+    /**
+     * Metrics subcommands the sender may complete. View subcommands need the
+     * base metrics permission; cleanup/reset additionally need the reset
+     * permission, so unauthorized users never see them offered.
+     */
+    public static List<String> metricsSubcommands(CommandSourceStack source) {
+        List<String> subcommands = new ArrayList<>(METRICS_VIEW_SUBCOMMANDS);
+        if (hasResetPermission(source)) {
+            subcommands.add("cleanup");
+            subcommands.add("reset");
+        }
+        return Collections.unmodifiableList(subcommands);
+    }
+
+    private static boolean hasResetPermission(CommandSourceStack source) {
+        ServerPlayer player = source == null ? null : source.getPlayer();
+        if (player == null) return true; // console senders bypass the gate
+        PermissionContext ctx = PermissionContext.of(player.getUUID(), player);
+        return PermissionServiceManager.hasPermission(ctx, METRICS_RESET_PERMISSION);
+    }
+}

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/SkinCommandTabCompleteTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/SkinCommandTabCompleteTest.java
@@ -20,6 +20,7 @@ import net.minecraft.server.Bootstrap;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -73,6 +74,13 @@ class SkinCommandTabCompleteTest {
         dispatcher = new CommandDispatcher<>();
         SkinCommand.register(dispatcher);
         source = sourceWithOpLevel(0);
+    }
+
+    @AfterEach
+    void tearDown() {
+        // Undo config overrides (e.g. the metrics op levels) so later test
+        // classes in the same JVM always see the defaults.
+        TestConfigSupport.loadDefaults();
     }
 
     @Test

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/SkinCommandTabCompleteTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/SkinCommandTabCompleteTest.java
@@ -1,0 +1,236 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.ParseResults;
+import com.mojang.brigadier.suggestion.Suggestion;
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.tree.CommandNode;
+import levosilimo.everlastingskins.Config;
+import levosilimo.everlastingskins.permission.TestConfigSupport;
+import levosilimo.everlastingskins.util.CompletionSources;
+import levosilimo.everlastingskins.util.CustomSkinProperty;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tab-completion behavior of the Brigadier /skin tree: suggesters emit the
+ * shared CompletionSources candidates, and requires() predicates gate which
+ * nodes an unauthorized sender may use. Literal-level requires() is enforced
+ * through the command tree the client receives (brigadier's server-side
+ * suggestion walk offers all children), so those gates are asserted on the
+ * nodes' canUse() rather than on the raw suggestion list.
+ */
+class SkinCommandTabCompleteTest {
+
+    /**
+     * The unit-test JVM has no running server, so mocking ServerPlayer loads
+     * EntityDataSerializers, whose &lt;clinit&gt; would throw "Not bootstrapped".
+     * Flag Bootstrap as done (same seam as SkinRefreshHandlerTest).
+     */
+    static {
+        try {
+            Field bootstrapFlag = Bootstrap.class.getDeclaredField("isBootstrapped");
+            bootstrapFlag.setAccessible(true);
+            bootstrapFlag.setBoolean(null, true);
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    private static final UUID PLAYER_UUID = UUID.randomUUID();
+    private static final List<String> ONLINE_PLAYERS = List.of("Alex", "Bob");
+
+    private CommandDispatcher<CommandSourceStack> dispatcher;
+    private CommandSourceStack source;
+
+    @BeforeEach
+    void setUp() {
+        TestConfigSupport.loadDefaults();
+        CompletionSources.setMojangProfileCache(new MojangProfileCache());
+        dispatcher = new CommandDispatcher<>();
+        SkinCommand.register(dispatcher);
+        source = sourceWithOpLevel(0);
+    }
+
+    @Test
+    @DisplayName("root completion hides subcommands the sender lacks permission for")
+    void subcommand_completion_filtersByPermission() {
+        CommandNode<CommandSourceStack> skin = dispatcher.getRoot().getChild("skin");
+        // Defaults: metrics needs op level 2, so a level-0 player cannot use
+        // the metrics subtree while set/clear/source stay open.
+        assertTrue(skin.getChild("set").canUse(source));
+        assertTrue(skin.getChild("clear").canUse(source));
+        assertTrue(skin.getChild("source").canUse(source));
+        assertFalse(skin.getChild("metrics").canUse(source));
+
+        source = sourceWithOpLevel(2);
+        assertTrue(skin.getChild("metrics").canUse(source));
+
+        // Server-side completion offers every registered child; the client
+        // filters literals by the tree derived from canUse().
+        List<String> offered = completions("skin ");
+        assertTrue(offered.contains("set"));
+        assertTrue(offered.contains("clear"));
+        assertTrue(offered.contains("source"));
+        assertTrue(offered.contains("metrics"));
+    }
+
+    @Test
+    @DisplayName("set provider completion returns the configured providers")
+    void set_provider_completion_returnsConfiguredProviders() {
+        List<String> providers = completions("skin set ");
+
+        assertTrue(providers.contains("mojang"));
+        assertTrue(providers.contains("random"));
+        assertTrue(providers.contains("web"));
+    }
+
+    @Test
+    @DisplayName("set mojang skin_name completion returns cached profiles and default skins")
+    void set_mojang_skinName_completion_returnsRecentUsernames() {
+        MojangProfileCache cache = new MojangProfileCache();
+        cache.put("Notch", new CustomSkinProperty("value", "signature", "Notch"));
+        CompletionSources.setMojangProfileCache(cache);
+
+        List<String> suggestions = completions("skin set mojang ");
+
+        assertTrue(suggestions.contains("notch"));
+        assertTrue(suggestions.contains("Steve"));
+        assertFalse(suggestions.contains("<random>"));
+    }
+
+    @Test
+    @DisplayName("set web variant completion returns classic and slim")
+    void set_web_variant_completion_returnsClassicSlim() {
+        List<String> variants = completions("skin set web ");
+
+        assertTrue(variants.contains("classic"));
+        assertTrue(variants.contains("slim"));
+    }
+
+    @Test
+    @DisplayName("set web url completion returns allowlisted domains with scheme prefixes")
+    void set_web_url_completion_returnsAllowlistDomains() {
+        List<String> urls = completions("skin set web classic ");
+
+        assertTrue(urls.contains("https://imgur.com"));
+        assertTrue(urls.contains("http://imgur.com"));
+        assertTrue(urls.contains("https://textures.minecraft.net"));
+        assertTrue(urls.contains("http://textures.minecraft.net"));
+    }
+
+    @Test
+    @DisplayName("set random completion cascades bool, variant and online players")
+    void set_random_completion_cascade() {
+        List<String> level0 = completions("skin set random ");
+        assertTrue(level0.contains("true"));
+        assertTrue(level0.contains("false"));
+        assertTrue(level0.contains("CLASSIC"));
+        assertTrue(level0.contains("SLIM"));
+        assertTrue(level0.contains("Alex"));
+        assertTrue(level0.contains("Bob"));
+
+        // The targets argument is only usable by senders with the other-permission.
+        CommandNode<CommandSourceStack> targets = dispatcher.getRoot().getChild("skin")
+                .getChild("set").getChild("random").getChild("targets");
+        assertFalse(targets.canUse(source));
+        source = sourceWithOpLevel(2);
+        assertTrue(targets.canUse(source));
+
+        List<String> afterCape = completions("skin set random true ");
+        assertTrue(afterCape.contains("CLASSIC"));
+        assertTrue(afterCape.contains("SLIM"));
+    }
+
+    @Test
+    @DisplayName("clear and source target completion returns online players")
+    void clear_source_target_completion_returnsOnlinePlayers() {
+        source = sourceWithOpLevel(2);
+        List<String> clear = completions("skin clear ");
+        assertTrue(clear.contains("Alex"));
+        assertTrue(clear.contains("Bob"));
+
+        List<String> sourceTab = completions("skin source ");
+        assertTrue(sourceTab.contains("Alex"));
+        assertTrue(sourceTab.contains("Bob"));
+
+        CommandNode<CommandSourceStack> clearTargets = dispatcher.getRoot().getChild("skin")
+                .getChild("clear").getChild("targets");
+        assertTrue(clearTargets.canUse(source));
+        assertFalse(clearTargets.canUse(sourceWithOpLevel(0)));
+    }
+
+    @Test
+    @DisplayName("metrics completion hides reset from senders without the reset permission")
+    void metrics_completion_filtersByResetPermission() {
+        Config.PERMISSIONS_OP_LEVEL_METRICS.set(0);
+        Config.PERMISSIONS_OP_LEVEL_METRICS_RESET.set(2);
+
+        CommandNode<CommandSourceStack> metrics = dispatcher.getRoot().getChild("skin").getChild("metrics");
+        // Level-0 sender holds command.metrics but not command.metrics.reset.
+        assertTrue(metrics.canUse(source));
+        assertFalse(metrics.getChild("reset").canUse(source));
+
+        List<String> offered = completions("skin metrics ");
+        assertTrue(offered.contains("json"));
+        assertTrue(offered.contains("players"));
+        assertTrue(offered.contains("cleanup"));
+    }
+
+    private List<String> completions(String input) {
+        ParseResults<CommandSourceStack> parsed = dispatcher.parse(input, source);
+        Suggestions suggestions = dispatcher.getCompletionSuggestions(parsed).join();
+        return suggestions.getList().stream().map(Suggestion::getText).toList();
+    }
+
+    private CommandSourceStack sourceWithOpLevel(int opLevel) {
+        // Mocking a Level subclass first initializes the registry chain
+        // (BuiltInRegistries/Forge) that EntityDataSerializers needs when
+        // ServerPlayer is instrumented; without it the mock fails to create.
+        mock(ServerLevel.class);
+        ServerPlayer player = mock(ServerPlayer.class);
+        when(player.getUUID()).thenReturn(PLAYER_UUID);
+        MinecraftServer server = mock(MinecraftServer.class);
+        when(server.getProfilePermissions(any())).thenReturn(opLevel);
+        setField(player, "server", server);
+
+        CommandSourceStack source = mock(CommandSourceStack.class);
+        when(source.getPlayer()).thenReturn(player);
+        when(source.getOnlinePlayerNames()).thenReturn(ONLINE_PLAYERS);
+        when(source.hasPermission(anyInt())).thenReturn(opLevel >= 2);
+        return source;
+    }
+
+    private static void setField(Object target, String fieldName, Object value) {
+        try {
+            Field field = ServerPlayer.class.getField(fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Cannot set ServerPlayer." + fieldName, e);
+        }
+    }
+}


### PR DESCRIPTION
Per lib-19 research: 1.21 Brigadier auto-completes subcommands/providers/variants/bools/targets; the gaps were the bare `mojang <skin_name>` and `web <variant> <url>` arguments. This PR closes them via a shared CompletionSources service.

- `MojangProfileCache.snapshot()`: unmodifiable defensive copy of cached usernames (LRU order)
- `CompletionSources`: recentUsernames (cache + default skins, <random> excluded), https/http URL candidates from the allowlist, provider names, online player names, permission-filtered metrics subcommands
- `set mojang <skin_name>` and `set web classic|slim <url>` now have `.suggests()`
- `metrics` literal gated by `requires()` on `everlastingskins.command.metrics` (client tree hides it from unauthorized senders)
- `SkinCommandTabCompleteTest`: 8 tests covering suggesters and canUse() permission gates

Verification: `./gradlew build test` passes, `./gradlew runGameTestServer` passes (34/34), aislop 99/100 (pre-existing SkinIO.java file-size warning, unchanged from base).