### PR TITLE
fix(1.12.2): Cosmetica cape filter — only official-service capes are vanilla-visible (mirror of 1.21)

### DIFF
--- a/src/main/java/levosilimo/everlastingskins/skinchanger/CosmeticaApi.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/CosmeticaApi.java
@@ -136,27 +136,36 @@ public class CosmeticaApi {
             return player != null ? player : user;
         }
 
-        /** Whether either account variant carries an external or internal cape. */
+        /**
+         * Whether the account carries a Mojang {@code official} cape: only
+         * {@code externalCape.service == "official"} maps to a Mojang CAPE key
+         * visible in vanilla Forge 1.12.2 (verified against forgeSrc and the
+         * OptiFine source in lib-25). Other services (optifine,
+         * minecraft-capes, labymod, 5zig, tlauncher, skinmc) are client-mod
+         * only and invisible to vanilla players; {@code internalCape} requires
+         * the Cosmetica Forge mod on the viewing client and is excluded too.
+         */
         public boolean hasCape() {
             Account account = account();
             return account != null
-                    && (account.externalCape() != null || account.internalCape() != null);
+                    && account.externalCape() != null
+                    && "official".equalsIgnoreCase(account.externalCape().service());
         }
 
-        /** Direct cape texture URL (external preferred, then internal), or null. */
+        /**
+         * Direct cape texture URL when the account carries an official Mojang
+         * cape, or null otherwise: non-official services and internal capes
+         * are not visible to vanilla players, so they yield no texture for
+         * our purposes.
+         */
         @Nullable
         public String capeTextureUrl() {
             Account account = account();
-            if (account == null) {
+            if (account == null || account.externalCape() == null
+                    || !"official".equalsIgnoreCase(account.externalCape().service())) {
                 return null;
             }
-            if (account.externalCape() != null && account.externalCape().texture() != null) {
-                return account.externalCape().texture();
-            }
-            if (account.internalCape() != null && account.internalCape().texture() != null) {
-                return account.internalCape().texture();
-            }
-            return null;
+            return account.externalCape().texture();
         }
     }
 

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/RandomCapeSource.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/RandomCapeSource.java
@@ -139,10 +139,12 @@ public class RandomCapeSource {
     }
 
     /**
-     * Cosmetica verdict on a listing candidate: keep players with a cape
-     * (texture URL attached) and players Cosmetica does not know (null
-     * texture — the consumer decides); drop players Cosmetica knows to be
-     * cape-less.
+     * Cosmetica verdict on a listing candidate: keep players Cosmetica
+     * reports as bearing an {@code official} cape (only those map to a Mojang
+     * CAPE key visible in vanilla — OptiFine, MinecraftCapes, LabyMod and
+     * Cosmetica-internal capes are client-mod-only and are dropped) and
+     * players Cosmetica does not know (null texture — the consumer decides);
+     * drop everyone else.
      */
     @Nullable
     private CapeCandidate probeCape(String username) {

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/CosmeticaApiTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/CosmeticaApiTest.java
@@ -51,7 +51,7 @@ class CosmeticaApiTest {
                     "{\"isUser\":false,\"player\":{\"uuid\":\"069a79f4-44e9-4726-a5be-fca90e38aaf5\","
                             + "\"username\":\"Notch\",\"type\":\"player\","
                             + "\"externalCape\":{\"id\":\"578631b3-4049-42bd-a205-3971f0965c5f\","
-                            + "\"service\":\"optifine\",\"serviceName\":\"OptiFine\",\"texture\":\"" + CAPE_TEXTURE + "\","
+                            + "\"service\":\"official\",\"serviceName\":\"Mojang\",\"texture\":\"" + CAPE_TEXTURE + "\","
                             + "\"hasElytra\":true,\"active\":true,\"frames\":1}}}");
 
             CosmeticaApi.CosmeticaPlayer player = api.getPlayer("Notch");
@@ -64,7 +64,7 @@ class CosmeticaApiTest {
             assertEquals(CAPE_TEXTURE, player.capeTextureUrl());
             assertNotNull(player.account().externalCape());
             assertEquals("578631b3-4049-42bd-a205-3971f0965c5f", player.account().externalCape().id());
-            assertEquals("optifine", player.account().externalCape().service());
+            assertEquals("official", player.account().externalCape().service());
             assertTrue(player.account().externalCape().hasElytra());
         }
 
@@ -83,8 +83,8 @@ class CosmeticaApiTest {
         }
 
         @Test
-        @DisplayName("parses a player with an internal Cosmetica cape")
-        void parses_player_with_internal_cape() {
+        @DisplayName("parses an internal Cosmetica cape (not vanilla-visible)")
+        void hasCape_ignores_internalCape() {
             httpClient.addResponse(playerUri("InternalCapeLad"), 200,
                     "{\"isUser\":false,\"player\":{\"username\":\"InternalCapeLad\",\"type\":\"player\","
                             + "\"internalCape\":{\"id\":\"cap-1\",\"texture\":\"https://assets.namet.ag/internal.png\","
@@ -93,8 +93,10 @@ class CosmeticaApiTest {
             CosmeticaApi.CosmeticaPlayer player = api.getPlayer("InternalCapeLad");
 
             assertNotNull(player);
-            assertTrue(player.hasCape());
-            assertEquals("https://assets.namet.ag/internal.png", player.capeTextureUrl());
+            assertNotNull(player.account().internalCape());
+            assertEquals("cap-1", player.account().internalCape().id());
+            assertFalse(player.hasCape());
+            assertNull(player.capeTextureUrl());
         }
     }
 
@@ -118,6 +120,72 @@ class CosmeticaApiTest {
             assertTrue(player.hasCape());
             assertEquals(CAPE_TEXTURE, player.capeTextureUrl());
             assertEquals("CapeLad", player.account().username());
+        }
+    }
+
+    @Nested
+    @DisplayName("Service filter: only official capes are vanilla-visible")
+    class ServiceFilter {
+
+        private String externalCapePayload(String service) {
+            return "{\"isUser\":false,\"player\":{\"username\":\"CapeLad\",\"type\":\"player\","
+                    + "\"externalCape\":{\"id\":\"cap-1\",\"service\":\"" + service + "\","
+                    + "\"texture\":\"" + CAPE_TEXTURE + "\",\"hasElytra\":true}}}";
+        }
+
+        @Test
+        @DisplayName("hasCape is false for an OptiFine external cape")
+        void hasCape_returns_false_for_optifine_externalCape() {
+            httpClient.addResponse(playerUri("CapeLad"), 200, externalCapePayload("optifine"));
+
+            CosmeticaApi.CosmeticaPlayer player = api.getPlayer("CapeLad");
+
+            assertNotNull(player);
+            assertFalse(player.hasCape());
+        }
+
+        @Test
+        @DisplayName("hasCape is false for a MinecraftCapes external cape")
+        void hasCape_returns_false_for_minecraftCapes_externalCape() {
+            httpClient.addResponse(playerUri("CapeLad"), 200, externalCapePayload("minecraft-capes"));
+
+            CosmeticaApi.CosmeticaPlayer player = api.getPlayer("CapeLad");
+
+            assertNotNull(player);
+            assertFalse(player.hasCape());
+        }
+
+        @Test
+        @DisplayName("hasCape is true for an official external cape")
+        void hasCape_returns_true_for_official_externalCape() {
+            httpClient.addResponse(playerUri("CapeLad"), 200, externalCapePayload("official"));
+
+            CosmeticaApi.CosmeticaPlayer player = api.getPlayer("CapeLad");
+
+            assertNotNull(player);
+            assertTrue(player.hasCape());
+        }
+
+        @Test
+        @DisplayName("capeTextureUrl is null for an OptiFine cape")
+        void capeTextureUrl_returns_null_for_optifine() {
+            httpClient.addResponse(playerUri("CapeLad"), 200, externalCapePayload("optifine"));
+
+            CosmeticaApi.CosmeticaPlayer player = api.getPlayer("CapeLad");
+
+            assertNotNull(player);
+            assertNull(player.capeTextureUrl());
+        }
+
+        @Test
+        @DisplayName("capeTextureUrl carries the official cape texture for the official service")
+        void capeTextureUrl_returns_official_texture_for_official_service() {
+            httpClient.addResponse(playerUri("CapeLad"), 200, externalCapePayload("official"));
+
+            CosmeticaApi.CosmeticaPlayer player = api.getPlayer("CapeLad");
+
+            assertNotNull(player);
+            assertEquals(CAPE_TEXTURE, player.capeTextureUrl());
         }
     }
 

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/RandomCapeSourceTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/RandomCapeSourceTest.java
@@ -91,6 +91,20 @@ class RandomCapeSourceTest {
         }
 
         @Test
+        @DisplayName("filters out players whose cape is OptiFine-only, keeping official cape bearers")
+        void filters_out_optifine_capebearer() throws Exception {
+            httpClient.addResponse(pageUri(1), 200, htmlOf("Notch", "Dinnerbone"));
+            cosmetica.withOptifineCape("Notch", CAPE_TEXTURE);
+            cosmetica.withCape("Dinnerbone", CAPE_TEXTURE);
+
+            List<RandomCapeSource.CapeCandidate> candidates = source.findCapeBearers();
+
+            assertEquals(1, candidates.size());
+            assertEquals("Dinnerbone", candidates.get(0).username());
+            assertEquals(CAPE_TEXTURE, candidates.get(0).capeTextureUrl());
+        }
+
+        @Test
         @DisplayName("keeps players with an external cape and carries the texture URL")
         void keeps_players_with_external_cape() throws Exception {
             httpClient.addResponse(pageUri(1), 200, htmlOf("Notch"));
@@ -283,6 +297,12 @@ class RandomCapeSourceTest {
         }
 
         void withCape(String username, String texture) {
+            players.put(username, new CosmeticaPlayer(false,
+                    new Account(null, username, new ExternalCape("cap-" + username, "official", texture, true), null),
+                    null));
+        }
+
+        void withOptifineCape(String username, String texture) {
             players.put(username, new CosmeticaPlayer(false,
                     new Account(null, username, new ExternalCape("cap-" + username, "optifine", texture, true), null),
                     null));


### PR DESCRIPTION
## Summary

Round 12 mirror of #246 for Forge 1.12.2: implement the `service == "official"` filter for Cosmetica cape lookups (lib-25).

Cosmetica's `externalCape` carries a `service` discriminator (`official`, `optifine`, `minecraft-capes`, `labymod`, `5zig`, `tlauncher`, `skinmc`). Only `service == "official"` corresponds to a Mojang CAPE key visible in vanilla Forge 1.12.2 (verified via forgeSrc + OptiFine source inspection). The other services are client-mod-only — invisible to ~99% of vanilla players.

## Changes

- **CosmeticaApi.hasCape()**: requires `externalCape != null && service.equalsIgnoreCase("official")`; `internalCape` excluded entirely (needs the Cosmetica Forge mod on the viewing client). Rationale documented in Javadoc (lib-25 + OptiFine source).
- **CosmeticaApi.capeTextureUrl()**: returns texture URLs only from official capes; null for non-official.
- **RandomCapeSource.probeCape()**: comment documents the official-service requirement — Notch/xxitey/fh3287h2378h are correctly dropped.

## Tests

- `CosmeticaApiTest.ServiceFilter`: 5 new filter tests (optifine/minecraft-capes negative, official positive, texture null/positive, internalCape ignored via renamed `hasCape_ignores_internalCape`).
- Existing external-cape parse fixture updated optifine → official.
- `RandomCapeSourceTest.filters_out_optifine_capebearer`: OptiFine-serviced name dropped, official name kept; stub `withCape` now serves official-service capes.

## Verification

- `./gradlew build test` — BUILD SUCCESSFUL
- aislop 100/100 on every commit (pre-commit hook, no --no-verify)
- Commits: dd5a713 (A1), 4eddc71 (B1), 7b82543 (C1)