### PR TITLE
fix(1.21): gate metrics cleanup behind the reset op level

### DIFF
--- a/src/main/java/levosilimo/everlastingskins/skinchanger/command/SkinMetricsCommand.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/command/SkinMetricsCommand.java
@@ -38,7 +38,16 @@ public final class SkinMetricsCommand {
                         .executes(context -> metrics(context, true)))
                 .then(Commands.literal("players")
                         .executes(SkinMetricsCommand::players))
+                /**
+                 * cleanup is destructive like reset: gate it behind the same
+                 * op level (everlastingskins.command.metrics.reset) so the
+                 * client tree and tab completion do not offer it to senders
+                 * holding only everlastingskins.command.metrics. The executor
+                 * still re-checks the reset permission (parity with 1.12.2's
+                 * metricsSubcommands filter).
+                 */
                 .then(Commands.literal("cleanup")
+                        .requires(source -> source.hasPermission(2))
                         .executes(SkinMetricsCommand::cleanup))
                 .then(Commands.literal("reset")
                         .requires(source -> source.hasPermission(2))

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/SkinCommandTabCompleteTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/SkinCommandTabCompleteTest.java
@@ -208,6 +208,22 @@ class SkinCommandTabCompleteTest {
         assertTrue(offered.contains("cleanup"));
     }
 
+    @Test
+    @DisplayName("metrics cleanup requires the reset permission like reset does")
+    void metrics_cleanup_completion_requiresResetPermission() {
+        Config.PERMISSIONS_OP_LEVEL_METRICS.set(0);
+        Config.PERMISSIONS_OP_LEVEL_METRICS_RESET.set(2);
+
+        CommandNode<CommandSourceStack> metrics = dispatcher.getRoot().getChild("skin").getChild("metrics");
+        // Level-0 sender holds command.metrics but not command.metrics.reset.
+        assertTrue(metrics.canUse(source));
+        assertFalse(metrics.getChild("cleanup").canUse(source));
+
+        // Level-2 sender holds both.
+        source = sourceWithOpLevel(2);
+        assertTrue(metrics.getChild("cleanup").canUse(source));
+    }
+
     private List<String> completions(String input) {
         ParseResults<CommandSourceStack> parsed = dispatcher.parse(input, source);
         Suggestions suggestions = dispatcher.getCompletionSuggestions(parsed).join();


### PR DESCRIPTION
## Summary

Closes the MEDIUM lib-22 audit finding: on 1.21 the `cleanup` literal under `/skin metrics` had no `requires()` predicate, so any sender holding the base `everlastingskins.command.metrics` permission was offered `cleanup` in the client command tree and tab completion — even though the executor re-checks the higher `everlastingskins.command.metrics.reset` permission (SkinMetricsCommand.java:77).

## Changes

- `SkinMetricsCommand.java`: add `.requires(source -> source.hasPermission(2))` to the `cleanup` literal, mirroring the `reset` node. This is a client-visible candidate/permission-surface divergence fix only — server-side authorization was already intact.
- `SkinCommandTabCompleteTest.java`: new `metrics_cleanup_completion_requiresResetPermission` test — asserts `cleanup.canUse()` is false for a level-0 sender (holds `command.metrics` only) and true for a level-2 sender (holds both), same pattern as the existing `metrics_completion_filtersByResetPermission`.

Parity: 1.12.2 filters `cleanup`/`reset` from tab completion via `metricsSubcommands()` on `everlastingskins.command.metrics.reset`; the 1.21 equivalent is the vanilla op-level gate (default `op_level.metrics_reset` = 2, matching the `reset` node's existing shape).

## Verification

- `./gradlew build test` — passed (9/9 in SkinCommandTabCompleteTest, 0 failures)
- `./gradlew runGameTestServer` — passed (All 34 required tests passed)
- aislop 100/100 clean on the commit (pre-commit hook, no --no-verify)