### PR TITLE
feat(hooks): extend pre-commit + add pre-push + test-count gate + lefthook config

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,34 +1,28 @@
 #!/usr/bin/env bash
-# Pre-commit quality gate for EverlastingSkins.
-# Runs aislop against staged files to catch AI-slop patterns:
-# god-files, god-functions, narrative comments, swallowed exceptions,
-# FizzBuzz-Enterprise-style overengineering, etc.
+# Pre-commit quality gate for EverlastingSkins (fail-fast tier, <30s).
+# Sequential order: aislop staged scan -> test-count gate -> verifyNoMixin ->
+# offline parallel compile. Heavier checks live in .githooks/pre-push.
 #
-# Requires: bunx (bun) or npx on PATH. aislop is fetched on demand.
+# Requires: bunx (bun) or npx on PATH; JVM 17+ for the root gradlew.
 # Setup: git config core.hooksPath .githooks
 
 set -euo pipefail
-
-if ! command -v bunx >/dev/null 2>&1 && ! command -v npx >/dev/null 2>&1; then
-  echo "[aislop] neither bunx nor npx found on PATH; skipping scan" >&2
-  exit 0
-fi
 
 if [ -z "$(git diff --cached --name-only --diff-filter=ACMR | head -n1)" ]; then
   exit 0
 fi
 
-echo "[aislop] scanning staged files..."
-
-if command -v bunx >/dev/null 2>&1; then
-  RUNNER=bunx
-else
-  RUNNER=npx
-fi
-
-# shellcheck disable=SC2086
-if ! $RUNNER aislop scan --staged; then
-  cat >&2 <<'EOF'
+# 1. aislop scan of staged files (skipped if no runner on PATH)
+if command -v bunx >/dev/null 2>&1 || command -v npx >/dev/null 2>&1; then
+  if command -v bunx >/dev/null 2>&1; then
+    RUNNER=bunx
+  else
+    RUNNER=npx
+  fi
+  echo "[aislop] scanning staged files..."
+  # shellcheck disable=SC2086
+  if ! $RUNNER aislop scan --staged; then
+    cat >&2 <<'EOF'
 
 aislop reported findings on staged files.
 
@@ -40,5 +34,19 @@ Common fixes:
 Disable this hook for a single commit with: git commit --no-verify
 Re-enable per the project setup note in AGENTS.md.
 EOF
-  exit 1
+    exit 1
+  fi
+else
+  echo "[aislop] neither bunx nor npx found on PATH; skipping scan" >&2
 fi
