### PR TITLE
ci(publish): consume point-release tags (mc1.21.1/1.21.4/1.21.8-v*)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,11 +7,14 @@ on:
   push:
     tags:
       - 'mc1.21-v*'
+      - 'mc1.21.1-v*'
+      - 'mc1.21.4-v*'
+      - 'mc1.21.8-v*'
       - 'mc1.12.2-v*'
 
 jobs:
   publish-1_21:
-    if: startsWith(github.ref_name, 'mc1.21')
+    if: startsWith(github.ref_name, 'mc1.21-v')
     runs-on: ubuntu-latest
     name: java-21
 
@@ -58,6 +61,171 @@ jobs:
           version-type: release
           loaders: forge
           game-versions: "1.21"
+          game-version-filter: releases
+          environment: server
+          files: build/libs/*.jar
+          fail-mode: warn
+          retry-attempts: 3
+          retry-delay: 15000
+
+  publish-1_21_1:
+    if: startsWith(github.ref_name, 'mc1.21.1-v')
+    runs-on: ubuntu-latest
+    name: java-21
+
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
+        with:
+          ref: "${{ github.ref_name }}"
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961  # v5
+        with:
+          java-version: "21"
+          distribution: temurin
+
+      - name: Cache Gradle
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5
+        with:
+          path: |
+            ~/.gradle/wrapper/dists
+            ~/.gradle/caches
+          key: gradle-${{ runner.os }}-1.21.1
+          restore-keys: |
+            gradle-${{ runner.os }}-1.21.1-
+            gradle-${{ runner.os }}-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build
+        run: ./gradlew build --no-daemon
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+
+      - name: Publish to CurseForge, Modrinth, GitHub Releases
+        uses: Kira-NT/mc-publish@52307b03863581dec6b652b83e597aec02ebb075  # v3
+        with:
+          curseforge-id: 538149
+          curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
+          modrinth-id: everlasting-skins
+          modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          version: ${{ github.ref_name }}
+          name: "Everlasting Skins ${{ github.ref_name }}"
+          version-type: release
+          loaders: forge
+          game-versions: "1.21.1"
+          game-version-filter: releases
+          environment: server
+          files: build/libs/*.jar
+          fail-mode: warn
+          retry-attempts: 3
+          retry-delay: 15000
+
+  publish-1_21_4:
+    if: startsWith(github.ref_name, 'mc1.21.4-v')
+    runs-on: ubuntu-latest
+    name: java-21
+
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
+        with:
+          ref: "${{ github.ref_name }}"
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961  # v5
+        with:
+          java-version: "21"
+          distribution: temurin
+
+      - name: Cache Gradle
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5
+        with:
+          path: |
+            ~/.gradle/wrapper/dists
+            ~/.gradle/caches
+          key: gradle-${{ runner.os }}-1.21.4
+          restore-keys: |
+            gradle-${{ runner.os }}-1.21.4-
+            gradle-${{ runner.os }}-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build
+        run: ./gradlew build --no-daemon
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+
+      - name: Publish to CurseForge, Modrinth, GitHub Releases
+        uses: Kira-NT/mc-publish@52307b03863581dec6b652b83e597aec02ebb075  # v3
+        with:
+          curseforge-id: 538149
+          curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
+          modrinth-id: everlasting-skins
+          modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          version: ${{ github.ref_name }}
+          name: "Everlasting Skins ${{ github.ref_name }}"
+          version-type: release
+          loaders: forge
+          game-versions: "1.21.4"
+          game-version-filter: releases
+          environment: server
+          files: build/libs/*.jar
+          fail-mode: warn
+          retry-attempts: 3
+          retry-delay: 15000
+
+  publish-1_21_8:
+    if: startsWith(github.ref_name, 'mc1.21.8-v')
+    runs-on: ubuntu-latest
+    name: java-21
+
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
+        with:
+          ref: "${{ github.ref_name }}"
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961  # v5
+        with:
+          java-version: "21"
+          distribution: temurin
+
+      - name: Cache Gradle
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5
+        with:
+          path: |
+            ~/.gradle/wrapper/dists
+            ~/.gradle/caches
+          key: gradle-${{ runner.os }}-1.21.8
+          restore-keys: |
+            gradle-${{ runner.os }}-1.21.8-
+            gradle-${{ runner.os }}-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build
+        run: ./gradlew build --no-daemon
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+
+      - name: Publish to CurseForge, Modrinth, GitHub Releases
+        uses: Kira-NT/mc-publish@52307b03863581dec6b652b83e597aec02ebb075  # v3
+        with:
+          curseforge-id: 538149
+          curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
+          modrinth-id: everlasting-skins
+          modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          version: ${{ github.ref_name }}
+          name: "Everlasting Skins ${{ github.ref_name }}"
+          version-type: release
+          loaders: forge
+          game-versions: "1.21.8"
           game-version-filter: releases
           environment: server
           files: build/libs/*.jar


### PR DESCRIPTION
GitHub Actions evaluates the **default branch's** workflow file for tag pushes, so the per-branch publish.yml files (fix/121-point-release-*) never fire. Add the three point-release tag patterns + dedicated jobs (checkout the tag, game-versions per release) to the 1.21 branch workflow, and tighten the publish-1_21 guard to 'mc1.21-v' so point-release tags don't double-publish through the 1.21 job.

Required before the mc1.21.1-v2.1.0-rc1 / mc1.21.4-v2.1.0-rc1 tags (already pushed) can trigger publish runs; those tags will need re-push (delete+recreate) after merge.