### PR TITLE
ci: add main to ci.yml triggers (fix promotion blocker)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: ["integration/m2-monorepo"]
+    branches: ["integration/m2-monorepo", "main"]
   pull_request:
-    branches: ["integration/m2-monorepo"]
+    branches: ["integration/m2-monorepo", "main"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Fixes the promotion blocker: `main` is the new default branch with 12 required status checks, but ci.yml only triggers on `integration/m2-monorepo`. The pull_request trigger matches the base branch, so PRs targeting `main` (e.g. #285) never run CI and are permanently blocked.

Adds `main` to both `on.push.branches` and `on.pull_request.branches` so the 12 required checks can run on the new default branch.