+
+# 2. test-count gate (mirrors ci.yml "Verify test count meets minimum")
+bash scripts/test-count-gate.sh
+
+# 3. verifyNoMixin on :common and :forge-1.21
+echo "[gradle] verifyNoMixin..."
+./gradlew --no-daemon --offline :common:verifyNoMixin :forge-1.21:verifyNoMixin
+
+# 4. fast compile (offline, parallel)
+echo "[gradle] compile..."
+./gradlew --no-daemon --offline :common:compileJava :forge-1.21:compileJava --parallel

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Pre-push quality gate for EverlastingSkins (heavy tier, 5-10 min).
+# Order: full unit test suite -> GameTest (1.21) -> aislop ci (mirrors CI's
+# "aislop (M2)" job). Skip for one push with: git push --no-verify
+#
+# Requires: JVM 17+ for the root gradlew; bunx (bun) or npx for aislop.
+# Setup: git config core.hooksPath .githooks
+
+set -euo pipefail
+
+echo "[pre-push] gradle: full unit test suite (parallel)..."
+./gradlew --no-daemon --offline test --parallel
+
+echo "[pre-push] gametest: forge-1.21 runGameTestServer..."
+forge-1.21/test-infrastructure/run-gametest-local.sh
+
+echo "[pre-push] aislop: ci --changes vs origin/integration/m2-monorepo..."
+if command -v bunx >/dev/null 2>&1; then
+  bunx aislop ci --changes --base origin/integration/m2-monorepo
+else
+  npx -y aislop ci --changes --base origin/integration/m2-monorepo
+fi
+
+echo "[pre-push] all checks passed."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,39 @@ Source status: every lane is SOURCE-COMPLETE — forge-1.16.5 (post-#274),
 forge-1.20.1 (post-#273), and the 1.21.1 / 1.21.4 / 1.21.8 point releases
 (post-#278 / #280 / #281).
 
+## Fail-fast hooks
+
+Tiered local gates mirroring CI (see `.githooks/` and `lefthook.yml`):
+
+- **pre-commit** (<30s, sequential): aislop staged scan → test-count gate →
+  `verifyNoMixin` → offline parallel compile. Active via
+  `git config core.hooksPath .githooks` (already set in this repo).
+- **pre-push** (5-10 min, heavy): full unit test suite → GameTest (1.21) via
+  `forge-1.21/test-infrastructure/run-gametest-local.sh` → `aislop ci
+  --changes` (mirrors CI's `aislop (M2)` job). Skip once with
+  `git push --no-verify`.
+- `scripts/test-count-gate.sh` mirrors ci.yml's `@Test >= 150` floor: counts
+  `@Test` + `@ParameterizedTest` in `common/src` + `forge-1.21/src`.
+
+The root `gradlew` requires JVM 17+ (the mc1.12.2 lane keeps its own JDK 8
+wrapper). Hooks pass `--offline`; a first run needs a prior online build to
+populate `~/.gradle`.
+
+Local dev should set `~/.gradle/gradle.properties` (operational, not
+committed) to:
+
+```properties
+org.gradle.daemon=true
+org.gradle.parallel=true
+org.gradle.caching=true
+```
+
+Validate `ci.yml` changes locally with `act --dryrun` before pushing.
+
+`lefthook.yml` documents the intended lefthook adoption (Go binary, parallel
+pre-push); `.githooks/` stays active until lefthook is installed and
+`core.hooksPath` unset.
+
 ## Required checks (integration/m2-monorepo branch protection)
 
 Enforced via the gh API — do not edit branch protection in-repo. `Build

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,37 @@
+# lefthook.yml — Go-binary git hook manager (no Python/Node runtime).
+# STATUS: documented, NOT yet adopted. `.githooks/` (via `git config
+# core.hooksPath .githooks`) remains the active path; this file is the
+# intended replacement so behavior stays identical when adopted (same
+# scripts, same order).
+#
+# Adopt (operational, not part of this repo):
+#   brew install lefthook            # or: go install github.com/evilmartians/lefthook@latest
+#   lefthook install                 # writes .git/hooks/pre-commit + pre-push
+#   git config --unset core.hooksPath
+#   # follow up: delete .githooks/ so the two paths cannot drift
+#
+# Pre-commit stays sequential (fail-fast tier, <30s); pre-push runs in
+# parallel (heavy tier, 5-10 min). Note: the two gradle jobs in pre-push
+# serialize on the project lock; aislop-ci is the true parallel win.
+
+pre-commit:
+  parallel: false
+  commands:
+    aislop:
+      run: bunx aislop scan --staged
+    test-count:
+      run: bash scripts/test-count-gate.sh
+    verify-no-mixin:
+      run: ./gradlew --no-daemon --offline :common:verifyNoMixin :forge-1.21:verifyNoMixin
+    compile:
+      run: ./gradlew --no-daemon --offline :common:compileJava :forge-1.21:compileJava --parallel
+
+pre-push:
+  parallel: true
+  commands:
+    unit-tests:
+      run: ./gradlew --no-daemon --offline test --parallel
+    gametest:
+      run: forge-1.21/test-infrastructure/run-gametest-local.sh
+    aislop-ci:
+      run: npx -y aislop ci --changes --base origin/integration/m2-monorepo

--- a/scripts/test-count-gate.sh
+++ b/scripts/test-count-gate.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Test-count gate: mirrors ci.yml "Verify test count meets minimum".
+# Counts @Test / @ParameterizedTest annotations in common/src and
+# forge-1.21/src; exits 1 if below the CI floor of 150, 0 otherwise.
+#
+# Usage: bash scripts/test-count-gate.sh
+
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+COUNT=$(grep -rE "@(Test|ParameterizedTest)\b" --include="*.java" common/src forge-1.21/src 2>/dev/null | wc -l)
+echo "Test count: $COUNT"
+
+if [ "$COUNT" -lt 150 ]; then
+  echo "ERROR: Test count dropped below 150 (got $COUNT)" >&2
+  exit 1
+fi


### PR DESCRIPTION
Tiered fail-fast local gates mirroring CI (lib-17 quick wins 2,3 + medium 5,8).

**Changes**
- `.githooks/pre-commit` extended to <30s fail-fast chain: aislop staged scan -> test-count gate -> verifyNoMixin -> offline parallel compile (measured 15s warm).
- `.githooks/pre-push` added (heavy tier, 5-10 min): full unit test suite -> GameTest (1.21) -> aislop ci --changes (mirrors CI `aislop (M2)` job). Escape hatch: `git push --no-verify`.
- `scripts/test-count-gate.sh`: mirrors ci.yml `@Test >= 150` floor; counts `@Test` + `@ParameterizedTest` in common/src + forge-1.21/src (current: 435; CI-equivalent count 426).
- `lefthook.yml`: documents Go-binary lefthook adoption (parallel pre-push). Config only — lefthook NOT installed (operational); `.githooks/` stays active until then.
- AGENTS.md: `## Fail-fast hooks` section (tiered model, JVM 17+ for root gradlew, ~/.gradle/gradle.properties daemon/parallel/caching, `act --dryrun` for ci.yml validation).

**Verified end-to-end** (this branch)
- pre-commit hook passed on commit: aislop clean, gate 435, verifyNoMixin + compile OK.
- pre-push hook passed on push: unit tests (all modules) OK, GameTest 34/34 passed, aislop ci 0 errors.

**Notes**
- Hooks pass `--offline`; first run needs a prior online build to populate ~/.gradle.
- Root gradlew requires JVM 17+ (mc1.12.2 lane keeps its own JDK 8 wrapper).
- No ci.yml or build-file changes (scope: hooks + scripts + lefthook.yml + AGENTS.md).