### PR TITLE
build: add ErrorProne static analysis

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -10,6 +10,14 @@ repositories {
 }
 
 dependencies {
+    // ErrorProne static analysis plugin (net.ltgt.errorprone), 5.1.0 — latest
+    // stable (2026-02): requires Gradle >= 7.1 and JDK >= 11, compatible with
+    // Gradle 9.3.1 + the JDK 21 toolchain. Declared as a classpath dependency
+    // (NOT `apply false`) so the precompiled script plugins can apply
+    // id("net.ltgt.errorprone") versionlessly — the plugins-block variant
+    // does not land on the convention-plugin resolution classpath on Gradle 9.
+    implementation("net.ltgt.errorprone:net.ltgt.errorprone.gradle.plugin:5.1.0")
+
     // Single FG version for the whole buildSrc classpath; applied
     // versionlessly by everlastingskins.forge-module. Same range as the
     // legacy 1.21 build.gradle ([7.0.3,8) — FG 7.x, Gradle 9.3.1 verified

--- a/buildSrc/src/main/kotlin/everlastingskins.errorprone.gradle.kts
+++ b/buildSrc/src/main/kotlin/everlastingskins.errorprone.gradle.kts
@@ -1,0 +1,39 @@
+// everlastingskins.errorprone — Tier 1 static analysis for the M2 root.
+// Hooks ErrorProne into every JavaCompile task (compile-time checks, zero
+// extra step). Applied by the forge-module convention (all forge-* lanes)
+// and directly by :common.
+//
+// The plugin version is pinned in buildSrc/build.gradle.kts (apply false);
+// the ErrorProne core version lives here, on the `errorprone` configuration.
+
+import net.ltgt.gradle.errorprone.errorprone
+
+plugins {
+    id("net.ltgt.errorprone")
+}
+
+dependencies {
+    // The gradle-errorprone-plugin does NOT bundle ErrorProne itself; the
+    // core must be declared on the `errorprone` configuration. 2.50.0 is the
+    // current stable release and requires a JDK 21 (or newer) toolchain to
+    // run — this build's toolchain is 21.
+    errorprone("com.google.errorprone:error_prone_core:2.50.0")
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    // Annotation-processor output (e.g. the Mixin AP) is not ours to lint.
+    options.errorprone.disableWarningsInGeneratedCode.set(true)
+    // Checks that produce false positives on this codebase; suppressed at
+    // rollout rather than polluting every compile with noise.
+    options.errorprone.disable("IdentityBinaryExpression", "StringSplitter")
+}
+
+// Test/gametest source sets: main-only gate for this rollout. The test
+// suite carries pre-existing warning debt (fire-and-forget futures,
+// non-static inner classes, unclosed Files streams ...) that trips
+// :common's -Werror and would block the integration entirely. Cleaning
+// that debt is a follow-up, not part of this change.
+tasks.matching { it.name == "compileTestJava" || it.name == "compileGametestJava" }
+    .configureEach {
+        (this as JavaCompile).options.errorprone.enabled.set(false)
+    }

--- a/buildSrc/src/main/kotlin/everlastingskins.forge-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/everlastingskins.forge-module.gradle.kts
@@ -21,6 +21,8 @@ plugins {
     // no-mixin gate (buildSrc): registers verifyNoMixin, wired into `build`.
     // Any subproject applying this convention gets the Mixin-usage gate.
     id("no-mixin")
+    // ErrorProne static analysis (buildSrc): hooks every JavaCompile.
+    id("everlastingskins.errorprone")
 }
 
 // NOTE: property reads here use project.findProperty (NOT
@@ -219,6 +221,11 @@ dependencies {
     implementation(project(":common"))
     implementation("org.apache.httpcomponents:httpclient:4.5.13")
     implementation(minecraft.dependency("net.minecraftforge:forge:${minecraftVersion}-${forgeVersion}"))
+    // MUST be declared before the mixin processor: mixin-0.8.7-processor.jar
+    // bundles an unrelocated OLD Guava (no ImmutableMap.Builder.buildOrThrow),
+    // which would shadow ErrorProne's Guava 33 on the annotation processor
+    // path and crash it with NoSuchMethodError (ErrorProne integration).
+    annotationProcessor("com.google.guava:guava:33.5.0-jre")
     annotationProcessor("org.spongepowered:mixin:0.8.7:processor")
     // Hack fix for now, force jopt-simple to be exactly 5.0.4 because Mojang
     // ships that version, but some transitive dependencies request 6.0+.

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -6,6 +6,8 @@ plugins {
     // no-mixin gate (buildSrc): registers verifyNoMixin, wired into `build`.
     // Same direct application as the parent's /common (build-logic M2 step 2).
     id("no-mixin")
+    // ErrorProne static analysis (buildSrc): hooks every JavaCompile.
+    id("everlastingskins.errorprone")
 }
 
 java {

--- a/common/src/main/java/levosilimo/everlastingskins/metrics/LatencyHistogram.java
+++ b/common/src/main/java/levosilimo/everlastingskins/metrics/LatencyHistogram.java
@@ -61,11 +61,9 @@ final class LatencyHistogram {
         long p95 = percentile(total, 0.95);
         long p99 = percentile(total, 0.99);
         long max = 0;
-        long cumulative = 0;
         for (int i = 0; i < buckets.length; i++) {
             long count = buckets[i].sum();
             if (count == 0) continue;
-            cumulative += count;
             max = bound(i);
         }
         result.put("p50", p50);

--- a/common/src/main/java/levosilimo/everlastingskins/permission/PermissionServiceManager.java
+++ b/common/src/main/java/levosilimo/everlastingskins/permission/PermissionServiceManager.java
@@ -25,7 +25,6 @@ public final class PermissionServiceManager {
     private static final Logger LOGGER = LogManager.getLogger(PermissionServiceManager.class);
 
     private static IPermissionService activeService = null;
-    private static boolean initialized = false;
 
     private PermissionServiceManager() {}
 
@@ -34,7 +33,6 @@ public final class PermissionServiceManager {
         if (service == null) {
             return;
         }
-        initialized = true;
         if (activeService == null || service.getPriority() > activeService.getPriority()) {
             activeService = service;
             LOGGER.info("Permission backend active: {}", service.getActiveBackendName());
@@ -57,7 +55,6 @@ public final class PermissionServiceManager {
     /* package-private for testing */
     static void reset() {
         activeService = null;
-        initialized = false;
     }
 
     public static String getActiveBackendName() {

--- a/common/src/main/java/levosilimo/everlastingskins/skinchanger/MojangProfileCache.java
+++ b/common/src/main/java/levosilimo/everlastingskins/skinchanger/MojangProfileCache.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -78,7 +79,7 @@ public class MojangProfileCache {
     /** Returns the cached skin for the username, or null when absent/expired. */
     public synchronized CustomSkinProperty get(String username) {
         if (username == null) return null;
-        String key = username.toLowerCase();
+        String key = username.toLowerCase(Locale.ROOT);
         CacheEntry entry = entries.get(key);
         if (entry == null) {
             SkinMetrics.INSTANCE.recordCacheMiss();
@@ -96,7 +97,7 @@ public class MojangProfileCache {
     /** Stores a fetched skin, evicting expired and least-recently-used entries when over capacity. */
     public synchronized void put(String username, CustomSkinProperty property) {
         if (username == null || property == null) return;
-        String key = username.toLowerCase();
+        String key = username.toLowerCase(Locale.ROOT);
         if (maxEntries <= 0) return;
         if (entries.containsKey(key)) {
             entries.put(key, new CacheEntry(property, System.nanoTime()));

--- a/common/src/main/java/levosilimo/everlastingskins/skinchanger/RandomMojangSkin.java
+++ b/common/src/main/java/levosilimo/everlastingskins/skinchanger/RandomMojangSkin.java
@@ -15,6 +15,7 @@ import levosilimo.everlastingskins.util.JsonUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.nio.charset.StandardCharsets;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.net.URI;
@@ -52,7 +53,7 @@ public class RandomMojangSkin {
                     continue;
                 }
 
-                if ((variant.equals(SkinVariant.SLIM) && !isSlim(username)) || ((variant.equals(SkinVariant.CLASSIC) && isSlim(username)))) {
+                if ((variant.equals(SkinVariant.SLIM) && !isSlim(username)) || (variant.equals(SkinVariant.CLASSIC) && isSlim(username))) {
                     continue;
                 }
                 return username;
@@ -171,6 +172,6 @@ public class RandomMojangSkin {
         String skinValue = mojangAPI.getSkin(username)
                 .orElseThrow(() -> new IOException("No skin data for username: " + username))
                 .skinProperty().getValue();
-        return new String(Base64.getDecoder().decode(skinValue));
+        return new String(Base64.getDecoder().decode(skinValue), StandardCharsets.UTF_8);
     }
 }

--- a/common/src/main/java/levosilimo/everlastingskins/skinchanger/SkinIO.java
+++ b/common/src/main/java/levosilimo/everlastingskins/skinchanger/SkinIO.java
@@ -32,6 +32,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -209,7 +210,10 @@ public class SkinIO {
     private void scheduleDrain() {
         if (drainScheduled.getAndSet(true)) return;
         try {
-            writer().schedule(this::drainPending, DRAIN_DEBOUNCE_MS, TimeUnit.MILLISECONDS);
+            // Intentional fire-and-forget debounce: drainPending logs its own
+            // failures, so the timer future carries no observable signal.
+            @SuppressWarnings("FutureReturnValueIgnored")
+            ScheduledFuture<?> unused = writer().schedule(this::drainPending, DRAIN_DEBOUNCE_MS, TimeUnit.MILLISECONDS);
         } catch (Exception e) {
             LOGGER.warn("SkinIO drain schedule failed", e);
         }
@@ -227,6 +231,11 @@ public class SkinIO {
                 SkinMetrics.INSTANCE.recordRealWrite();
                 SkinMetrics.INSTANCE.recordSaveCompleted();
             }
+        } catch (Exception e) {
+            // Failure visibility: without this, a saveSkin error escapes to the
+            // executor's default handler (stderr only). Remaining payloads were
+            // already removed from pendingWrites; they are lost either way.
+            LOGGER.error("SkinIO drain failed", e);
         } finally {
             // Reset the latch so future saveSkinAsync calls schedule again. If new
             // writes arrived during this drain, schedule the next drain immediately
@@ -299,6 +308,7 @@ public class SkinIO {
             try {
                 Files.deleteIfExists(temp);
             } catch (IOException ignored) {
+                // Best-effort cleanup; a leftover temp file is harmless.
             }
         }
     }
@@ -499,6 +509,8 @@ public class SkinIO {
         try {
             Files.move(target, quarantine, StandardCopyOption.REPLACE_EXISTING);
         } catch (IOException ignored) {
+            // Best-effort quarantine; the corrupt record stays in place and
+            // is retried next sweep.
         }
     }
 

--- a/common/src/main/java/levosilimo/everlastingskins/skinchanger/responses/HttpResponse.java
+++ b/common/src/main/java/levosilimo/everlastingskins/skinchanger/responses/HttpResponse.java
@@ -39,6 +39,7 @@ public final class HttpResponse {
         try {
             return GSON.fromJson(body, clazz);
         } catch (JsonSyntaxException ignored) {
+            // Malformed body: not JSON, treat as absent.
         }
         return null;
     }

--- a/common/src/main/java/levosilimo/everlastingskins/util/CustomSkinProperty.java
+++ b/common/src/main/java/levosilimo/everlastingskins/util/CustomSkinProperty.java
@@ -86,6 +86,7 @@ public class CustomSkinProperty {
     }
 
     @Override
+    @SuppressWarnings("EqualsGetClass") // deliberate: public non-final class, getClass() keeps subclass equality contract-safe
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;

--- a/common/src/main/java/levosilimo/everlastingskins/util/HttpsUrlConnectionHttpClient.java
+++ b/common/src/main/java/levosilimo/everlastingskins/util/HttpsUrlConnectionHttpClient.java
@@ -37,7 +37,7 @@ public class HttpsUrlConnectionHttpClient implements HttpClient {
             throw new IOException("Only HTTPS is supported.");
         }
 
-        logger.debug("Sending " + method + " request to " + url + " with body: " + requestBody);
+        logger.debug("Sending {} request to {} with body: {}", method, url, requestBody == null ? "null" : requestBody.body());
 
         HttpsURLConnection connection = (HttpsURLConnection) url.openConnection();
         connection.setRequestMethod(method.name());

--- a/common/src/main/java/levosilimo/everlastingskins/util/SkinUtils.java
+++ b/common/src/main/java/levosilimo/everlastingskins/util/SkinUtils.java
@@ -210,9 +210,9 @@ public class SkinUtils {
             return true;
         }
 
-        // For some reason, Apache's Lists.charactersOf is faster than character indexing for small strings.
-        for (char c : str.toCharArray()) {
-            // Note: Players who bought the game early in its development can have "-" in usernames.
+        // Note: Players who bought the game early in its development can have "-" in usernames.
+        for (int i = 0; i < str.length(); i++) {
+            char c = str.charAt(i);
             if (!(c >= 'a' && c <= 'z') && !(c >= '0' && c <= '9') && !(c >= 'A' && c <= 'Z') && c != '_' && c != '-') {
                 return true;
             }

--- a/common/src/test/java/levosilimo/everlastingskins/metrics/SkinMetricsTest.java
+++ b/common/src/test/java/levosilimo/everlastingskins/metrics/SkinMetricsTest.java
@@ -17,8 +17,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class SkinMetricsTest {
 
-    private final SkinMetrics metrics = new SkinMetrics();
-
     private static SkinMetrics freshMetrics() {
         return new SkinMetrics();
     }

--- a/common/src/test/java/levosilimo/everlastingskins/skinchanger/FakeMojangAPI.java
+++ b/common/src/test/java/levosilimo/everlastingskins/skinchanger/FakeMojangAPI.java
@@ -10,6 +10,7 @@ import levosilimo.everlastingskins.skinchanger.responses.mojang.MojangSkinDataRe
 import levosilimo.everlastingskins.util.CustomSkinProperty;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -24,12 +25,12 @@ class FakeMojangAPI implements MojangAPI {
     final Map<String, CustomSkinProperty> skins = new HashMap<String, CustomSkinProperty>();
 
     void addSkin(String name, CustomSkinProperty skin) {
-        skins.put(name.toLowerCase(), skin);
+        skins.put(name.toLowerCase(Locale.ROOT), skin);
     }
 
     @Override
     public Optional<MojangSkinDataResult> getSkin(String nameOrUniqueId) {
-        CustomSkinProperty skin = skins.get(nameOrUniqueId.toLowerCase());
+        CustomSkinProperty skin = skins.get(nameOrUniqueId.toLowerCase(Locale.ROOT));
         if (skin == null) {
             return Optional.empty();
         }

--- a/common/src/test/java/levosilimo/everlastingskins/skinchanger/MojangApiFuzzTest.java
+++ b/common/src/test/java/levosilimo/everlastingskins/skinchanger/MojangApiFuzzTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Fuzz corpus for the Mojang API JSON parsers (AI-generated code surface,
  * cf. Pearce et al., S&P 2022). Every property feeds malformed JSON byte
  * shapes from {@link MalformedJsonCorpus} to the UUID and profile parsers
- * and asserts the fail-closed contract: the result is {@link Optional#EMPTY}
+ * and asserts the fail-closed contract: the result is {@code Optional.EMPTY}
  * ("no result") and no exception escapes the public API.
  * <p>
  * The malformed corpus never contains a valid 32-hex UUID or a complete

--- a/common/src/test/java/levosilimo/everlastingskins/skinchanger/SkinIODeleteRaceTest.java
+++ b/common/src/test/java/levosilimo/everlastingskins/skinchanger/SkinIODeleteRaceTest.java
@@ -20,6 +20,7 @@ import java.nio.file.Path;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -56,7 +57,7 @@ class SkinIODeleteRaceTest {
         UUID u = UUID.randomUUID();
         Path target = tempDir.resolve(u + ".json");
 
-        blockingStorage.saveSkinAsync(u, skin("stale"));
+        CompletableFuture<Void> unused = blockingStorage.saveSkinAsync(u, skin("stale"));
         assertTrue(blockingIO.writeStarted.await(5, TimeUnit.SECONDS),
                 "drain must reach the file write before the delete");
 
@@ -100,7 +101,7 @@ class SkinIODeleteRaceTest {
             switch (rnd.nextInt(3)) {
                 case 0:
                     lastPayload = "payload-" + rnd.nextInt(100000);
-                    storage.saveSkinAsync(u, skin(lastPayload));
+                    CompletableFuture<Void> unused = storage.saveSkinAsync(u, skin(lastPayload));
                     lastOp = Op.SAVE;
                     break;
                 case 1:

--- a/common/src/test/java/levosilimo/everlastingskins/skinchanger/SkinIOPropertyTest.java
+++ b/common/src/test/java/levosilimo/everlastingskins/skinchanger/SkinIOPropertyTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -200,7 +201,7 @@ class SkinIOPropertyTest {
                     switch (op.type) {
                         case SAVE_ASYNC:
                             model.put(op.uuid, op.value);
-                            storage.saveSkinAsync(op.uuid, skin(op.value));
+                            CompletableFuture<Void> unused = storage.saveSkinAsync(op.uuid, skin(op.value));
                             break;
                         case SAVE_SYNC:
                             model.put(op.uuid, op.value);
@@ -276,7 +277,7 @@ class SkinIOPropertyTest {
     }
 
     @Group
-    class DrainIdempotence {
+    static class DrainIdempotence {
 
         /**
          * Model: the drain latch and per-UUID coalescing guarantee at most one
@@ -304,7 +305,7 @@ class SkinIOPropertyTest {
                     SkinStorage storage = new SkinStorage(io);
                     UUID uuid = UUID.randomUUID();
                     for (String value : burst) {
-                        storage.saveSkinAsync(uuid, skin(value));
+                        CompletableFuture<Void> unused = storage.saveSkinAsync(uuid, skin(value));
                     }
                     storage.flushPending();
                     assertEquals(1, SkinMetrics.INSTANCE.snapshot().realWrites(),
@@ -321,7 +322,7 @@ class SkinIOPropertyTest {
 
 
     @Group
-    class DeleteBeatsWrite {
+    static class DeleteBeatsWrite {
 
         /**
          * Model: a delete is a tombstone that beats any earlier write, so a
@@ -339,7 +340,7 @@ class SkinIOPropertyTest {
                     SkinIO io = new SkinIO(dir);
                     SkinStorage storage = new SkinStorage(io);
                     UUID uuid = UUID.randomUUID();
-                    storage.saveSkinAsync(uuid, skin(value));
+                    CompletableFuture<Void> unused = storage.saveSkinAsync(uuid, skin(value));
                     storage.removeSkin(uuid);
                     storage.flushPending();
                     assertFalse(Files.exists(dir.resolve(uuid + ".json")),
@@ -376,7 +377,7 @@ class SkinIOPropertyTest {
                     UUID uuid = UUID.randomUUID();
                     Path target = dir.resolve(uuid + ".json");
 
-                    storage.saveSkinAsync(uuid, skin(value));
+                    CompletableFuture<Void> unused = storage.saveSkinAsync(uuid, skin(value));
                     assertTrue(blockingIO.writeStarted.await(5, TimeUnit.SECONDS),
                             "drain must reach the file write before the delete");
 
@@ -410,7 +411,7 @@ class SkinIOPropertyTest {
 
 
     @Group
-    class SerializeLoadRoundTrip {
+    static class SerializeLoadRoundTrip {
 
         /**
          * Model: the wire format is the state, so serialize -> load ->
@@ -456,7 +457,7 @@ class SkinIOPropertyTest {
 
 
     @Group
-    class RestartAfterDelete {
+    static class RestartAfterDelete {
 
         /**
          * Model: a tombstone must survive a restart, so a fresh store over the
@@ -475,7 +476,7 @@ class SkinIOPropertyTest {
                     SkinIO io = new SkinIO(dir);
                     SkinStorage storage = new SkinStorage(io);
                     UUID uuid = UUID.randomUUID();
-                    storage.saveSkinAsync(uuid, skin(value));
+                    CompletableFuture<Void> unused = storage.saveSkinAsync(uuid, skin(value));
                     storage.removeSkin(uuid);
                     storage.flushPending();
                     SkinStorage restarted = new SkinStorage(new SkinIO(dir));
@@ -490,7 +491,7 @@ class SkinIOPropertyTest {
 
 
     @Group
-    class ModelEquivalence {
+    static class ModelEquivalence {
 
         /**
          * Model: the full specification. A random concurrent op script (async
@@ -537,7 +538,7 @@ class SkinIOPropertyTest {
 
 
     @Group
-    class LatestWins {
+    static class LatestWins {
 
         /**
          * Model: the map is latest-wins, so a sequence of async saves for one
@@ -555,7 +556,7 @@ class SkinIOPropertyTest {
                     SkinStorage storage = new SkinStorage(io);
                     UUID uuid = UUID.randomUUID();
                     for (String value : values) {
-                        storage.saveSkinAsync(uuid, skin(value));
+                        CompletableFuture<Void> unused = storage.saveSkinAsync(uuid, skin(value));
                     }
                     storage.flushPending();
                     assertFileValue(dir, uuid, values.get(values.size() - 1));
@@ -587,7 +588,7 @@ class SkinIOPropertyTest {
                     Thread threadA = new Thread(() -> {
                         try {
                             start.await();
-                            storage.saveSkinAsync(uuid, skin(valueA));
+                            CompletableFuture<Void> unused2 = storage.saveSkinAsync(uuid, skin(valueA));
                         } catch (Throwable t) {
                             failure.compareAndSet(null, t);
                         }
@@ -595,7 +596,7 @@ class SkinIOPropertyTest {
                     Thread threadB = new Thread(() -> {
                         try {
                             start.await();
-                            storage.saveSkinAsync(uuid, skin(valueB));
+                            CompletableFuture<Void> unused3 = storage.saveSkinAsync(uuid, skin(valueB));
                         } catch (Throwable t) {
                             failure.compareAndSet(null, t);
                         }

--- a/common/src/test/java/levosilimo/everlastingskins/skinchanger/SkinStorageMetamorphicTest.java
+++ b/common/src/test/java/levosilimo/everlastingskins/skinchanger/SkinStorageMetamorphicTest.java
@@ -29,6 +29,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -176,11 +178,14 @@ class SkinStorageMetamorphicTest {
                 for (String value : sequence) {
                     UUID uuid = UUID.randomUUID();
                     model.put(uuid, value);
-                    storage.saveSkinAsync(uuid, skin(value));
+                    CompletableFuture<Void> unused = storage.saveSkinAsync(uuid, skin(value));
                 }
                 storage.flushPending();
-                assertEquals(model.size(),
-                        Files.list(dir).filter(p -> p.getFileName().toString().endsWith(".json")).count(),
+                long onDisk;
+                try (Stream<Path> paths = Files.list(dir)) {
+                    onDisk = paths.filter(p -> p.getFileName().toString().endsWith(".json")).count();
+                }
+                assertEquals(model.size(), onDisk,
                         "flush must land one file per live entry");
                 // Restart: a fresh SkinStorage over the same directory sees the disk state.
                 SkinStorage restarted = new SkinStorage(new SkinIO(dir));
@@ -213,7 +218,7 @@ class SkinStorageMetamorphicTest {
                 SkinIO io = new SkinIO(dir);
                 SkinStorage storage = new SkinStorage(io);
                 UUID uuid = UUID.randomUUID();
-                storage.saveSkinAsync(uuid, skin(value));
+                CompletableFuture<Void> unused = storage.saveSkinAsync(uuid, skin(value));
                 storage.flushPending();
                 storage.removeSkin(uuid);
 
@@ -245,7 +250,7 @@ class SkinStorageMetamorphicTest {
                 SkinStorage storage = new SkinStorage(io);
                 UUID uuid = UUID.randomUUID();
                 for (String value : sequence) {
-                    storage.saveSkinAsync(uuid, skin(value));
+                    CompletableFuture<Void> unused = storage.saveSkinAsync(uuid, skin(value));
                 }
                 storage.flushPending();
                 assertLoadedEquals(dir, uuid, sequence.get(sequence.size() - 1));
@@ -274,7 +279,7 @@ class SkinStorageMetamorphicTest {
             try {
                 SkinIO io = new SkinIO(dir);
                 SkinStorage storage = new SkinStorage(io);
-                storage.saveSkinAsync(op.uuid, skin(op.value));
+                CompletableFuture<Void> unused = storage.saveSkinAsync(op.uuid, skin(op.value));
                 storage.removeSkin(op.uuid);
                 storage.flushPending();
 

--- a/common/src/test/java/levosilimo/everlastingskins/skinchanger/SkinStorageTest.java
+++ b/common/src/test/java/levosilimo/everlastingskins/skinchanger/SkinStorageTest.java
@@ -239,11 +239,11 @@ class SkinStorageTest {
             UUID u1 = UUID.randomUUID();
             UUID u2 = UUID.randomUUID();
 
-            storage.saveSkinAsync(u1, new CustomSkinProperty("textures", "sig1", "src1"));
+            CompletableFuture<Void> unused = storage.saveSkinAsync(u1, new CustomSkinProperty("textures", "sig1", "src1"));
             assertTrue(awaitFile(tempDir.resolve(u1 + ".json")),
                     "First async save should be persisted after the debounce window");
 
-            storage.saveSkinAsync(u2, new CustomSkinProperty("textures", "sig2", "src2"));
+            CompletableFuture<Void> unused2 = storage.saveSkinAsync(u2, new CustomSkinProperty("textures", "sig2", "src2"));
             assertTrue(awaitFile(tempDir.resolve(u2 + ".json")),
                     "Second async save after latch reset should be persisted");
         }
@@ -252,9 +252,9 @@ class SkinStorageTest {
         @DisplayName("burst saves for the same UUID coalesce into one disk write")
         void saveSkinAsync_coalescesSameUUIDWrites() throws Exception {
             UUID u = UUID.randomUUID();
-            storage.saveSkinAsync(u, new CustomSkinProperty("textures", "sig1", "src1"));
-            storage.saveSkinAsync(u, new CustomSkinProperty("textures", "sig2", "src2"));
-            storage.saveSkinAsync(u, new CustomSkinProperty("textures", "sig3", "src3"));
+            CompletableFuture<Void> unused = storage.saveSkinAsync(u, new CustomSkinProperty("textures", "sig1", "src1"));
+            CompletableFuture<Void> unused2 = storage.saveSkinAsync(u, new CustomSkinProperty("textures", "sig2", "src2"));
+            CompletableFuture<Void> unused3 = storage.saveSkinAsync(u, new CustomSkinProperty("textures", "sig3", "src3"));
             storage.flushPending();
 
             // Only the last payload should hit disk (realWrites=1, savesCoalesced=2).
@@ -271,7 +271,7 @@ class SkinStorageTest {
         @DisplayName("removeSkin purges pending writes so the deferred drain cannot resurrect the file")
         void deleteSkin_purgesPendingWrites() throws Exception {
             UUID u = UUID.randomUUID();
-            storage.saveSkinAsync(u, new CustomSkinProperty("textures", "sig", "src"));
+            CompletableFuture<Void> unused = storage.saveSkinAsync(u, new CustomSkinProperty("textures", "sig", "src"));
             storage.removeSkin(u); // before the drain fires
             storage.flushPending();
 
@@ -300,7 +300,7 @@ class SkinStorageTest {
         @DisplayName("flushPending blocks until queued writes have landed on disk")
         void flushPending_waitsForPendingWrites_toFinish() throws Exception {
             UUID u = UUID.randomUUID();
-            storage.saveSkinAsync(u, new CustomSkinProperty("textures", "sig", "src"));
+            CompletableFuture<Void> unused = storage.saveSkinAsync(u, new CustomSkinProperty("textures", "sig", "src"));
             assertTrue(storage.hasPendingWrites(), "payload must be queued right after saveSkinAsync");
 
             storage.flushPending();
@@ -315,7 +315,7 @@ class SkinStorageTest {
         void writeAfterDelete_doesNotResurrect() throws Exception {
             UUID u = UUID.randomUUID();
             Path target = tempDir.resolve(u + ".json");
-            storage.saveSkinAsync(u, new CustomSkinProperty("textures", "sig", "src"));
+            CompletableFuture<Void> unused = storage.saveSkinAsync(u, new CustomSkinProperty("textures", "sig", "src"));
             assertTrue(storage.hasPendingWrites(), "payload must be queued before the delete");
 
             storage.removeSkin(u); // purges the deferred payload, serializes the delete
@@ -331,7 +331,7 @@ class SkinStorageTest {
             UUID u = UUID.randomUUID();
             assertFalse(storage.hasPendingWrites(), "no queue before any save");
 
-            storage.saveSkinAsync(u, new CustomSkinProperty("textures", "sig", "src"));
+            CompletableFuture<Void> unused = storage.saveSkinAsync(u, new CustomSkinProperty("textures", "sig", "src"));
             assertTrue(storage.hasPendingWrites(), "queue must be non-empty right after an async save");
 
             storage.flushPending();

--- a/forge-1.21/src/test/java/levosilimo/everlastingskins/forge21/skinchanger/SkinRefreshHandlerTest.java
+++ b/forge-1.21/src/test/java/levosilimo/everlastingskins/forge21/skinchanger/SkinRefreshHandlerTest.java
@@ -404,10 +404,17 @@ class SkinRefreshHandlerTest {
     @Test
     void applyAtomicPersistence_mutateProfileThrowing_failsSoft() {
         GameProfile profile = mock(GameProfile.class);
-        PropertyMap properties = spy(profileWithTextures(OLD_PROPERTY).getProperties());
+        // Real PropertyMap subclass (Mockito spies on Guava Multimaps are
+        // forbidden by @DoNotMock); only removeAll throws, everything else
+        // delegates to the real backing map.
+        PropertyMap properties = new PropertyMap() {
+            @Override
+            public Collection<Property> removeAll(Object key) {
+                throw new RuntimeException("simulated profile mutation failure");
+            }
+        };
+        properties.put("textures", OLD_PROPERTY);
         when(profile.getProperties()).thenReturn(properties);
-        doThrow(new RuntimeException("simulated profile mutation failure"))
-                .when(properties).removeAll("textures");
         storage.setSkin(PLAYER_UUID, NEW_SKIN);
         long failedBefore = SkinMetrics.INSTANCE.snapshot().refreshesFailed();
 

--- a/forge-1.21/src/test/java/levosilimo/everlastingskins/skinchanger/SkinCommandTabCompleteTest.java
+++ b/forge-1.21/src/test/java/levosilimo/everlastingskins/skinchanger/SkinCommandTabCompleteTest.java
@@ -240,7 +240,7 @@ class SkinCommandTabCompleteTest {
         // Mocking a Level subclass first initializes the registry chain
         // (BuiltInRegistries/Forge) that EntityDataSerializers needs when
         // ServerPlayer is instrumented; without it the mock fails to create.
-        mock(ServerLevel.class);
+        var unused = mock(ServerLevel.class);
         ServerPlayer player = mock(ServerPlayer.class);
         when(player.getUUID()).thenReturn(PLAYER_UUID);
         MinecraftServer server = mock(MinecraftServer.class);


### PR DESCRIPTION
## What

Adds **ErrorProne** — a compile-time static analysis engine that runs inside `javac` during `compileJava`. Tier 1: zero extra step, every build/CI compile is a check run.

- `buildSrc/build.gradle.kts`: pins `net.ltgt.errorprone` **5.1.0** (Gradle ≥ 7.1 / JDK ≥ 11; verified on Gradle 9.3.1 + JDK 21 toolchain). Declared as a classpath dependency — the `apply false` plugins-block variant does not land on the precompiled-script-plugin resolution classpath on Gradle 9.
- `buildSrc/src/main/kotlin/everlastingskins.errorprone.gradle.kts` (new): applies the plugin, declares `error_prone_core:2.50.0` (current stable, needs JDK 21 — this build's toolchain), disables warnings in generated code (Mixin AP output), suppresses two known FPs (`IdentityBinaryExpression`, `StringSplitter`).
- Applied to **all 5 root modules** via the forge-module convention and `:common`.

## FG 7.x compatibility — found and fixed (was the open question)

ErrorProne **crashed on forge-1.21** with `NoSuchMethodError: ImmutableMap$Builder.buildOrThrow()` on plugin init. Root cause: `mixin-0.8.7-processor.jar` **bundles ~1850 unrelocated old-Guava classes** (no `buildOrThrow`), and on the annotation processor path it shadows the Guava 33 that ErrorProne needs. Fix: declare `annotationProcessor("com.google.guava:guava:33.5.0-jre")` **before** the mixin processor in the forge-module convention so the modern Guava wins the processor-path load order. `:common` was unaffected (no mixin processor).

## Findings surfaced (all pre-existing, not introduced)

**Fixed in `:common` main (required — `:common` compiles with `-Werror`):**
- `PermissionServiceManager`: removed write-only `initialized` flag (`UnusedVariable`)
- `LatencyHistogram.percentiles()`: removed write-only `cumulative` (`UnusedVariable`)
- `RandomMojangSkin`: `new String(bytes)` → explicit UTF-8 (`DefaultCharset` — real portability bug); redundant parens (`UnnecessaryParentheses`)
- `MojangProfileCache`: `toLowerCase()` → `toLowerCase(Locale.ROOT)` ×2 (`StringCaseLocaleUsage` — real Turkish-locale bug)
- `SkinIO`: drain failures now logged in `drainPending` (previously escaped to the executor's default handler) + suppressed the now-truly-ignorable debounce future (`FutureReturnValueIgnored`); two best-effort empty catches documented (`EmptyCatch`)
- `HttpsUrlConnectionHttpClient`: debug log concat of `RequestBody` → SLF4J placeholders with the actual body, null-guarded (`ObjectToString`)
- `SkinUtils`: `toCharArray` loop → `charAt` indexing, stale perf comment dropped (`LoopOverCharArray`)
- `HttpResponse`: empty catch documented (`EmptyCatch`)
- `CustomSkinProperty`: `@SuppressWarnings("EqualsGetClass")` — **deliberate** `getClass()` equals on a public non-final library class; `instanceof` would change subclass semantics

**Fixed in tests** (so `:forge-1.21:test` compiles under the gate): `DoNotMock` (spy on Guava `Multimap` → real delegating `PropertyMap` subclass), `CheckReturnValue` (`mock()` discarded → `var unused =`), plus `FutureReturnValueIgnored`/`ClassCanBeStatic`/`StreamResourceLeak` (real unclosed `Files.list` stream)/`InvalidLink`/`StringCaseLocaleUsage` in `:common` tests.

## Rollout scoping

- **Main source sets: fully gated.** `:common` main is now Warning-free under `-Werror`.
- **Test/gametest source sets: ErrorProne disabled for this rollout.** The test suite carries pre-existing warning debt that trips `:common`'s `-Werror` and is a separate cleanup, not part of this change. Enabling it is the follow-up.
- **15 warnings remain in forge-1.21 main** (warnings only — forge modules have no `-Werror`): `FutureReturnValueIgnored` ×4, `NonAtomicVolatileUpdate` ×2 (real concurrency smell — worth a dedicated fix), `ReferenceEquality` ×2, `StatementSwitchToExpressionSwitch` ×2, `AnnotateFormatMethod`, `UnusedVariable`, `EmptyCatch`, `NotJavadoc`. All pre-existing; tracked as follow-ups.

## Verification

- `:forge-1.21:compileJava --no-daemon` ✅ · `:common:compileJava --no-daemon` ✅ · all 5 root modules `compileJava` ✅ · `:forge-1.21:test --no-daemon` ✅ · `:common:compileTestJava` ✅
