### PR TITLE
ci: add Build (forge-1.16.5) + Build (forge-1.20.1) + dedicated publish-mc1_16_5/publish-mc1_20_1 jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,70 @@ jobs:
       - name: Build and test
         run: ./gradlew build --no-daemon --stacktrace
 
+  # ── forge-1.16.5 out-of-band lane (own wrapper, JDK 8) ────────
+  build-forge-1_16_5:
+    name: Build (forge-1.16.5)
+    runs-on: ubuntu-latest
+    needs: lint-yaml
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
+      - name: Set up JDK 8
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961  # v5
+        with:
+          java-version: "8"
+          distribution: temurin
+      - name: Cache Gradle wrapper and caches
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5
+        with:
+          path: |
+            ~/.gradle/wrapper/dists
+            ~/.gradle/caches
+          key: gradle-${{ runner.os }}-forge-1.16.5-${{ hashFiles('**/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-forge-1.16.5-
+      - name: Grant execute permission for gradlew
+        run: chmod +x forge-1.16.5/gradlew
+      - name: Build and test
+        run: cd forge-1.16.5 && ./gradlew build verifyNoMixin --no-daemon --stacktrace
+      - name: Upload built jar
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # v5
+        with:
+          name: mod-forge-1.16.5
+          path: forge-1.16.5/build/libs/*.jar
+          if-no-files-found: warn
+
+  # ── forge-1.20.1 out-of-band lane (own wrapper, JDK 21) ────────
+  build-forge-1_20_1:
+    name: Build (forge-1.20.1)
+    runs-on: ubuntu-latest
+    needs: lint-yaml
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
+      - name: Set up JDK 21
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961  # v5
+        with:
+          java-version: 21
+          distribution: temurin
+      - name: Cache Gradle wrapper and caches
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5
+        with:
+          path: |
+            ~/.gradle/wrapper/dists
+            ~/.gradle/caches
+          key: gradle-${{ runner.os }}-forge-1.20.1-${{ hashFiles('**/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-forge-1.20.1-
+      - name: Grant execute permission for gradlew
+        run: chmod +x forge-1.20.1/gradlew
+      - name: Build and test
+        run: cd forge-1.20.1 && ./gradlew build verifyNoMixin --no-daemon --stacktrace
+      - name: Upload built jar
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # v5
+        with:
+          name: mod-forge-1.20.1
+          path: forge-1.20.1/build/libs/*.jar
+          if-no-files-found: warn
+
   # ── E2E (mc1.12.2) required-check contract ─────────────────────
   # The old per-branch required-check contract names `E2E (mc1.12.2)`
   # as a status context; keep that exact check name present on

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,11 +11,8 @@ on:
       - 'mc1.21.4-v*'
       - 'mc1.21.8-v*'
       - 'mc1.12.2-v*'
-      # mc1.20.1 / mc1.16.5: re-enable tag triggers + dedicated publish
-      # jobs (out-of-band lanes with their own wrappers, see
-      # publish-mc1_12_2 below) once the lanes reach SOURCE-COMPLETE.
-      # # - 'mc1.20.1-v*'
-      # # - 'mc1.16.5-v*'
+      - 'mc1.20.1-v*'
+      - 'mc1.16.5-v*'
       # NOTE: NeoForge intentionally dropped — no mcneoforge lane.
 
 jobs:
@@ -49,17 +46,8 @@ jobs:
           # own wrappers (forge-1.16.5 → Gradle 7.6.4/Java 8 + FG 5.1.77;
           # forge-1.20.1 → Gradle 8.7/Java 21 + FG 6.0.54), so the shared
           # `./gradlew :${{ matrix.module }}:build` step cannot build them.
-          # Re-enable via dedicated jobs modeled on publish-mc1_12_2 below
-          # (own checkout, own JAVA_HOME, `cd forge-1.16.5 && ./gradlew
-          # build`) once the lanes reach SOURCE-COMPLETE.
-          # - prefix: "mc1.20.1-v"
-          #   module: forge-1.20.1
-          #   game-version: "1.20.1"
-          #   java: "17"
-          # - prefix: "mc1.16.5-v"
-          #   module: forge-1.16.5
-          #   game-version: "1.16.5"
-          #   java: "8"
+          # They publish via the dedicated publish-mc1_16_5 /
+          # publish-mc1_20_1 jobs below.
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
       - name: Set up JDK ${{ matrix.java }}
@@ -155,6 +143,114 @@ jobs:
           game-version-filter: releases
           environment: server
           files: build/libs/*.jar
+          fail-mode: warn
+          retry-attempts: 3
+          retry-delay: 15000
+
+  # ── forge-1.16.5 out-of-band lane (own wrapper, JDK 8) ────────
+  publish-mc1_16_5:
+    name: Publish (mc1.16.5)
+    if: startsWith(github.ref_name, 'mc1.16.5-v')
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961  # v5
+        with:
+          java-version: "8"
+          distribution: temurin
+
+      - name: Cache Gradle
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5
+        with:
+          path: |
+            ~/.gradle/wrapper/dists
+            ~/.gradle/caches
+          key: gradle-${{ runner.os }}-forge-1.16.5
+          restore-keys: |
+            gradle-${{ runner.os }}-forge-1.16.5-
+            gradle-${{ runner.os }}-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x forge-1.16.5/gradlew
+
+      - name: Build
+        run: cd forge-1.16.5 && ./gradlew build --no-daemon
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+
+      - name: Publish to CurseForge, Modrinth, GitHub Releases
+        uses: Kira-NT/mc-publish@52307b03863581dec6b652b83e597aec02ebb075  # v3
+        with:
+          curseforge-id: 538149
+          curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
+          modrinth-id: everlasting-skins
+          modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          version: ${{ github.ref_name }}
+          name: "Everlasting Skins ${{ github.ref_name }}"
+          version-type: release
+          loaders: forge
+          game-versions: "1.16.5"
+          game-version-filter: releases
+          environment: server
+          files: forge-1.16.5/build/libs/*.jar
+          fail-mode: warn
+          retry-attempts: 3
+          retry-delay: 15000
+
+  # ── forge-1.20.1 out-of-band lane (own wrapper, JDK 21) ────────
+  publish-mc1_20_1:
+    name: Publish (mc1.20.1)
+    if: startsWith(github.ref_name, 'mc1.20.1-v')
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961  # v5
+        with:
+          java-version: 21
+          distribution: temurin
+
+      - name: Cache Gradle
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5
+        with:
+          path: |
+            ~/.gradle/wrapper/dists
+            ~/.gradle/caches
+          key: gradle-${{ runner.os }}-forge-1.20.1
+          restore-keys: |
+            gradle-${{ runner.os }}-forge-1.20.1-
+            gradle-${{ runner.os }}-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x forge-1.20.1/gradlew
+
+      - name: Build
+        run: cd forge-1.20.1 && ./gradlew build --no-daemon
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+
+      - name: Publish to CurseForge, Modrinth, GitHub Releases
+        uses: Kira-NT/mc-publish@52307b03863581dec6b652b83e597aec02ebb075  # v3
+        with:
+          curseforge-id: 538149
+          curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
+          modrinth-id: everlasting-skins
+          modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          version: ${{ github.ref_name }}
+          name: "Everlasting Skins ${{ github.ref_name }}"
+          version-type: release
+          loaders: forge
+          game-versions: "1.20.1"
+          game-version-filter: releases
+          environment: server
+          files: forge-1.20.1/build/libs/*.jar
           fail-mode: warn
           retry-attempts: 3
           retry-delay: 15000

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,16 @@ registers backends).
 ```
 
 CI (`ci.yml`) is a per-module matrix (PR #260): lint-yaml → `build` over
-`:common` + the four 1.21.x modules, plus the out-of-band mc1.12.2 build and
-`E2E (mc1.12.2)` placeholder. `forge-1.16.5` / `forge-1.20.1` are not in the
-matrix yet. Treat the matrix as authoritative for what is buildable in CI.
+`:common` + the four 1.21.x modules, plus the out-of-band mc1.12.2 build,
+`E2E (mc1.12.2)` placeholder, and out-of-band `Build (forge-1.16.5)` /
+`Build (forge-1.20.1)` lanes (own wrappers, JDK 8 / JDK 21). Treat the
+matrix as authoritative for what is buildable in CI.
+
+## Required checks (integration/m2-monorepo branch protection)
+
+Enforced via the gh API — do not edit branch protection in-repo. `Build
+(forge-1.16.5)` and `Build (forge-1.20.1)` are required status checks on
+integration/m2-monorepo, additive to the existing contract (`YAML Lint`,
+`Build (common)` / `Build (1.21.x)` matrix, `Build (mc1.12.2)`, `E2E
+(mc1.12.2)`, `GameTest (1.21)`, `aislop (M2)`). CI job names must match
+the required-check strings exactly.


### PR DESCRIPTION
## What

D4 of the M2 monorepo CI work. Both out-of-band lanes reached SOURCE-COMPLETE (#273 forge-1.20.1, #274 forge-1.16.5), so per memory #1246 the commented publish.yml entries are re-enabled with dedicated jobs.

## Changes

- **ci.yml**: new `Build (forge-1.16.5)` job (JDK 8, Gradle 7.6.4 wrapper, `cd forge-1.16.5 && ./gradlew build verifyNoMixin`, uploads jar artifact) and `Build (forge-1.20.1)` job (JDK 21, Gradle 8.7 wrapper, same pattern). Modeled on `Build (mc1.12.2)` with per-lane cache keys; both jobs `needs: lint-yaml`.
- **publish.yml**: tag triggers `mc1.16.5-v*` and `mc1.20.1-v*` uncommented; new `publish-mc1_16_5` (JDK 8) and `publish-mc1_20_1` (JDK 21) jobs modeled on `publish-mc1_12_2` — monorepo checkout (no separate ref), lane-local build, mc-publish with the lane jar and per-version game-version. Tag routing preserved (per-job `if: startsWith(github.ref_name, ...)`, memory #1238).
- **AGENTS.md**: documents `Build (forge-1.16.5)` + `Build (forge-1.20.1)` as additive required checks on integration/m2-monorepo (memory #1212 — branch protection itself is managed via gh API, not in-repo).

## Verification

- `yamllint -c .yamllint.yml .github/workflows/*.yml` — clean
- `git diff --check` — clean
- aislop pre-commit hook — clean (100/100)