### PR TITLE
docs: add missing CHANGELOG entries + bump pack.mcmeta + fix stale README CI note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 ## M2 (monorepo) — unreleased
 
-### consumeCommon gate removed
+### Missing CHANGELOG entries backfilled
+
+- **#266** — docs: sync monorepo README/AGENTS/CHANGELOG + add
+  common/AGENTS.md + supersede forge-1.21/AGENTS.md
+- **#275** — docs: sync README + CHANGELOG to reflect post-M2
+  SOURCE-COMPLETE state (modules Status column, post-#270/#274 markers)
+- **#277** — ci: add Build (forge-1.16.5) + Build (forge-1.20.1) +
+  dedicated publish-mc1_16_5/publish-mc1_20_1 jobs; uncomment
+  mc1.16.5-v*/mc1.20.1-v* tag triggers
+
+### #276 — consumeCommon gate removed
 
 The `consumeCommon=false` opt-out gate in
 `buildSrc/.../everlastingskins.forge-module.gradle.kts` is gone: every
@@ -13,7 +23,7 @@ relocation to `forge21.*` (#268) resolved the conflict — no module ever
 sets `consumeCommon=false`. Docs updated (root AGENTS.md Rule 6,
 common/AGENTS.md, README.md).
 
-### FG lane separation: forge-1.16.5 / forge-1.20.1 go out-of-band
+### #267 — FG lane separation: forge-1.16.5 / forge-1.20.1 go out-of-band
 
 ForgeGradle 5.1.x hard-rejects Gradle 8.0+ and ForgeGradle 6.0.x
 hard-rejects Gradle 9.0+ (verified empirically 2026-08-06 against
@@ -33,10 +43,10 @@ from the lane dir: `cd forge-1.16.5 && ./gradlew build`.
   `everlastingskins.fg6-forge-module` and unused
   `everlastingskins.java8-forge-module` buildSrc convention plugins
   (the lanes can no longer use buildSrc).
-- Follow-ups: CI wiring for the lane wrappers (publish.yml entries stay
-  commented out until the lanes reach SOURCE-COMPLETE) and the actual
-  userdev pipeline runs (prepareRuns/runClient/runServer, reobfJar) —
-  configuration now uses the real FG 5.1/6.0 for the first time.
+- Follow-ups: the actual userdev pipeline runs
+  (prepareRuns/runClient/runServer, reobfJar) — configuration now uses
+  the real FG 5.1/6.0 for the first time. CI wiring for the lane
+  wrappers is done (dedicated Build + publish jobs).
 
 ### step 2: multi-module scaffold
 
@@ -117,8 +127,5 @@ Mixin gate, CI matrix, and forge-1.21 compat fixes.
 
 - Port the 1.21.1 / 1.21.4 / 1.21.8 point-release sources (currently
   placeholders; source carries over separately, same shape as #273).
-- Wire the CI matrix for the out-of-band 1.16.5 / 1.20.1 lanes
-  (publish.yml entries stay commented out until lane verification).
-- Fix `forge-1.21/src/main/resources/pack.mcmeta` staleness: `pack_format`
-  is still 6 (a 1.16.2-era value; 1.21 needs 15+) and the `_comment` is
-  stale.
+- Run the lane userdev pipelines end-to-end on the out-of-band
+  1.16.5 / 1.20.1 wrappers (prepareRuns/runClient/runServer, reobfJar).

--- a/README.md
+++ b/README.md
@@ -65,20 +65,22 @@ canonical copy; no JPMS on Java 8).
 ## Notes / known state
 
 - **Source layout (post-M2):** `:common` is the single canonical copy of
-  shared code; every forge module consumes it (`consumeCommon` on for all,
-  post-#268), and the out-of-band lanes share it as an extra source dir.
+  shared code; every forge module consumes it unconditionally (the
+  `consumeCommon` gate is gone, post-#276), and the out-of-band lanes
+  share it as an extra source dir.
   The legacy lanes are SOURCE-COMPLETE; the 1.21.x point-release
   subprojects are placeholders whose sources port over separately.
 - **No mixingradle:** the convention plugin applies mixin annotation
   processing + jar-manifest attributes only (Lane C). Enforced by the
   `verifyNoMixin` gate in `buildSrc/` (`no-mixin.gradle.kts`, ported from the
   parent's `common/build-logic`), which fails the build on any Mixin usage.
-- **CI:** `.github/workflows/ci.yml` is a per-module matrix (PR #260):
-  lint-yaml, then `build` over `:common` + the four 1.21.x modules, an
-  out-of-band mc1.12.2 build (own wrapper, JDK 8), and the `E2E (mc1.12.2)`
-  required-check placeholder. `publish.yml` was reworked in the same PR.
-  The out-of-band 1.16.5 / 1.20.1 lanes are not in the matrix yet
-  (publish.yml entries stay commented out until lane verification).
+- **CI:** `.github/workflows/ci.yml` is a per-module matrix (PR #260,
+  extended by #277): lint-yaml, then `build` over `:common` + the four
+  1.21.x modules, out-of-band builds for mc1.12.2 / forge-1.16.5 /
+  forge-1.20.1 (own wrappers), and the `E2E (mc1.12.2)` required-check
+  placeholder. `publish.yml` gained dedicated `publish-mc1_16_5` /
+  `publish-mc1_20_1` jobs in #277, with the `mc1.16.5-v*` /
+  `mc1.20.1-v*` tag triggers uncommented.
 - **Artifact naming:** `everlastingskins-<mc>` (was `EverlastingSkins-<mc>`).
 - `mc1.12.2/` is imported from the parent checkout's history and builds
   out-of-band with its own wrapper (Gradle 4.10.3 + FG 2.3.4 + Java 8). Its
@@ -115,7 +117,14 @@ canonical copy; no JPMS on Java 8).
   (SOURCE-COMPLETE).
 - **#274** — `forge-1.16.5` SOURCE-COMPLETE (version-shape errors fixed for
   Java 8).
+- **#275** — docs sync: README + CHANGELOG reflect the post-M2
+  SOURCE-COMPLETE state (modules Status column, post-#270/#274 markers).
+- **#276** — `consumeCommon` gate removed: every forge-* subproject
+  consumes `:common` unconditionally.
+- **#277** — CI: `Build (forge-1.16.5)` / `Build (forge-1.20.1)` jobs +
+  dedicated `publish-mc1_16_5` / `publish-mc1_20_1` jobs;
+  `mc1.16.5-v*` / `mc1.20.1-v*` tag triggers uncommented.
 
-Still ahead: source ports for the 1.21.x point-release placeholders, CI
-wiring for the out-of-band lanes, and the `pack.mcmeta` format bump (see
-CHANGELOG).
+Still ahead: source ports for the 1.21.x point-release placeholders. CI
+wiring for the out-of-band lanes (#277) and the `pack.mcmeta` format bump
+are DONE (see CHANGELOG).

--- a/forge-1.21/src/main/resources/pack.mcmeta
+++ b/forge-1.21/src/main/resources/pack.mcmeta
@@ -1,7 +1,7 @@
 {
     "pack": {
         "description": "everlastingskins resources",
-        "pack_format": 6,
-        "_comment": "A pack_format of 6 requires json lang files and some texture changes from 1.16.2. Note: we require v6 pack meta for all mods."
+        "pack_format": 34,
+        "_comment": "pack_format 34 is the 1.21-1.21.1 resource-pack format (minecraft.wiki Pack format); the previous value 6 was 1.16.2-era."
     }
 }


### PR DESCRIPTION
## Summary

Closes the HIGH-severity docs gap from lib-9's audit of `integration/m2-monorepo` @ `4b94561`.

## Changes

- **CHANGELOG.md** — backfilled missing entries for #266, #275, #277 and added PR markers to the existing #267 / #276 narrative sections; removed the now-done 'wire CI matrix' and 'pack.mcmeta staleness' items from Known follow-ups (replaced with the remaining lane userdev-pipeline item).
- **README.md** — CI note now reflects #277 (Build (forge-1.16.5) / Build (forge-1.20.1) jobs, dedicated publish-mc1_16_5 / publish-mc1_20_1 jobs, uncommented mc1.16.5-v* / mc1.20.1-v* tag triggers); 'Still ahead' marks CI wiring + pack.mcmeta bump as DONE; #275/#276/#277 added to the merged list; stale `consumeCommon on for all` wording updated (gate is gone, post-#276).
- **forge-1.21/src/main/resources/pack.mcmeta** — `pack_format` 6 → 34 (1.21–1.21.1 resource-pack format per minecraft.wiki), stale `_comment` updated.

## Verification

- `grep -c "not in the matrix yet" README.md` → 0
- `grep -c "stay commented" README.md` → 0
- `grep -c '#266|#267|#275|#276|#277' CHANGELOG.md` → 5 (one per PR)
- `yamllint -c .yamllint.yml .github/workflows/*.yml` → clean
- aislop pre-commit gate → 100/100, no issues