### PR TITLE
feat(monorepo): remove consumeCommon gate (all forge-* subprojects consume :common unconditionally)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,15 +64,16 @@ settings.gradle.kts does not include them.
 5. **Point-release parity:** keep `forge-1.21.x` gradle.properties versions
    in sync with the tags (`mc1.21.x-v2.1.0-rc1` etc.). Verify against git
    history before changing.
-6. **`consumeCommon` gate:** each forge module opts into the `:common`
-   dependency unless `consumeCommon=false` in its `gradle.properties`; the
-   default is to consume. No module currently sets it `false` — `forge-1.21`
-   was flipped on by #268 (the JPMS split-package that forced the old
-   opt-out was resolved by the #268 dedup), so every forge-* module consumes
-   `:common`. The gate is kept as a safety valve: if a future forge-*
-   subproject requires vendored copies, `consumeCommon=false` is the
-   documented escape hatch and may need to be re-added there. (The dead
-   plugin-era gate was deleted in #267.)
+6. **`:common` consumed unconditionally:** every forge-* subproject depends
+   on `:common` via `implementation(project(":common"))` in
+   buildSrc `everlastingskins.forge-module.gradle.kts`; there is no opt-out.
+   Historical context: a `consumeCommon=false` gate existed as a safety
+   valve for forge-1.21's JPMS split-package (#265) and was removed after
+   the Option B1 relocation to `forge21.*` (#268) resolved the conflict.
+   Re-add caveat: if a future forge-* subproject (e.g., forge-1.7.10 /
+   forge-1.8.9) requires vendored `:common` copies for tooling reasons,
+   re-add the gate to buildSrc `forge-module.gradle.kts` and re-introduce
+   the opt-out property. (The dead plugin-era gate was deleted in #267.)
 7. **1.12.2 lane:** never include it in `settings.gradle.kts`. It builds
    out-of-band (`cd mc1.12.2 && ./gradlew build` with Java 8); changes there
    are reviewed against the shared `:common` contract, not against this build.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## M2 (monorepo) — unreleased
 
+### consumeCommon gate removed
+
+The `consumeCommon=false` opt-out gate in
+`buildSrc/.../everlastingskins.forge-module.gradle.kts` is gone: every
+forge-* subproject now consumes `:common` unconditionally via
+`implementation(project(":common"))`. The gate was a safety valve for
+forge-1.21's JPMS split-package (#265) and became dead after the Option B1
+relocation to `forge21.*` (#268) resolved the conflict — no module ever
+sets `consumeCommon=false`. Docs updated (root AGENTS.md Rule 6,
+common/AGENTS.md, README.md).
+
 ### FG lane separation: forge-1.16.5 / forge-1.20.1 go out-of-band
 
 ForgeGradle 5.1.x hard-rejects Gradle 8.0+ and ForgeGradle 6.0.x

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ canonical copy; no JPMS on Java 8).
   per-lane wrappers (own Gradle + FG per lane).
 - **#268** — dedup of `forge-1.21` / `forge-1.16.5` against `:common`;
   JPMS split-package resolved (Option B1, 12 survivors relocated to
-  `forge21.*`); `consumeCommon` flipped on for the forge modules.
+  `forge21.*`); `forge-1.21` consumes `:common` like the other modules.
 - **#269** — feat(monorepo): integrate mc1.12.2 lane + source-dir share
   `:common` (#269) — 162 files, 514 tests pass; mc1.12.2 now lives in the
   monorepo as per-lane wrapper directory.

--- a/buildSrc/src/main/kotlin/everlastingskins.forge-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/everlastingskins.forge-module.gradle.kts
@@ -209,17 +209,14 @@ tasks.matching { it.name == "runGameTestServer" }.configureEach {
 }
 
 dependencies {
-    // :common is the shared version-independent core (M2). forge-1.21 is the
-    // original pre-M2 module: it still ships its own copies of every :common
-    // class, so pulling the jar in also puts common.jar on the dev-run module
-    // path, where the launcher turns it into automatic module "common". Both
-    // it and the main module then export levosilimo.everlastingskins.
-    // skinchanger.responses.*, which fails the JPMS layer build (split
-    // package) before the game test server boots. Modules that own their
-    // classes opt out via consumeCommon=false in gradle.properties.
-    if (project.findProperty("consumeCommon")?.toString() != "false") {
-        implementation(project(":common"))
-    }
+    // :common is the shared version-independent core (M2); every forge-*
+    // module consumes it unconditionally. An opt-out gate existed as a
+    // safety valve for forge-1.21's JPMS split-package issue (#265); it
+    // became dead after the Option B1 relocation to forge21.* (#268)
+    // resolved the conflict — no module ever opted out. If a future
+    // forge-* lane needs vendored :common copies for tooling reasons,
+    // re-add the gate + opt-out property here.
+    implementation(project(":common"))
     implementation("org.apache.httpcomponents:httpclient:4.5.13")
     implementation(minecraft.dependency("net.minecraftforge:forge:${minecraftVersion}-${forgeVersion}"))
     annotationProcessor("org.spongepowered:mixin:0.8.7:processor")

--- a/common/AGENTS.md
+++ b/common/AGENTS.md
@@ -24,8 +24,6 @@ SkinStorage), utils (JsonUtils, CustomSkinProperty, HttpClient).
 
 Every `forge-*` module depends on `:common` via
 `implementation(project(":common"))` — `:common` is unconditionally consumed.
-The `consumeCommon=false` opt-out in `gradle.properties` exists but is
-currently unused by every forge module (post-#268).
 
 The union of `:common` + each per-version binding layer covers the full mod.
 


### PR DESCRIPTION
## What

Removes the `consumeCommon=false` opt-out gate from `buildSrc/.../everlastingskins.forge-module.gradle.kts`. All forge-* subprojects (1.21, 1.21.1, 1.21.4, 1.21.8, 1.16.5, 1.20.1) now consume `:common` unconditionally via `implementation(project(":common"))`.

## Why

The gate was a safety valve for forge-1.21's JPMS split-package issue (#265). Option B1 relocated the MC-bound survivors to `forge21.*` (#268), resolving the conflict — no module ever sets `consumeCommon=false`, so the gate is dead code.

## Changes

- `buildSrc/.../forge-module.gradle.kts`: conditional gate → unconditional `implementation(project(":common"))`; stale JPMS comment replaced with removal rationale + re-add caveat.
- `AGENTS.md` Rule 6: rewritten — `:common` consumed unconditionally, historical context (#265/#268), re-add caveat for future lanes (e.g. forge-1.7.10/1.8.9).
- `common/AGENTS.md`: opt-out clause removed.
- `README.md`: `consumeCommon` reference removed from the #268 entry.
- `CHANGELOG.md`: new entry documenting the removal (historical #265/#268 lines kept).

## Verification

- `./gradlew :common:build :forge-1.21:tasks :forge-1.21.1:tasks :forge-1.21.4:tasks :forge-1.21.8:tasks` (Java 21) — green
- `forge-1.16.5 ./gradlew build verifyNoMixin` (Java 8) — green
- `forge-1.20.1 ./gradlew build verifyNoMixin` (Java 21) — green
- `mc1.12.2 ./gradlew tasks` (Java 8) — green
- `grep -rn consumeCommon --include=*.kts --include=*.properties` — zero hits (docs mentions only)