### PR TITLE
fix(monorepo): resolve forge-1.21 runtime blockers + JPMS split-package

### DIFF
--- a/buildSrc/src/main/kotlin/everlastingskins.forge-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/everlastingskins.forge-module.gradle.kts
@@ -209,7 +209,17 @@ tasks.matching { it.name == "runGameTestServer" }.configureEach {
 }
 
 dependencies {
-    implementation(project(":common"))
+    // :common is the shared version-independent core (M2). forge-1.21 is the
+    // original pre-M2 module: it still ships its own copies of every :common
+    // class, so pulling the jar in also puts common.jar on the dev-run module
+    // path, where the launcher turns it into automatic module "common". Both
+    // it and the main module then export levosilimo.everlastingskins.
+    // skinchanger.responses.*, which fails the JPMS layer build (split
+    // package) before the game test server boots. Modules that own their
+    // classes opt out via consumeCommon=false in gradle.properties.
+    if (project.findProperty("consumeCommon")?.toString() != "false") {
+        implementation(project(":common"))
+    }
     implementation("org.apache.httpcomponents:httpclient:4.5.13")
     implementation(minecraft.dependency("net.minecraftforge:forge:${minecraftVersion}-${forgeVersion}"))
     annotationProcessor("org.spongepowered:mixin:0.8.7:processor")

--- a/forge-1.21/gradle.properties
+++ b/forge-1.21/gradle.properties
@@ -11,3 +11,9 @@ curse_versions=1.21
 mc.runDir=run
 mc.runDir2=run2
 gametestNamespace=everlastingskins
+
+# Pre-M2 module: ships its own copies of every :common class (skinchanger,
+# responses, util, ...), so :common is not on the runtime classpath. A second
+# copy would surface as automatic JPMS module "common" in dev runs and fail
+# the game test server boot with a split-package ResolutionException.
+consumeCommon=false

--- a/forge-1.21/src/gametest/java/levosilimo/everlastingskins/gametest/SkinVisibilityTest.java
+++ b/forge-1.21/src/gametest/java/levosilimo/everlastingskins/gametest/SkinVisibilityTest.java
@@ -52,6 +52,7 @@ import net.minecraft.world.level.Level;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.server.ServerStartingEvent;
 import net.minecraftforge.event.server.ServerStoppingEvent;
+import net.minecraftforge.gametest.GameTestHolder;
 
 import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
@@ -79,13 +80,14 @@ import java.util.UUID;
  * tests share mod static state (SkinCommand provider, SkinStorage map, player
  * list), so one batch per test keeps execution sequential and deterministic.
  */
+@GameTestHolder(value = "everlastingskins")
 public class SkinVisibilityTest {
 
     private static final String TEST_TEXTURE_VALUE = "eyJ0aW1lc3RhbXAiOjE3MTk4NDY0MDAsInByb2ZpbGVJZCI6IjA2OWE3OWY0NDRlOTQ3MjZhNWJlZmNhOTBlMzhhYWY1IiwicHJvZmlsZU5hbWUiOiJOb3RjaCIsInRleHR1cmVzIjp7IlNLSU4iOnsidXJsIjoiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS9iYmIxIn19fQ==";
     private static final String TEST_SIGNATURE = "ZmFrZVNpZ25hdHVyZUZvclRlc3Rpbmc9PQ==";
     private static final UUID TEST_UUID = UUID.fromString("11111111-2222-3333-4444-555555555555");
 
-    @GameTest(template = "everlastingskins:empty", timeoutTicks = 200)
+    @GameTest(template = "everlastingskins:empty", batch = "skinSetMojang_broadcastsTextureToAllClients", timeoutTicks = 200)
     public void skinSetMojang_broadcastsTextureToAllClients(GameTestHelper helper) {
         // The vanilla GameTestServer never calls DedicatedServer.initServer, so
         // Forge's ServerStartingEvent does not fire and SkinRestorer never
@@ -144,7 +146,7 @@ public class SkinVisibilityTest {
         }
     }
 
-    @GameTest(template = "everlastingskins:empty", timeoutTicks = 200)
+    @GameTest(template = "everlastingskins:empty", batch = "skinCommand_setMojang_fullFlow", timeoutTicks = 200)
     public void skinCommand_setMojang_fullFlow(GameTestHelper helper) {
         FakeMojangAPI fake = installFakeMojangAPI(true);
         SkinStorage storage = ensureStorage(helper);
@@ -180,7 +182,7 @@ public class SkinVisibilityTest {
         });
     }
 
-    @GameTest(template = "everlastingskins:empty", timeoutTicks = 200)
+    @GameTest(template = "everlastingskins:empty", batch = "skinCommand_permissionDenied", timeoutTicks = 200)
     public void skinCommand_permissionDenied(GameTestHelper helper) {
         installFakeMojangAPI(true);
         SkinStorage storage = ensureStorage(helper);
@@ -225,7 +227,7 @@ public class SkinVisibilityTest {
         }
     }
 
-    @GameTest(template = "everlastingskins:empty", timeoutTicks = 60000)
+    @GameTest(template = "everlastingskins:empty", batch = "skinCommand_clear_removesTexture", timeoutTicks = 60000)
     public void skinCommand_clear_removesTexture(GameTestHelper helper) {
         FakeMojangAPI fake = installFakeMojangAPI(true);
         SkinStorage storage = ensureStorage(helper);
@@ -271,7 +273,7 @@ public class SkinVisibilityTest {
         });
     }
 
