### PR TITLE
ci(publish): rewire publish-mc1_12_2 to build monorepo lane

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -99,8 +99,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
-        with:
-          ref: "mc1.12.2"
 
       - name: Set up JDK 8
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961  # v5
@@ -120,10 +118,10 @@ jobs:
             gradle-${{ runner.os }}-
 
       - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
+        run: chmod +x mc1.12.2/gradlew
 
       - name: Build
-        run: ./gradlew build --no-daemon
+        run: cd mc1.12.2 && ./gradlew build --no-daemon
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
 
@@ -142,7 +140,7 @@ jobs:
           game-versions: "1.12.2"
           game-version-filter: releases
           environment: server
-          files: build/libs/*.jar
+          files: mc1.12.2/build/libs/*.jar
           fail-mode: warn
           retry-attempts: 3
           retry-delay: 15000


### PR DESCRIPTION
## Summary

Rewires the `publish-mc1_12_2` job in `.github/workflows/publish.yml` to build the monorepo `mc1.12.2/` lane instead of the legacy standalone `mc1.12.2` branch (head `253de53`).

## Why

- Pre-promotion fix for the mainline rename (Option A): after promotion, the standalone `mc1.12.2` branch is retired, so `actions/checkout ref: "mc1.12.2"` would break this job.
- The job now mirrors the already-correct pattern from `publish-mc1_16_5` / `publish-mc1_20_1` (#277).

## Changes (job only)

- Drop `ref: "mc1.12.2"` from checkout — builds the tag that triggered the workflow.
- `chmod +x mc1.12.2/gradlew`
- Build: `cd mc1.12.2 && ./gradlew build --no-daemon`
- `files: mc1.12.2/build/libs/*.jar`
- JDK 8 kept (lane is Gradle 4.10.3 / Java 8); `if: startsWith(github.ref_name, 'mc1.12.2-v')` tag routing untouched.

## Verification

- `yamllint -c .yamllint.yml .github/workflows/*.yml` clean
- `git diff --check` clean
- aislop gate: 100/100 clean