### PR TITLE
ci: rewire build-mc1_12_2 to build monorepo lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,15 +80,13 @@ jobs:
           path: ${{ matrix.module }}/build/libs/*.jar
           if-no-files-found: warn
 
-  # ── mc1.12.2 stays out-of-band: own wrapper, JDK 8 ─────────────
+  # ── mc1.12.2 out-of-band lane (own wrapper, JDK 8) ─────────────
   build-mc1_12_2:
     name: Build (mc1.12.2)
     runs-on: ubuntu-latest
     needs: lint-yaml
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
-        with:
-          ref: "mc1.12.2"
       - name: Set up JDK 8
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961  # v5
         with:
@@ -104,9 +102,15 @@ jobs:
           restore-keys: |
             gradle-${{ runner.os }}-mc1.12.2-
       - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
+        run: chmod +x mc1.12.2/gradlew
       - name: Build and test
-        run: ./gradlew build --no-daemon --stacktrace
+        run: cd mc1.12.2 && ./gradlew build --no-daemon --stacktrace
+      - name: Upload built jar
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # v5
+        with:
+          name: mod-mc1.12.2
+          path: mc1.12.2/build/libs/*.jar
+          if-no-files-found: warn
 
   # ── forge-1.16.5 out-of-band lane (own wrapper, JDK 8) ────────
   build-forge-1_16_5:


### PR DESCRIPTION
## Summary

Pre-promotion rewire (Lane A2). The `build-mc1_12_2` job currently checks out the legacy standalone `mc1.12.2` branch (`ref: "mc1.12.2"`, head `253de53`) and runs `./gradlew build` at the repo root. After mainline promotion (Option A), that branch is retired and this job would break.

This PR rewires the job to build the monorepo `mc1.12.2/` lane, mirroring the `build-forge-1_16_5` / `build-forge-1_20_1` pattern from #277:

- Drop `ref: "mc1.12.2"` from checkout — the workflow now builds the trigger ref (PR head / `integration/m2-monorepo`)
- `chmod +x mc1.12.2/gradlew`
- Build: `cd mc1.12.2 && ./gradlew build --no-daemon --stacktrace`
- Add upload-artifact step (`mod-mc1.12.2`, `mc1.12.2/build/libs/*.jar`)
- JDK 8 retained (lane uses Gradle 4.10.3 wrapper, ForgeGradle 2.3.4)
- Job display name stays exactly `Build (mc1.12.2)` (required-check contract, memory #1212)

## Note on verifyNoMixin

The forge-1.16.5/1.20.1 lanes run `build verifyNoMixin`; the mc1.12.2 lane does **not** define that task (mixin sources are excluded from the build — no Mixin annotation processor for 1.12.2; fix-25's `verifyNoMixin` gate lives in monorepo `buildSrc` conventions that this standalone Gradle 4.10.3 build does not consume). Adding it would fail the job with "Task 'verifyNoMixin' not found", so the build step mirrors the lane's actual capabilities.

## Verification

- `yamllint -c .yamllint.yml .github/workflows/ci.yml` — clean
- `git diff --check` — clean
- aislop gate — 100/100, no issues