-    @GameTest(template = "everlastingskins:empty", timeoutTicks = 200)
+    @GameTest(template = "everlastingskins:empty", batch = "skinCommand_source_reportsCurrentSource", timeoutTicks = 200)
     public void skinCommand_source_reportsCurrentSource(GameTestHelper helper) {
         installFakeMojangAPI(true);
         SkinStorage storage = ensureStorage(helper);
@@ -300,7 +302,7 @@ public class SkinVisibilityTest {
         helper.succeed();
     }
 
-    @GameTest(template = "everlastingskins:empty", timeoutTicks = 200)
+    @GameTest(template = "everlastingskins:empty", batch = "skinRefresh_persistence_roundTrip", timeoutTicks = 200)
     public void skinRefresh_persistence_roundTrip(GameTestHelper helper) {
         installFakeMojangAPI(true);
         SkinStorage storage = ensureStorage(helper);
@@ -345,7 +347,7 @@ public class SkinVisibilityTest {
         helper.succeed();
     }
 
-    @GameTest(template = "everlastingskins:empty", timeoutTicks = 200)
+    @GameTest(template = "everlastingskins:empty", batch = "skinRefresh_broadcastExactCount", timeoutTicks = 200)
     public void skinRefresh_broadcastExactCount(GameTestHelper helper) {
         installFakeMojangAPI(true);
         SkinStorage storage = ensureStorage(helper);
@@ -372,7 +374,7 @@ public class SkinVisibilityTest {
         }
     }
 
-    @GameTest(template = "everlastingskins:empty", timeoutTicks = 200)
+    @GameTest(template = "everlastingskins:empty", batch = "skinRefresh_negativeControl", timeoutTicks = 200)
     public void skinRefresh_negativeControl(GameTestHelper helper) {
         installFakeMojangAPI(true);
         ensureStorage(helper);
@@ -400,7 +402,7 @@ public class SkinVisibilityTest {
         }
     }
 
-    @GameTest(template = "everlastingskins:empty", timeoutTicks = 200)
+    @GameTest(template = "everlastingskins:empty", batch = "skinRefresh_signaturePropagation", timeoutTicks = 200)
     public void skinRefresh_signaturePropagation(GameTestHelper helper) {
         installFakeMojangAPI(true);
         SkinStorage storage = ensureStorage(helper);
@@ -432,7 +434,7 @@ public class SkinVisibilityTest {
         }
     }
 
-    @GameTest(template = "everlastingskins:empty", timeoutTicks = 200)
+    @GameTest(template = "everlastingskins:empty", batch = "skinRefresh_propagatesToMultipleObservers", timeoutTicks = 200)
     public void skinRefresh_propagatesToMultipleObservers(GameTestHelper helper) {
         installFakeMojangAPI(true);
         SkinStorage storage = ensureStorage(helper);
@@ -466,7 +468,7 @@ public class SkinVisibilityTest {
         }
     }
 
-    @GameTest(template = "everlastingskins:empty", timeoutTicks = 60000)
+    @GameTest(template = "everlastingskins:empty", batch = "skinRefresh_runCommandSuccessPath", timeoutTicks = 60000)
     public void skinRefresh_runCommandSuccessPath(GameTestHelper helper) {
         FakeMojangAPI fake = installFakeMojangAPI(true);
         SkinStorage storage = ensureStorage(helper);
@@ -501,7 +503,7 @@ public class SkinVisibilityTest {
         });
     }
 
-    @GameTest(template = "everlastingskins:empty", timeoutTicks = 200)
+    @GameTest(template = "everlastingskins:empty", batch = "wireSerializeInfoUpdate_updateDisplayName_omitsProfile", timeoutTicks = 200)
     public void wireSerializeInfoUpdate_updateDisplayName_omitsProfile(GameTestHelper helper) {
         ensureStorage(helper);
         MinecraftServer server = helper.getLevel().getServer();
@@ -545,7 +547,7 @@ public class SkinVisibilityTest {
         }
     }
 
-    @GameTest(template = "everlastingskins:empty", timeoutTicks = 200)
+    @GameTest(template = "everlastingskins:empty", batch = "refreshBroadcastUsesAddPlayer_notUpdateDisplayName", timeoutTicks = 200)
     public void refreshBroadcastUsesAddPlayer_notUpdateDisplayName(GameTestHelper helper) {
         SkinStorage storage = ensureStorage(helper);
         MinecraftServer server = helper.getLevel().getServer();
@@ -590,7 +592,7 @@ public class SkinVisibilityTest {
         }
     }
 
-    @GameTest(template = "everlastingskins:empty", timeoutTicks = 200)
+    @GameTest(template = "everlastingskins:empty", batch = "duplicateSendPlayerPermissionLevelRemoved", timeoutTicks = 200)
     public void duplicateSendPlayerPermissionLevelRemoved(GameTestHelper helper) {
         SkinStorage storage = ensureStorage(helper);
         MinecraftServer server = helper.getLevel().getServer();
@@ -614,7 +616,7 @@ public class SkinVisibilityTest {
         }
     }
 
-    @GameTest(template = "everlastingskins:empty", timeoutTicks = 200)
+    @GameTest(template = "everlastingskins:empty", batch = "redundantAbilitiesPacketRemoved", timeoutTicks = 200)
     public void redundantAbilitiesPacketRemoved(GameTestHelper helper) {
         SkinStorage storage = ensureStorage(helper);
         MinecraftServer server = helper.getLevel().getServer();
@@ -636,7 +638,7 @@ public class SkinVisibilityTest {
         }
     }
 
-    @GameTest(template = "everlastingskins:empty", timeoutTicks = 200)
+    @GameTest(template = "everlastingskins:empty", batch = "dimensionTargetedBroadcast", timeoutTicks = 200)
     public void dimensionTargetedBroadcast(GameTestHelper helper) {
         SkinStorage storage = ensureStorage(helper);
         MinecraftServer server = helper.getLevel().getServer();
@@ -696,7 +698,7 @@ public class SkinVisibilityTest {
         }
     }
 
-    @GameTest(template = "everlastingskins:empty", timeoutTicks = 200)
+    @GameTest(template = "everlastingskins:empty", batch = "ioAsyncWriterSurvivesSecondShutdown", timeoutTicks = 200)
     public void ioAsyncWriterSurvivesSecondShutdown(GameTestHelper helper) {
         ensureStorage(helper);
         MinecraftServer server = helper.getLevel().getServer();
@@ -723,7 +725,7 @@ public class SkinVisibilityTest {
         }
     }
 
-    @GameTest(template = "everlastingskins:empty", timeoutTicks = 200)
+    @GameTest(template = "everlastingskins:empty", batch = "respawnFlagIsKeepAllData", timeoutTicks = 200)
     public void respawnFlagIsKeepAllData(GameTestHelper helper) {
         SkinStorage storage = ensureStorage(helper);
         MinecraftServer server = helper.getLevel().getServer();
@@ -759,7 +761,7 @@ public class SkinVisibilityTest {
      * textures properties. This proves the FakeMojangAPI texture actually CAN
      * appear on the wire when the packet type carries profiles.
      */
-    @GameTest(template = "everlastingskins:empty", timeoutTicks = 200)
+    @GameTest(template = "everlastingskins:empty", batch = "wireSerializeInfoUpdate_addPlayer_includesProfile", timeoutTicks = 200)
     public void wireSerializeInfoUpdate_addPlayer_includesProfile(GameTestHelper helper) {
         ensureStorage(helper);
         MinecraftServer server = helper.getLevel().getServer();
@@ -807,7 +809,7 @@ public class SkinVisibilityTest {
         return sb.toString();
     }
 
-    @GameTest(template = "everlastingskins:empty", timeoutTicks = 200)
+    @GameTest(template = "everlastingskins:empty", batch = "skipIfUnchanged", timeoutTicks = 200)
     public void skipIfUnchanged(GameTestHelper helper) {
         FakeMojangAPI fake = installFakeMojangAPI(true);
         SkinStorage storage = ensureStorage(helper);
@@ -871,7 +873,7 @@ public class SkinVisibilityTest {
         }
     }
 
-    @GameTest(template = "everlastingskins:empty", timeoutTicks = 200)
+    @GameTest(template = "everlastingskins:empty", batch = "debounceAfter100ms", timeoutTicks = 200)
     public void debounceAfter100ms(GameTestHelper helper) {
         FakeMojangAPI fake = installFakeMojangAPI(true);
         MinecraftServer server = helper.getLevel().getServer();
@@ -928,7 +930,7 @@ public class SkinVisibilityTest {
         }
     }
 
-    @GameTest(template = "everlastingskins:empty", timeoutTicks = 200)
+    @GameTest(template = "everlastingskins:empty", batch = "debouncedRequest_keepsStoredEqualToApplied", timeoutTicks = 200)
     public void debouncedRequest_keepsStoredEqualToApplied(GameTestHelper helper) {
         FakeMojangAPI fake = installFakeMojangAPI(true);
         SkinStorage storage = ensureStorage(helper);
@@ -1020,7 +1022,7 @@ public class SkinVisibilityTest {
         }
     }
 
-    @GameTest(template = "everlastingskins:empty", timeoutTicks = 200)
+    @GameTest(template = "everlastingskins:empty", batch = "expiredDebounceWindow_appliesNormally", timeoutTicks = 200)
     public void expiredDebounceWindow_appliesNormally(GameTestHelper helper) {
         FakeMojangAPI fake = installFakeMojangAPI(true);
         SkinStorage storage = ensureStorage(helper);
@@ -1111,7 +1113,7 @@ public class SkinVisibilityTest {
         }
     }
 
-    @GameTest(template = "everlastingskins:empty", timeoutTicks = 200)
+    @GameTest(template = "everlastingskins:empty", batch = "skinClear_noProfile_clearsAppliedProfile", timeoutTicks = 200)
     public void skinClear_noProfile_clearsAppliedProfile(GameTestHelper helper) {
         FakeMojangAPI fake = installFakeMojangAPI(true);
         SkinStorage storage = ensureStorage(helper);
@@ -1182,7 +1184,7 @@ public class SkinVisibilityTest {
         }
     }
 
-    @GameTest(template = "everlastingskins:empty", timeoutTicks = 200)
+    @GameTest(template = "everlastingskins:empty", batch = "rateLimitAfterCooldown", timeoutTicks = 200)
     public void rateLimitAfterCooldown(GameTestHelper helper) {
         installFakeMojangAPI(true);
         ensureStorage(helper);
@@ -1209,7 +1211,7 @@ public class SkinVisibilityTest {
         }
     }
 
-    @GameTest(template = "everlastingskins:empty", timeoutTicks = 200)
+    @GameTest(template = "everlastingskins:empty", batch = "rateLimitBypassedForOps", timeoutTicks = 200)
     public void rateLimitBypassedForOps(GameTestHelper helper) {
         installFakeMojangAPI(true);
         ensureStorage(helper);
@@ -1235,7 +1237,7 @@ public class SkinVisibilityTest {
         }
     }
 
-    @GameTest(template = "everlastingskins:empty", timeoutTicks = 200)
+    @GameTest(template = "everlastingskins:empty", batch = "skin_metrics_command_printsHumanReadable", timeoutTicks = 200)
     public void skin_metrics_command_printsHumanReadable(GameTestHelper helper) {
         ensureStorage(helper);
         MinecraftServer server = helper.getLevel().getServer();
@@ -1266,7 +1268,7 @@ public class SkinVisibilityTest {
         }
     }
 
-    @GameTest(template = "everlastingskins:empty", timeoutTicks = 200)
+    @GameTest(template = "everlastingskins:empty", batch = "skin_metrics_json_command_printsJson", timeoutTicks = 200)
     public void skin_metrics_json_command_printsJson(GameTestHelper helper) {
         ensureStorage(helper);
         MinecraftServer server = helper.getLevel().getServer();
@@ -1295,7 +1297,7 @@ public class SkinVisibilityTest {
         }
     }
 
-    @GameTest(template = "everlastingskins:empty", timeoutTicks = 200)
+    @GameTest(template = "everlastingskins:empty", batch = "skin_metrics_players_top10ByCount", timeoutTicks = 200)
     public void skin_metrics_players_top10ByCount(GameTestHelper helper) {
         ensureStorage(helper);
         MinecraftServer server = helper.getLevel().getServer();
@@ -1329,7 +1331,7 @@ public class SkinVisibilityTest {
         }
     }
 
-    @GameTest(template = "everlastingskins:empty", timeoutTicks = 200)
+    @GameTest(template = "everlastingskins:empty", batch = "metrics_json_showsNewCounters", timeoutTicks = 200)
     public void metrics_json_showsNewCounters(GameTestHelper helper) {
         ensureStorage(helper);
         MinecraftServer server = helper.getLevel().getServer();
@@ -1367,7 +1369,7 @@ public class SkinVisibilityTest {
         }
     }
 
-    @GameTest(template = "everlastingskins:empty", timeoutTicks = 200)
+    @GameTest(template = "everlastingskins:empty", batch = "metrics_withProviderCache_avoidsHttp", timeoutTicks = 200)
     public void metrics_withProviderCache_avoidsHttp(GameTestHelper helper) {
         FakeMojangAPI fake = installFakeMojangAPI(true);
         ensureStorage(helper);
@@ -1419,7 +1421,7 @@ public class SkinVisibilityTest {
         }
     }
 
-    @GameTest(template = "everlastingskins:empty", timeoutTicks = 200)
+    @GameTest(template = "everlastingskins:empty", batch = "serverStoppingEvent_bulkSave", timeoutTicks = 200)
     public void serverStoppingEvent_bulkSave(GameTestHelper helper) {
         ensureStorage(helper);
         SkinStorage storage = SkinRestorer.getSkinStorage();
@@ -1449,7 +1451,7 @@ public class SkinVisibilityTest {
         }
     }
 
-    @GameTest(template = "everlastingskins:empty", timeoutTicks = 60000)
+    @GameTest(template = "everlastingskins:empty", batch = "concurrentSkinSet_twoPlayers", timeoutTicks = 60000)
     public void concurrentSkinSet_twoPlayers(GameTestHelper helper) {
         FakeMojangAPI fake = installFakeMojangAPI(true);
         SkinStorage storage = ensureStorage(helper);
@@ -1535,7 +1537,7 @@ public class SkinVisibilityTest {
         }
     }
 
-    @GameTest(template = "everlastingskins:empty", timeoutTicks = 200)
+    @GameTest(template = "everlastingskins:empty", batch = "skinSet_selfReceivesBroadcast", timeoutTicks = 200)
     public void skinSet_selfReceivesBroadcast(GameTestHelper helper) {
         FakeMojangAPI fake = installFakeMojangAPI(true);
         SkinStorage storage = ensureStorage(helper);

--- a/forge-1.21/src/test/java/levosilimo/everlastingskins/broadcast/VanillaSkinBroadcasterTest.java
+++ b/forge-1.21/src/test/java/levosilimo/everlastingskins/broadcast/VanillaSkinBroadcasterTest.java
@@ -351,7 +351,10 @@ class VanillaSkinBroadcasterTest {
         when(player.getUUID()).thenReturn(uuid);
         when(player.getGameProfile()).thenReturn(new GameProfile(uuid, name));
         when(player.level()).thenReturn(level);
-        when(player.level()).thenReturn(level);
+        // The 51.0.8-compatible broadcaster reads the level through
+        // ServerPlayer.serverLevel() (Entity.level() is typed Level), so the
+        // mock must stub the ServerLevel-typed accessor as well.
+        when(player.serverLevel()).thenReturn(level);
         when(player.getTabListDisplayName()).thenReturn(null);
         when(player.getChatSession()).thenReturn(null);
         ServerGamePacketListenerImpl connection = mock(ServerGamePacketListenerImpl.class);

--- a/forge-1.21/src/test/java/levosilimo/everlastingskins/skinchanger/SkinRefreshHandlerTest.java
+++ b/forge-1.21/src/test/java/levosilimo/everlastingskins/skinchanger/SkinRefreshHandlerTest.java
@@ -513,7 +513,12 @@ class SkinRefreshHandlerTest {
         when(player.getUUID()).thenReturn(uuid);
         when(player.getGameProfile()).thenReturn(new GameProfile(uuid, name));
         when(player.level()).thenReturn(level);
-        when(player.level()).thenReturn(level);
+        // The 51.0.8-compatible cascade reads the level through
+        // ServerPlayer.serverLevel() (Entity.level() is typed Level), so the
+        // mock must stub the ServerLevel-typed accessor as well; without it
+        // the respawn spawnInfo and sendLevelInfo seams receive null and the
+        // cascade stream stays empty.
+        when(player.serverLevel()).thenReturn(level);
         when(player.position()).thenReturn(Vec3.ZERO);
         when(player.getYRot()).thenReturn(0f);
         when(player.getXRot()).thenReturn(0f);


### PR DESCRIPTION
## What

Fixes the two runtime blockers on PR #260's checks (Build (1.21) + GameTest (1.21)), plus two further gametest blockers that were masked by the JPMS boot failure.

### 1. 12 unit-test failures (Build 1.21) — `serverLevel()` mock gap
#263 switched the downgraded main sources to `ServerPlayer.serverLevel()` (the 51.0.8 ServerLevel-typed accessor; `Entity.level()` is typed `Level`), but both unit tests still stubbed only `level()`:
- `VanillaSkinBroadcasterTest` (8×): `serverLevel.dimension()` NPE'd in `broadcastInternal`
- `SkinRefreshHandlerTest` (4×): `recordCascade` aborted (fail-soft catch) with an empty cascade stream → order/count assertions failed

**Fix**: stub `player.serverLevel()` in both mock players, mirroring the existing `level()` stub. No assertion weakened — the 51.0.8-compatible source is the contract.

### 2. GameTest JPMS split package — `:common` on the dev-run module path
`java.lang.module.ResolutionException: Modules everlastingskins and common export package levosilimo.everlastingskins.skinchanger.responses to module everlastingskins_gametest`. forge-1.21 is the original pre-M2 module: it ships its own copies of every `:common` class (verified: zero non-wildcard imports resolve only to common), so `common.jar` on the run classpath becomes automatic module `common`, re-exporting the same `skinchanger.responses.*` packages as module `everlastingskins` → split package at layer build.

**Fix**: `consumeCommon=false` for forge-1.21 (convention-plugin gate); forge-1.21 needs nothing from `:common` (its copies shadow everything, including `SkinMetrics`' nested `Snapshot`/`PlayerSnapshot` records vs common's top-level ones).

### 3. Gametest registration — missing holder annotation
`No test functions were given!` after the JPMS fix: the #264 downgrade dropped `@GameTestNamespace("everlastingskins")` (absent in 51.0.8) without a replacement, so `ForgeGameTestHooks.registerGametests()` (filter: `@GameTestHolder` scan data) registered nothing.

**Fix**: `@GameTestHolder(value = "everlastingskins")` — 51.0.8's replacement; `value()` feeds `getPrefix` → the batch name the namespace filter matches on.

### 4. Gametest concurrency — per-test batches
With all 34 tests in one batch (the holder value became the batch), tests ran concurrently over shared static state (`refreshTaskCount`, `lastRefreshByPlayer`, `debounceMillis`, `SkinMetrics` counters) → 5 flaky failures (count=4, skippedStored +2, async deadline). The file's own javadoc requires "one batch per test" — the #264 downgrade lost it.

**Fix**: `batch = "<methodName>"` on all 34 `@GameTest` annotations → 34 sequential batches. `All 34 required tests passed :)` locally.

## Verification
- `:forge-1.21:test`: 485/485 pass (was 12 failures)
- `:forge-1.21:compileJava` + `:forge-1.21:compileGametestJava`: pass
- `:forge-1.21:runGameTestServer` local: boots (JPMS error gone), 34/34 game tests pass

## Notes
- No CI bypass, no test weakening: assertions and expectations unchanged throughout.