### PR TITLE
docs: sync README + CHANGELOG to reflect post-M2 SOURCE-COMPLETE state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ One Gradle root (9.3.1) for the Forge line. Modules:
 
 - `:common` — version-independent core, `--release 8`. NEVER add a forge
   binding here; never raise the release level. Consumer of last resort:
-  every `forge-*` module and (future) the 1.12.2 lane.
+  every `forge-*` module and the mc1.12.2 lane.
 - `:forge-1.21`, `:forge-1.21.1`, `:forge-1.21.4`, `:forge-1.21.8` —
   thin binding layers applying `everlastingskins.forge-module`; MC/Forge
   versions live in each subproject's `gradle.properties`.
@@ -32,7 +32,7 @@ One Gradle root (9.3.1) for the Forge line. Modules:
 
 ## Legacy lanes (forge-1.16.5 / forge-1.20.1) — out-of-band
 
-Not part of this Gradle root (lib-34 lane separation, PR #2xx): ForgeGradle
+Not part of this Gradle root (lib-34 lane separation, PR #267): ForgeGradle
 5.1.x rejects Gradle 8.0+ and ForgeGradle 6.0.x rejects Gradle 9.0+, so
 neither can run inside the root's Gradle 9.3.1 (verified empirically
 2026-08-06 against 5.1.77 / 6.0.54). Each lane is its own build with its
@@ -49,9 +49,10 @@ settings.gradle.kts does not include them.
 
 ## Rules
 
-1. **No source edits in scaffold land.** Ports are separate PRs: move
-   version-independent classes into `:common`, keep bindings in the
-   `forge-*` module, then delete the moved copy from the module.
+1. **No source edits in placeholder land.** Point-release ports (1.21.1 /
+   1.21.4 / 1.21.8) are separate PRs: move version-independent classes into
+   `:common`, keep bindings in the `forge-*` module, then delete the moved
+   copy from the module.
 2. **`:common` is frozen at `--release 8`** with `-Werror`. Compile it with
    `./gradlew :common:build`; if it fails, fix it before touching forge
    modules.
@@ -111,3 +112,7 @@ CI (`ci.yml`) is a per-module matrix (PR #260): lint-yaml → `build` over
 `:common` + the four 1.21.x modules, plus the out-of-band mc1.12.2 build and
 `E2E (mc1.12.2)` placeholder. `forge-1.16.5` / `forge-1.20.1` are not in the
 matrix yet. Treat the matrix as authoritative for what is buildable in CI.
+
+Source status: `forge-1.16.5` and `forge-1.20.1` are SOURCE-COMPLETE
+(post-#274 / post-#273); the 1.21.1 / 1.21.4 / 1.21.8 point-release
+subprojects are placeholders whose source carries over separately.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,14 +82,32 @@ Mixin gate, CI matrix, and forge-1.21 compat fixes.
   `forge-1.21` opts out of `:common` via `consumeCommon=false` until its
   duplicate classes are removed).
 
+### M2 completion: SOURCE-COMPLETE (PRs #270–#274)
+
+- **#270 — REPOSITORY-STRUCTURE.md + standalone archival tags:** new doc
+  explaining the one-root-plus-out-of-band-lanes layout; the standalone
+  parent checkout is documented as archived (its lanes folded in here).
+- **#271 — docs wart fixes:** stale `consumeCommon` docs corrected
+  (post-#268), #269 added to the README merged list.
+- **#272 — P0 forge-1.16.5 compile fix:** Java-16 syntax (instanceof
+  patterns, records, `List.of`) downgraded to Java 8; duplicate `SkinUtils`
+  and the vendored httpclient-4.5.13.jar dropped; build script adjusted.
+  The lane compiles on Java 8 again.
+- **#273 — forge-1.20.1 source carry-over:** full main source brought over
+  from `forge-1.21` (bindings, lang files, inlined no-mixin gate) — the
+  lane is SOURCE-COMPLETE.
+- **#274 — forge-1.16.5 SOURCE-COMPLETE:** version-shape errors fixed for
+  Java 8 (e.g. `List.of`/`Map.of` → Java-8 equivalents, lambdas kept Java-8
+  compatible); stray `endpoints.properties`, `mixins.json` and
+  `default-skin.properties` dropped; `JavaHttpClient` removed. The lane is
+  SOURCE-COMPLETE.
+
 ### Known follow-ups (next PRs)
 
-- Port `forge-1.21` sources onto `:common` (reconcile the two copies), then
-  flip `consumeCommon` back on.
-- Port 1.21.1/1.21.4/1.21.8 sources.
-- Wire the `minecraft {}` blocks for the 1.16.5 / 1.20.1 lanes (source
-  carry-over) and add them to the CI matrix.
+- Port the 1.21.1 / 1.21.4 / 1.21.8 point-release sources (currently
+  placeholders; source carries over separately, same shape as #273).
+- Wire the CI matrix for the out-of-band 1.16.5 / 1.20.1 lanes
+  (publish.yml entries stay commented out until lane verification).
 - Fix `forge-1.21/src/main/resources/pack.mcmeta` staleness: `pack_format`
   is still 6 (a 1.16.2-era value; 1.21 needs 15+) and the `_comment` is
   stale.
-- Clean up the superseded `java8-forge-module` convention plugin stub.

--- a/README.md
+++ b/README.md
@@ -24,16 +24,16 @@ mc1.12.2/                    NOT a subproject — own Gradle 4.10.3 wrapper + FG
 
 ## Modules
 
-| Module | MC | Forge | FG | Gradle | Toolchain |
-|---|---|---|---|---|---|
-| `:common` | — | — | — | root 9.3.1 | build JDK 21, `--release 8` |
-| `:forge-1.21` | 1.21 | 51.0.8 | 7.x | root 9.3.1 | 21 |
-| `:forge-1.21.1` | 1.21.1 | 52.1.16 | 7.x | root 9.3.1 | 21 |
-| `:forge-1.21.4` | 1.21.4 | 54.1.18 | 7.x | root 9.3.1 | 21 |
-| `:forge-1.21.8` | 1.21.8 | 58.1.21 | 7.x | root 9.3.1 | 21 |
-| `forge-1.16.5/` (not a subproject) | 1.16.5 | 36.2.34 | 5.1.x | own 7.6.4 wrapper | JDK 8 |
-| `forge-1.20.1/` (not a subproject) | 1.20.1 | 47.4.10 | 6.x | own 8.7 wrapper | JDK 21 (17 toolchain) |
-| `mc1.12.2/` (not a subproject) | 1.12.2 | 14.23.5.2847 | 2.3.4 | own 4.10.3 wrapper | JDK 8 |
+| Module | MC | Forge | FG | Gradle | Toolchain | Status |
+|---|---|---|---|---|---|---|
+| `:common` | — | — | — | root 9.3.1 | build JDK 21, `--release 8` | canonical shared core |
+| `:forge-1.21` | 1.21 | 51.0.8 | 7.x | root 9.3.1 | 21 | SOURCE-COMPLETE |
+| `:forge-1.21.1` | 1.21.1 | 52.1.16 | 7.x | root 9.3.1 | 21 | point-release placeholder — source carries over separately |
+| `:forge-1.21.4` | 1.21.4 | 54.1.18 | 7.x | root 9.3.1 | 21 | point-release placeholder — source carries over separately |
+| `:forge-1.21.8` | 1.21.8 | 58.1.21 | 7.x | root 9.3.1 | 21 | point-release placeholder — source carries over separately |
+| `forge-1.16.5/` (not a subproject) | 1.16.5 | 36.2.34 | 5.1.x | own 7.6.4 wrapper | JDK 8 | SOURCE-COMPLETE (post-#274) |
+| `forge-1.20.1/` (not a subproject) | 1.20.1 | 47.4.10 | 6.x | own 8.7 wrapper | JDK 21 (17 toolchain) | SOURCE-COMPLETE (post-#273) |
+| `mc1.12.2/` (not a subproject) | 1.12.2 | 14.23.5.2847 | 2.3.4 | own 4.10.3 wrapper | JDK 8 | SOURCE-COMPLETE (post-#269) |
 
 `forge-1.16.5` / `forge-1.20.1` are out-of-band per-lane wrappers (own Gradle
 wrapper, FG applied per-lane — see AGENTS.md "Legacy lanes"): they are NOT
@@ -64,13 +64,11 @@ canonical copy; no JPMS on Java 8).
 
 ## Notes / known state
 
-- **Scaffold stage (M2 step 2):** this branch establishes the multi-module
-  layout and convention plugins. The per-subproject source ports (splitting
-  `forge-1.21` into binding layer + `:common`) land in later PRs. Until then
-  `forge-1.21/` still carries the full pre-split source, and `common/` holds
-  the standalone module copied from the parent `Everlasting-Skins/common/`
-  (Lane B's in-flight lift; the two copies intentionally diverge until the
-  port reconciles them).
+- **Source layout (post-M2):** `:common` is the single canonical copy of
+  shared code; every forge module consumes it (`consumeCommon` on for all,
+  post-#268), and the out-of-band lanes share it as an extra source dir.
+  The legacy lanes are SOURCE-COMPLETE; the 1.21.x point-release
+  subprojects are placeholders whose sources port over separately.
 - **No mixingradle:** the convention plugin applies mixin annotation
   processing + jar-manifest attributes only (Lane C). Enforced by the
   `verifyNoMixin` gate in `buildSrc/` (`no-mixin.gradle.kts`, ported from the
@@ -79,7 +77,8 @@ canonical copy; no JPMS on Java 8).
   lint-yaml, then `build` over `:common` + the four 1.21.x modules, an
   out-of-band mc1.12.2 build (own wrapper, JDK 8), and the `E2E (mc1.12.2)`
   required-check placeholder. `publish.yml` was reworked in the same PR.
-  The 1.16.5 / 1.20.1 scaffolds are not in the matrix yet.
+  The out-of-band 1.16.5 / 1.20.1 lanes are not in the matrix yet
+  (publish.yml entries stay commented out until lane verification).
 - **Artifact naming:** `everlastingskins-<mc>` (was `EverlastingSkins-<mc>`).
 - `mc1.12.2/` is imported from the parent checkout's history and builds
   out-of-band with its own wrapper (Gradle 4.10.3 + FG 2.3.4 + Java 8). Its
@@ -89,11 +88,11 @@ canonical copy; no JPMS on Java 8).
 
 ## Recently merged (M2 campaign)
 
-- **#257** — initial `forge-1.16.5` subproject scaffold (+ lib-35 first shims).
+- **#257** — initial `forge-1.16.5` subproject (+ lib-35 first shims).
 - **#258** — `verifyNoMixin` build gate ported into `buildSrc/`.
 - **#259** — `run-gametest-local.sh` paths corrected for the multi-module layout.
 - **#260** — `ci.yml` + `publish.yml` reworked to a per-module matrix.
-- **#261** — initial `forge-1.20.1` subproject scaffold.
+- **#261** — initial `forge-1.20.1` subproject.
 - **#263** — `forge-1.21` compile compat restored with Forge 51.0.8.
 - **#264** — `forge-1.21` test/gametest sources downgraded for Forge 51.0.8.
 - **#265** — `forge-1.21` runtime blockers resolved (incl. JPMS split-package).
@@ -105,7 +104,18 @@ canonical copy; no JPMS on Java 8).
   `forge21.*`); `consumeCommon` flipped on for the forge modules.
 - **#269** — feat(monorepo): integrate mc1.12.2 lane + source-dir share
   `:common` (#269) — 162 files, 514 tests pass; mc1.12.2 now lives in the
-  monorepo as per-lane wrapper directory.
+  monorepo as per-lane wrapper directory (SOURCE-COMPLETE).
+- **#270** — `REPOSITORY-STRUCTURE.md` added; standalone parent checkout
+  documented as archived (tags on the standalone history).
+- **#271** — docs wart fixes (stale `consumeCommon` docs; #269 added to the
+  merged list).
+- **#272** — P0: `forge-1.16.5` compiles on Java 8 again (Java-16 syntax
+  downgraded, duplicate `SkinUtils` + vendored httpclient jar dropped).
+- **#273** — `forge-1.20.1` main source carried over from `forge-1.21`
+  (SOURCE-COMPLETE).
+- **#274** — `forge-1.16.5` SOURCE-COMPLETE (version-shape errors fixed for
+  Java 8).
 
-Still ahead: source carry-over onto `:common` for the legacy lanes and the
-`pack.mcmeta` format bump (see CHANGELOG).
+Still ahead: source ports for the 1.21.x point-release placeholders, CI
+wiring for the out-of-band lanes, and the `pack.mcmeta` format bump (see
+CHANGELOG).


### PR DESCRIPTION
## Summary

D3 doc sync for the post-M2 SOURCE-COMPLETE state (`integration/m2-monorepo` @ `3cd6332`).

## Changes

- **README modules table**: added a Status column — `forge-1.16.5` SOURCE-COMPLETE (post-#274), `forge-1.20.1` SOURCE-COMPLETE (post-#273), `mc1.12.2` SOURCE-COMPLETE (post-#269); `forge-1.21.1`/`1.21.4`/`1.21.8` marked as point-release placeholders (source carries over separately).
- **README notes**: replaced the stale "Scaffold stage" note with the post-M2 source layout (`:common` canonical, `consumeCommon` on for all); 1.16.5/1.20.1 no longer called "scaffolds"; recently-merged list extended with #270–#274; "Still ahead" updated (point-release ports + CI wiring + pack.mcmeta).
- **CHANGELOG**: new "M2 completion: SOURCE-COMPLETE (PRs #270–#274)" section; stale known-follow-ups removed (forge-1.21 → :common port done in #268, java8-forge-module stub cleaned up in #267).
- **AGENTS.md**: fixed `PR #2xx` placeholder → PR #267; "scaffold land" rule reworded to "placeholder land" (1.21.x point releases); `(future) the 1.12.2 lane` → current state; source-status note added.

## Verification

- `grep -c scaffold README.md AGENTS.md` → 0 (CHANGELOG keeps only historical mentions).
- `yamllint -c .yamllint.yml .github/workflows/*.yml` → clean.
- aislop pre-commit gate → 100/100, no issues.