### PR TITLE
ci(monorepo): port verifyNoMixin build gate into buildSrc/

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,12 @@ One Gradle root (9.3.1) for the Forge line. Modules:
 - `everlastingskins.java8-forge-module.gradle.kts` — stub for 1.16.5/1.20.1
   (Java 8 source, FG 5.1+/6.x). Reconcile its `minecraft {}` block against
   the FG6 API when the port starts.
+- `no-mixin.gradle.kts` — the Mixin-usage gate (port from the parent's
+  `common/build-logic`, M2 step 2). Registers `verifyNoMixin` (fails the
+  build on `@Mixin` annotations, mixingradle, the mixin plugin id, `mixin {}`
+  blocks, or mixins.json bundling) and wires it into `build`. Applied by
+  `everlastingskins.forge-module`, `everlastingskins.java8-forge-module` and
+  `:common` itself; new forge convention plugins must apply it too.
 
 ## Rules
 
@@ -33,7 +39,8 @@ One Gradle root (9.3.1) for the Forge line. Modules:
    `./gradlew :common:build`; if it fails, fix it before touching forge
    modules.
 3. **No mixingradle** anywhere. Mixins are annotation-processor + jar
-   manifest only.
+   manifest only. Enforced by the `verifyNoMixin` gate (buildSrc
+   `no-mixin.gradle.kts`) on every forge module and `:common`.
 4. **No new dependencies without a lane decision** — same Maven deps as the
    legacy 1.21/mc1.12.2 builds (gson, authlib, log4j-api arrive transitively
    on Minecraft classpaths).

--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ cd mc1.12.2 && ./gradlew build   # Gradle 4.10.3 wrapper, Java 8
   (Lane B's in-flight lift; the two copies intentionally diverge until the
   port reconciles them).
 - **No mixingradle:** the convention plugin applies mixin annotation
