### PR TITLE
fix(monorepo): restore forge-1.21 compile compat with Forge 51.0.8

### DIFF
--- a/forge-1.21/src/main/java/levosilimo/everlastingskins/CommandRegistrationHandler.java
+++ b/forge-1.21/src/main/java/levosilimo/everlastingskins/CommandRegistrationHandler.java
@@ -11,7 +11,7 @@ import com.mojang.brigadier.CommandDispatcher;
 import levosilimo.everlastingskins.skinchanger.SkinCommand;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraftforge.event.RegisterCommandsEvent;
-import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
 @Mod.EventBusSubscriber(modid = EverlastingSkins.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)

--- a/forge-1.21/src/main/java/levosilimo/everlastingskins/EverlastingSkins.java
+++ b/forge-1.21/src/main/java/levosilimo/everlastingskins/EverlastingSkins.java
@@ -21,7 +21,7 @@ import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.network.ConnectionStartEvent;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.server.ServerAboutToStartEvent;
-import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
@@ -48,10 +48,10 @@ public class EverlastingSkins {
         PermissionServiceManager.init();
         ForgePermissionService.registerNodes();
         MinecraftForge.EVENT_BUS.register(new SkinRestorer());
-        TickEvent.ServerTickEvent.BUS.addListener(new MetricsDumper()::onServerTick);
+        MinecraftForge.EVENT_BUS.addListener(new MetricsDumper()::onServerTick);
         ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, Config.COMMON_CONFIG);
-        PermissionGatherEvent.Nodes.BUS.addListener(ForgePermissionService::onPermissionGather);
-        ConnectionStartEvent.BUS.addListener(EverlastingSkins::onConnectionStart);
+        MinecraftForge.EVENT_BUS.addListener(ForgePermissionService::onPermissionGather);
+        MinecraftForge.EVENT_BUS.addListener(EverlastingSkins::onConnectionStart);
         PlaceholderApiHook.tryRegister();
     }
 

