### PR TITLE
docs: fix stale consumeCommon docs + add #269 to recently-merged list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,10 +65,14 @@ settings.gradle.kts does not include them.
    in sync with the tags (`mc1.21.x-v2.1.0-rc1` etc.). Verify against git
    history before changing.
 6. **`consumeCommon` gate:** each forge module opts into the `:common`
-   dependency unless `consumeCommon=false` in its `gradle.properties`.
-   `forge-1.21` currently sets it `false` — it still ships its own copies of
-   every `:common` class, and pulling the jar in would create a JPMS split
-   package. When the source port reconciles the duplicates, flip it back.
+   dependency unless `consumeCommon=false` in its `gradle.properties`; the
+   default is to consume. No module currently sets it `false` — `forge-1.21`
+   was flipped on by #268 (the JPMS split-package that forced the old
+   opt-out was resolved by the #268 dedup), so every forge-* module consumes
+   `:common`. The gate is kept as a safety valve: if a future forge-*
+   subproject requires vendored copies, `consumeCommon=false` is the
+   documented escape hatch and may need to be re-added there. (The dead
+   plugin-era gate was deleted in #267.)
 7. **1.12.2 lane:** never include it in `settings.gradle.kts`. It builds
    out-of-band (`cd mc1.12.2 && ./gradlew build` with Java 8); changes there
    are reviewed against the shared `:common` contract, not against this build.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ canonical copy; no JPMS on Java 8).
 - **#268** — dedup of `forge-1.21` / `forge-1.16.5` against `:common`;
   JPMS split-package resolved (Option B1, 12 survivors relocated to
   `forge21.*`); `consumeCommon` flipped on for the forge modules.
+- **#269** — feat(monorepo): integrate mc1.12.2 lane + source-dir share
+  `:common` (#269) — 162 files, 514 tests pass; mc1.12.2 now lives in the
+  monorepo as per-lane wrapper directory.
 
 Still ahead: source carry-over onto `:common` for the legacy lanes and the
 `pack.mcmeta` format bump (see CHANGELOG).

--- a/common/AGENTS.md
+++ b/common/AGENTS.md
@@ -23,9 +23,9 @@ SkinStorage), utils (JsonUtils, CustomSkinProperty, HttpClient).
 ## Consumption
 
 Every `forge-*` module depends on `:common` via
-`implementation(project(":common"))` unless it opts out with
-`consumeCommon=false` in its `gradle.properties` (currently only
-`forge-1.21`, which still ships duplicate copies until the source port).
+`implementation(project(":common"))` — `:common` is unconditionally consumed.
+The `consumeCommon=false` opt-out in `gradle.properties` exists but is
+currently unused by every forge module (post-#268).
 
 The union of `:common` + each per-version binding layer covers the full mod.
 


### PR DESCRIPTION
## What

D1 wart fixes from lib-7's final audit of `integration/m2-monorepo` (@ 902b201):

1. **AGENTS.md Rule 6** — removed the stale claim that `forge-1.21` still sets `consumeCommon=false`. Post-#268 it consumes `:common`; the gate default is `consume` and no module currently opts out. Documented the gate as a safety valve (with caveat that `consumeCommon=false` may need re-adding if a future forge-* subproject requires vendored copies). References #268 (flipped forge-1.21) and #267 (deleted the dead plugin-era gate).
2. **common/AGENTS.md Consumption** — removed the stale "currently only forge-1.21" clause; `:common` is now stated as unconditionally consumed (post-#268).
3. **README.md Recently merged** — added the missing **#269** entry (mc1.12.2 lane integration + source-dir share `:common`).

## Verification

- `grep -n "currently sets it false" AGENTS.md common/AGENTS.md README.md` → 0 hits
- `consumeCommon` gate still documented in AGENTS.md (exists as safety valve, no false claim)
- `yamllint -c .yamllint.yml .github/workflows/*.yml` → clean (no YAML touched)
- No code changes; docs-only PR