-  processing + jar-manifest attributes only (Lane C).
+  processing + jar-manifest attributes only (Lane C). Enforced by the
+  `verifyNoMixin` gate in `buildSrc/` (`no-mixin.gradle.kts`, ported from the
+  parent's `common/build-logic`), which fails the build on any Mixin usage.
 - **CI:** `.github/workflows/` still targets the old single-module layout and
   is NOT green on this branch; the module-matrix CI rework is a follow-up
   (see AGENTS.md).

--- a/buildSrc/src/main/kotlin/everlastingskins.forge-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/everlastingskins.forge-module.gradle.kts
@@ -18,6 +18,9 @@ plugins {
     `maven-publish`
     jacoco
     id("net.minecraftforge.gradle")
+    // no-mixin gate (buildSrc): registers verifyNoMixin, wired into `build`.
+    // Any subproject applying this convention gets the Mixin-usage gate.
+    id("no-mixin")
 }
 
 // NOTE: property reads here use project.findProperty (NOT

--- a/buildSrc/src/main/kotlin/everlastingskins.java8-forge-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/everlastingskins.java8-forge-module.gradle.kts
@@ -13,6 +13,8 @@ plugins {
     `java-library`
     `maven-publish`
     jacoco
+    // no-mixin gate (buildSrc): registers verifyNoMixin, wired into `build`.
+    id("no-mixin")
 }
 
 val minecraftVersion: String = requireNotNull(project.findProperty("minecraft_version")?.toString()) {

--- a/buildSrc/src/main/kotlin/no-mixin.gradle.kts
+++ b/buildSrc/src/main/kotlin/no-mixin.gradle.kts
@@ -1,0 +1,88 @@
+// no-mixin convention plugin (precompiled script plugin, id "no-mixin").
+//
+// Mixin policy: this project and every consumer (forge subprojects) contain
+// ZERO Mixin annotations and ZERO Mixin Gradle plugin usage. The Mixin Gradle
+// plugin (mixingradle) was dropped because it is incompatible with the newer
+// Gradle line used by the 1.21.x point-release builds (PR #251) and because
+// there are no active Mixins anyway (empty mixins/client/server arrays).
+//
+// This plugin registers the verifyNoMixin gate and wires it into `build`.
+// It is applied by /common itself and is the file consumers copy into their
+// own buildSrc/ (M2 step 2) or apply via an included build.
+//
+// Note: the banned strings below are written in escaped-regex form on
+// purpose so this file never contains the literal strings it scans for.
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.SourceSetContainer
+
+val bannedLiterals = listOf(
+    "mixingradle coordinate" to "org.spongepowered:mixingradle",
+    "mixin plugin id" to "org.spongepowered.mixin",
+    "mixin config bundling" to "everlastingskins.mixins.json",
+)
+
+val bannedPatterns = listOf(
+    "Mixin annotation" to Regex("@Mixin\\b"),
+    "mixin block" to Regex("^\\s*mixin\\s*\\{"),
+)
+
+fun scanFile(file: java.io.File, offenders: MutableList<String>) {
+    if (!file.isFile) return
+    val text = file.readText()
+    for ((label, literal) in bannedLiterals) {
+        if (text.contains(literal)) {
+            offenders += "${file.relativeTo(projectDir)}: $label reference ('$literal')"
+        }
+    }
+    for ((label, pattern) in bannedPatterns) {
+        pattern.findAll(text).forEach { match ->
+            offenders += "${file.relativeTo(projectDir)}: $label at line ${text.substring(0, match.range.first).count { it == '\n' } + 1}"
+        }
+    }
+}
+
+val verifyNoMixin = tasks.register("verifyNoMixin") {
+    group = "verification"
+    description = "Fails the build if any Mixin usage is detected: annotations, mixingradle, mixin plugin id, mixin {} blocks, or mixins.json bundling."
+
+    val projectDir = project.projectDir
+    val buildFiles = listOf(
+        projectDir.resolve("build.gradle"),
+        projectDir.resolve("build.gradle.kts"),
+        projectDir.resolve("settings.gradle"),
+        projectDir.resolve("settings.gradle.kts"),
+        projectDir.resolve("gradle.properties"),
+    ).filter { it.isFile }
+
+    doLast {
+        val offenders = mutableListOf<String>()
+
+        // All source + resource files of every source set (main, test, ...).
+        // Consumers are forge subprojects (always apply java/java-library),
+        // but stay safe if the plugin is applied to a non-Java project.
+        val sourceSets = project.extensions.findByType(SourceSetContainer::class.java)
+        val sourceRoots = (sourceSets?.flatMap { it.allSource.srcDirs } ?: emptyList())
+            .filter { it.exists() }
+        sourceRoots.forEach { root ->
+            root.walkTopDown()
+                .filter { it.isFile && (it.extension == "java" || it.extension == "json" || it.extension == "properties") }
+                .forEach { scanFile(it, offenders) }
+        }
+        buildFiles.forEach { scanFile(it, offenders) }
+
+        if (offenders.isNotEmpty()) {
+            throw GradleException(
+                "Mixin policy violated:\n" +
+                    offenders.joinToString("\n") +
+                    "\n\nMixin policy: /common and its consumers contain ZERO Mixin usage. " +
+                    "If a consumer requires Mixin support, fork the consumer - it is a sign " +
+                    "that should not happen in /common."
+            )
+        }
+        logger.lifecycle("Mixin check passed: zero Mixin annotations, zero mixingradle references.")
+    }
+}
+
+tasks.named("build") {
+    dependsOn(verifyNoMixin)
+}

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -3,6 +3,9 @@
 // implementation(project(":common")).
 plugins {
     `java-library`
+    // no-mixin gate (buildSrc): registers verifyNoMixin, wired into `build`.
+    // Same direct application as the parent's /common (build-logic M2 step 2).
+    id("no-mixin")
 }
 
 java {


### PR DESCRIPTION
## Summary

M2 step 2 follow-up (resolves lib-36 MEDIUM): the Mixin-usage build gate that Lane C (fix-52) built in the parent's `common/build-logic/` is now monorepo-resident, as the gate's own header prescribes ("consumers … copy the file into their own buildSrc/, M2 step 2").

## Changes

- **`buildSrc/src/main/kotlin/no-mixin.gradle.kts`** — byte-identical copy of the parent's gate (verified with `diff`). Registers `verifyNoMixin` (fails the build on `@Mixin` annotations, the mixingradle coordinate, the `org.spongepowered.mixin` plugin id, `mixin {}` blocks, or `everlastingskins.mixins.json` bundling) and wires it into `build`.
- **`everlastingskins.forge-module` / `everlastingskins.java8-forge-module`** — now `id("no-mixin")`; every subproject applying a forge convention plugin gets the gate.
- **`:common`** — applies the gate directly, same as the parent's `/common`.
- **AGENTS.md / README.md** — document the gate as buildSrc-resident and its enforcement.

## Verification

- `:forge-1.21 / 1.21.1 / 1.21.4 / 1.21.8 / :common:verifyNoMixin` — all PASS ("Mixin check passed").
- Negative test: planted `org.spongepowered:mixingradle` in `common/gradle.properties` → gate FAILED as designed (probe reverted; no source changes).
- `:common:build` green (gate runs inside `build`).
- aislop: 0 errors (98/100; only pre-existing `file-too-large` style warnings on untouched SkinIO.java copies).

## Follow-up (not in this PR)

`everlastingskins.fg5-forge-module` (1.16.5 lane, PR #257) gets the same `id("no-mixin")` wiring once it is on this branch — the file does not exist on `integration/m2-monorepo` yet. A matching one-line wiring commit is pushed to `fix/m2-monorepo-forge-1_16_5` so #257 ships with the gate.