### PR TITLE
docs: document act --dryrun for local ci.yml validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,23 @@ Source status: every lane is SOURCE-COMPLETE — forge-1.16.5 (post-#274),
 forge-1.20.1 (post-#273), and the 1.21.1 / 1.21.4 / 1.21.8 point releases
 (post-#278 / #280 / #281).
 
+### Local CI validation with act
+
+Validate workflow syntax locally with [act](https://github.com/nektos/act);
+`--dryrun` parses the workflow without Docker:
+
+```bash
+brew install act   # or: curl -s https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash
+act --dryrun --workflows .github/workflows/ci.yml     # syntax gate (no Docker)
+act --self-hosted -j lint-yaml -j aislop               # cheap jobs on the host runner
+```
+
+Use it for any `.github/workflows/*.yml` change, especially during GitHub
+outages (the ci.yml trigger fix, #286, sat blocked by one). `--self-hosted`
+runs the cheap `lint-yaml` / `aislop` jobs on the host runner; the Forge build
+matrix is not reliable under act (Docker JDK image fragility) — treat `act` as
+a syntax gate, not a build substitute.
+
 ## Required checks (integration/m2-monorepo branch protection)
 
 Enforced via the gh API — do not edit branch protection in-repo. `Build

--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ cd mc1.12.2 && ./gradlew build   # own Gradle 4.10.3 wrapper, Java 8, FG 2.3.4
 so the lane compiles the same `:common` sources as the Forge line (single
 canonical copy; no JPMS on Java 8).
 
+### Local validation
+
+`act --dryrun --workflows .github/workflows/ci.yml` validates workflow syntax
+locally with no Docker. See AGENTS.md → "Local CI validation with act".
+
 ## Notes / known state
 
 - **Source layout (post-M2):** `:common` is the single canonical copy of


### PR DESCRIPTION
## What

Document local workflow validation with [act](https://github.com/nektos/act) so devs can fail-fast on ci.yml changes without waiting on GitHub — especially during outages.

## Changes

- **AGENTS.md** — new `### Local CI validation with act` subsection under `## Verification`:
  - install via `brew install act` or the curl installer
  - `act --dryrun --workflows .github/workflows/ci.yml` as a Docker-free syntax gate
  - `act --self-hosted -j lint-yaml -j aislop` for the cheap jobs on the host runner
  - when to use (any workflow change, especially during outages — cf. #286, blocked by one)
  - limitations (Forge build matrix unreliable under act due to Docker JDK fragility; syntax gate only, not a build substitute)
- **README.md** — brief `### Local validation` note under `## Build` pointing at AGENTS.md.

## Context

The 1-line ci.yml trigger fix (#286) was blocked by the GitHub outage; local dryrun validation would have kept the loop moving. Docs-only, no install, no CI changes.