### PR TITLE
feat(1.12.2): cape-bearing random skin source (RandomCapeSource + Cosmetica)

### DIFF
--- a/src/main/java/levosilimo/everlastingskins/skinchanger/CosmeticaApi.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/CosmeticaApi.java
@@ -1,0 +1,256 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import com.google.gson.JsonParseException;
+import levosilimo.everlastingskins.EverlastingSkins;
+import levosilimo.everlastingskins.skinchanger.responses.HttpResponse;
+import levosilimo.everlastingskins.util.EndpointsConfig;
+import levosilimo.everlastingskins.util.HttpClient;
+import levosilimo.everlastingskins.util.HttpsUrlConnectionHttpClient;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collections;
+
+/**
+ * Cape lookups against the Cosmetica API (api.cosmetica.cc), the public cape
+ * directory that backs mskins.net's "with capes" skin listing.
+ * <p>
+ * {@code GET /players/{name-or-uuid}} returns the player's known capes
+ * (OptiFine, MinecraftCapes, LabyMod, ...) as an {@code externalCape} object
+ * with a direct {@code texture} URL and a {@code hasElytra} flag. The schema
+ * is documented in the Cosmetica OpenAPI at https://api.cosmetica.cc/docs-json
+ * (operation {@code getPlayer}).
+ * <p>
+ * Every failure mode fails closed: non-200 status, transport error and
+ * malformed JSON all yield {@code null}, so callers never see an exception
+ * escape the lookup path.
+ */
+public class CosmeticaApi {
+
+    private static final String USER_AGENT = "EverlastingSkins/1.0";
+    private static final int REQUEST_TIMEOUT = 10000;
+
+    private final HttpClient httpClient;
+    private final String playerEndpointTemplate;
+
+    public CosmeticaApi() {
+        this(new HttpsUrlConnectionHttpClient());
+    }
+
+    public CosmeticaApi(HttpClient httpClient) {
+        this(httpClient, EndpointsConfig.getString("endpoint.cosmetica.player"));
+    }
+
+    /** Test seam: fixed endpoint template instead of the configured one. */
+    public CosmeticaApi(HttpClient httpClient, String playerEndpointTemplate) {
+        this.httpClient = httpClient;
+        this.playerEndpointTemplate = playerEndpointTemplate;
+    }
+
+    /**
+     * Cape state of a player by name or UUID. Returns {@code null} when the
+     * player is unknown to Cosmetica or any failure occurred; callers treat
+     * null as "keep the candidate, decide elsewhere".
+     */
+    @Nullable
+    public CosmeticaPlayer getPlayer(String nameOrUuid) {
+        String url = playerEndpointTemplate.replace("%player%", nameOrUuid);
+        try {
+            HttpResponse response = httpClient.execute(
+                    URI.create(url),
+                    null,
+                    HttpClient.HttpType.JSON,
+                    USER_AGENT,
+                    HttpClient.HttpMethod.GET,
+                    Collections.emptyMap(),
+                    REQUEST_TIMEOUT
+            );
+            if (response.statusCode() != 200) {
+                return null;
+            }
+            return parseBodyOrNull(response);
+        } catch (IOException e) {
+            EverlastingSkins.logger.warn("Cosmetica lookup failed for {}: {}", nameOrUuid, e);
+            return null;
+        }
+    }
+
+    /**
+     * Gson's strict {@code fromJson} (inside {@link HttpResponse#getBodyAs})
+     * throws raw NumberFormatException on truncated {@code \\uXXXX} escapes
+     * and IllegalStateException on valid non-object roots. Every parse failure
+     * must fail closed to null, never an exception escaping the lookup path.
+     */
+    @Nullable
+    private static CosmeticaPlayer parseBodyOrNull(HttpResponse response) {
+        try {
+            return response.getBodyAs(CosmeticaPlayer.class);
+        } catch (JsonParseException | NumberFormatException | IllegalStateException e) {
+            EverlastingSkins.logger.warn("Failed to parse Cosmetica response: " + e);
+            return null;
+        } catch (RuntimeException e) {
+            EverlastingSkins.logger.warn("Failed to parse Cosmetica response: " + e);
+            return null;
+        }
+    }
+
+    /**
+     * Parsed subset of {@code GET /players/{id}} (PlayerResponse). The account
+     * is nested under {@code player} for non-Cosmetica accounts and under
+     * {@code user} for Cosmetica accounts; both carry the same cape fields.
+     */
+    public static final class CosmeticaPlayer {
+
+        private final boolean isUser;
+        private final Account player;
+        private final Account user;
+
+        public CosmeticaPlayer(boolean isUser, Account player, Account user) {
+            this.isUser = isUser;
+            this.player = player;
+            this.user = user;
+        }
+
+        public boolean isUser() {
+            return isUser;
+        }
+
+        public Account player() {
+            return player;
+        }
+
+        public Account user() {
+            return user;
+        }
+
+        /** The populated account variant, or null when neither was returned. */
+        @Nullable
+        public Account account() {
+            return player != null ? player : user;
+        }
+
+        /** Whether either account variant carries an external or internal cape. */
+        public boolean hasCape() {
+            Account account = account();
+            return account != null
+                    && (account.externalCape() != null || account.internalCape() != null);
+        }
+
+        /** Direct cape texture URL (external preferred, then internal), or null. */
+        @Nullable
+        public String capeTextureUrl() {
+            Account account = account();
+            if (account == null) {
+                return null;
+            }
+            if (account.externalCape() != null && account.externalCape().texture() != null) {
+                return account.externalCape().texture();
+            }
+            if (account.internalCape() != null && account.internalCape().texture() != null) {
+                return account.internalCape().texture();
+            }
+            return null;
+        }
+    }
+
+    /** Account payload shared by the player and user response variants. */
+    public static final class Account {
+
+        private final String uuid;
+        private final String username;
+        private final ExternalCape externalCape;
+        private final InternalCape internalCape;
+
+        public Account(String uuid, String username, ExternalCape externalCape, InternalCape internalCape) {
+            this.uuid = uuid;
+            this.username = username;
+            this.externalCape = externalCape;
+            this.internalCape = internalCape;
+        }
+
+        public String uuid() {
+            return uuid;
+        }
+
+        public String username() {
+            return username;
+        }
+
+        @Nullable
+        public ExternalCape externalCape() {
+            return externalCape;
+        }
+
+        @Nullable
+        public InternalCape internalCape() {
+            return internalCape;
+        }
+    }
+
+    /** Third-party cape (OptiFine, MinecraftCapes, LabyMod, ...). */
+    public static final class ExternalCape {
+
+        private final String id;
+        private final String service;
+        private final String texture;
+        private final boolean hasElytra;
+
+        public ExternalCape(String id, String service, String texture, boolean hasElytra) {
+            this.id = id;
+            this.service = service;
+            this.texture = texture;
+            this.hasElytra = hasElytra;
+        }
+
+        public String id() {
+            return id;
+        }
+
+        public String service() {
+            return service;
+        }
+
+        @Nullable
+        public String texture() {
+            return texture;
+        }
+
+        public boolean hasElytra() {
+            return hasElytra;
+        }
+    }
+
+    /** Cape hosted by Cosmetica itself. */
+    public static final class InternalCape {
+
+        private final String id;
+        private final String texture;
+        private final boolean hasElytra;
+
+        public InternalCape(String id, String texture, boolean hasElytra) {
+            this.id = id;
+            this.texture = texture;
+            this.hasElytra = hasElytra;
+        }
+
+        public String id() {
+            return id;
+        }
+
+        @Nullable
+        public String texture() {
+            return texture;
+        }
+
+        public boolean hasElytra() {
+            return hasElytra;
+        }
+    }
+}

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/RandomCapeSource.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/RandomCapeSource.java
@@ -1,0 +1,189 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import levosilimo.everlastingskins.util.EndpointsConfig;
+import levosilimo.everlastingskins.util.HttpClient;
+import levosilimo.everlastingskins.util.HttpsUrlConnectionHttpClient;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * Cape-bearing random skin source: mskins.net's "with capes" listing
+ * ({@code /en/skins/with_capes?page=N}, 48 cape-tagged player skins per page)
+ * filtered through the Cosmetica cape directory.
+ * <p>
+ * mskins renders the cape client-side, so the listing HTML carries no cape
+ * identity; each candidate name is therefore checked against
+ * {@link CosmeticaApi} and only players Cosmetica reports as cape-bearing are
+ * returned. Players unknown to Cosmetica are kept with a {@code null} texture
+ * URL so the consumer can still try a Mojang-side lookup.
+ */
+public class RandomCapeSource {
+
+    private static final String USER_AGENT = "EverlastingSkins/1.0";
+    private static final int REQUEST_TIMEOUT = 10000;
+
+    /** Pages of the with_capes listing scanned per lookup when not tuned. */
+    static final int DEFAULT_PAGE_COUNT = 2;
+    /** Cap on returned candidates per lookup when not tuned. */
+    static final int DEFAULT_RESULT_LIMIT = 10;
+
+    private final HttpClient httpClient;
+    private final CosmeticaApi cosmeticaApi;
+    private final String withCapesTemplate;
+    private final int pageCount;
+    private final int resultLimit;
+    private final Random random = new Random();
+
+    public RandomCapeSource() {
+        this(new HttpsUrlConnectionHttpClient(), new CosmeticaApi(),
+                EndpointsConfig.getString("url.mskins.with_capes"), DEFAULT_PAGE_COUNT, DEFAULT_RESULT_LIMIT);
+    }
+
+    /** Test seam: injected client, Cosmetica API and scan tuning. */
+    public RandomCapeSource(HttpClient httpClient, CosmeticaApi cosmeticaApi, String withCapesTemplate,
+                            int pageCount, int resultLimit) {
+        this.httpClient = httpClient;
+        this.cosmeticaApi = cosmeticaApi;
+        this.withCapesTemplate = withCapesTemplate;
+        this.pageCount = Math.max(1, pageCount);
+        this.resultLimit = Math.max(1, resultLimit);
+    }
+
+    /** A cape-bearing player name plus the cape texture Cosmetica knows. */
+    public static final class CapeCandidate {
+
+        private final String username;
+        private final String capeTextureUrl;
+
+        CapeCandidate(String username, String capeTextureUrl) {
+            this.username = username;
+            this.capeTextureUrl = capeTextureUrl;
+        }
+
+        public String username() {
+            return username;
+        }
+
+        @Nullable
+        public String capeTextureUrl() {
+            return capeTextureUrl;
+        }
+    }
+
+    /**
+     * Scans up to {@link #pageCount} pages of the with_capes listing from a
+     * random start page (wrapping around) and returns up to
+     * {@link #resultLimit} candidates: players Cosmetica reports as
+     * cape-bearing (with their cape texture URL) plus players unknown to
+     * Cosmetica (null texture — the consumer decides).
+     * <p>
+     * A transport failure fetching a listing page aborts the scan; Cosmetica
+     * failures never abort it (they fail closed per player).
+     */
+    public List<CapeCandidate> findCapeBearers() throws IOException {
+        List<CapeCandidate> candidates = new ArrayList<CapeCandidate>();
+        int startPage = random.nextInt(pageCount) + 1;
+        for (int offset = 0; offset < pageCount && candidates.size() < resultLimit; offset++) {
+            int page = (startPage - 1 + offset) % pageCount + 1;
+            for (String username : extractUsernames(fetchPage(page))) {
+                if (username.isEmpty() || username.equals("ad")) {
+                    continue;
+                }
+                CapeCandidate candidate = probeCape(username);
+                if (candidate != null) {
+                    candidates.add(candidate);
+                    if (candidates.size() >= resultLimit) {
+                        break;
+                    }
+                }
+            }
+        }
+        return candidates;
+    }
+
+    /**
+     * Random cape-bearing username for the {@code /skin set random <cape>}
+     * path, or {@code null} when the scan found no usable candidate.
+     */
+    @Nullable
+    public String pickRandomCapeUsername() throws IOException {
+        List<CapeCandidate> candidates = findCapeBearers();
+        if (candidates.isEmpty()) {
+            return null;
+        }
+        return candidates.get(random.nextInt(candidates.size())).username();
+    }
+
+    private String fetchPage(int page) throws IOException {
+        return httpClient.execute(
+                URI.create(String.format(withCapesTemplate, page)),
+                null,
+                HttpClient.HttpType.JSON,
+                USER_AGENT,
+                HttpClient.HttpMethod.GET,
+                Collections.emptyMap(),
+                REQUEST_TIMEOUT
+        ).body();
+    }
+
+    /**
+     * Cosmetica verdict on a listing candidate: keep players with a cape
+     * (texture URL attached) and players Cosmetica does not know (null
+     * texture — the consumer decides); drop players Cosmetica knows to be
+     * cape-less.
+     */
+    @Nullable
+    private CapeCandidate probeCape(String username) {
+        CosmeticaApi.CosmeticaPlayer player = cosmeticaApi.getPlayer(username);
+        if (player == null) {
+            return new CapeCandidate(username, null);
+        }
+        if (!player.hasCape()) {
+            return null;
+        }
+        return new CapeCandidate(username, player.capeTextureUrl());
+    }
+
+    /**
+     * Same span-based parser as {@link RandomMojangSkin}: the with_capes
+     * listing uses the identical {@code card-title green-text truncate} card
+     * markup.
+     */
+    private static List<String> extractUsernames(String html) {
+        List<String> usernames = new ArrayList<String>();
+        int currentIndex = 0;
+
+        while (true) {
+            int charPointer = html.indexOf("<span class=\"card-title green-text truncate\">", currentIndex);
+            if (charPointer == -1 || charPointer <= currentIndex) {
+                break;
+            }
+            charPointer += 45;
+            int stopIndex = html.indexOf("<", charPointer);
+            if (stopIndex == -1) {
+                break;
+            }
+
+            String username = html.substring(charPointer, stopIndex);
+            if (!username.isEmpty()) {
+                usernames.add(username);
+            }
+
+            currentIndex = stopIndex;
+        }
+
+        return usernames;
+    }
+}

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinAction.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinAction.java
@@ -122,7 +122,15 @@ final class SkinAction {
                     case NEW: {
                         String fetchName = customSource;
                         if (type == SkinActionType.random) {
-                            fetchName = RandomMojangSkin.randomUsername(withCape, variant);
+                            // Cape mode swaps the candidate source: RandomMojangSkin's
+                            // decoded-CAPE check only finds legacy cape holders (Mojang
+                            // stopped embedding CAPE in the textures payload), so
+                            // RandomCapeSource (mskins with_capes + Cosmetica) is used
+                            // instead. The variant filter is intentionally not applied in
+                            // cape mode: the listing is not variant-tagged.
+                            fetchName = withCape
+                                ? new RandomCapeSource().pickRandomCapeUsername()
+                                : RandomMojangSkin.randomUsername(false, variant);
                         } else if (type == SkinActionType.NEW) {
                             fetchName = RandomMojangSkin.newUsername(variant);
                         }

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinCommand.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinCommand.java
@@ -237,17 +237,36 @@ public class SkinCommand extends CommandBase {
                 SkinAction.apply(targets, sender, SkinActionType.url, variant, false, args[3]);
                 break;
             }
-            case "random":
-                Collection<EntityPlayerMP> targets = parseTargets(server, sender, args, false, 3);
+            case "random": {
+                // /skin set random [<cape> [<variant>]] [<targets...>]: the
+                // cape flag and variant are optional and parsed to match the
+                // tab-completion cascade (bool, then variant, then targets).
+                boolean cape = args.length >= 3 && "true".equalsIgnoreCase(args[2]);
+                SkinVariant variant = parseRandomVariant(args);
+                Collection<EntityPlayerMP> targets = parseTargets(server, sender, args, false, 4);
                 String node = targets.size() == 1 && targets.iterator().next() == sender
                     ? "everlastingskins.command.skin"
                     : "everlastingskins.command.skin.other";
                 if (!checkPermission(sender, node)) return;
-                SkinAction.apply(targets, sender, SkinActionType.random, SkinVariant.ALL, false, null);
+                SkinAction.apply(targets, sender, SkinActionType.random, variant, cape, null);
                 break;
+            }
             default:
                 sender.sendMessage(new TextComponentString(PREFIX + "Usage: /skin set <mojang|web|random>"));
         }
+    }
+
+    /**
+     * Variant argument of {@code /skin set random}: optional, defaults to ALL.
+     */
+    private static SkinVariant parseRandomVariant(String[] args) {
+        if (args.length >= 4 && "slim".equalsIgnoreCase(args[3])) {
+            return SkinVariant.SLIM;
+        }
+        if (args.length >= 4 && "classic".equalsIgnoreCase(args[3])) {
+            return SkinVariant.CLASSIC;
+        }
+        return SkinVariant.ALL;
     }
 
     private boolean checkPermission(ICommandSender sender, String node) {

--- a/src/main/resources/endpoints.properties
+++ b/src/main/resources/endpoints.properties
@@ -26,3 +26,9 @@ url.namemc.img=https://s.namemc.com/i/%s.png
 url.mskins.latest=https://mskins.net/ru/skins/latest
 url.mskins.random=https://mskins.net/en/skins/random
 url.mskins.cape=https://mskins.net/en/cape/minecon_
+# Cape-bearing skin listing (48 players/page); the %d is the page number.
+url.mskins.with_capes=https://mskins.net/en/skins/with_capes?page=%d
+
+# --- Cosmetica (cape directory; OpenAPI at https://api.cosmetica.cc/docs-json) ---
+# GET /players/{name-or-uuid} returns the player's known capes (externalCape).
+endpoint.cosmetica.player=https://api.cosmetica.cc/players/%player%

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/CosmeticaApiTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/CosmeticaApiTest.java
@@ -1,0 +1,176 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import levosilimo.everlastingskins.FakeHttpClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link CosmeticaApi}: GET /players/{id} parsing (player and
+ * user account variants) and the fail-closed contract for every non-200
+ * status, transport error and malformed JSON. All HTTP responses are served
+ * by {@link FakeHttpClient}; no live endpoint is ever contacted.
+ */
+class CosmeticaApiTest {
+
+    private static final String ENDPOINT_TEMPLATE = "http://test.local/players/%player%";
+    private static final String CAPE_TEXTURE = "https://assets.namet.ag/test/cape.png";
+
+    private FakeHttpClient httpClient;
+    private CosmeticaApi api;
+
+    @BeforeEach
+    void setUp() {
+        httpClient = new FakeHttpClient();
+        api = new CosmeticaApi(httpClient, ENDPOINT_TEMPLATE);
+    }
+
+    private URI playerUri(String name) {
+        return URI.create(ENDPOINT_TEMPLATE.replace("%player%", name));
+    }
+
+    @Nested
+    @DisplayName("Player account variant (isUser=false)")
+    class PlayerVariant {
+
+        @Test
+        @DisplayName("parses a player with an external cape")
+        void parses_player_with_external_cape() {
+            httpClient.addResponse(playerUri("Notch"), 200,
+                    "{\"isUser\":false,\"player\":{\"uuid\":\"069a79f4-44e9-4726-a5be-fca90e38aaf5\","
+                            + "\"username\":\"Notch\",\"type\":\"player\","
+                            + "\"externalCape\":{\"id\":\"578631b3-4049-42bd-a205-3971f0965c5f\","
+                            + "\"service\":\"optifine\",\"serviceName\":\"OptiFine\",\"texture\":\"" + CAPE_TEXTURE + "\","
+                            + "\"hasElytra\":true,\"active\":true,\"frames\":1}}}");
+
+            CosmeticaApi.CosmeticaPlayer player = api.getPlayer("Notch");
+
+            assertNotNull(player);
+            assertFalse(player.isUser());
+            assertEquals("Notch", player.account().username());
+            assertEquals("069a79f4-44e9-4726-a5be-fca90e38aaf5", player.account().uuid());
+            assertTrue(player.hasCape());
+            assertEquals(CAPE_TEXTURE, player.capeTextureUrl());
+            assertNotNull(player.account().externalCape());
+            assertEquals("578631b3-4049-42bd-a205-3971f0965c5f", player.account().externalCape().id());
+            assertEquals("optifine", player.account().externalCape().service());
+            assertTrue(player.account().externalCape().hasElytra());
+        }
+
+        @Test
+        @DisplayName("parses a player without a cape")
+        void parses_player_without_cape() {
+            httpClient.addResponse(playerUri("Jeb_"), 200,
+                    "{\"isUser\":false,\"player\":{\"uuid\":\"853c80ef-3c37-49fd-aa49-938b674adae6\","
+                            + "\"username\":\"Jeb_\",\"type\":\"player\"}}");
+
+            CosmeticaApi.CosmeticaPlayer player = api.getPlayer("Jeb_");
+
+            assertNotNull(player);
+            assertFalse(player.hasCape());
+            assertNull(player.capeTextureUrl());
+        }
+
+        @Test
+        @DisplayName("parses a player with an internal Cosmetica cape")
+        void parses_player_with_internal_cape() {
+            httpClient.addResponse(playerUri("InternalCapeLad"), 200,
+                    "{\"isUser\":false,\"player\":{\"username\":\"InternalCapeLad\",\"type\":\"player\","
+                            + "\"internalCape\":{\"id\":\"cap-1\",\"texture\":\"https://assets.namet.ag/internal.png\","
+                            + "\"hasElytra\":false}}}");
+
+            CosmeticaApi.CosmeticaPlayer player = api.getPlayer("InternalCapeLad");
+
+            assertNotNull(player);
+            assertTrue(player.hasCape());
+            assertEquals("https://assets.namet.ag/internal.png", player.capeTextureUrl());
+        }
+    }
+
+    @Nested
+    @DisplayName("Cosmetica user account variant (isUser=true)")
+    class UserVariant {
+
+        @Test
+        @DisplayName("parses a Cosmetica user with an external cape")
+        void parses_user_with_external_cape() {
+            httpClient.addResponse(playerUri("CapeLad"), 200,
+                    "{\"isUser\":true,\"user\":{\"uuid\":\"12345678-1234-1234-1234-123456789abc\","
+                            + "\"username\":\"CapeLad\","
+                            + "\"externalCape\":{\"id\":\"usercape-1\",\"service\":\"official\","
+                            + "\"texture\":\"" + CAPE_TEXTURE + "\",\"hasElytra\":false}}}");
+
+            CosmeticaApi.CosmeticaPlayer player = api.getPlayer("CapeLad");
+
+            assertNotNull(player);
+            assertTrue(player.isUser());
+            assertTrue(player.hasCape());
+            assertEquals(CAPE_TEXTURE, player.capeTextureUrl());
+            assertEquals("CapeLad", player.account().username());
+        }
+    }
+
+    @Nested
+    @DisplayName("Fail-closed contract")
+    class FailClosed {
+
+        @Test
+        @DisplayName("returns null on 404")
+        void returns_null_on_404() {
+            httpClient.addResponse(playerUri("Ghost"), 404, "");
+
+            assertNull(api.getPlayer("Ghost"));
+        }
+
+        @Test
+        @DisplayName("returns null on 400 (unknown player)")
+        void returns_null_on_400() {
+            httpClient.addResponse(playerUri("Ghost"), 400, "{\"error\":\"No such player\"}");
+
+            assertNull(api.getPlayer("Ghost"));
+        }
+
+        @Test
+        @DisplayName("returns null on 5xx")
+        void returns_null_on_5xx() {
+            httpClient.addResponse(playerUri("Ghost"), 500, "internal error");
+
+            assertNull(api.getPlayer("Ghost"));
+        }
+
+        @Test
+        @DisplayName("returns null on malformed JSON")
+        void returns_null_on_malformed_json() {
+            httpClient.addResponse(playerUri("Ghost"), 200, "{not valid json");
+
+            assertNull(api.getPlayer("Ghost"));
+        }
+
+        @Test
+        @DisplayName("returns null on a JSON array root")
+        void returns_null_on_array_root() {
+            httpClient.addResponse(playerUri("Ghost"), 200, "[1,2,3]");
+
+            assertNull(api.getPlayer("Ghost"));
+        }
+
+        @Test
+        @DisplayName("returns null on transport error")
+        void returns_null_on_transport_error() {
+            httpClient.addTimeout(playerUri("Ghost"));
+
+            assertNull(api.getPlayer("Ghost"));
+        }
+    }
+}

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/RandomCapeSourceTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/RandomCapeSourceTest.java
@@ -1,0 +1,302 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import levosilimo.everlastingskins.FakeHttpClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link RandomCapeSource}: the with_capes listing scan, the
+ * Cosmetica cape filter and the page/result limits. HTML is canned and the
+ * Cosmetica verdict is stubbed via {@link FakeCosmeticaApi}; no live endpoint
+ * is ever contacted.
+ */
+class RandomCapeSourceTest {
+
+    private static final String WITH_CAPES_TEMPLATE = "http://test.local/with_capes?page=%d";
+
+    private static final String CAPE_TEXTURE = "https://assets.namet.ag/test/cape.png";
+
+    private FakeHttpClient httpClient;
+    private FakeCosmeticaApi cosmetica;
+    private RandomCapeSource source;
+
+    @BeforeEach
+    void setUp() {
+        httpClient = new FakeHttpClient();
+        cosmetica = new FakeCosmeticaApi();
+        source = new RandomCapeSource(httpClient, cosmetica, WITH_CAPES_TEMPLATE, 1, 10);
+    }
+
+    private URI pageUri(int page) {
+        return URI.create(String.format(WITH_CAPES_TEMPLATE, page));
+    }
+
+    private static String htmlOf(String... usernames) {
+        StringBuilder html = new StringBuilder("<html><main>");
+        for (String username : usernames) {
+            html.append("\n<span class=\"card-title green-text truncate\">").append(username).append("</span>");
+        }
+        return html.append("\n</main></html>").toString();
+    }
+
+    @Nested
+    @DisplayName("Listing scan and Cosmetica filter")
+    class ScanAndFilter {
+
+        @Test
+        @DisplayName("fetches the with_capes page and returns every cape-bearing name")
+        void fetches_with_capes_returns_names() throws Exception {
+            httpClient.addResponse(pageUri(1), 200, htmlOf("Notch", "Jeb_", "Dinnerbone"));
+            cosmetica.withCape("Notch", CAPE_TEXTURE);
+            cosmetica.withCape("Jeb_", CAPE_TEXTURE);
+            cosmetica.withCape("Dinnerbone", CAPE_TEXTURE);
+
+            List<RandomCapeSource.CapeCandidate> candidates = source.findCapeBearers();
+
+            assertEquals(3, candidates.size());
+            assertEquals("Notch", candidates.get(0).username());
+            assertEquals("Jeb_", candidates.get(1).username());
+            assertEquals("Dinnerbone", candidates.get(2).username());
+        }
+
+        @Test
+        @DisplayName("filters out players Cosmetica knows to be cape-less")
+        void filters_out_players_without_cape() throws Exception {
+            httpClient.addResponse(pageUri(1), 200, htmlOf("Notch", "Jeb_", "Dinnerbone"));
+            cosmetica.withCape("Notch", CAPE_TEXTURE);
+            cosmetica.withoutCape("Jeb_");
+            cosmetica.withCape("Dinnerbone", CAPE_TEXTURE);
+
+            List<RandomCapeSource.CapeCandidate> candidates = source.findCapeBearers();
+
+            assertEquals(2, candidates.size());
+            assertEquals("Notch", candidates.get(0).username());
+            assertEquals("Dinnerbone", candidates.get(1).username());
+        }
+
+        @Test
+        @DisplayName("keeps players with an external cape and carries the texture URL")
+        void keeps_players_with_external_cape() throws Exception {
+            httpClient.addResponse(pageUri(1), 200, htmlOf("Notch"));
+            cosmetica.withCape("Notch", CAPE_TEXTURE);
+
+            List<RandomCapeSource.CapeCandidate> candidates = source.findCapeBearers();
+
+            assertEquals(1, candidates.size());
+            assertEquals("Notch", candidates.get(0).username());
+            assertEquals(CAPE_TEXTURE, candidates.get(0).capeTextureUrl());
+        }
+
+        @Test
+        @DisplayName("keeps players unknown to Cosmetica with a null texture")
+        void keeps_players_unknown_to_cosmetica() throws Exception {
+            httpClient.addResponse(pageUri(1), 200, htmlOf("Notch", "Ghost"));
+            cosmetica.withCape("Notch", CAPE_TEXTURE);
+            // "Ghost" is absent from the stub: getPlayer returns null.
+
+            List<RandomCapeSource.CapeCandidate> candidates = source.findCapeBearers();
+
+            assertEquals(2, candidates.size());
+            assertEquals("Notch", candidates.get(0).username());
+            assertEquals("Ghost", candidates.get(1).username());
+            assertNull(candidates.get(1).capeTextureUrl());
+        }
+
+        @Test
+        @DisplayName("skips the 'ad' placeholder entry")
+        void skips_ad_placeholder() throws Exception {
+            httpClient.addResponse(pageUri(1), 200, htmlOf("ad", "Steve"));
+            cosmetica.withCape("ad", CAPE_TEXTURE);
+            cosmetica.withCape("Steve", CAPE_TEXTURE);
+
+            List<RandomCapeSource.CapeCandidate> candidates = source.findCapeBearers();
+
+            assertEquals(1, candidates.size());
+            assertEquals("Steve", candidates.get(0).username());
+        }
+
+        @Test
+        @DisplayName("returns an empty list for a page without cards")
+        void empty_page_returns_empty_list() throws Exception {
+            httpClient.addResponse(pageUri(1), 200, "<html><main></main></html>");
+
+            assertTrue(source.findCapeBearers().isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("Scan limits")
+    class Limits {
+
+        @Test
+        @DisplayName("scans at most the configured page count")
+        void respects_page_limit() throws Exception {
+            httpClient.addResponse(pageUri(1), 200, htmlOf("Alice"));
+            httpClient.addResponse(pageUri(2), 200, htmlOf("Bob"));
+            cosmetica.withCape("Alice", CAPE_TEXTURE);
+            cosmetica.withCape("Bob", CAPE_TEXTURE);
+
+            // One page: only page-1 candidates are reachable.
+            RandomCapeSource singlePage = new RandomCapeSource(httpClient, cosmetica, WITH_CAPES_TEMPLATE, 1, 10);
+            List<RandomCapeSource.CapeCandidate> onePage = singlePage.findCapeBearers();
+            assertEquals(1, onePage.size());
+            assertEquals("Alice", onePage.get(0).username());
+
+            // Two pages: both pages are scanned regardless of the random start.
+            RandomCapeSource twoPages = new RandomCapeSource(httpClient, cosmetica, WITH_CAPES_TEMPLATE, 2, 10);
+            List<RandomCapeSource.CapeCandidate> bothPages = twoPages.findCapeBearers();
+            assertEquals(2, bothPages.size());
+            assertTrue(containsUsername(bothPages, "Alice"));
+            assertTrue(containsUsername(bothPages, "Bob"));
+        }
+
+        @Test
+        @DisplayName("caps the result list at the configured limit")
+        void respects_result_limit() throws Exception {
+            httpClient.addResponse(pageUri(1), 200, htmlOf("A", "B", "C", "D", "E"));
+            for (String name : Arrays.asList("A", "B", "C", "D", "E")) {
+                cosmetica.withCape(name, CAPE_TEXTURE);
+            }
+
+            RandomCapeSource limited = new RandomCapeSource(httpClient, cosmetica, WITH_CAPES_TEMPLATE, 1, 3);
+            List<RandomCapeSource.CapeCandidate> candidates = limited.findCapeBearers();
+
+            assertEquals(3, candidates.size());
+            assertEquals("A", candidates.get(0).username());
+            assertEquals("B", candidates.get(1).username());
+            assertEquals("C", candidates.get(2).username());
+        }
+    }
+
+    @Nested
+    @DisplayName("Random pick")
+    class RandomPick {
+
+        @Test
+        @DisplayName("returns the only candidate's username")
+        void pick_returns_candidate() throws Exception {
+            httpClient.addResponse(pageUri(1), 200, htmlOf("Notch"));
+            cosmetica.withCape("Notch", CAPE_TEXTURE);
+
+            assertEquals("Notch", source.pickRandomCapeUsername());
+        }
+
+        @Test
+        @DisplayName("returns null when no candidate passes the filter")
+        void pick_returns_null_when_empty() throws Exception {
+            httpClient.addResponse(pageUri(1), 200, htmlOf("Notch"));
+            cosmetica.withoutCape("Notch");
+
+            assertNull(source.pickRandomCapeUsername());
+        }
+
+        @Test
+        @DisplayName("picks from the candidate pool when several qualify")
+        void pick_returns_member_of_pool() throws Exception {
+            httpClient.addResponse(pageUri(1), 200, htmlOf("A", "B", "C"));
+            for (String name : Arrays.asList("A", "B", "C")) {
+                cosmetica.withCape(name, CAPE_TEXTURE);
+            }
+
+            String picked = source.pickRandomCapeUsername();
+
+            assertTrue(Arrays.asList("A", "B", "C").contains(picked));
+        }
+    }
+
+    @Nested
+    @DisplayName("mskins with_capes snapshot regression")
+    class SnapshotRegression {
+
+        @Test
+        @DisplayName("extracts the same usernames as the saved snapshot")
+        void snapshotUsernames() throws Exception {
+            httpClient.addResponse(pageUri(1), 200, fixture("with_capes_page1.html"));
+
+            List<RandomCapeSource.CapeCandidate> candidates = source.findCapeBearers();
+
+            // 8 cards in the snapshot; the real 'ad' placeholder card is skipped.
+            assertEquals(7, candidates.size());
+            assertEquals("AntuYoutuber", candidates.get(0).username());
+            assertEquals("ByeCode", candidates.get(1).username());
+            assertEquals("Sanr1z", candidates.get(6).username());
+        }
+    }
+
+    private static boolean containsUsername(List<RandomCapeSource.CapeCandidate> candidates, String username) {
+        for (RandomCapeSource.CapeCandidate candidate : candidates) {
+            if (username.equals(candidate.username())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String fixture(String name) throws Exception {
+        java.io.InputStream in = RandomCapeSourceTest.class.getResourceAsStream("/fixtures/mskins/" + name);
+        if (in == null) {
+            throw new AssertionError("Missing fixture: " + name);
+        }
+        try {
+            return readAll(in);
+        } finally {
+            in.close();
+        }
+    }
+
+    private static String readAll(java.io.InputStream in) throws java.io.IOException {
+        java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
+        byte[] buffer = new byte[1024];
+        int read;
+        while ((read = in.read(buffer)) != -1) {
+            out.write(buffer, 0, read);
+        }
+        return new String(out.toByteArray(), java.nio.charset.StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Cosmetica verdict stub: canned per-player cape state, with names absent
+     * from the map representing players Cosmetica does not know (null).
+     */
+    private static final class FakeCosmeticaApi extends CosmeticaApi {
+
+        private final Map<String, CosmeticaPlayer> players = new HashMap<String, CosmeticaPlayer>();
+
+        FakeCosmeticaApi() {
+            super(new FakeHttpClient(), "http://unused/players/%player%");
+        }
+
+        void withCape(String username, String texture) {
+            players.put(username, new CosmeticaPlayer(false,
+                    new Account(null, username, new ExternalCape("cap-" + username, "optifine", texture, true), null),
+                    null));
+        }
+
+        void withoutCape(String username) {
+            players.put(username, new CosmeticaPlayer(false,
+                    new Account(null, username, null, null),
+                    null));
+        }
+
+        @Override
+        public CosmeticaPlayer getPlayer(String nameOrUuid) {
+            return players.get(nameOrUuid);
+        }
+    }
+}

--- a/src/test/resources/fixtures/mskins/with_capes_page1.html
+++ b/src/test/resources/fixtures/mskins/with_capes_page1.html
@@ -1,0 +1,270 @@
+<div class="card-content">
+				<span class="card-title green-text truncate">AntuYoutuber</span>				
+				<a class="btn-floating halfway-fab waves-effect waves-light green item-btn-copy tooltipped-click" data-clipboard-text="AntuYoutuber" data-position="top" data-delay="50" data-tooltip="Copy nickname"><i class="material-icons">content_copy</i></a>
+			</div>
+			<div class="card-action">
+				<span class="item-res grey-text">
+					<span class="numb">64x64</span>	
+				</span>
+ 													<span class="item-count grey-text right">
+						<i class="material-icons">file_download</i>
+						<span class="numb">6</span>
+					</span>				
+					<span class="item-count grey-text right">
+						<i class="material-icons">visibility</i>
+						<span class="numb">32</span>	
+					</span>	
+					             
+			</div>
+		</div>
+	</div>	
+	
+	
+			     
+
+
+
+
+	<div class="col l3 m6 s12">
+		<div class="card card-main item  hoverable">
+			<div class="card-image card-skin grey lighten-5 waves-effect waves-block waves-light">
+								  
+				<a class="skin_link" href="https://mskins.net/en/skin/ByeCode-Q4yP9">
+					<img class="item-img" width="212" height="350" src="/uploads/preview3d/dc/37/ByeCode_350.png" alt="Minecraft skin ByeCode"> 
+				</a>
+			</div>
+			<div class="card-content">
+				<span class="card-title green-text truncate">ByeCode</span>				
+				<a class="btn-floating halfway-fab waves-effect waves-light green item-btn-copy tooltipped-click" data-clipboard-text="ByeCode" data-position="top" data-delay="50" data-tooltip="Copy nickname"><i class="material-icons">content_copy</i></a>
+			</div>
+			<div class="card-action">
+				<span class="item-res grey-text">
+					<span class="numb">64x64</span>	
+				</span>
+ 													<span class="item-count grey-text right">
+						<i class="material-icons">file_download</i>
+						<span class="numb">146</span>
+					</span>				
+					<span class="item-count grey-text right">
+						<i class="material-icons">visibility</i>
+						<span class="numb">173</span>	
+					</span>	
+					             
+			</div>
+		</div>
+	</div>	
+	
+	
+			     
+
+
+
+
+	<div class="col l3 m6 s12">
+		<div class="card card-main item  hoverable">
+			<div class="card-image card-skin grey lighten-5 waves-effect waves-block waves-light">
+								  
+				<a class="skin_link" href="https://mskins.net/en/skin/Sayorikies-O4wNr">
+					<img class="item-img" width="212" height="350" src="/uploads/preview3d/b7/e7/Sayorikies_350.png" alt="Minecraft skin Sayorikies"> 
+				</a>
+			</div>
+			<div class="card-content">
+				<span class="card-title green-text truncate">Sayorikies</span>				
+				<a class="btn-floating halfway-fab waves-effect waves-light green item-btn-copy tooltipped-click" data-clipboard-text="Sayorikies" data-position="top" data-delay="50" data-tooltip="Copy nickname"><i class="material-icons">content_copy</i></a>
+			</div>
+			<div class="card-action">
+				<span class="item-res grey-text">
+					<span class="numb">64x64</span>	
+				</span>
+ 													<span class="item-count grey-text right">
+						<i class="material-icons">file_download</i>
+						<span class="numb">5</span>
+					</span>				
+					<span class="item-count grey-text right">
+						<i class="material-icons">visibility</i>
+						<span class="numb">39</span>	
+					</span>	
+					             
+			</div>
+		</div>
+	</div>	
+	
+	
+			     
+
+
+
+
+	<div class="col l3 m6 s12">
+		<div class="card card-main item  hoverable">
+			<div class="card-image card-skin grey lighten-5 waves-effect waves-block waves-light">
+								  
+				<a class="skin_link" href="https://mskins.net/en/skin/Glexus-N4vMv">
+					<img class="item-img" width="212" height="350" src="/uploads/preview3d/10/bf/Glexus_350.png" alt="Minecraft skin Glexus"> 
+				</a>
+			</div>
+			<div class="card-content">
+				<span class="card-title green-text truncate">Glexus</span>				
+				<a class="btn-floating halfway-fab waves-effect waves-light green item-btn-copy tooltipped-click" data-clipboard-text="Glexus" data-position="top" data-delay="50" data-tooltip="Copy nickname"><i class="material-icons">content_copy</i></a>
+			</div>
+			<div class="card-action">
+				<span class="item-res grey-text">
+					<span class="numb">64x64</span>	
+				</span>
+ 													<span class="item-count grey-text right">
+						<i class="material-icons">file_download</i>
+						<span class="numb">13</span>
+					</span>				
+					<span class="item-count grey-text right">
+						<i class="material-icons">visibility</i>
+						<span class="numb">74</span>	
+					</span>	
+					             
+			</div>
+		</div>
+	</div>	
+	
+	
+			     
+
+
+
+
+	<div class="col l3 m6 s12">
+		<div class="card card-main item  hoverable">
+			<div class="card-image card-skin grey lighten-5 waves-effect waves-block waves-light">
+								  
+				<a class="skin_link" href="https://mskins.net/en/skin/D4rk_8unny-L4qKr">
+					<img class="item-img" width="212" height="350" src="/uploads/preview3d/f0/49/D4rk_8unny_350.png" alt="Minecraft skin D4rk_8unny"> 
+				</a>
+			</div>
+			<div class="card-content">
+				<span class="card-title green-text truncate">D4rk_8unny</span>				
+				<a class="btn-floating halfway-fab waves-effect waves-light green item-btn-copy tooltipped-click" data-clipboard-text="D4rk_8unny" data-position="top" data-delay="50" data-tooltip="Copy nickname"><i class="material-icons">content_copy</i></a>
+			</div>
+			<div class="card-action">
+				<span class="item-res grey-text">
+					<span class="numb">64x64</span>	
+				</span>
+ 													<span class="item-count grey-text right">
+						<i class="material-icons">file_download</i>
+						<span class="numb">7</span>
+					</span>				
+					<span class="item-count grey-text right">
+						<i class="material-icons">visibility</i>
+						<span class="numb">47</span>	
+					</span>	
+					             
+			</div>
+		</div>
+	</div>	
+	
+	
+			     
+
+
+
+
+	<div class="col l3 m6 s12">
+		<div class="card card-main item  hoverable">
+			<div class="card-image card-skin grey lighten-5 waves-effect waves-block waves-light">
+								  
+				<a class="skin_link" href="https://mskins.net/en/skin/ChelzMC-K4pJx">
+					<img class="item-img" width="212" height="350" src="/uploads/preview3d/17/17/ChelzMC_350.png" alt="Minecraft skin ChelzMC"> 
+				</a>
+			</div>
+			<div class="card-content">
+				<span class="card-title green-text truncate">ChelzMC</span>				
+				<a class="btn-floating halfway-fab waves-effect waves-light green item-btn-copy tooltipped-click" data-clipboard-text="ChelzMC" data-position="top" data-delay="50" data-tooltip="Copy nickname"><i class="material-icons">content_copy</i></a>
+			</div>
+			<div class="card-action">
+				<span class="item-res grey-text">
+					<span class="numb">64x64</span>	
+				</span>
+ 													<span class="item-count grey-text right">
+						<i class="material-icons">file_download</i>
+						<span class="numb">9</span>
+					</span>				
+					<span class="item-count grey-text right">
+						<i class="material-icons">visibility</i>
+						<span class="numb">68</span>	
+					</span>	
+					             
+			</div>
+		</div>
+	</div>	
+	
+	
+			 			<div class="col l3 m6 s12">
+				<div class="card card-main item item-promo">
+					<div class="item_ad">
+						<div class="center-align">
+							                            <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8794966854388692"
+                                crossorigin="anonymous"></script>
+                            <!-- MSKINS FEED Adaptive -->
+                            <ins class="adsbygoogle"
+                                style="display:block; width: 100%; height: 100%;"
+                                data-ad-client="ca-pub-8794966854388692"
+                                data-ad-slot="5682043220"
+                                data-full-width-responsive="false"
+                                data-alternate-ad-url="https://mskins.net/themes/mc/assets/promo/app_feed.php?lang=en"></ins>
+                            <script>
+                                (adsbygoogle = window.adsbygoogle || []).push({})
+                            </script>
+
+						</div>
+					</div>			
+					<div class="card-image">
+						<img class="item-img" width="212" height="350" src="https://mskins.net/themes/mc/assets/img/blank.webp">
+					</div>
+					<div class="card-content">
+						<span class="card-title green-text truncate">ad</span>			
+					</div>
+					<div class="card-action">
+						<span class="item-res grey-text">
+							<span class="numb">#</span>	
+						</span>	
+					</div>
+				</div>
+			</div>		
+		    
+
+
+
+
+	<div class="col l3 m6 s12">
+		<div class="card card-main item  hoverable">
+			<div class="card-image card-skin grey lighten-5 waves-effect waves-block waves-light">
+								  
+				<a class="skin_link" href="https://mskins.net/en/skin/Sanr1z-J5o0g">
+					<img class="item-img" width="212" height="350" src="/uploads/preview3d/56/80/Sanr1z_350.png" alt="Minecraft skin Sanr1z"> 
+				</a>
+			</div>
+			<div class="card-content">
+				<span class="card-title green-text truncate">Sanr1z</span>				
+				<a class="btn-floating halfway-fab waves-effect waves-light green item-btn-copy tooltipped-click" data-clipboard-text="Sanr1z" data-position="top" data-delay="50" data-tooltip="Copy nickname"><i class="material-icons">content_copy</i></a>
+			</div>
+			<div class="card-action">
+				<span class="item-res grey-text">
+					<span class="numb">64x64</span>	
+				</span>
+ 													<span class="item-count grey-text right">
+						<i class="material-icons">file_download</i>
+						<span class="numb">3</span>
+					</span>				
+					<span class="item-count grey-text right">
+						<i class="material-icons">visibility</i>
+						<span class="numb">40</span>	
+					</span>	
+					             
+			</div>
+		</div>
+	</div>	
+	
+	
+			     
+
+
+
+
+	


### PR DESCRIPTION
## Summary
Mirror of #244 (round 11 cape source wins) for the 1.12.2 branch, per the porting policy (narrow commits, identical scope).

- **A1** `CosmeticaApi` — GET api.cosmetica.cc/players/{name-or-uuid} (`externalCape` + `hasElytra` per the Cosmetica OpenAPI at api.cosmetica.cc/docs-json). Fail-closed null on non-200 / transport error / malformed JSON. Java 8 DTOs with field-style accessors, matching the 1.12.2 response convention.
- **B1** `RandomCapeSource` — mskins.net/en/skins/with_capes scan (same selector as RandomMojangSkin) filtered by Cosmetica; unknown-to-Cosmetica players kept with null texture; page/result limits; random start page; snapshot fixture.
- **C1** `/skin set random <cape>` — withCape=true routes through RandomCapeSource. Also parses the previously ignored random arguments to match the tab-completion cascade (`/skin set random [<cape> [<variant>]] [<targets...>]`); target parsing moves from index 3 to index 4.

## Tests
- `CosmeticaApiTest` (11) + `RandomCapeSourceTest` (12), mirroring the 1.21 coverage.
- Full suite: 507 unit tests, 0 failures; aislop 100/100 per commit.