### PR TITLE
ci: document publish.yml unblock condition for mc1.20.1-v*/mc1.16.5-v*

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,8 +11,13 @@ on:
       - 'mc1.21.4-v*'
       - 'mc1.21.8-v*'
       - 'mc1.12.2-v*'
-      # mc1.20.1 / mc1.16.5: re-enable tag triggers + matrix entries
-      # below after PR #261 merges (subprojects land in settings.gradle.kts).
+      # mc1.20.1 / mc1.16.5: tag triggers + matrix entries stay commented
+      # until both lanes reach SOURCE-COMPLETE state. PR #261 landed the
+      # subprojects in settings.gradle.kts, but they are scaffold-only
+      # (no main-source carry-over): a publish run on these tags would fail
+      # :forge-1.20.1:build / :forge-1.16.5:build and ship no jar. ENABLE
+      # the tag triggers AND the matrix entries together, once those builds
+      # produce a real jar.
       # - 'mc1.20.1-v*'
       # - 'mc1.16.5-v*'
       # NOTE: NeoForge intentionally dropped — no mcneoforge lane.
@@ -43,10 +48,11 @@ jobs:
             module: forge-1.21.8
             game-version: "1.21.8"
             java: "21"
-          # NOTE: mc1.20.1 / mc1.16.5 matrix entries commented out —
-          # forge-1.20.1 and forge-1.16.5 are not in settings.gradle.kts
-          # at this PR's head (1.16.5 is on integration via #257;
-          # 1.20.1 lands with PR #261). Re-enable after #261 merges.
+          # mc1.20.1 / mc1.16.5 matrix entries stay commented: the
+          # subprojects are scaffold-only until the partial ports complete
+          # (main-source carry-over). Re-enable once :forge-1.20.1:build
+          # and :forge-1.16.5:build pass and produce a jar with mod
+          # classes — not just resources.
           # - prefix: "mc1.20.1-v"
           #   module: forge-1.20.1
           #   game-version: "1.20.1"


### PR DESCRIPTION
**Context.** The mc1.20.1 / mc1.16.5 tag triggers + matrix entries in publish.yml were commented out (lib-41 audit) with a note reading *"re-enable after PR #261 merges"*. PR #261 is now merged — forge-1.20.1 and forge-1.16.5 are both in settings.gradle.kts — so that stated condition is satisfied and the comment is a trap for a future lane.

**Finding.** The commented entries live on this chain's parent (#260, ci/publish rework) — integration's publish.yml is still the pre-rework per-version file with no 1.20.1/1.16.5 entries at all. No publish.yml on integration was touched here.

**Decision: keep commented (do not re-enable).** Both subprojects are scaffold-only: no main-source carry-over (forge-1.20.1 ships only mods.toml/pack.mcmeta; forge-1.16.5 only resources + a test file). The build.gradle.kts files themselves note the userdev setup under the applied FG 7 engine is expected to fail. A tag push of mc1.20.1-v* / mc1.16.5-v* would route to `:forge-1.20.1:build` / `:forge-1.16.5:build` and go red, publishing nothing.

**Change.** Documentation-only: rewrote both comment blocks to state the real unblock condition — re-enable the tag triggers AND matrix entries together once the lanes reach SOURCE-COMPLETE state (i.e. `:forge-1.20.1:build` / `:forge-1.16.5:build` pass and produce a jar with mod classes). Grep marker `ENABLE` left in the comment.

No functional change; entries remain commented. yamllint clean.