### PR TITLE
feat(1.12.2): permission-aware tab completion for /skin (mirror of 1.21)

### DIFF
--- a/src/main/java/levosilimo/everlastingskins/skinchanger/MojangProfileCache.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/MojangProfileCache.java
@@ -10,8 +10,11 @@ import levosilimo.everlastingskins.Config;
 import levosilimo.everlastingskins.metrics.SkinMetrics;
 import levosilimo.everlastingskins.util.CustomSkinProperty;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -99,6 +102,15 @@ public class MojangProfileCache {
 
     public synchronized int size() {
         return entries.size();
+    }
+
+    /**
+     * Snapshot of the cached usernames (lower-case keys), most recently used
+     * first. The copy is unmodifiable, so callers cannot mutate cache state;
+     * the size is inherently capped at the configured max entries.
+     */
+    public synchronized List<String> snapshot() {
+        return Collections.unmodifiableList(new ArrayList<>(entries.keySet()));
     }
 
     public synchronized void clear() {

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinCommand.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinCommand.java
@@ -16,6 +16,7 @@ import levosilimo.everlastingskins.metrics.SkinMetrics;
 import levosilimo.everlastingskins.permission.PermissionContext;
 import levosilimo.everlastingskins.permission.PermissionServiceManager;
 import levosilimo.everlastingskins.skinchanger.responses.mojang.MojangSkinDataResult;
+import levosilimo.everlastingskins.util.CompletionSources;
 import levosilimo.everlastingskins.util.CustomSkinProperty;
 import levosilimo.everlastingskins.util.I18nUtils;
 import net.minecraft.command.CommandBase;
@@ -29,7 +30,6 @@ import net.minecraft.util.text.TextComponentString;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -103,11 +103,65 @@ public class SkinCommand extends CommandBase {
     @Override
     public List<String> getTabCompletions(MinecraftServer server, ICommandSender sender,
             String[] args, @Nullable BlockPos targetPos) {
-        if (args.length == 1) return Arrays.asList("set", "clear", "source", "metrics");
-        if (args.length == 2 && "metrics".equals(args[0])) {
-            return getListOfStringsMatchingLastWord(args, "human", "json", "players", "cleanup", "reset");
+        if (args.length == 1) {
+            return subcommandCompletions(sender, args);
+        }
+        if ("set".equals(args[0])) {
+            return setTabCompletions(server, sender, args);
+        }
+        if (("clear".equals(args[0]) || "source".equals(args[0])) && args.length == 2) {
+            return canTargetOthers(sender)
+                ? getListOfStringsMatchingLastWord(args, CompletionSources.onlinePlayerNames(server))
+                : Collections.emptyList();
+        }
+        if ("metrics".equals(args[0]) && args.length == 2) {
+            return getListOfStringsMatchingLastWord(args, CompletionSources.metricsSubcommands(sender));
         }
         return Collections.emptyList();
+    }
+
+    /** Subcommand names the sender may actually use, in /skin usage order. */
+    private List<String> subcommandCompletions(ICommandSender sender, String[] args) {
+        List<String> subcommands = new ArrayList<>();
+        if (CompletionSources.hasPermission(sender, "everlastingskins.command.skin")) {
+            subcommands.add("set");
+        }
+        if (CompletionSources.hasPermission(sender, "everlastingskins.command.skin.clear")) {
+            subcommands.add("clear");
+        }
+        if (CompletionSources.hasPermission(sender, "everlastingskins.command.skin")) {
+            subcommands.add("source");
+        }
+        if (CompletionSources.hasPermission(sender, "everlastingskins.command.metrics")) {
+            subcommands.add("metrics");
+        }
+        return getListOfStringsMatchingLastWord(args, subcommands);
+    }
+
+    /** Per-position candidates under {@code /skin set ...}. */
+    private List<String> setTabCompletions(MinecraftServer server, ICommandSender sender, String[] args) {
+        if (args.length == 2) {
+            return getListOfStringsMatchingLastWord(args, CompletionSources.providerNames());
+        }
+        if ("mojang".equals(args[1]) && args.length == 3) {
+            return getListOfStringsMatchingLastWord(args, CompletionSources.recentUsernames());
+        }
+        if ("web".equals(args[1])) {
+            if (args.length == 3) return getListOfStringsMatchingLastWord(args, "classic", "slim");
+            if (args.length == 4) return getListOfStringsMatchingLastWord(args, CompletionSources.urlCandidates());
+        }
+        if ("random".equals(args[1]) && args.length >= 3 && args.length <= 5) {
+            if (args.length == 3) return getListOfStringsMatchingLastWord(args, "true", "false");
+            if (args.length == 4) return getListOfStringsMatchingLastWord(args, "classic", "slim");
+            return canTargetOthers(sender)
+                ? getListOfStringsMatchingLastWord(args, CompletionSources.onlinePlayerNames(server))
+                : Collections.emptyList();
+        }
+        return Collections.emptyList();
+    }
+
+    private boolean canTargetOthers(ICommandSender sender) {
+        return CompletionSources.hasPermission(sender, "everlastingskins.command.skin.other");
     }
 
     public static void register(MinecraftServer server) {

--- a/src/main/java/levosilimo/everlastingskins/util/CompletionSources.java
+++ b/src/main/java/levosilimo/everlastingskins/util/CompletionSources.java
@@ -1,0 +1,121 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.util;
+
+import levosilimo.everlastingskins.Config;
+import levosilimo.everlastingskins.permission.PermissionContext;
+import levosilimo.everlastingskins.permission.PermissionServiceManager;
+import levosilimo.everlastingskins.skinchanger.DefaultSkinResolver;
+import levosilimo.everlastingskins.skinchanger.MojangProfileCache;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.server.MinecraftServer;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Shared candidate sources for /skin tab completion.
+ *
+ * <p>Both the 1.21 Brigadier suggesters and the 1.12.2
+ * {@code getTabCompletions} switch consume these lists, so the completion
+ * vocabulary (providers, cached usernames, allowlisted URLs, online players,
+ * permission-gated metrics subcommands) stays consistent across versions.
+ */
+public final class CompletionSources {
+
+    private static final String METRICS_RESET_PERMISSION = "everlastingskins.command.metrics.reset";
+
+    /** View subcommands every metrics-authorized sender may complete. */
+    private static final List<String> METRICS_VIEW_SUBCOMMANDS =
+            Collections.unmodifiableList(Arrays.asList("human", "json", "players"));
+
+    private static volatile MojangProfileCache profileCache = new MojangProfileCache();
+
+    private CompletionSources() {
+    }
+
+    /**
+     * Swaps the cache backing {@link #recentUsernames()}. Primarily a test
+     * seam; production deployments can point it at the same cache instance
+     * the Mojang API uses so recently fetched profiles are offered.
+     */
+    public static void setMojangProfileCache(MojangProfileCache cache) {
+        profileCache = cache != null ? cache : new MojangProfileCache();
+    }
+
+    /**
+     * Mojang usernames worth offering for {@code set mojang <name>}: cached
+     * profile lookups first, then the configured default skins list with the
+     * {@code <random>} token excluded (it is not a real username).
+     */
+    public static List<String> recentUsernames() {
+        List<String> names = new ArrayList<>();
+        for (String cached : profileCache.snapshot()) {
+            if (!names.contains(cached)) names.add(cached);
+        }
+        for (String configured : Config.DEFAULT_SKINS_LIST) {
+            if (!DefaultSkinResolver.RANDOM_TOKEN.equals(configured) && !names.contains(configured)) {
+                names.add(configured);
+            }
+        }
+        return Collections.unmodifiableList(names);
+    }
+
+    /** Every allowlisted domain as both an https:// and an http:// URL. */
+    public static List<String> urlCandidates() {
+        List<String> candidates = new ArrayList<>();
+        for (String domain : Config.urlAllowlistDomains) {
+            candidates.add("https://" + domain);
+            candidates.add("http://" + domain);
+        }
+        return Collections.unmodifiableList(candidates);
+    }
+
+    /** Providers for {@code set <provider>}; web only when MineSkin is enabled. */
+    public static List<String> providerNames() {
+        List<String> providers = new ArrayList<>(Arrays.asList("mojang", "random"));
+        if (Config.MINESKIN_ENABLED) {
+            providers.add("web");
+        }
+        return Collections.unmodifiableList(providers);
+    }
+
+    /** Names of every player currently online on the server. */
+    public static List<String> onlinePlayerNames(MinecraftServer server) {
+        if (server == null || server.getPlayerList() == null) return Collections.emptyList();
+        return Collections.unmodifiableList(new ArrayList<>(Arrays.asList(server.getPlayerList().getOnlinePlayerNames())));
+    }
+
+    /**
+     * Metrics subcommands the sender may complete. View subcommands need the
+     * base metrics permission; cleanup/reset additionally need the reset
+     * permission, so unauthorized users never see them offered.
+     */
+    public static List<String> metricsSubcommands(ICommandSender sender) {
+        List<String> subcommands = new ArrayList<>(METRICS_VIEW_SUBCOMMANDS);
+        if (hasPermission(sender, METRICS_RESET_PERMISSION)) {
+            subcommands.add("cleanup");
+            subcommands.add("reset");
+        }
+        return Collections.unmodifiableList(subcommands);
+    }
+
+    /**
+     * Silent permission check (no denial message is sent, unlike the command
+     * execution paths). Console senders pass, mirroring the execution gates.
+     */
+    public static boolean hasPermission(ICommandSender sender, String node) {
+        if (!(sender instanceof EntityPlayerMP)) return true;
+        EntityPlayerMP player = (EntityPlayerMP) sender;
+        PermissionContext ctx = PermissionContext.of(player.getUniqueID(), player);
+        return PermissionServiceManager.hasPermission(ctx, node);
+    }
+}

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/SkinCommandTabCompleteTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/SkinCommandTabCompleteTest.java
@@ -1,0 +1,185 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import levosilimo.everlastingskins.Config;
+import levosilimo.everlastingskins.util.CompletionSources;
+import levosilimo.everlastingskins.util.CustomSkinProperty;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.management.PlayerList;
+import net.minecraft.server.management.UserListOps;
+import net.minecraft.server.management.UserListOpsEntry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tab-completion behavior of the 1.12.2 getTabCompletions switch: the
+ * candidate lists mirror the 1.21 Brigadier tree and permission gates hide
+ * subcommands, other-player targets, and metrics cleanup/reset from
+ * unauthorized senders.
+ */
+class SkinCommandTabCompleteTest {
+
+    private static final String[] ONLINE_PLAYERS = {"Alex", "Bob"};
+
+    private final SkinCommand command = new SkinCommand();
+    private MinecraftServer server;
+
+    @BeforeEach
+    void setUp() {
+        Config.MINESKIN_ENABLED = false;
+        Config.permissionsOpLevelMetrics = 2;
+        Config.permissionsOpLevelMetricsReset = 2;
+        CompletionSources.setMojangProfileCache(new MojangProfileCache());
+
+        server = mock(MinecraftServer.class);
+        PlayerList playerList = mock(PlayerList.class);
+        when(server.getPlayerList()).thenReturn(playerList);
+        when(playerList.getOnlinePlayerNames()).thenReturn(ONLINE_PLAYERS);
+    }
+
+    @AfterEach
+    void tearDown() {
+        Config.MINESKIN_ENABLED = false;
+        Config.permissionsOpLevelMetrics = 2;
+        Config.permissionsOpLevelMetricsReset = 2;
+    }
+
+    @Test
+    @DisplayName("root completion filters subcommands by permission")
+    void subcommand_completion_filtersByPermission() {
+        assertEquals(Arrays.asList("set", "clear", "source"),
+                command.getTabCompletions(server, playerSender(0), new String[]{""}, null));
+        assertEquals(Arrays.asList("set", "clear", "source", "metrics"),
+                command.getTabCompletions(server, playerSender(2), new String[]{""}, null));
+    }
+
+    @Test
+    @DisplayName("set provider completion returns the configured providers")
+    void set_provider_completion_returnsConfiguredProviders() {
+        assertEquals(Arrays.asList("mojang", "random"),
+                command.getTabCompletions(server, playerSender(0), new String[]{"set", ""}, null));
+
+        Config.MINESKIN_ENABLED = true;
+        assertEquals(Arrays.asList("mojang", "random", "web"),
+                command.getTabCompletions(server, playerSender(0), new String[]{"set", ""}, null));
+    }
+
+    @Test
+    @DisplayName("set mojang skin_name completion returns cached profiles and default skins")
+    void set_mojang_skinName_completion_returnsRecentUsernames() {
+        MojangProfileCache cache = new MojangProfileCache();
+        cache.put("Notch", new CustomSkinProperty("value", "signature", "Notch"));
+        CompletionSources.setMojangProfileCache(cache);
+
+        List<String> suggestions = command.getTabCompletions(
+                server, playerSender(0), new String[]{"set", "mojang", ""}, null);
+
+        assertTrue(suggestions.contains("notch"));
+        assertTrue(suggestions.contains("Steve"));
+        assertFalse(suggestions.contains("<random>"));
+    }
+
+    @Test
+    @DisplayName("set web variant completion returns classic and slim")
+    void set_web_variant_completion_returnsClassicSlim() {
+        assertEquals(Arrays.asList("classic", "slim"),
+                command.getTabCompletions(server, playerSender(0), new String[]{"set", "web", ""}, null));
+    }
+
+    @Test
+    @DisplayName("set web url completion returns allowlisted domains with scheme prefixes")
+    void set_web_url_completion_returnsAllowlistDomains() {
+        List<String> urls = command.getTabCompletions(
+                server, playerSender(0), new String[]{"set", "web", "classic", ""}, null);
+
+        assertTrue(urls.contains("https://imgur.com"));
+        assertTrue(urls.contains("http://imgur.com"));
+        assertTrue(urls.contains("https://textures.minecraft.net"));
+        assertTrue(urls.contains("http://textures.minecraft.net"));
+    }
+
+    @Test
+    @DisplayName("set random completion cascades bool, variant and permission-gated players")
+    void set_random_completion_cascade() {
+        assertEquals(Arrays.asList("true", "false"),
+                command.getTabCompletions(server, playerSender(0), new String[]{"set", "random", ""}, null));
+        assertEquals(Arrays.asList("classic", "slim"),
+                command.getTabCompletions(server, playerSender(0), new String[]{"set", "random", "true", ""}, null));
+
+        assertEquals(Arrays.asList("Alex", "Bob"), command.getTabCompletions(
+                server, playerSender(2), new String[]{"set", "random", "true", "classic", ""}, null));
+        assertEquals(Collections.emptyList(), command.getTabCompletions(
+                server, playerSender(0), new String[]{"set", "random", "true", "classic", ""}, null));
+    }
+
+    @Test
+    @DisplayName("clear and source target completion returns online players for authorized senders")
+    void clear_source_target_completion_returnsOnlinePlayers() {
+        assertEquals(Arrays.asList("Alex", "Bob"),
+                command.getTabCompletions(server, playerSender(2), new String[]{"clear", ""}, null));
+        assertEquals(Arrays.asList("Alex", "Bob"),
+                command.getTabCompletions(server, playerSender(2), new String[]{"source", ""}, null));
+
+        assertEquals(Collections.emptyList(), command.getTabCompletions(server, playerSender(0), new String[]{"clear", ""}, null));
+    }
+
+    @Test
+    @DisplayName("metrics completion hides cleanup and reset from senders without the reset permission")
+    void metrics_completion_filtersByResetPermission() {
+        Config.permissionsOpLevelMetrics = 0;
+        Config.permissionsOpLevelMetricsReset = 2;
+
+        assertEquals(Arrays.asList("human", "json", "players"),
+                command.getTabCompletions(server, playerSender(0), new String[]{"metrics", ""}, null));
+        assertEquals(Arrays.asList("human", "json", "players", "cleanup", "reset"),
+                command.getTabCompletions(server, playerSender(2), new String[]{"metrics", ""}, null));
+    }
+
+    private static EntityPlayerMP playerSender(int opLevel) {
+        EntityPlayerMP player = mock(EntityPlayerMP.class);
+        when(player.getUniqueID()).thenReturn(UUID.randomUUID());
+
+        MinecraftServer mcServer = mock(MinecraftServer.class);
+        PlayerList playerList = mock(PlayerList.class);
+        when(mcServer.getPlayerList()).thenReturn(playerList);
+        UserListOps ops = mock(UserListOps.class);
+        when(playerList.getOppedPlayers()).thenReturn(ops);
+        UserListOpsEntry entry = mock(UserListOpsEntry.class);
+        when(entry.getPermissionLevel()).thenReturn(opLevel);
+        when(ops.getEntry(any())).thenReturn(entry);
+
+        setField(player, "mcServer", mcServer);
+        return player;
+    }
+
+    private static void setField(Object target, String fieldName, Object value) {
+        try {
+            Field field = EntityPlayerMP.class.getField(fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Cannot set EntityPlayerMP." + fieldName, e);
+        }
+    }
+}


### PR DESCRIPTION
Per lib-19 research: 1.12.2 CommandHandler has no implicit online-player fallback and `getTabCompletions` returned empty for the set branch entirely; metrics `cleanup`/`reset` also leaked to unauthorized users. This PR mirrors the 1.21 tab-completion implementation.

- `MojangProfileCache.snapshot()`: unmodifiable defensive copy of cached usernames (LRU order)
- `CompletionSources`: recentUsernames (cache + default skins, <random> excluded), https/http URL candidates from the allowlist, provider names (web gated by MINESKIN_ENABLED), online player names, metrics subcommands filtered by the reset permission
- `getTabCompletions` full switch: subcommands filtered by permission, set providers/mojang names/web variant+url/random cascade, clear/source targets gated by the other-permission, metrics subcommands with cleanup/reset gated by `everlastingskins.command.metrics.reset`
- `SkinCommandTabCompleteTest`: 8 tests covering every branch and permission gate

Verification: `./gradlew build test` passes, aislop 100/100.