### PR TITLE
release(1.21.4): point-release v2.1.0-rc1 (MC 1.21.4 / Forge 54.1.18)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
   push:
     tags:
       - 'mc1.21-v*'
+      - 'mc1.21.4-v*'
       - 'mc1.12.2-v*'
 
 jobs:
@@ -58,6 +59,61 @@ jobs:
           version-type: release
           loaders: forge
           game-versions: "1.21"
+          game-version-filter: releases
+          environment: server
+          files: build/libs/*.jar
+          fail-mode: warn
+          retry-attempts: 3
+          retry-delay: 15000
+
+  publish-1_21_4:
+    if: startsWith(github.ref_name, 'mc1.21.1-v')
+    runs-on: ubuntu-latest
+    name: java-21
+
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
+        with:
+          ref: "${{ github.ref_name }}"
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961  # v5
+        with:
+          java-version: "21"
+          distribution: temurin
+
+      - name: Cache Gradle
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5
+        with:
+          path: |
+            ~/.gradle/wrapper/dists
+            ~/.gradle/caches
+          key: gradle-${{ runner.os }}-1.21.4
+          restore-keys: |
+            gradle-${{ runner.os }}-1.21.4-
+            gradle-${{ runner.os }}-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build
+        run: ./gradlew build --no-daemon
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+
+      - name: Publish to CurseForge, Modrinth, GitHub Releases
+        uses: Kira-NT/mc-publish@52307b03863581dec6b652b83e597aec02ebb075  # v3
+        with:
+          curseforge-id: 538149
+          curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
+          modrinth-id: everlasting-skins
+          modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          version: ${{ github.ref_name }}
+          name: "Everlasting Skins ${{ github.ref_name }}"
+          version-type: release
+          loaders: forge
+          game-versions: "1.21.4"
           game-version-filter: releases
           environment: server
           files: build/libs/*.jar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.1.0-rc.1 (2026-08-05) — Minecraft 1.21.4 port
+
+First 1.21.4 point-release build of the 2.1.0-rc.1 feature set: identical code to the 1.21
+build, re-targeted at Minecraft 1.21.4 / Forge 54.1.18 (ForgeGradle 7.0.x, Gradle 9.3.1).
+Configuration-only port — no logic deltas vs. the 1.21 branch.
+
 ## 2.1.0-rc.1 (2026-08-02)
 
 ### Added

--- a/build.gradle
+++ b/build.gradle
@@ -10,18 +10,18 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '[6.0,6.2)', changing: true
-        classpath 'org.spongepowered:mixingradle:0.7.+'
+        classpath group: 'net.minecraftforge', name: 'forgegradle', version: '[7.0.3,8)', changing: true
         classpath 'org.apache.httpcomponents:httpclient:4.5.13'
     }
 }
 
 plugins {
+    id 'java'
+    id 'base'
     id 'eclipse'
     id 'idea'
     id 'maven-publish'
-    id 'net.minecraftforge.gradle' version '[6.0.24,6.2)'
-    id 'org.spongepowered.mixin' version '0.7.+'
+    id 'net.minecraftforge.gradle' version '[7.0.3,8)'
     id 'jacoco'
 }
 
@@ -30,6 +30,9 @@ jacoco {
 }
 
 repositories {
+    minecraft.mavenizer(it)
+    maven fg.forgeMaven
+    maven fg.minecraftLibsMaven
     maven {
         // location of a maven mirror for JEI files, as a fallback
         name = "ModMaven"
@@ -67,7 +70,9 @@ repositories {
 }
 
 version = "${mod_version}"
-archivesBaseName = "${mod_name}-${minecraft_version}"
+base {
+    archivesName = "${mod_name}-${minecraft_version}"
+}
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 tasks.withType(JavaCompile).configureEach {
     it.options.release = 21
@@ -101,60 +106,45 @@ configurations {
 minecraft {
 
     mappings channel: 'official', version: "${minecraft_version}".toString()
-    reobf = false
 
-    accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
-    copyIdeResources = true
-	
+    accessTransformer = true
+
     runs {
 
         configureEach {
-            workingDirectory project.file(project.findProperty('mc.runDir') ?: 'run')
-            property 'forge.logging.console.level', 'debug'
-            property 'fml.earlyprogresswindow', 'false'
-            property 'mixin.env.disableRefMap', 'true'
-
-            mods {
-                "everlastingskins" {
-                    source sourceSets.main
-                }
-            }
+            workingDir = layout.projectDirectory.dir(project.findProperty('mc.runDir') ?: 'run')
+            systemProperty 'forge.logging.console.level', 'debug'
+            systemProperty 'fml.earlyprogresswindow', 'false'
+            systemProperty 'mixin.env.disableRefMap', 'true'
         }
 
         client {
-            properties 'mixin.env.remapRefMap': 'true'
-            property 'mixin.env.refMapRemappingFile', "${project.projectDir}/build/createSrgToMcp/output.srg"
+            systemProperty 'mixin.env.remapRefMap', 'true'
+            systemProperty 'mixin.env.refMapRemappingFile', "${project.projectDir}/build/createSrgToMcp/output.srg"
 
-            property 'forge.logging.markers', 'REGISTRYDUMP'
+            systemProperty 'forge.logging.markers', 'REGISTRYDUMP'
         }
 
         server {
-            workingDirectory project.file('server')
-            property 'mixin.env.disableRefMap', 'true'
-            property 'mixin.env.refMapRemappingFile', "${project.projectDir}/build/createSrgToMcp/output.srg"
-            property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
+            workingDir = layout.projectDirectory.dir('server')
+            systemProperty 'mixin.env.disableRefMap', 'true'
+            systemProperty 'mixin.env.refMapRemappingFile', "${project.projectDir}/build/createSrgToMcp/output.srg"
+            systemProperty 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
         }
 
         client2 {
-            parent runs.client
-            taskName 'runClient2'
-            workingDirectory project.file(project.findProperty('mc.runDir2') ?: 'run2')
+            workingDir = layout.projectDirectory.dir(project.findProperty('mc.runDir2') ?: 'run2')
             args '--username', 'PlayerB'
             args '--uuid', 'd1b05a3e-9909-3e16-95e5-7eef2d6c713b'
-            mods {
-                everlastingskins {
-                    source sourceSets.main
-                }
-            }
         }
 
         // Forge ships a built-in gameTestServer run definition (launchTarget
         // forge_userdev_server_gametest); ForgeGradle names the task
-        // runGameTestServer. The gametest source set must be part of the mod so
-        // its @GameTestHolder classes are scanned and its structure templates
-        // are loaded from the dev mod jar's datapack.
+        // runGameTestServer. FG7 auto-includes every project source set
+        // (main + gametest) in dev runs, so the @GameTestHolder classes are
+        // scanned and structure templates load from the dev mod datapack.
         gameTestServer {
-            property 'forge.enabledGameTestNamespaces', project.findProperty('gametestNamespace') ?: 'everlastingskins'
+            systemProperty 'forge.enabledGameTestNamespaces', project.findProperty('gametestNamespace') ?: 'everlastingskins'
             // Netty 4.1 needs reflective access into the JDK on Java 21
             // (GameTest job failed with "Reflective setAccessible(true)
             // disabled" / module exports). Applied to the forked GameTest
@@ -196,12 +186,6 @@ minecraft {
                 '--add-exports=java.base/jdk.internal.misc=io.netty.resolver',
                 '-Dio.netty.tryReflectionSetAccessible=false'
             )
-            mods {
-                everlastingskins {
-                    source sourceSets.main
-                    source sourceSets.gametest
-                }
-            }
         }
     }
 }
@@ -212,6 +196,12 @@ minecraft {
 // the GameTest server starts clean (vanilla defaults; the server rewrites
 // the file on shutdown anyway).
 tasks.matching { it.name == 'runGameTestServer' }.configureEach {
+    // FG7 removed the FG6 `mods {}` wiring that put the gametest source set
+    // into the dev mod; put its output (classes + structure-template datapack
+    // resources) on the run classpath so @GameTestHolder classes are scanned
+    // and the empty.nbt template loads.
+    classpath += sourceSets.gametest.output
+
     doFirst {
         def runDir = project.file(project.findProperty('mc.runDir') ?: 'run')
         runDir.mkdirs()
@@ -225,15 +215,10 @@ tasks.matching { it.name == 'runGameTestServer' }.configureEach {
     }
 }
 
-mixin {
-    add sourceSets.main, "everlastingskins.refmap.json"
-    config 'everlastingskins.mixins.json'
-}
-
 dependencies {
     implementation 'org.apache.httpcomponents:httpclient:4.5.13'
-    minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
-    annotationProcessor "org.spongepowered:mixin:0.8.5:processor"
+    implementation minecraft.dependency("net.minecraftforge:forge:${minecraft_version}-${forge_version}")
+    annotationProcessor "org.spongepowered:mixin:0.8.7:processor"
     // Hack fix for now, force jopt-simple to be exactly 5.0.4 because Mojang ships that version, but some transitive dependencies request 6.0+
     implementation('net.sf.jopt-simple:jopt-simple:5.0.4') { version { strictly '5.0.4' } }
 
@@ -301,7 +286,7 @@ jar {
             'Specification-Title': "${mod_name}",
             'Specification-Vendor': "${mod_vendor}",
             'Specification-Version': "${version}",
-            'Implementation-Title': project.archivesBaseName,
+            'Implementation-Title': "${mod_name}-${minecraft_version}",
             'Implementation-Version': project.version,
             'Implementation-Vendor' :"${mod_vendor}",
             'Implementation-Timestamp': new Date().format("yyyy-MM-dd'T'HH:mm:ssZ"),

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,14 +14,14 @@ mod_authors=Levosilimo
 mod_description=Server-side persistent custom skins on pure Forge servers — no client mod required.
 
 # Dep Versions
-minecraft_version=1.21
-minecraft_version_range=[1.21,1.22)
-forge_version=51.0.8
-forge_version_range=[51.0.8,52)
+minecraft_version=1.21.4
+minecraft_version_range=[1.21.4,1.21.5)
+forge_version=54.1.18
+forge_version_range=[54.1.18,55)
 loader_version_range=[31,)
 
 # Curse properties
-curse_versions=1.21
+curse_versions=1.21.4
 curse_project=538149
 
 # Mixins

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/levosilimo/everlastingskins/permission/forge/ForgePermissionService.java
+++ b/src/main/java/levosilimo/everlastingskins/permission/forge/ForgePermissionService.java
@@ -95,10 +95,10 @@ public class ForgePermissionService implements IPermissionService {
         // Prefer the live permission of the online player (PermissionAPI consults
         // the registered handler, so non-op grants are honored — not just ops).
         ServerPlayer player = resolvePlayer(context.uuid());
-        if (player != null) {
-            return PermissionAPI.getPermission(player, node);
-        }
         try {
+            if (player != null) {
+                return PermissionAPI.getPermission(player, node);
+            }
             return PermissionAPI.getOfflinePermission(context.uuid(), node);
         } catch (Exception e) {
             return new VanillaPermissionService().hasPermission(context, permissionNode);

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRefreshHandler.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRefreshHandler.java
@@ -24,6 +24,8 @@ import net.minecraft.network.protocol.game.*;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.players.PlayerList;
+import net.minecraft.world.entity.PositionMoveRotation;
+import net.minecraft.world.phys.Vec3;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -184,7 +186,7 @@ public class SkinRefreshHandler {
 
         player.connection.send(new ClientboundRespawnPacket(player.createCommonSpawnInfo(serverLevel), ClientboundRespawnPacket.KEEP_ALL_DATA));
         player.absMoveTo(x, y, z, yaw, pitch);
-        player.connection.send(new ClientboundPlayerPositionPacket(x, y, z, yaw, pitch, Collections.emptySet(), 0));
+        player.connection.send(new ClientboundPlayerPositionPacket(0, new PositionMoveRotation(new Vec3(x, y, z), Vec3.ZERO, yaw, pitch), Collections.emptySet()));
         playerlist.sendLevelInfo(player, serverLevel);
         playerlist.sendPlayerPermissionLevel(player);
         playerlist.sendAllPlayerInfo(player);
@@ -193,7 +195,7 @@ public class SkinRefreshHandler {
         playerlist.sendActivePlayerEffects(player);
 
         SkinMetrics.INSTANCE.recordSpikeCascade(System.nanoTime() - start);
-        SkinMetrics.INSTANCE.recordBroadcast(wireSize(new ClientboundPlayerPositionPacket(x, y, z, yaw, pitch, Collections.emptySet(), 0))
+        SkinMetrics.INSTANCE.recordBroadcast(wireSize(new ClientboundPlayerPositionPacket(0, new PositionMoveRotation(new Vec3(x, y, z), Vec3.ZERO, yaw, pitch), Collections.emptySet()))
                 + wireSize(new ClientboundPlayerAbilitiesPacket(player.getAbilities()))
                 + CASCADE_SEND_LEVEL_INFO_BYTES + CASCADE_SEND_PERMISSION_BYTES
                 + CASCADE_SEND_ALL_PLAYER_INFO_BYTES + CASCADE_SEND_EFFECTS_BYTES);

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/SkinRefreshHandlerTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/SkinRefreshHandlerTest.java
@@ -563,7 +563,7 @@ class SkinRefreshHandlerTest {
         return new CommonPlayerSpawnInfo(
                 mock(Holder.class), level.dimension(), 0L,
                 GameType.SURVIVAL, GameType.SURVIVAL,
-                false, false, Optional.empty(), 0);
+                false, false, Optional.empty(), 0, 0);
     }
 
     private static void assertCascadeOrder(List<Object> stream) {


### PR DESCRIPTION
Point-release branch for MC 1.21.4 (Forge 54.1.18, FG 7.0.x, Gradle 9.3.1).

- chore: point-release config
- fix(permission): fall back to vanilla when Forge PermissionAPI is uninitialized
- port(1.21.4): adapt to Mojang packet/record API changes

Tag `mc1.21.4-v2.1.0-rc1` already pushed at branch tip 8fa5684.