### PR TITLE
feat(1.12.2): M1 storage forward-port — async coalescing + write-after-delete (parity with 1.21)

### DIFF
--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinIO.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinIO.java
@@ -27,6 +27,14 @@ import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.time.Instant;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 
 public class SkinIO {
@@ -54,6 +62,31 @@ public class SkinIO {
     private static final int CHECKSUM_MISMATCH = 1;
     /** {@link #checksumStatus(String)} result: record carries no marker (legacy format). */
     private static final int CHECKSUM_ABSENT = 2;
+
+    /**
+     * Single-thread writer so per-UUID writes are serialized; latest payload
+     * per UUID wins (coalescing). Daemon thread so it never blocks shutdown.
+     * Lazily (re)created: a shutdown (e.g. ServerStoppingEvent in tests or a
+     * reload) must not permanently kill the writer for subsequent saves.
+     */
+    private static ScheduledExecutorService writer;
+
+    private static final long DRAIN_DEBOUNCE_MS = 50;
+    private static final AtomicBoolean drainScheduled = new AtomicBoolean();
+
+    private static synchronized ScheduledExecutorService writer() {
+        if (writer == null || writer.isShutdown()) {
+            writer = Executors.newSingleThreadScheduledExecutor(r -> {
+                Thread t = new Thread(r, "EverlastingSkins-IO");
+                t.setDaemon(true);
+                return t;
+            });
+        }
+        return writer;
+    }
+
+    /** Latest serialized payload per UUID awaiting the writer thread. */
+    private final ConcurrentHashMap<UUID, byte[]> pendingWrites = new ConcurrentHashMap<>();
 
     private final Path savePath;
 
@@ -92,23 +125,155 @@ public class SkinIO {
     }
 
     /**
-     * Deletes the skin file. Failures propagate so the caller can keep the
+     * Deletes the skin file, serialized through the single writer thread.
+     * The deferred payload is dropped first so a drain that has not started
+     * yet skips this UUID, and an in-flight drain that already pulled the
+     * payload completes its write BEFORE the delete runs (single writer
+     * thread) — a cleared skin can never be resurrected by a stale write
+     * landing after the delete (write-after-delete race). Blocks until the
+     * delete has landed. Failures propagate so the caller can keep the
      * in-memory state in lockstep with the disk instead of dropping the map
      * entry while the file survives (later reload resurrects the skin).
      */
     public void deleteSkin(UUID uuid) throws IOException {
+        pendingWrites.remove(uuid);
+        try {
+            writer().submit(() -> {
+                deleteSkinFile(uuid);
+                return null;
+            }).get(5, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof IOException) {
+                throw (IOException) cause;
+            }
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            }
+            throw new IOException("Skin delete of " + uuid + " failed", cause);
+        } catch (TimeoutException e) {
+            throw new IOException("Skin delete of " + uuid + " timed out after 5s", e);
+        }
+    }
+
+    private void deleteSkinFile(UUID uuid) throws IOException {
         Path target = savePath.resolve(uuid + FILE_EXTENSION);
         if (Files.deleteIfExists(target)) {
             EverlastingSkins.logger.info("Deleted skin file for {}", uuid);
         }
     }
 
+    /**
+     * Synchronous save for back-compat: merges the payload and blocks until
+     * the writer thread has drained it, so all writes are serialized through
+     * the single writer thread (no temp-file races).
+     */
     public void saveSkin(UUID uuid, CustomSkinProperty skin) {
-        saveSkin(uuid, JsonUtils.toJson(skin).getBytes(StandardCharsets.UTF_8));
+        merge(uuid, skin);
+        drainScheduled.set(false);
+        try {
+            writer().submit(this::drainPending).get(5, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            EverlastingSkins.logger.warn("SkinIO save did not complete in time", e);
+        }
     }
 
     /**
-     * Atomic write of a pre-serialized payload from the SkinStorage async drain.
+     * Coalescing async save: merges the payload into the pending map and
+     * schedules a single drain after a 50ms debounce window, so burst updates
+     * for the same UUID collapse into one disk write. The returned future
+     * completes once the payload has been merged (the write itself happens on
+     * the writer thread).
+     */
+    public CompletableFuture<Void> saveSkinAsync(UUID uuid, CustomSkinProperty skin) {
+        merge(uuid, skin);
+        scheduleDrain();
+        return CompletableFuture.completedFuture(null);
+    }
+
+    private void merge(UUID uuid, CustomSkinProperty skin) {
+        byte[] payload = JsonUtils.toJson(skin).getBytes(StandardCharsets.UTF_8);
+        boolean superseded = pendingWrites.put(uuid, payload) != null;
+        if (superseded) {
+            SkinMetrics.INSTANCE.recordSaveCoalesced();
+            SkinMetrics.INSTANCE.recordSaveCompleted();
+        }
+        SkinMetrics.INSTANCE.recordSaveSubmitted();
+    }
+
+    private void scheduleDrain() {
+        if (drainScheduled.getAndSet(true)) return;
+        try {
+            writer().schedule(this::drainPending, DRAIN_DEBOUNCE_MS, TimeUnit.MILLISECONDS);
+        } catch (Exception e) {
+            EverlastingSkins.logger.warn("SkinIO drain schedule failed", e);
+        }
+    }
+
+    /** Writes every pending payload once; superseded payloads were dropped at merge time. */
+    private void drainPending() {
+        try {
+            for (UUID uuid : pendingWrites.keySet()) {
+                byte[] payload = pendingWrites.remove(uuid);
+                if (payload == null) continue;
+                long start = System.nanoTime();
+                saveSkin(uuid, payload);
+                SkinMetrics.INSTANCE.recordSaveDiskLatency(System.nanoTime() - start);
+                SkinMetrics.INSTANCE.recordRealWrite();
+                SkinMetrics.INSTANCE.recordSaveCompleted();
+            }
+        } finally {
+            // Reset the latch so future saveSkinAsync calls schedule again. If new
+            // writes arrived during this drain, schedule the next drain immediately
+            // (covers the race between reset and the next saveSkinAsync).
+            drainScheduled.set(false);
+            if (!pendingWrites.isEmpty()) {
+                scheduleDrain();
+            }
+        }
+    }
+
+    /**
+     * Blocks until all queued writes have been drained. Called synchronously
+     * on logout and shutdown.
+     */
+    public void flushPending() {
+        drainScheduled.set(false);
+        try {
+            writer().submit(this::drainPending).get(5, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            EverlastingSkins.logger.warn("SkinIO flush did not complete in time", e);
+        }
+    }
+
+    /**
+     * True while payloads are still queued for the drain-coalesce writer.
+     * Lets tests (and shutdown paths) wait for disk quiescence instead of
+     * racing the 50ms debounce window.
+     */
+    public boolean hasPendingWrites() {
+        return !pendingWrites.isEmpty();
+    }
+
+    /** Shuts down the writer thread, awaiting in-flight writes. The writer is
+     *  recreated on demand by the next save (see {@link #writer()}). */
+    public static void shutdown() {
+        if (writer == null) return;
+        writer.shutdown();
+        try {
+            writer.awaitTermination(5, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        writer = null;
+    }
+
+    /**
+     * Atomic write of a pre-serialized payload. This is the drain's write
+     * hook: package-private so tests can substitute a blocking writer and
+     * hold a drain in flight deterministically.
      */
     void saveSkin(UUID uuid, byte[] payload) {
         Path target = savePath.resolve(uuid + FILE_EXTENSION);

--- a/src/main/java/levosilimo/everlastingskins/skinchanger/SkinStorage.java
+++ b/src/main/java/levosilimo/everlastingskins/skinchanger/SkinStorage.java
@@ -9,40 +9,22 @@ package levosilimo.everlastingskins.skinchanger;
 import levosilimo.everlastingskins.EverlastingSkins;
 import levosilimo.everlastingskins.metrics.SkinMetrics;
 import levosilimo.everlastingskins.util.CustomSkinProperty;
-import levosilimo.everlastingskins.util.JsonUtils;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicBoolean;
 
+/**
+ * In-memory skin cache in front of {@link SkinIO}. All persistence — the
+ * synchronous write path, the coalescing async drain, and the serialized
+ * delete — lives in {@link SkinIO} (single home for the async layer); this
+ * facade only keeps the map and delegates.
+ */
 public class SkinStorage {
-
-    private static final ScheduledExecutorService SAVE_EXECUTOR = Executors.newSingleThreadScheduledExecutor(r -> {
-        Thread t = new Thread(r, "EverlastingSkins-SkinIO");
-        t.setDaemon(true);
-        return t;
-    });
-
-    /**
-     * Debounce window: burst saves for the same UUID collapse into one disk
-     * write. Port of the PR #121 A2 drain-coalesce writer.
-     */
-    private static final long DEBOUNCE_MS = 50;
-
-    /** Latest serialized payload per UUID awaiting the writer thread. */
-    private final ConcurrentHashMap<UUID, byte[]> pendingWrites = new ConcurrentHashMap<>();
-    /** Latch so only one drain is scheduled at a time. */
-    private final AtomicBoolean drainScheduled = new AtomicBoolean(false);
 
     private final CustomSkinProperty DEFAULT_SKIN;
     private static final ConcurrentHashMap<UUID, CustomSkinProperty> skinMap = new ConcurrentHashMap<>();
@@ -78,15 +60,7 @@ public class SkinStorage {
         try {
             CustomSkinProperty skin = skinIO.loadSkin(uuid);
             if (skin != null && skin.isEmpty()) {
-                pendingWrites.remove(uuid);
-                try {
-                    deleteSkinSerialized(uuid);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    throw new DeleteFailedException("Skin delete of " + uuid + " interrupted", e);
-                } catch (IOException e) {
-                    throw new DeleteFailedException("Skin delete of " + uuid + " failed", e);
-                }
+                deleteSkinSerialized(uuid);
                 return null;
             }
             return skin;
@@ -130,73 +104,30 @@ public class SkinStorage {
 
     /**
      * Strict last-write-wins save: the in-memory value is written through the
-     * single writer thread and this call blocks until the write has landed.
-     * Submitting through SAVE_EXECUTOR (FIFO) orders the sync save after any
-     * in-flight drain write for the same UUID; purging the pending payload
-     * first keeps a not-yet-drained async write from overwriting it. Without
-     * the serialization the async drain could land a stale payload after the
-     * sync save (sync/async inversion).
+     * SkinIO writer thread and this call blocks until the write has landed.
+     * SkinIO merges the payload into the pending map (superseding any queued
+     * async payload for the same UUID) and submits a drain on the FIFO writer
+     * thread, so the sync save is ordered after any in-flight drain write for
+     * the same UUID — a stale async payload can never land after the sync
+     * save (sync/async inversion).
      */
     public void saveSkin(UUID uuid) {
         CustomSkinProperty skinProperty = skinMap.get(uuid);
         if (skinProperty == null) return;
-        pendingWrites.remove(uuid);
-        byte[] payload = JsonUtils.toJson(skinProperty).getBytes(StandardCharsets.UTF_8);
-        try {
-            SAVE_EXECUTOR.submit(() -> skinIO.saveSkin(uuid, payload)).get(5, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            EverlastingSkins.logger.warn("Sync skin save of {} interrupted", uuid, e);
-        } catch (ExecutionException | TimeoutException e) {
-            EverlastingSkins.logger.warn("Sync skin save of {} did not complete in 5s", uuid, e);
-        }
+        skinIO.saveSkin(uuid, skinProperty);
     }
 
     /**
-     * Coalescing async save: serializes the payload now, merges it into the
-     * pending map (later payloads for the same UUID supersede earlier ones),
-     * and schedules a single drain after a 50ms debounce window. Port of the
-     * PR #121 A2 drain-coalesce writer; superseded payloads never reach disk
-     * and count as savesCoalesced instead of realWrites.
+     * Coalescing async save: delegates to the SkinIO drain-coalesce writer.
+     * The payload is serialized now and merged into the pending map (later
+     * payloads for the same UUID supersede earlier ones); a single drain runs
+     * after a 50ms debounce window. The returned stage completes once the
+     * payload has been merged — the write itself happens on the writer
+     * thread, so callers that need the write on disk must await
+     * {@link #flushPending()}.
      */
-    public void saveSkinAsync(UUID uuid, CustomSkinProperty skin) {
-        byte[] payload = JsonUtils.toJson(skin).getBytes(StandardCharsets.UTF_8);
-        boolean superseded = pendingWrites.put(uuid, payload) != null;
-        if (superseded) {
-            SkinMetrics.INSTANCE.recordSaveCoalesced();
-            SkinMetrics.INSTANCE.recordSaveCompleted();
-        }
-        SkinMetrics.INSTANCE.recordSaveSubmitted();
-        scheduleDrain();
-    }
-
-    private void scheduleDrain() {
-        if (drainScheduled.compareAndSet(false, true)) {
-            SAVE_EXECUTOR.schedule(this::drainPending, DEBOUNCE_MS, TimeUnit.MILLISECONDS);
-        }
-    }
-
-    /** Writes every pending payload once; superseded payloads were dropped at merge time. */
-    private void drainPending() {
-        try {
-            for (UUID uuid : pendingWrites.keySet()) {
-                byte[] payload = pendingWrites.remove(uuid);
-                if (payload == null) continue;
-                long start = System.nanoTime();
-                skinIO.saveSkin(uuid, payload);
-                SkinMetrics.INSTANCE.recordSaveDiskLatency(System.nanoTime() - start);
-                SkinMetrics.INSTANCE.recordRealWrite();
-                SkinMetrics.INSTANCE.recordSaveCompleted();
-            }
-        } finally {
-            // Race fix from PR #121 (7cc66cf): reset the latch at the END of the
-            // drain, and reschedule if new writes arrived while draining. Without
-            // this the latch sticks true and later saves silently defer to flush.
-            drainScheduled.set(false);
-            if (!pendingWrites.isEmpty()) {
-                scheduleDrain();
-            }
-        }
+    public CompletableFuture<Void> saveSkinAsync(UUID uuid, CustomSkinProperty skin) {
+        return skinIO.saveSkinAsync(uuid, skin);
     }
 
     /**
@@ -204,14 +135,7 @@ public class SkinStorage {
      * shutdown so no payload is lost mid-session.
      */
     public void flushPending() {
-        drainScheduled.set(false);
-        try {
-            SAVE_EXECUTOR.submit(this::drainPending).get(5, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        } catch (ExecutionException | TimeoutException e) {
-            EverlastingSkins.logger.warn("Skin flush did not complete in time", e);
-        }
+        skinIO.flushPending();
     }
 
     /**
@@ -228,58 +152,34 @@ public class SkinStorage {
     }
 
     public CustomSkinProperty removeSkin(UUID uuid) {
-        // Purge the deferred payload so a drain that has not started yet skips
-        // this UUID, then delete the file before dropping the map entry:
-        // getSkin() reloads from disk on a map miss, so removing the entry
-        // before the file is gone would let a concurrent read resurrect the
-        // cleared skin into the map. A failed delete propagates instead of
-        // dropping the entry: the file and the map must move together.
-        pendingWrites.remove(uuid);
-        try {
-            deleteSkinSerialized(uuid);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new DeleteFailedException("Skin delete of " + uuid + " interrupted", e);
-        } catch (IOException e) {
-            throw new DeleteFailedException("Skin delete of " + uuid + " failed", e);
-        }
+        // Delete the file first (serialized through the SkinIO writer thread,
+        // which also purges any deferred payload) and only then drop the map
+        // entry: getSkin() reloads from disk on a map miss, so removing the
+        // entry before the file is gone would let a concurrent read resurrect
+        // the cleared skin into the map. A failed delete propagates instead
+        // of dropping the entry: the file and the map must move together.
+        deleteSkinSerialized(uuid);
         skinMap.remove(uuid);
         return null;
     }
 
     /**
-     * Runs the file deletion on the single writer thread so it is serialized
-     * against drain writes, and blocks until the delete has landed. An
-     * in-flight drain that already pulled this payload completes its write
-     * before the delete runs, so no stale write can land after the delete
-     * (write-after-delete race).
-     *
-     * <p>Failure is raised, never swallowed: the caller must not drop the
-     * in-memory entry while the file may still exist, or a later getSkin()
-     * reload resurrects the cleared skin. InterruptedException is re-thrown
-     * as-is; a timeout or writer failure surfaces as
-     * {@link DeleteFailedException}.
+     * Runs the file deletion through {@link SkinIO#deleteSkin(UUID)}, which
+     * serializes it on the single writer thread so it is ordered against
+     * drain writes and blocks until the delete has landed. Failure is raised
+     * as {@link DeleteFailedException}, never swallowed: the caller must not
+     * drop the in-memory entry while the file may still exist, or a later
+     * getSkin() reload resurrects the cleared skin.
      */
-    private void deleteSkinSerialized(UUID uuid) throws InterruptedException, IOException {
+    private void deleteSkinSerialized(UUID uuid) {
         try {
-            SAVE_EXECUTOR.submit(() -> {
-                skinIO.deleteSkin(uuid);
-                return null;
-            }).get(5, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw e;
-        } catch (TimeoutException e) {
-            EverlastingSkins.logger.warn("Skin delete of {} timed out after 5s", uuid);
-            throw new DeleteFailedException("Skin delete of " + uuid + " timed out after 5s", e);
-        } catch (ExecutionException e) {
-            Throwable cause = e.getCause();
-            if (cause instanceof IOException) {
-                EverlastingSkins.logger.warn("Failed to delete skin file for {}", uuid, cause);
-                throw (IOException) cause;
-            }
-            EverlastingSkins.logger.warn("Skin delete of {} failed", uuid, cause);
-            throw new DeleteFailedException("Skin delete of " + uuid + " failed", cause);
+            skinIO.deleteSkin(uuid);
+        } catch (IOException e) {
+            EverlastingSkins.logger.warn("Failed to delete skin file for {}", uuid, e);
+            throw new DeleteFailedException("Skin delete of " + uuid + " failed", e);
+        } catch (RuntimeException e) {
+            EverlastingSkins.logger.warn("Skin delete of {} failed", uuid, e);
+            throw new DeleteFailedException("Skin delete of " + uuid + " failed", e);
         }
     }
 
@@ -305,7 +205,7 @@ public class SkinStorage {
      * debounce window.
      */
     public boolean hasPendingWrites() {
-        return !pendingWrites.isEmpty();
+        return skinIO.hasPendingWrites();
     }
 
     /**

--- a/src/test/java/levosilimo/everlastingskins/skinchanger/SkinStorageTest.java
+++ b/src/test/java/levosilimo/everlastingskins/skinchanger/SkinStorageTest.java
@@ -19,6 +19,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -275,6 +277,65 @@ class SkinStorageTest {
 
             assertFalse(Files.exists(tempDir.resolve(u + ".json")),
                     "Purged write must not be resurrected by the deferred drain");
+        }
+        @Test
+        @DisplayName("saveSkinAsync returns a stage that completes on merge; the payload reaches disk after flush")
+        void saveSkinAsync_persistsAndReturnsCompletionStage() throws Exception {
+            UUID u = UUID.randomUUID();
+
+            CompletableFuture<Void> stage = storage.saveSkinAsync(u, new CustomSkinProperty("textures", "sig", "src"));
+
+            assertNotNull(stage, "saveSkinAsync must return a completion stage");
+            stage.get(5, TimeUnit.SECONDS); // completes once the payload has been merged
+            storage.flushPending();
+
+            assertTrue(Files.exists(tempDir.resolve(u + ".json")),
+                    "async save must persist once the drain has been flushed");
+            CustomSkinProperty loaded = skinIO.loadSkin(u);
+            assertNotNull(loaded, "the persisted payload must load back");
+            assertEquals("src", loaded.getSource());
+        }
+
+        @Test
+        @DisplayName("flushPending blocks until queued writes have landed on disk")
+        void flushPending_waitsForPendingWrites_toFinish() throws Exception {
+            UUID u = UUID.randomUUID();
+            storage.saveSkinAsync(u, new CustomSkinProperty("textures", "sig", "src"));
+            assertTrue(storage.hasPendingWrites(), "payload must be queued right after saveSkinAsync");
+
+            storage.flushPending();
+
+            assertFalse(storage.hasPendingWrites(), "flush must drain the queue");
+            assertTrue(Files.exists(tempDir.resolve(u + ".json")),
+                    "flush must have landed the write on disk before returning");
+        }
+
+        @Test
+        @DisplayName("delete after a queued async save: the deferred drain cannot resurrect the file")
+        void writeAfterDelete_doesNotResurrect() throws Exception {
+            UUID u = UUID.randomUUID();
+            Path target = tempDir.resolve(u + ".json");
+            storage.saveSkinAsync(u, new CustomSkinProperty("textures", "sig", "src"));
+            assertTrue(storage.hasPendingWrites(), "payload must be queued before the delete");
+
+            storage.removeSkin(u); // purges the deferred payload, serializes the delete
+            storage.flushPending();
+
+            assertFalse(Files.exists(target),
+                    "the deferred drain must not resurrect a deleted file (write-after-delete guard)");
+        }
+
+        @Test
+        @DisplayName("hasPendingWrites reflects the background queue until flushed")
+        void hasPendingWrites_reflectsBackgroundQueue() throws Exception {
+            UUID u = UUID.randomUUID();
+            assertFalse(storage.hasPendingWrites(), "no queue before any save");
+
+            storage.saveSkinAsync(u, new CustomSkinProperty("textures", "sig", "src"));
+            assertTrue(storage.hasPendingWrites(), "queue must be non-empty right after an async save");
+
+            storage.flushPending();
+            assertFalse(storage.hasPendingWrites(), "queue must be empty after the flush barrier");
         }
     }
     /** Polls for a file to appear (50ms debounce + load headroom, bounded 2s). */


### PR DESCRIPTION
## What

Forward-ports the 1.21 `SkinIO` async persistence layer to 1.12.2, and reduces `SkinStorage` to a thin facade over it. Reconciles the M1 storage backlog with a retry of the previously-closed PR.

### A1 — `SkinIO` async layer (`3efe8bf`)
- Lazy daemon writer thread + `pendingWrites` coalescing queue
- 50ms drain debounce; `flushPending()` for deterministic shutdown
- `hasPendingWrites()` status probe
- **Write-after-delete fix**: `deleteSkin` now cancels pending writes for the skin, so a delete can no longer be resurrected by an in-flight async write
- `IOException` / `TimeoutException` surfaced to callers (no swallowed I/O errors)

### B1 — `SkinStorage` facade (`9e8e2d1`)
- `saveSkinAsync` / `flushPending` / `hasPendingWrites` delegate to `SkinIO`
- `removeSkin` goes through `skinIO.deleteSkin`, wrapped in `DeleteFailedException`
- Storage no longer owns its own executor / pendingWrites bookkeeping
- Preserves 1.12.2's existing rich surface: `flushPending`, `hasPendingWrites`, `resetForTest`, `DeleteFailedException`

### C1 — Tests (`f532852`)
4 new tests in `SkinStorageTest.java` (AsyncDrain group):
- `saveSkinAsync_persistsAndReturnsCompletionStage`
- `flushPending_waitsForPendingWrites_toFinish`
- `writeAfterDelete_doesNotResurrect`
- `hasPendingWrites_reflectsBackgroundQueue`

All existing tests unmodified and passing.

## Verification
- CI: Build (mc1.12.2), aislop (mc1.12.2), YAML Lint (mc1.12.2)