--- a/forge-1.21/src/main/java/levosilimo/everlastingskins/broadcast/VanillaSkinBroadcaster.java
+++ b/forge-1.21/src/main/java/levosilimo/everlastingskins/broadcast/VanillaSkinBroadcaster.java
@@ -56,7 +56,7 @@ public final class VanillaSkinBroadcaster implements SkinBroadcaster {
 
     private void broadcastInternal(ServerPlayer target, ServerPlayer[] explicitObservers) {
         PlayerList playerlist = target.getServer().getPlayerList();
-        ServerLevel serverLevel = target.level();
+        ServerLevel serverLevel = target.serverLevel();
         ResourceKey<Level> dimension = serverLevel.dimension();
         Packet<ClientGamePacketListener> removePacket =
             new ClientboundPlayerInfoRemovePacket(List.of(target.getUUID()));

--- a/forge-1.21/src/main/java/levosilimo/everlastingskins/metrics/MetricsDumper.java
+++ b/forge-1.21/src/main/java/levosilimo/everlastingskins/metrics/MetricsDumper.java
@@ -11,7 +11,7 @@ import levosilimo.everlastingskins.Config;
 import levosilimo.everlastingskins.EverlastingSkins;
 import net.minecraft.server.MinecraftServer;
 import net.minecraftforge.event.TickEvent;
-import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;

--- a/forge-1.21/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRefreshHandler.java
+++ b/forge-1.21/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRefreshHandler.java
@@ -24,8 +24,6 @@ import net.minecraft.network.protocol.game.*;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.players.PlayerList;
-import net.minecraft.world.entity.PositionMoveRotation;
-import net.minecraft.world.phys.Vec3;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -175,7 +173,7 @@ public class SkinRefreshHandler {
      * == (byte) 3 in 1.21 (1/2/3 flags) — preserves the client-side inventory.
      */
     private static void recordCascade(ServerPlayer player) {
-        ServerLevel serverLevel = player.level();
+        ServerLevel serverLevel = player.serverLevel();
         PlayerList playerlist = player.getServer().getPlayerList();
         double x = player.position().x;
         double y = player.position().y;
@@ -188,7 +186,7 @@ public class SkinRefreshHandler {
         player.setPos(x, y, z);
         player.setYRot(yaw);
         player.setXRot(pitch);
-        player.connection.send(new ClientboundPlayerPositionPacket(0, new PositionMoveRotation(new Vec3(x, y, z), Vec3.ZERO, yaw, pitch), Collections.emptySet()));
+        player.connection.send(new ClientboundPlayerPositionPacket(x, y, z, yaw, pitch, Collections.emptySet(), 0));
         playerlist.sendLevelInfo(player, serverLevel);
         playerlist.sendPlayerPermissionLevel(player);
         playerlist.sendAllPlayerInfo(player);
@@ -197,7 +195,7 @@ public class SkinRefreshHandler {
         playerlist.sendActivePlayerEffects(player);
 
         SkinMetrics.INSTANCE.recordSpikeCascade(System.nanoTime() - start);
-        SkinMetrics.INSTANCE.recordBroadcast(wireSize(new ClientboundPlayerPositionPacket(0, new PositionMoveRotation(new Vec3(x, y, z), Vec3.ZERO, yaw, pitch), Collections.emptySet()))
+        SkinMetrics.INSTANCE.recordBroadcast(wireSize(new ClientboundPlayerPositionPacket(x, y, z, yaw, pitch, Collections.emptySet(), 0))
                 + wireSize(new ClientboundPlayerAbilitiesPacket(player.getAbilities()))
                 + CASCADE_SEND_LEVEL_INFO_BYTES + CASCADE_SEND_PERMISSION_BYTES
                 + CASCADE_SEND_ALL_PLAYER_INFO_BYTES + CASCADE_SEND_EFFECTS_BYTES);

--- a/forge-1.21/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRestorer.java
+++ b/forge-1.21/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRestorer.java
@@ -19,7 +19,7 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.server.ServerStartingEvent;
 import net.minecraftforge.event.server.ServerStoppingEvent;
-import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 import javax.annotation.Nullable;
 import java.io.IOException;


### PR DESCRIPTION
## Summary

Unblocks #260 by restoring `:forge-1.21:compileJava` (pinned to Forge 51.0.8 / MC 1.21.0).

Per memory #1245 (fix-69 diagnosis): forge-1.21 was scaffolded with code written against
Forge 52.x (1.21.1-era) APIs, which only ship with EventBus 7. Forge 51.0.8 ships
EventBus 6, which has neither the `eventbus.api.listener` subpackage nor the static
`.BUS` fields on event classes, and 1.21.0's `Entity.level()` returns `Level`, not
`ServerLevel`.

## Changes (import/API downgrades only — no behavior change)

- 5 files: `net.minecraftforge.eventbus.api.listener.SubscribeEvent` →
  `net.minecraftforge.eventbus.api.SubscribeEvent` (EventBus 6 location)
  - `CommandRegistrationHandler.java`, `EverlastingSkins.java`, `metrics/MetricsDumper.java`,
    `skinchanger/SkinRefreshHandler.java`, `skinchanger/SkinRestorer.java`
- `EverlastingSkins.java`: `TickEvent.ServerTickEvent.BUS` / `PermissionGatherEvent.Nodes.BUS` /
  `ConnectionStartEvent.BUS` `.addListener(...)` → `MinecraftForge.EVENT_BUS.addListener(...)`
  (EventBus 7 static-bus API → EventBus 6 canonical form)
- `skinchanger/SkinRefreshHandler.java` + `broadcast/VanillaSkinBroadcaster.java`:
  `player.level()` / `target.level()` → `player.serverLevel()` / `target.serverLevel()`
  (`Entity.level()` returns `Level` on 1.21.0; `ServerPlayer.serverLevel()` returns
  `ServerLevel`, keeping `createCommonSpawnInfo` / `sendLevelInfo` call sites valid)
- `skinchanger/SkinRefreshHandler.java`: `ClientboundPlayerPositionPacket` constructed with
  the 1.21.0 signature `(x, y, z, yaw, pitch, Set<Relative>, int)` — the 1.21.1
  `(int, PositionMoveRotation, Set<Relative>)` ctor does not exist on 1.21.0

## Verification

- `JAVA_HOME=.../21.0.2-tem ./gradlew :forge-1.21:compileJava` → **BUILD SUCCESSFUL**
- `./gradlew :forge-1.21:tasks` → lists tasks cleanly
- Zero remaining `eventbus.api.listener` / `.bus.` / `.event.` subpackage imports

The Forge 51.0.8 pin is untouched — forge-1.21 stays on 1.21.0.