### PR TITLE
test(forge-1.16.5): add unit tests for MC 1.16.5-specific binding code

### DIFF
--- a/forge-1.16.5/build.gradle.kts
+++ b/forge-1.16.5/build.gradle.kts
@@ -154,6 +154,12 @@ dependencies {
     testImplementation("com.mojang:authlib:1.5.25")
     testImplementation("org.apache.logging.log4j:log4j-api:2.8.1")
     testImplementation("com.google.code.findbugs:jsr305:3.0.2")
+    // Mockito 4.x (not 5.x, which requires Java 11): this lane compiles and
+    // runs on Java 8. mockito-inline provides the inline mock maker needed
+    // for mockStatic (mirrors the root convention plugin's mockito usage).
+    testImplementation("org.mockito:mockito-core:4.11.0")
+    testImplementation("org.mockito:mockito-inline:4.11.0")
+    testImplementation("org.mockito:mockito-junit-jupiter:4.11.0")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.10.3")
 }
 

--- a/forge-1.16.5/src/test/java/levosilimo/everlastingskins/ConfigTest.java
+++ b/forge-1.16.5/src/test/java/levosilimo/everlastingskins/ConfigTest.java
@@ -1,0 +1,188 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins;
+
+import com.electronwill.nightconfig.core.InMemoryCommentedFormat;
+import net.minecraftforge.common.ForgeConfigSpec;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Config defaults and toggle behavior for the 1.16.5 lane's own
+ * {@link ForgeConfigSpec} definition (per-lane binding code; the MineSkin
+ * API-key threading covered by the 1.21 {@code ConfigTest} lives in
+ * {@code :common} and is covered there).
+ */
+class ConfigTest {
+
+    @BeforeAll
+    static void initConfig() {
+        // ForgeConfigSpec.ConfigValue.get() requires the spec to be loaded.
+        // Use an in-memory file config so defaults are served by the spec.
+        Config.COMMON_CONFIG.setConfig(
+                InMemoryCommentedFormat.defaultInstance().createConfig(java.util.HashMap::new));
+    }
+
+    /* ================================================================== */
+    /*  Config defaults                                                    */
+    /* ================================================================== */
+
+    @Nested
+    @DisplayName("Config defaults")
+    class ConfigDefaults {
+
+        @Test
+        @DisplayName("Default language is English")
+        void defaultLanguageIsEnglish() {
+            assertEquals("en", Config.LANGUAGE.get());
+        }
+
+        @Test
+        @DisplayName("Default toggle is true")
+        void defaultToggleIsTrue() {
+            assertTrue(Config.TOGGLE.get());
+        }
+
+        @Test
+        @DisplayName("Default MineSkin API key is empty")
+        void defaultMineskinApiKeyIsEmpty() {
+            assertEquals("", Config.MINESKIN_API_KEY.get());
+        }
+
+        @Test
+        @DisplayName("Default DiscordSRV enabled is false")
+        void defaultDiscordSrvEnabledIsFalse() {
+            assertFalse(Config.DISCORDSRV_ENABLED.get());
+        }
+
+        @Test
+        @DisplayName("Default DiscordSRV channel ID is empty")
+        void defaultDiscordSrvChannelIdIsEmpty() {
+            assertEquals("", Config.DISCORDSRV_CHANNEL_ID.get());
+        }
+
+        @Test
+        @DisplayName("Broadcast flags default: dim-scoped off, bundle off, entity tracker on")
+        void defaultBroadcastFlags() {
+            assertFalse(Config.DIMENSION_SCOPED_BROADCAST.get());
+            // BROADCAST_USE_BUNDLE is inert on 1.16.5 (no ClientboundBundlePacket),
+            // but the key must still default off.
+            assertFalse(Config.BROADCAST_USE_BUNDLE.get());
+            assertTrue(Config.REFRESH_VIA_ENTITY_TRACKER.get());
+        }
+
+        @Test
+        @DisplayName("Default permission op levels (mojang/clear/random all, url/other/metrics op)")
+        void defaultPermissionOpLevels() {
+            assertEquals(0, Config.PERMISSIONS_OP_LEVEL_MOJANG.get());
+            assertEquals(2, Config.PERMISSIONS_OP_LEVEL_URL.get());
+            assertEquals(0, Config.PERMISSIONS_OP_LEVEL_CLEAR.get());
+            assertEquals(0, Config.PERMISSIONS_OP_LEVEL_RANDOM.get());
+            assertEquals(2, Config.PERMISSIONS_OP_LEVEL_OTHER.get());
+            assertEquals(2, Config.PERMISSIONS_OP_LEVEL_METRICS.get());
+            assertEquals(2, Config.PERMISSIONS_OP_LEVEL_METRICS_RESET.get());
+        }
+
+        @Test
+        @DisplayName("Default message keys resolve to canonical English text")
+        void defaultMessageKeys() {
+            assertEquals("Skin change queued", Config.MESSAGES_CHANGE.get());
+            assertEquals("Permission denied", Config.MESSAGES_PERMISSION_DENIED.get());
+            assertEquals("Please wait %ds before using /skin again", Config.MESSAGES_COOLDOWN.get());
+            assertEquals("No skin found for \"%s\"", Config.MESSAGES_NO_SKIN_FOUND.get());
+            assertEquals("Metrics cleanup: pruned %d stale player entries", Config.MESSAGES_METRICS_CLEANUP.get());
+        }
+
+        @Test
+        @DisplayName("Default rate-limit window is 5 commands per minute")
+        void defaultRateLimit() {
+            assertEquals(3, Config.COOLDOWN_SECONDS.get());
+            assertTrue(Config.RATE_LIMIT_ENABLED.get());
+            assertEquals(5, Config.MAX_COMMANDS_PER_MINUTE.get());
+        }
+    }
+
+    /* ================================================================== */
+    /*  Toggle behavior                                                    */
+    /* ================================================================== */
+
+    @Nested
+    @DisplayName("Toggle behavior")
+    class ToggleBehavior {
+
+        @Test
+        @DisplayName("TOGGLE can be set to false and read back")
+        void toggleCanBeSetFalse() {
+            ForgeConfigSpec.BooleanValue toggle = Config.TOGGLE;
+            boolean original = toggle.get();
+            try {
+                toggle.set(false);
+                assertFalse(toggle.get());
+            } finally {
+                toggle.set(original);
+            }
+        }
+
+        @Test
+        @DisplayName("DIMENSION_SCOPED_BROADCAST can be toggled and read back")
+        void dimScopedCanBeToggled() {
+            ForgeConfigSpec.BooleanValue flag = Config.DIMENSION_SCOPED_BROADCAST;
+            boolean original = flag.get();
+            try {
+                flag.set(true);
+                assertTrue(flag.get());
+            } finally {
+                flag.set(original);
+            }
+        }
+    }
+
+    /* ================================================================== */
+    /*  Mojang cache config                                                */
+    /* ================================================================== */
+
+    @Nested
+    @DisplayName("Mojang cache config")
+    class MojangCacheConfig {
+
+        @Test
+        @DisplayName("MOJANG_CACHE_ENABLED defaults to true")
+        void mojangCacheEnabledDefault() {
+            assertTrue(Config.MOJANG_CACHE_ENABLED.get());
+        }
+
+        @Test
+        @DisplayName("MOJANG_CACHE_TTL_MS defaults to 1 hour")
+        void mojangCacheTtlDefault() {
+            assertEquals(3600000L, Config.MOJANG_CACHE_TTL_MS.get());
+        }
+
+        @Test
+        @DisplayName("MOJANG_CACHE_MAX_SIZE defaults to 1000")
+        void mojangCacheMaxSizeDefault() {
+            assertEquals(1000, Config.MOJANG_CACHE_MAX_SIZE.get());
+        }
+
+        @Test
+        @DisplayName("TTL can be set to 0 to disable caching")
+        void mojangCacheTtlZeroDisablesCaching() {
+            long orig = Config.MOJANG_CACHE_TTL_MS.get();
+            try {
+                Config.MOJANG_CACHE_TTL_MS.set(0L);
+                assertEquals(0L, Config.MOJANG_CACHE_TTL_MS.get());
+            } finally {
+                Config.MOJANG_CACHE_TTL_MS.set(orig);
+            }
+        }
+    }
+}

--- a/forge-1.16.5/src/test/java/levosilimo/everlastingskins/broadcast/FakeSkinBroadcaster.java
+++ b/forge-1.16.5/src/test/java/levosilimo/everlastingskins/broadcast/FakeSkinBroadcaster.java
@@ -1,0 +1,75 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.broadcast;
+
+import com.mojang.authlib.GameProfile;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.ServerPlayerEntity;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Recording fake of {@link SkinBroadcaster} for tests that want to assert
+ * the handler's call shape (broadcast then tracker) without rebuilding the
+ * REMOVE+ADD+cascade pipeline. Records every call into observable lists so
+ * tests can pin order and arguments.
+ *
+ * <p>Java 8 port note: the 1.21 lane's inner {@code record} is flattened to
+ * a plain final class — this lane compiles at source level 8.
+ */
+public class FakeSkinBroadcaster implements SkinBroadcaster {
+
+    public static final class BroadcastCall {
+        public final GameProfile profile;
+        public final ServerPlayerEntity target;
+        public final List<ServerPlayerEntity> observers;
+
+        BroadcastCall(GameProfile profile, ServerPlayerEntity target, ServerPlayerEntity[] observers) {
+            this.profile = profile;
+            this.target = target;
+            this.observers = observers == null ? Collections.emptyList() : Arrays.asList(observers);
+        }
+
+        public GameProfile profile() {
+            return profile;
+        }
+
+        public ServerPlayerEntity target() {
+            return target;
+        }
+
+        public List<ServerPlayerEntity> observers() {
+            return observers;
+        }
+    }
+
+    public final List<BroadcastCall> broadcastCalls = new ArrayList<>();
+    public final List<Entity> trackerCalls = new ArrayList<>();
+
+    @Override
+    public void broadcastProfileChange(GameProfile newProfile, ServerPlayerEntity target) {
+        broadcastCalls.add(new BroadcastCall(newProfile, target, (ServerPlayerEntity[]) null));
+    }
+
+    @Override
+    public void broadcastProfileChange(GameProfile newProfile, ServerPlayerEntity target, ServerPlayerEntity[] observers) {
+        broadcastCalls.add(new BroadcastCall(newProfile, target, observers));
+    }
+
+    @Override
+    public void trackerUntrackRetrack(Entity entity) {
+        trackerCalls.add(entity);
+    }
+
+    public void reset() {
+        broadcastCalls.clear();
+        trackerCalls.clear();
+    }
+}

--- a/forge-1.16.5/src/test/java/levosilimo/everlastingskins/broadcast/VanillaSkinBroadcasterTest.java
+++ b/forge-1.16.5/src/test/java/levosilimo/everlastingskins/broadcast/VanillaSkinBroadcasterTest.java
@@ -1,0 +1,398 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.broadcast;
+
+import com.electronwill.nightconfig.core.InMemoryCommentedFormat;
+import com.mojang.authlib.GameProfile;
+import com.mojang.authlib.properties.Property;
+import levosilimo.everlastingskins.Config;
+import levosilimo.everlastingskins.permission.TestConfigSupport;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.PlayerAbilities;
+import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.network.IPacket;
+import net.minecraft.network.play.ServerPlayNetHandler;
+import net.minecraft.network.play.server.SPlayerListItemPacket;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.management.PlayerInteractionManager;
+import net.minecraft.server.management.PlayerList;
+import net.minecraft.util.RegistryKey;
+import net.minecraft.world.GameType;
+import net.minecraft.world.World;
+import net.minecraft.world.server.ServerChunkProvider;
+import net.minecraft.world.server.ServerWorld;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Direct test of the production 1.16.5 {@link VanillaSkinBroadcaster}: pins
+ * the packet sequence the broadcaster emits for each combination of
+ * {@code DIMENSION_SCOPED_BROADCAST} and the explicit-observer vs
+ * broadcast-all variants.
+ *
+ * <p>1.16.5 delta vs the 1.21 lane (pinned here): there is no
+ * ClientboundBundlePacket and no separate REMOVE packet — the unified
+ * {@code SPlayerListItemPacket} carries both {@code REMOVE_PLAYER} and
+ * {@code ADD_PLAYER} actions, and {@code BROADCAST_USE_BUNDLE} is inert
+ * (the REMOVE+ADD pair is sent standalone either way).
+ */
+class VanillaSkinBroadcasterTest {
+
+    /**
+     * The unit-test JVM has no running server. On 1.16.5 the vanilla
+     * registry chain is self-initializing, but the order matters:
+     * {@code World.<clinit>} → {@code Registry.<clinit>} →
+     * {@code MemoryModuleType.<clinit>} → {@code GlobalPos.<clinit>} reads
+     * {@code World.RESOURCE_KEY_CODEC} — if {@code World} started the chain
+     * it is mid-clinit there and the read is null (NPE). The game initializes
+     * {@code Registry} first; force the same order here so {@code World}'s
+     * clinit always runs fresh. (1.16.5 has no isBootstrapped gate on
+     * registry access, so no flag trick is needed — but {@link
+     * Bootstrap#bootStrap()} itself must not be called: Forge patches it to
+     * run GameData.vanillaSnapshot(), which needs the FML runtime.)
+     */
+    static {
+        try {
+            Class.forName("net.minecraft.util.registry.Registry");
+        } catch (ClassNotFoundException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    private static final String TEXTURE_VALUE = "cGF5bG9hZA==";
+    private static final String TEXTURE_SIGNATURE = "c2lnbmF0dXJl";
+    private static final RegistryKey<World> OVERWORLD = World.OVERWORLD;
+    private static final RegistryKey<World> NETHER = World.NETHER;
+
+    private MinecraftServer server;
+    private PlayerList playerlist;
+    private ServerWorld overworldLevel;
+    private ServerWorld netherLevel;
+    private ServerChunkProvider chunkSource;
+
+    private ServerPlayerEntity target;
+    private ServerPlayerEntity observer1;
+    private ServerPlayerEntity netherObserver;
+
+    private final List<Object> targetStream = new ArrayList<>();
+    private final List<Object> observer1Stream = new ArrayList<>();
+    private final List<Object> netherStream = new ArrayList<>();
+    private final List<IPacket<?>> globalSink = new ArrayList<>();
+    private final List<String> chunkTrace = new ArrayList<>();
+
+    private VanillaSkinBroadcaster broadcaster;
+
+    @BeforeAll
+    static void loadConfig() {
+        TestConfigSupport.loadDefaults();
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        Config.COMMON_CONFIG.setConfig(
+                InMemoryCommentedFormat.defaultInstance().createConfig(HashMap::new));
+        Config.BROADCAST_USE_BUNDLE.set(false);
+        Config.DIMENSION_SCOPED_BROADCAST.set(false);
+        Config.REFRESH_VIA_ENTITY_TRACKER.set(true);
+
+        overworldLevel = levelMock(OVERWORLD);
+        netherLevel = levelMock(NETHER);
+        chunkSource = mock(ServerChunkProvider.class);
+        doAnswer(inv -> { chunkTrace.add("removeEntity"); return null; })
+            .when(chunkSource).removeEntity(any(Entity.class));
+        doAnswer(inv -> { chunkTrace.add("addEntity"); return null; })
+            .when(chunkSource).addEntity(any(Entity.class));
+        when(overworldLevel.getChunkSource()).thenReturn(chunkSource);
+        when(netherLevel.getChunkSource()).thenReturn(chunkSource);
+
+        playerlist = mock(PlayerList.class);
+        server = mock(MinecraftServer.class);
+        when(server.getPlayerList()).thenReturn(playerlist);
+
+        target = newPlayer("Target", overworldLevel);
+        observer1 = newPlayer("ObserverOne", overworldLevel);
+        netherObserver = newPlayer("NetherObserver", netherLevel);
+
+        List<ServerPlayerEntity> online = new ArrayList<>();
+        online.add(target);
+        online.add(observer1);
+        online.add(netherObserver);
+        when(playerlist.getPlayers()).thenReturn(online);
+
+        attachStream(target, targetStream);
+        attachStream(observer1, observer1Stream);
+        attachStream(netherObserver, netherStream);
+
+        doAnswer(inv -> {
+            IPacket<?> packet = inv.getArgument(0);
+            globalSink.add(packet);
+            for (ServerPlayerEntity onlinePlayer : online) {
+                streamFor(onlinePlayer).add(packet);
+            }
+            return null;
+        }).when(playerlist).broadcastAll(any(IPacket.class));
+
+        doAnswer(inv -> {
+            IPacket<?> packet = inv.getArgument(0);
+            @SuppressWarnings("unchecked")
+            RegistryKey<World> dim = inv.getArgument(1);
+            globalSink.add(packet);
+            for (ServerPlayerEntity onlinePlayer : online) {
+                if (onlinePlayer.getLevel().dimension().equals(dim)) {
+                    streamFor(onlinePlayer).add(packet);
+                }
+            }
+            return null;
+        }).when(playerlist).broadcastAll(any(IPacket.class), any(RegistryKey.class));
+
+        broadcaster = new VanillaSkinBroadcaster();
+    }
+
+    @AfterEach
+    void tearDown() {
+        Config.BROADCAST_USE_BUNDLE.set(false);
+        Config.DIMENSION_SCOPED_BROADCAST.set(false);
+        Config.REFRESH_VIA_ENTITY_TRACKER.set(true);
+    }
+
+    /* ================================================================== */
+    /*  Packet sequence contract                                          */
+    /* ================================================================== */
+
+    @Test
+    @DisplayName("REMOVE is emitted strictly before ADD (single SPlayerListItemPacket pair)")
+    void removeStrictlyBeforeAdd() {
+        broadcaster.broadcastProfileChange(target.getGameProfile(), target);
+
+        assertEquals(2, globalSink.size(), "exactly one REMOVE + one ADD");
+        assertEquals(SPlayerListItemPacket.Action.REMOVE_PLAYER, actionOf(globalSink.get(0)),
+            "first broadcast must be REMOVE; sink=" + globalSink);
+        assertEquals(SPlayerListItemPacket.Action.ADD_PLAYER, actionOf(globalSink.get(1)),
+            "second broadcast must be ADD; sink=" + globalSink);
+        int removeIdx = indexOfAction(targetStream, SPlayerListItemPacket.Action.REMOVE_PLAYER);
+        int addIdx = indexOfAction(targetStream, SPlayerListItemPacket.Action.ADD_PLAYER);
+        assertTrue(removeIdx >= 0 && addIdx == removeIdx + 1,
+            "REMOVE+ADD must be neighbors in the captured stream; stream=" + targetStream);
+    }
+
+    @Test
+    @DisplayName("BROADCAST_USE_BUNDLE is inert on 1.16.5 — the pair is still sent standalone")
+    void bundleFlag_inert_pairStillStandalone() {
+        Config.BROADCAST_USE_BUNDLE.set(true);
+        broadcaster.broadcastProfileChange(target.getGameProfile(), target);
+
+        // No bundle packet exists on 1.16.5; the REMOVE+ADD pair must be
+        // delivered as two standalone SPlayerListItemPackets regardless.
+        assertEquals(2, globalSink.size(), "exactly one REMOVE + one ADD, no bundle");
+        assertEquals(SPlayerListItemPacket.Action.REMOVE_PLAYER, actionOf(globalSink.get(0)));
+        assertEquals(SPlayerListItemPacket.Action.ADD_PLAYER, actionOf(globalSink.get(1)));
+    }
+
+    @Test
+    @DisplayName("Explicit-observer variant sends REMOVE+ADD only to the given observers")
+    void explicitObserver_variantReachesOnlyGivenSet() {
+        ServerPlayerEntity[] onlyOverworld = new ServerPlayerEntity[]{target, observer1};
+        broadcaster.broadcastProfileChange(target.getGameProfile(), target, onlyOverworld);
+
+        assertTrue(!observer1Stream.isEmpty(),
+            "observer1 must receive the broadcast; stream=" + observer1Stream);
+        assertEquals(0, netherStream.size(),
+            "nether observer must receive nothing when not in the explicit set; stream=" + netherStream);
+    }
+
+    @Test
+    @DisplayName("Explicit-observer variant with DIMENSION_SCOPED_BROADCAST still excludes other dimensions")
+    void explicitObserver_dimScoped_excludesCrossDim() {
+        Config.DIMENSION_SCOPED_BROADCAST.set(true);
+        ServerPlayerEntity[] allPlayers = new ServerPlayerEntity[]{target, observer1, netherObserver};
+        broadcaster.broadcastProfileChange(target.getGameProfile(), target, allPlayers);
+
+        assertEquals(0, netherStream.size(),
+            "nether observer must receive nothing when dim scoping is on; stream=" + netherStream);
+        assertTrue(!observer1Stream.isEmpty(),
+            "same-dim observer must receive the broadcast; stream=" + observer1Stream);
+    }
+
+    @Test
+    @DisplayName("DIMENSION_SCOPED_BROADCAST=true excludes nether observer in broadcast-all mode")
+    void dimScoped_broadcastAll_excludesCrossDim() {
+        Config.DIMENSION_SCOPED_BROADCAST.set(true);
+        broadcaster.broadcastProfileChange(target.getGameProfile(), target);
+
+        assertEquals(0, netherStream.size(),
+            "nether observer must receive nothing; stream=" + netherStream);
+        assertTrue(!observer1Stream.isEmpty(),
+            "same-dim observer must receive the broadcast; stream=" + observer1Stream);
+    }
+
+    @Test
+    @DisplayName("DIMENSION_SCOPED_BROADCAST=false delivers to all online players including nether")
+    void dimScoped_false_deliversEverywhere() {
+        Config.DIMENSION_SCOPED_BROADCAST.set(false);
+        broadcaster.broadcastProfileChange(target.getGameProfile(), target);
+
+        assertTrue(!netherStream.isEmpty(),
+            "nether observer must receive the broadcast when not dim scoped; stream=" + netherStream);
+        assertTrue(!observer1Stream.isEmpty(),
+            "observer1 must receive the broadcast; stream=" + observer1Stream);
+    }
+
+    /* ================================================================== */
+    /*  Tracker untrack/retrack                                           */
+    /* ================================================================== */
+
+    @Test
+    @DisplayName("trackerUntrackRetrack drives removeEntity then addEntity when flag is on")
+    void trackerUntrackRetrack_runsWhenEnabled() {
+        broadcaster.trackerUntrackRetrack(target);
+
+        assertEquals(2, chunkTrace.size(), "removeEntity then addEntity expected");
+        assertEquals("removeEntity", chunkTrace.get(0));
+        assertEquals("addEntity", chunkTrace.get(1));
+    }
+
+    @Test
+    @DisplayName("trackerUntrackRetrack is a no-op when REFRESH_VIA_ENTITY_TRACKER is off")
+    void trackerUntrackRetrack_skippedWhenDisabled() {
+        Config.REFRESH_VIA_ENTITY_TRACKER.set(false);
+        broadcaster.trackerUntrackRetrack(target);
+
+        assertEquals(Collections.emptyList(), chunkTrace,
+            "no chunk-source interaction expected");
+        verify(chunkSource, never()).removeEntity(any(Entity.class));
+        verify(chunkSource, never()).addEntity(any(Entity.class));
+    }
+
+    @Test
+    @DisplayName("trackerUntrackRetrack ignores non-ServerPlayer entities")
+    void trackerUntrackRetrack_ignoresNonServerPlayer() {
+        Entity other = mock(Entity.class);
+        broadcaster.trackerUntrackRetrack(other);
+
+        assertEquals(Collections.emptyList(), chunkTrace,
+            "non-ServerPlayer entities must not be untracked");
+    }
+
+    /* ================================================================== */
+    /*  ADD packet payload                                                 */
+    /* ================================================================== */
+
+    @Test
+    @DisplayName("ADD packet carries the player's GameProfile")
+    void addPacket_carriesTargetProfile() {
+        // Add a textures property to the target's profile so the assertion
+        // is non-trivial.
+        target.getGameProfile().getProperties().put("textures",
+            new Property("textures", TEXTURE_VALUE, TEXTURE_SIGNATURE));
+        broadcaster.broadcastProfileChange(target.getGameProfile(), target);
+
+        SPlayerListItemPacket add = filterAction(targetStream, SPlayerListItemPacket.Action.ADD_PLAYER);
+        assertNotNull(add, "ADD packet missing from stream=" + targetStream);
+        GameProfile carried = add.getEntries().get(0).getProfile();
+        assertNotNull(carried, "ADD packet must carry the player's profile");
+        boolean hasTexture = carried.getProperties().get("textures").stream()
+            .anyMatch(prop -> TEXTURE_VALUE.equals(prop.getValue()));
+        assertTrue(hasTexture, "ADD packet must carry the textures property");
+    }
+
+    /* ================================================================== */
+    /*  Helpers                                                            */
+    /* ================================================================== */
+
+    private ServerPlayerEntity newPlayer(String name, ServerWorld level) {
+        UUID uuid = UUID.randomUUID();
+        ServerPlayerEntity player = mock(ServerPlayerEntity.class);
+        when(player.getUUID()).thenReturn(uuid);
+        when(player.getGameProfile()).thenReturn(new GameProfile(uuid, name));
+        when(player.getLevel()).thenReturn(level);
+        when(player.getTabListDisplayName()).thenReturn(null);
+        when(player.getServer()).thenReturn(server);
+        // SPlayerListItemPacket's entry ctor reads gameMode.getGameModeForPlayer()
+        // and the connection's NetworkManager; field-back both.
+        ServerPlayNetHandler connection = mock(ServerPlayNetHandler.class);
+        setField(player, "connection", connection);
+        PlayerInteractionManager gameMode = mock(PlayerInteractionManager.class);
+        when(gameMode.getGameModeForPlayer()).thenReturn(GameType.SURVIVAL);
+        setField(player, "gameMode", gameMode);
+        setField(player, "abilities", new PlayerAbilities());
+        return player;
+    }
+
+    private List<Object> streamFor(ServerPlayerEntity player) {
+        if (player == target) return targetStream;
+        if (player == observer1) return observer1Stream;
+        if (player == netherObserver) return netherStream;
+        throw new IllegalArgumentException("unknown player: " + player);
+    }
+
+    private void attachStream(ServerPlayerEntity player, List<Object> stream) {
+        doAnswer(inv -> {
+            stream.add(inv.getArgument(0));
+            return null;
+        }).when(player.connection).send(any(IPacket.class));
+    }
+
+    private static ServerWorld levelMock(RegistryKey<World> dimension) {
+        ServerWorld level = mock(ServerWorld.class);
+        when(level.dimension()).thenReturn(dimension);
+        return level;
+    }
+
+    private static SPlayerListItemPacket.Action actionOf(Object packet) {
+        return ((SPlayerListItemPacket) packet).getAction();
+    }
+
+    private static int indexOfAction(List<?> events, SPlayerListItemPacket.Action action) {
+        for (int i = 0; i < events.size(); i++) {
+            if (events.get(i) instanceof SPlayerListItemPacket
+                    && ((SPlayerListItemPacket) events.get(i)).getAction() == action) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static SPlayerListItemPacket filterAction(List<?> events, SPlayerListItemPacket.Action action) {
+        for (Object event : events) {
+            if (event instanceof SPlayerListItemPacket
+                    && ((SPlayerListItemPacket) event).getAction() == action) {
+                return (SPlayerListItemPacket) event;
+            }
+        }
+        return null;
+    }
+
+    private static void setField(Object target, String fieldName, Object value) {
+        try {
+            Field field = ServerPlayerEntity.class.getField(fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Cannot set ServerPlayerEntity." + fieldName, e);
+        }
+    }
+}

--- a/forge-1.16.5/src/test/java/levosilimo/everlastingskins/integration/discordsrv/DiscordSrvHookTest.java
+++ b/forge-1.16.5/src/test/java/levosilimo/everlastingskins/integration/discordsrv/DiscordSrvHookTest.java
@@ -1,0 +1,114 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
+package levosilimo.everlastingskins.integration.discordsrv;
+
+import levosilimo.everlastingskins.Config;
+import levosilimo.everlastingskins.util.I18nUtils;
+import net.minecraft.entity.player.ServerPlayerEntity;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.electronwill.nightconfig.core.InMemoryCommentedFormat;
+
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the 1.16.5 {@link DiscordSrvHook}.
+ *
+ * <p>Unlike the 1.21 lane (which compiles against the DiscordSRV API), the
+ * 1.16.5 hook is fully reflective: {@code Class.forName} is the only entry
+ * point, and DiscordSRV is not on this lane's (test) classpath. That means
+ * every DSRV scenario — plugin absent, JDA absent, channel unset — reduces
+ * to one graceful path: the class lookup fails and the hook skips. The
+ * localized announcement text (per-player i18n, null fallbacks) is the
+ * part with real logic and is pinned here directly.
+ */
+class DiscordSrvHookTest {
+
+    /**
+     * The unit-test JVM has no running server. On 1.16.5 the vanilla
+     * registry chain is self-initializing, but the order matters:
+     * {@code World.<clinit>} → {@code Registry.<clinit>} →
+     * {@code MemoryModuleType.<clinit>} → {@code GlobalPos.<clinit>} reads
+     * {@code World.RESOURCE_KEY_CODEC} — if {@code World} started the chain
+     * it is mid-clinit there and the read is null (NPE). The game initializes
+     * {@code Registry} first; force the same order here so {@code World}'s
+     * clinit always runs fresh. (1.16.5 has no isBootstrapped gate on
+     * registry access, so no flag trick is needed.)
+     */
+    static {
+        try {
+            Class.forName("net.minecraft.util.registry.Registry");
+        } catch (ClassNotFoundException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    @BeforeAll
+    static void init() {
+        // Serve Config defaults so the null-player fallback (Config.LANGUAGE) works.
+        Config.COMMON_CONFIG.setConfig(
+                InMemoryCommentedFormat.defaultInstance().createConfig(java.util.HashMap::new));
+        // Load classpath locale resources for the announce assertions.
+        I18nUtils.loadAll();
+    }
+
+    @Test
+    @DisplayName("announce text uses the requested client language")
+    void discI18n_discordAnnounce_usesLocalizedMessage() {
+        String german = I18nUtils.getLocalizedString("discord_announce", "de_de");
+        assertTrue(german.contains("geändert"), "expected German text, got: " + german);
+        assertNotEquals("discord_announce", german);
+    }
+
+    @Test
+    @DisplayName("unsupported client language falls back to English")
+    void discI18n_discordAnnounce_fallbackToEnglishWhenLanguageUnsupported() {
+        String result = I18nUtils.getLocalizedString("discord_announce", "zz_zz");
+        assertTrue(result.contains("changed their skin"), "expected English fallback, got: " + result);
+    }
+
+    @Test
+    @DisplayName("null player falls back to the global locale")
+    void discI18n_discordAnnounce_nullPlayerUsesGlobalLocale() {
+        String result = DiscordSrvHook.formatAnnounce(null, "Notch");
+        assertTrue(result.contains("changed their skin"), "expected global-locale text, got: " + result);
+    }
+
+    @Test
+    @DisplayName("null skin source uses the 'default' label")
+    void discI18n_discordAnnounce_nullSourceDefaultsLabel() {
+        String result = DiscordSrvHook.formatAnnounce(null, null);
+        assertTrue(result.contains("`default`"), "expected default label, got: " + result);
+        String withSource = DiscordSrvHook.formatAnnounce(null, "Notch");
+        assertTrue(withSource.contains("`Notch`"), "expected source label, got: " + withSource);
+    }
+
+    @Test
+    @DisplayName("per-player format includes the scoreboard name")
+    void discI18n_discordAnnounce_includesPlayerName() {
+        ServerPlayerEntity player = mock(ServerPlayerEntity.class);
+        when(player.getScoreboardName()).thenReturn("Steve");
+        String result = DiscordSrvHook.formatAnnounce(player, "Notch");
+        assertTrue(result.contains("Steve"), "expected player name in text, got: " + result);
+    }
+
+    @Test
+    @DisplayName("DiscordSRV absent on the classpath is handled gracefully (reflective chain)")
+    void announceSkinChange_handlesMissingDiscordSrvClass() {
+        // Class.forName("github.scarsz.discordsrv.DiscordSRV") cannot resolve
+        // in this JVM; the hook must skip without throwing.
+        assertDoesNotThrow(() -> DiscordSrvHook.announceSkinChange(null, "TestSource"));
+    }
+}

--- a/forge-1.16.5/src/test/java/levosilimo/everlastingskins/permission/TestConfigSupport.java
+++ b/forge-1.16.5/src/test/java/levosilimo/everlastingskins/permission/TestConfigSupport.java
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
+package levosilimo.everlastingskins.permission;
+
+import com.electronwill.nightconfig.core.CommentedConfig;
+import levosilimo.everlastingskins.Config;
+
+/** Loads the common config in unit tests so Config values are readable without FML boot. */
+public final class TestConfigSupport {
+
+    private TestConfigSupport() {
+    }
+
+    public static void loadDefaults() {
+        Config.COMMON_CONFIG.setConfig(CommentedConfig.inMemory());
+    }
+}

--- a/forge-1.16.5/src/test/java/levosilimo/everlastingskins/permission/VanillaPermissionServiceTest.java
+++ b/forge-1.16.5/src/test/java/levosilimo/everlastingskins/permission/VanillaPermissionServiceTest.java
@@ -1,0 +1,113 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
+package levosilimo.everlastingskins.permission;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class VanillaPermissionServiceTest {
+
+    private final VanillaPermissionService service = new VanillaPermissionService();
+
+    @BeforeAll
+    static void loadConfig() {
+        TestConfigSupport.loadDefaults();
+    }
+
+    @Test
+    @DisplayName("Backend name is correct")
+    void backendName() {
+        assertEquals("Vanilla (per-command op levels)", service.getActiveBackendName());
+    }
+
+    @Test
+    @DisplayName("Priority is 0")
+    void priority() {
+        assertEquals(0, service.getPriority());
+    }
+
+    @Test
+    @DisplayName("Service is an IPermissionService")
+    void implementsInterface() {
+        assertInstanceOf(IPermissionService.class, service);
+    }
+
+    @Test
+    @DisplayName("opLevel 0 meets required level 0 (mojang node default)")
+    void opLevel0_required0_granted() {
+        PermissionContext ctx = PermissionContext.of(UUID.randomUUID(), 0);
+        assertTrue(service.hasPermission(ctx.uuid(), ctx.opLevel(), "everlastingskins.command.skin"));
+    }
+
+    @Test
+    @DisplayName("opLevel 0 lacks required level 2 (metrics node default)")
+    void opLevel0_required2_denied() {
+        PermissionContext ctx = PermissionContext.of(UUID.randomUUID(), 0);
+        assertFalse(service.hasPermission(ctx.uuid(), ctx.opLevel(), "everlastingskins.command.metrics"));
+    }
+
+    @Test
+    @DisplayName("opLevel 2 meets required level 2")
+    void opLevel2_required2_granted() {
+        PermissionContext ctx = PermissionContext.of(UUID.randomUUID(), 2);
+        assertTrue(service.hasPermission(ctx.uuid(), ctx.opLevel(), "everlastingskins.command.metrics"));
+    }
+
+    @Test
+    @DisplayName("opLevel 4 meets required level 2")
+    void opLevel4_required2_granted() {
+        PermissionContext ctx = PermissionContext.of(UUID.randomUUID(), 4);
+        assertTrue(service.hasPermission(ctx.uuid(), ctx.opLevel(), "everlastingskins.command.skin.other"));
+    }
+
+    @Test
+    @DisplayName("Source node is always granted regardless of op level")
+    void hasPermission_sourceNode_returnsTrueForNonOp() {
+        PermissionContext ctx = PermissionContext.of(UUID.randomUUID(), 0);
+        assertTrue(service.hasPermission(ctx.uuid(), ctx.opLevel(), "everlastingskins.command.skin.source"));
+    }
+
+    @Test
+    @DisplayName("Bypass cooldown node requires op level 2")
+    void bypassCooldown_requiresOpLevel2() {
+        assertTrue(service.hasPermission(PermissionContext.of(UUID.randomUUID(), 2).uuid(), PermissionContext.of(UUID.randomUUID(), 2).opLevel(), "everlastingskins.bypass.cooldown"));
+        assertFalse(service.hasPermission(PermissionContext.of(UUID.randomUUID(), 0).uuid(), PermissionContext.of(UUID.randomUUID(), 0).opLevel(), "everlastingskins.bypass.cooldown"));
+    }
+
+    @Test
+    @DisplayName("Unknown nodes default to required level 0")
+    void unknownNode_defaultsToAll() {
+        PermissionContext ctx = PermissionContext.of(UUID.randomUUID(), 0);
+        assertTrue(service.hasPermission(ctx.uuid(), ctx.opLevel(), "any.node"));
+    }
+
+    @Test
+    @DisplayName("Op level outside 0-4 is rejected")
+    void opLevelOutOfRange_rejected() {
+        assertThrows(IllegalArgumentException.class,
+            () -> PermissionContext.of(UUID.randomUUID(), -1));
+        assertThrows(IllegalArgumentException.class,
+            () -> PermissionContext.of(UUID.randomUUID(), 5));
+    }
+
+    @Test
+    @DisplayName("null uuid is rejected")
+    void nullUuid_rejected() {
+        assertThrows(NullPointerException.class,
+            () -> PermissionContext.of(null, 0));
+    }
+}

--- a/forge-1.16.5/src/test/java/levosilimo/everlastingskins/permission/forge/ForgePermissionServiceTest.java
+++ b/forge-1.16.5/src/test/java/levosilimo/everlastingskins/permission/forge/ForgePermissionServiceTest.java
@@ -1,0 +1,288 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
+package levosilimo.everlastingskins.permission.forge;
+
+import com.mojang.authlib.GameProfile;
+import levosilimo.everlastingskins.permission.PermissionContext;
+import levosilimo.everlastingskins.permission.PermissionServiceManager;
+import levosilimo.everlastingskins.permission.TestConfigSupport;
+import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.management.PlayerList;
+import net.minecraftforge.fml.server.ServerLifecycleHooks;
+import net.minecraftforge.server.permission.DefaultPermissionLevel;
+import net.minecraftforge.server.permission.PermissionAPI;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the 1.16.5 {@link ForgePermissionService} — the legacy
+ * string-node Forge permission backend (1.16.5 has no PermissionNode API;
+ * nodes are registered via {@link PermissionAPI#registerNode} and checked
+ * via {@code PermissionAPI.hasPermission}). Pins the online-vs-offline
+ * routing (ServerLifecycleHooks → PlayerList lookup vs GameProfile fallback)
+ * and the vanilla op-level fallback when the API throws.
+ */
+class ForgePermissionServiceTest {
+
+    /**
+     * The unit-test JVM has no running server. On 1.16.5 the vanilla
+     * registry chain is self-initializing, but the order matters:
+     * {@code World.<clinit>} → {@code Registry.<clinit>} →
+     * {@code MemoryModuleType.<clinit>} → {@code GlobalPos.<clinit>} reads
+     * {@code World.RESOURCE_KEY_CODEC} — if {@code World} started the chain
+     * it is mid-clinit there and the read is null (NPE). The game initializes
+     * {@code Registry} first; force the same order here so {@code World}'s
+     * clinit always runs fresh. (1.16.5 has no isBootstrapped gate on
+     * registry access, so no flag trick is needed — but {@link
+     * Bootstrap#bootStrap()} itself must not be called: Forge patches it to
+     * run GameData.vanillaSnapshot(), which needs the FML runtime.)
+     */
+    static {
+        try {
+            Class.forName("net.minecraft.util.registry.Registry");
+        } catch (ClassNotFoundException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    private static final UUID TEST_UUID = UUID.fromString("069a79f4-44e9-4726-a5be-fca90e38aaf5");
+    private static final String SKIN_NODE = "everlastingskins.command.skin";
+    private static final String METRICS_NODE = "everlastingskins.command.metrics";
+    private static final String SKIN_OTHER_NODE = "everlastingskins.command.skin.other";
+
+    @BeforeAll
+    static void loadConfig() {
+        TestConfigSupport.loadDefaults();
+    }
+
+    /* ================================================================== */
+    /*  Offline routing (no server context)                                */
+    /* ================================================================== */
+
+    @Test
+    @DisplayName("hasPermission returns true when PermissionAPI grants it (offline GameProfile path)")
+    void hasPermission_granted_returnsTrue() {
+        try (MockedStatic<PermissionAPI> api = mockStatic(PermissionAPI.class)) {
+            UUID uuid = UUID.randomUUID();
+            PermissionContext ctx = PermissionContext.of(uuid, 0);
+            api.when(() -> PermissionAPI.hasPermission(any(GameProfile.class), eq(SKIN_NODE), isNull()))
+               .thenReturn(true);
+            ForgePermissionService service = new ForgePermissionService();
+            assertTrue(service.hasPermission(ctx.uuid(), ctx.opLevel(), SKIN_NODE));
+        }
+    }
+
+    @Test
+    @DisplayName("hasPermission returns false when PermissionAPI denies it (offline GameProfile path)")
+    void hasPermission_denied_returnsFalse() {
+        try (MockedStatic<PermissionAPI> api = mockStatic(PermissionAPI.class)) {
+            UUID uuid = UUID.randomUUID();
+            PermissionContext ctx = PermissionContext.of(uuid, 0);
+            api.when(() -> PermissionAPI.hasPermission(any(GameProfile.class), eq(SKIN_NODE), isNull()))
+               .thenReturn(false);
+            ForgePermissionService service = new ForgePermissionService();
+            assertFalse(service.hasPermission(ctx.uuid(), ctx.opLevel(), SKIN_NODE));
+        }
+    }
+
+    @Test
+    @DisplayName("delegates the exact permission node to the API")
+    void hasPermission_delegatesNodeString() {
+        try (MockedStatic<PermissionAPI> api = mockStatic(PermissionAPI.class)) {
+            UUID uuid = UUID.randomUUID();
+            PermissionContext ctx = PermissionContext.of(uuid, 0);
+            api.when(() -> PermissionAPI.hasPermission(any(GameProfile.class), eq(SKIN_OTHER_NODE), isNull()))
+               .thenReturn(true);
+            ForgePermissionService service = new ForgePermissionService();
+            assertTrue(service.hasPermission(ctx.uuid(), ctx.opLevel(), SKIN_OTHER_NODE));
+        }
+    }
+
+    @Test
+    @DisplayName(".skin.source is NOT special-cased on 1.16.5 — delegated to the API")
+    void hasPermission_sourceNode_delegatesToApi() {
+        // 1.21's backend short-circuits .source; the 1.16.5 legacy backend
+        // passes every node to PermissionAPI — pin that delta.
+        try (MockedStatic<PermissionAPI> api = mockStatic(PermissionAPI.class)) {
+            UUID uuid = UUID.randomUUID();
+            PermissionContext ctx = PermissionContext.of(uuid, 0);
+            api.when(() -> PermissionAPI.hasPermission(any(GameProfile.class), eq("everlastingskins.command.skin.source"), isNull()))
+               .thenReturn(false);
+            ForgePermissionService service = new ForgePermissionService();
+            assertFalse(service.hasPermission(ctx.uuid(), ctx.opLevel(), "everlastingskins.command.skin.source"));
+        }
+    }
+
+    /* ================================================================== */
+    /*  Online routing (live server context)                               */
+    /* ================================================================== */
+
+    @Test
+    @DisplayName("online player routes through PermissionAPI.hasPermission(PlayerEntity, node)")
+    void hasPermission_onlinePlayer_usesPlayerEntityVariant() {
+        try (MockedStatic<ServerLifecycleHooks> hooks = mockStatic(ServerLifecycleHooks.class);
+             MockedStatic<PermissionAPI> api = mockStatic(PermissionAPI.class)) {
+            MinecraftServer server = mock(MinecraftServer.class);
+            PlayerList playerlist = mock(PlayerList.class);
+            ServerPlayerEntity player = mock(ServerPlayerEntity.class);
+            when(server.getPlayerList()).thenReturn(playerlist);
+            when(playerlist.getPlayer(TEST_UUID)).thenReturn(player);
+            hooks.when(ServerLifecycleHooks::getCurrentServer).thenReturn(server);
+            api.when(() -> PermissionAPI.hasPermission(any(ServerPlayerEntity.class), eq(SKIN_NODE)))
+               .thenReturn(true);
+
+            ForgePermissionService service = new ForgePermissionService();
+            assertTrue(service.hasPermission(TEST_UUID, 0, SKIN_NODE));
+            api.verify(() -> PermissionAPI.hasPermission(eq(player), eq(SKIN_NODE)), times(1));
+        }
+    }
+
+    @Test
+    @DisplayName("no server context routes through the GameProfile path, never the live player path")
+    void hasPermission_noServer_usesGameProfilePath() {
+        try (MockedStatic<ServerLifecycleHooks> hooks = mockStatic(ServerLifecycleHooks.class);
+             MockedStatic<PermissionAPI> api = mockStatic(PermissionAPI.class)) {
+            hooks.when(ServerLifecycleHooks::getCurrentServer).thenReturn(null);
+            api.when(() -> PermissionAPI.hasPermission(any(GameProfile.class), eq(SKIN_NODE), isNull()))
+               .thenReturn(false);
+
+            ForgePermissionService service = new ForgePermissionService();
+            assertFalse(service.hasPermission(TEST_UUID, 0, SKIN_NODE));
+            api.verify(() -> PermissionAPI.hasPermission(any(GameProfile.class), eq(SKIN_NODE), isNull()));
+            api.verify(() -> PermissionAPI.hasPermission(any(ServerPlayerEntity.class), any(String.class)), never());
+        }
+    }
+
+    @Test
+    @DisplayName("getPlayer throws → treated as offline (null player path)")
+    void hasPermission_playerLookupThrows_usesGameProfilePath() {
+        try (MockedStatic<ServerLifecycleHooks> hooks = mockStatic(ServerLifecycleHooks.class);
+             MockedStatic<PermissionAPI> api = mockStatic(PermissionAPI.class)) {
+            MinecraftServer server = mock(MinecraftServer.class);
+            PlayerList playerlist = mock(PlayerList.class);
+            when(server.getPlayerList()).thenReturn(playerlist);
+            when(playerlist.getPlayer(TEST_UUID)).thenThrow(new RuntimeException("player list unavailable"));
+            hooks.when(ServerLifecycleHooks::getCurrentServer).thenReturn(server);
+            api.when(() -> PermissionAPI.hasPermission(any(GameProfile.class), eq(SKIN_NODE), isNull()))
+               .thenReturn(true);
+
+            ForgePermissionService service = new ForgePermissionService();
+            assertTrue(service.hasPermission(TEST_UUID, 0, SKIN_NODE),
+                "a failing player lookup must degrade to the offline path");
+        }
+    }
+
+    /* ================================================================== */
+    /*  Vanilla fallback when the API throws                               */
+    /* ================================================================== */
+
+    @Test
+    @DisplayName("PermissionAPI throws → falls back to per-node op levels")
+    void hasPermission_apiThrows_fallbackToVanillaOpLevels() {
+        try (MockedStatic<ServerLifecycleHooks> hooks = mockStatic(ServerLifecycleHooks.class);
+             MockedStatic<PermissionAPI> api = mockStatic(PermissionAPI.class)) {
+            hooks.when(ServerLifecycleHooks::getCurrentServer).thenReturn(null);
+            api.when(() -> PermissionAPI.hasPermission(any(GameProfile.class), eq(METRICS_NODE), isNull()))
+               .thenThrow(new RuntimeException("PermissionAPI unavailable"));
+
+            ForgePermissionService service = new ForgePermissionService();
+            PermissionContext opCtx = PermissionContext.of(TEST_UUID, 2);
+            assertTrue(service.hasPermission(opCtx.uuid(), opCtx.opLevel(), METRICS_NODE),
+                "op 2 meets the metrics default level");
+            PermissionContext nonOpCtx = PermissionContext.of(TEST_UUID, 0);
+            assertFalse(service.hasPermission(nonOpCtx.uuid(), nonOpCtx.opLevel(), METRICS_NODE),
+                "op 0 does not meet the metrics default level");
+        }
+    }
+
+    /* ================================================================== */
+    /*  Node registration                                                  */
+    /* ================================================================== */
+
+    @Test
+    @DisplayName("registerNodes registers all skin, source, bypass and metrics nodes")
+    void registerNodes_registersAllNodes() {
+        try (MockedStatic<PermissionAPI> api = mockStatic(PermissionAPI.class);
+             MockedStatic<PermissionServiceManager> manager = mockStatic(PermissionServiceManager.class)) {
+            ForgePermissionService.registerNodes();
+
+            api.verify(() -> PermissionAPI.registerNode(eq("everlastingskins.command.skin"), eq(DefaultPermissionLevel.ALL), any(String.class)));
+            api.verify(() -> PermissionAPI.registerNode(eq("everlastingskins.command.skin.other"), eq(DefaultPermissionLevel.OP), any(String.class)));
+            api.verify(() -> PermissionAPI.registerNode(eq("everlastingskins.command.skin.url"), eq(DefaultPermissionLevel.ALL), any(String.class)));
+            api.verify(() -> PermissionAPI.registerNode(eq("everlastingskins.command.skin.clear"), eq(DefaultPermissionLevel.ALL), any(String.class)));
+            api.verify(() -> PermissionAPI.registerNode(eq("everlastingskins.command.metrics"), eq(DefaultPermissionLevel.OP), any(String.class)));
+            api.verify(() -> PermissionAPI.registerNode(eq("everlastingskins.command.metrics.reset"), eq(DefaultPermissionLevel.OP), any(String.class)));
+            api.verify(() -> PermissionAPI.registerNode(eq("everlastingskins.command.skin.source"), eq(DefaultPermissionLevel.ALL), any(String.class)));
+            api.verify(() -> PermissionAPI.registerNode(eq("everlastingskins.bypass.cooldown"), eq(DefaultPermissionLevel.OP), any(String.class)));
+            manager.verify(() -> PermissionServiceManager.registerService(any(ForgePermissionService.class)));
+        }
+    }
+
+    /* ================================================================== */
+    /*  Metadata                                                           */
+    /* ================================================================== */
+
+    @Test
+    @DisplayName("Backend name is correct")
+    void getActiveBackendName() {
+        assertEquals("Forge PermissionAPI (1.16.5)", new ForgePermissionService().getActiveBackendName());
+    }
+
+    @Test
+    @DisplayName("Priority is 10")
+    void getPriority() {
+        assertEquals(10, new ForgePermissionService().getPriority());
+    }
+
+    /* ================================================================== */
+    /*  Exception resilience                                               */
+    /* ================================================================== */
+
+    @Nested
+    @DisplayName("Exception resilience")
+    class ExceptionResilience {
+
+        @Test
+        @DisplayName("PermissionAPI throws for .skin.other → falls back to per-node op levels")
+        void permissionApi_throwsOnOtherNode_fallbackToOp() {
+            try (MockedStatic<ServerLifecycleHooks> hooks = mockStatic(ServerLifecycleHooks.class);
+                 MockedStatic<PermissionAPI> api = mockStatic(PermissionAPI.class)) {
+                hooks.when(ServerLifecycleHooks::getCurrentServer).thenReturn(null);
+                api.when(() -> PermissionAPI.hasPermission(any(GameProfile.class), eq(SKIN_OTHER_NODE), isNull()))
+                   .thenThrow(new RuntimeException("node not registered"));
+
+                ForgePermissionService service = new ForgePermissionService();
+
+                PermissionContext opCtx = PermissionContext.of(TEST_UUID, 2);
+                assertTrue(service.hasPermission(opCtx.uuid(), opCtx.opLevel(), SKIN_OTHER_NODE));
+
+                PermissionContext nonOpCtx = PermissionContext.of(TEST_UUID, 0);
+                assertFalse(service.hasPermission(nonOpCtx.uuid(), nonOpCtx.opLevel(), SKIN_OTHER_NODE));
+            }
+        }
+    }
+}

--- a/forge-1.16.5/src/test/java/levosilimo/everlastingskins/skinchanger/SkinRefreshHandlerTest.java
+++ b/forge-1.16.5/src/test/java/levosilimo/everlastingskins/skinchanger/SkinRefreshHandlerTest.java
@@ -1,0 +1,795 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import com.electronwill.nightconfig.core.InMemoryCommentedFormat;
+import com.mojang.authlib.GameProfile;
+import com.mojang.authlib.properties.Property;
+import com.mojang.authlib.properties.PropertyMap;
+import levosilimo.everlastingskins.Config;
+import levosilimo.everlastingskins.broadcast.FakeSkinBroadcaster;
+import levosilimo.everlastingskins.broadcast.VanillaSkinBroadcaster;
+import levosilimo.everlastingskins.enums.SkinActionType;
+import levosilimo.everlastingskins.metrics.SkinMetrics;
+import levosilimo.everlastingskins.permission.TestConfigSupport;
+import levosilimo.everlastingskins.skinchanger.responses.mojang.MojangSkinDataResult;
+import levosilimo.everlastingskins.util.CustomSkinProperty;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.PlayerAbilities;
+import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.network.IPacket;
+import net.minecraft.network.play.ServerPlayNetHandler;
+import net.minecraft.network.play.server.SPlayerAbilitiesPacket;
+import net.minecraft.network.play.server.SPlayerPositionLookPacket;
+import net.minecraft.network.play.server.SRespawnPacket;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.management.PlayerInteractionManager;
+import net.minecraft.server.management.PlayerList;
+import net.minecraft.util.RegistryKey;
+import net.minecraft.util.math.vector.Vector3d;
+import net.minecraft.world.DimensionType;
+import net.minecraft.world.GameType;
+import net.minecraft.world.World;
+import net.minecraft.world.server.ServerChunkProvider;
+import net.minecraft.world.server.ServerWorld;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyFloat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+/**
+ * Broadcast/cascade ordering contract of the 1.16.5 refresh pipeline
+ * ({@link SkinRefreshHandler#task}). Pure Mockito unit test: players,
+ * server, player list and level are mocks; the per-connection packet
+ * stream is captured, and the broadcaster seam is exercised via
+ * {@link FakeSkinBroadcaster}.
+ *
+ * <p>1.16.5 cascade shape (pinned here): the target connection receives
+ * {@code SRespawnPacket} then the {@code ServerPlayNetHandler#teleport}
+ * call (which is what sends the vanilla {@code SPlayerPositionLookPacket}
+ * on this version — the handler never builds that packet itself), then the
+ * three PlayerList helper sends (level info, permission level, all player
+ * info), then an explicit {@code SPlayerAbilitiesPacket} (1.16.5's
+ * sendAllPlayerInfo does not include abilities). The teleport arguments
+ * must reproduce the player's position/yaw/pitch.
+ *
+ * <p>Cascade atomicity invariant (R3): the disk flush must be enqueued
+ * BEFORE the GameProfile is mutated, so a failed enqueue leaves the
+ * applied profile untouched — applied and on-disk skin stay consistent.
+ * The invariant lives in {@link SkinRefreshHandler#applyAtomicPersistence}
+ * so it is unit-testable without a ServerPlayerEntity.
+ */
+class SkinRefreshHandlerTest {
+
+    /**
+     * The unit-test JVM has no running server. On 1.16.5 the vanilla
+     * registry chain is self-initializing, but the order matters:
+     * {@code World.<clinit>} → {@code Registry.<clinit>} →
+     * {@code MemoryModuleType.<clinit>} → {@code GlobalPos.<clinit>} reads
+     * {@code World.RESOURCE_KEY_CODEC} — if {@code World} started the chain
+     * it is mid-clinit there and the read is null (NPE). The game initializes
+     * {@code Registry} first; force the same order here so {@code World}'s
+     * clinit always runs fresh. (1.16.5 has no isBootstrapped gate on
+     * registry access, so no flag trick is needed — but {@link
+     * Bootstrap#bootStrap()} itself must not be called: Forge patches it to
+     * run GameData.vanillaSnapshot(), which needs the FML runtime.)
+     */
+    static {
+        try {
+            Class.forName("net.minecraft.util.registry.Registry");
+        } catch (ClassNotFoundException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    private static final String TEXTURE_VALUE = "cGF5bG9hZA==";
+    private static final String TEXTURE_SIGNATURE = "c2lnbmF0dXJl";
+    private static final RegistryKey<World> OVERWORLD = World.OVERWORLD;
+
+    private static final UUID PLAYER_UUID = UUID.randomUUID();
+    private static final Property OLD_PROPERTY = new Property("textures", "oldValue", "oldSignature");
+    private static final CustomSkinProperty NEW_SKIN =
+            new CustomSkinProperty("textures", "newValue", "newSignature", "MojangAPI");
+
+    @TempDir
+    Path tempDir;
+
+    private SkinIO skinIO;
+    private SkinStorage storage;
+
+    private MinecraftServer server;
+    private PlayerList playerlist;
+    private ServerWorld overworldLevel;
+    private ServerChunkProvider chunkSource;
+
+    private ServerPlayerEntity target;
+
+    private FakeSkinBroadcaster fakeBroadcaster;
+
+    private final Map<ServerPlayerEntity, List<Object>> playerStreams = new HashMap<>();
+    private List<Object> targetStream;
+
+    private final List<Object> teleportCalls = new ArrayList<>();
+
+    @BeforeAll
+    static void loadConfig() {
+        TestConfigSupport.loadDefaults();
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        // Make the ForgeConfigSpec usable outside a loaded config file
+        // (same pattern as ConfigTest).
+        Config.COMMON_CONFIG.setConfig(
+                InMemoryCommentedFormat.defaultInstance().createConfig(HashMap::new));
+        Config.BROADCAST_USE_BUNDLE.set(false);
+        Config.DIMENSION_SCOPED_BROADCAST.set(false);
+        Config.REFRESH_VIA_ENTITY_TRACKER.set(true);
+
+        Path skinDir = tempDir.resolve("EverlastingSkins");
+        Files.createDirectories(skinDir);
+        skinIO = new SkinIO(skinDir);
+        storage = new SkinStorage(skinIO);
+        setStaticField(SkinRestorer.class, "skinStorage", storage);
+        SkinRestorer.server = null;
+        SkinMetrics.INSTANCE.reset();
+        SkinRefreshHandler.resetRefreshTaskCount();
+
+        playerStreams.clear();
+        teleportCalls.clear();
+
+        overworldLevel = levelMock(OVERWORLD);
+        chunkSource = mock(ServerChunkProvider.class);
+        when(overworldLevel.getChunkSource()).thenReturn(chunkSource);
+
+        playerlist = mock(PlayerList.class);
+        server = mock(MinecraftServer.class);
+        when(server.getPlayerList()).thenReturn(playerlist);
+        SkinRestorer.server = server;
+
+        target = newPlayer("Target", overworldLevel);
+
+        targetStream = streamFor(target);
+
+        // Faithful PlayerList seams: emit a marker for each helper send so
+        // the captured stream pins the cascade order.
+        doAnswer(inv -> {
+            streamFor(inv.getArgument(0)).add("sendLevelInfo");
+            return null;
+        }).when(playerlist).sendLevelInfo(any(ServerPlayerEntity.class), any(ServerWorld.class));
+        doAnswer(inv -> {
+            streamFor(inv.getArgument(0)).add("sendPlayerPermissionLevel");
+            return null;
+        }).when(playerlist).sendPlayerPermissionLevel(any(ServerPlayerEntity.class));
+        doAnswer(inv -> {
+            streamFor(inv.getArgument(0)).add("sendAllPlayerInfo");
+            return null;
+        }).when(playerlist).sendAllPlayerInfo(any(ServerPlayerEntity.class));
+
+        // Inject the recording fake; assertions read its call lists.
+        fakeBroadcaster = new FakeSkinBroadcaster();
+        SkinRefreshHandler.setBroadcaster(fakeBroadcaster);
+
+        storage.setSkin(target.getUUID(),
+                new CustomSkinProperty("textures", TEXTURE_VALUE, TEXTURE_SIGNATURE, "Notch"));
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        Config.BROADCAST_USE_BUNDLE.set(false);
+        Config.DIMENSION_SCOPED_BROADCAST.set(false);
+        Config.REFRESH_VIA_ENTITY_TRACKER.set(true);
+        skinIO.flushPending();
+        setStaticField(SkinRestorer.class, "skinStorage", null);
+        SkinRestorer.server = null;
+        // Restore the production broadcaster so a later test in the same JVM
+        // does not see the fake.
+        SkinRefreshHandler.setBroadcaster(new VanillaSkinBroadcaster());
+    }
+
+    /* ================================================================== */
+    /*  A. Broadcaster call shape                                          */
+    /* ================================================================== */
+
+    @Test
+    @DisplayName("handler invokes broadcastProfileChange then trackerUntrackRetrack (tracker flag enabled)")
+    void handlerCalls_broadcastThenTracker() {
+        refresh();
+
+        assertEquals(1, fakeBroadcaster.broadcastCalls.size(),
+            "exactly one broadcastProfileChange per refresh; calls=" + fakeBroadcaster.broadcastCalls);
+        assertEquals(1, fakeBroadcaster.trackerCalls.size(),
+            "exactly one trackerUntrackRetrack per refresh; calls=" + fakeBroadcaster.trackerCalls);
+        assertEquals(target, fakeBroadcaster.broadcastCalls.get(0).target(),
+            "broadcast target must be the refreshed player");
+        assertEquals(target, fakeBroadcaster.trackerCalls.get(0),
+            "tracker call must target the refreshed player");
+    }
+
+    @Test
+    @DisplayName("handler always invokes trackerUntrackRetrack; flag check lives in the broadcaster")
+    void handlerCalls_trackerEvenWhenFlagDisabled() {
+        // The handler unconditionally delegates to broadcaster.trackerUntrackRetrack;
+        // the broadcaster reads REFRESH_VIA_ENTITY_TRACKER and is a no-op when off.
+        Config.REFRESH_VIA_ENTITY_TRACKER.set(false);
+        refresh();
+
+        assertEquals(1, fakeBroadcaster.broadcastCalls.size(),
+            "broadcast still runs; calls=" + fakeBroadcaster.broadcastCalls);
+        assertEquals(1, fakeBroadcaster.trackerCalls.size(),
+            "handler still calls broadcaster.trackerUntrackRetrack; the flag is the broadcaster's concern");
+    }
+
+    @Test
+    @DisplayName("broadcaster is invoked once per refresh across the 8-flag matrix")
+    void configMatrix_handlerInvokesBroadcasterOnce() {
+        for (boolean bundle : new boolean[]{false, true}) {
+            for (boolean scoped : new boolean[]{false, true}) {
+                for (boolean tracker : new boolean[]{false, true}) {
+                    Config.BROADCAST_USE_BUNDLE.set(bundle);
+                    Config.DIMENSION_SCOPED_BROADCAST.set(scoped);
+                    Config.REFRESH_VIA_ENTITY_TRACKER.set(tracker);
+                    refresh();
+
+                    String combo = "bundle=" + bundle + ", scoped=" + scoped + ", tracker=" + tracker;
+                    assertEquals(1, fakeBroadcaster.broadcastCalls.size(),
+                        combo + ": exactly one broadcast");
+                    assertEquals(1, fakeBroadcaster.trackerCalls.size(),
+                        combo + ": handler always delegates tracker call");
+                }
+            }
+        }
+    }
+
+    /* ================================================================== */
+    /*  B. Cascade order on the target connection                          */
+    /* ================================================================== */
+
+    @Test
+    @DisplayName("Cascade order: respawn, teleport, levelInfo, permission, allPlayerInfo, abilities")
+    void cascadeOrderFullStream() {
+        refresh();
+
+        assertCascadeOrder(targetStream);
+    }
+
+    @Test
+    @DisplayName("Each cascade packet type is sent exactly once per refresh")
+    void eachPacketTypeExactlyOnce() {
+        // refresh() clears between runs, so drive task() directly to
+        // accumulate two refreshes in one captured stream.
+        resetStreams();
+        SkinRefreshHandler.task(target);
+        SkinRefreshHandler.task(target);
+
+        // Two refreshes: every cascade type appears exactly twice total.
+        assertEquals(2, countOfType(targetStream, SRespawnPacket.class));
+        assertEquals(2, countOfType(targetStream, "teleport", String.class));
+        assertEquals(2, countOfType(targetStream, "sendLevelInfo", String.class));
+        assertEquals(2, countOfType(targetStream, "sendPlayerPermissionLevel", String.class));
+        assertEquals(2, countOfType(targetStream, "sendAllPlayerInfo", String.class));
+        assertEquals(2, countOfType(targetStream, SPlayerAbilitiesPacket.class));
+    }
+
+    @Test
+    @DisplayName("teleport reproduces the player's position/yaw/pitch (SPlayerPositionLookPacket args)")
+    void teleportArgs_matchPlayerPosition() {
+        // Give the player a non-trivial position so the teleport args are
+        // meaningful; yRot/xRot are public Entity fields on the mock.
+        when(target.position()).thenReturn(new Vector3d(10.5, 64.0, -3.25));
+        target.yRot = 45f;
+        target.xRot = 10f;
+
+        refresh();
+
+        assertEquals(1, teleportCalls.size(), "exactly one teleport per refresh");
+        Object[] args = (Object[]) teleportCalls.get(0);
+        assertEquals(10.5d, args[0]);
+        assertEquals(64.0d, args[1]);
+        assertEquals(-3.25d, args[2]);
+        assertEquals(45f, args[3]);
+        assertEquals(10f, args[4]);
+    }
+
+    @Test
+    @DisplayName("Tracker untrack/retrack runs before the respawn packet (handler-side ordering)")
+    void trackerUntrackRetrack_beforeRespawn() {
+        // Use a tracking broadcaster to capture the call moment so we can
+        // compare it against the respawn index on the captured stream.
+        FakeSkinBroadcaster spyBroadcaster = new FakeSkinBroadcaster() {
+            @Override
+            public void trackerUntrackRetrack(Entity entity) {
+                targetStream.add("trackerUntrackRetrack");
+                super.trackerUntrackRetrack(entity);
+            }
+        };
+        SkinRefreshHandler.setBroadcaster(spyBroadcaster);
+
+        refresh();
+
+        int tracker = indexOfType(targetStream, "trackerUntrackRetrack", String.class);
+        int respawn = indexOfType(targetStream, SRespawnPacket.class);
+        assertTrue(tracker >= 0 && respawn > tracker,
+            "tracker must precede respawn; stream=" + targetStream);
+    }
+
+    @Test
+    @DisplayName("Cascade order holds for all 8 BROADCAST_USE_BUNDLE x DIMENSION_SCOPED_BROADCAST x REFRESH_VIA_ENTITY_TRACKER combos")
+    void configMatrix_allCombos_cascadeOrderHolds() {
+        for (boolean bundle : new boolean[]{false, true}) {
+            for (boolean scoped : new boolean[]{false, true}) {
+                for (boolean tracker : new boolean[]{false, true}) {
+                    Config.BROADCAST_USE_BUNDLE.set(bundle);
+                    Config.DIMENSION_SCOPED_BROADCAST.set(scoped);
+                    Config.REFRESH_VIA_ENTITY_TRACKER.set(tracker);
+                    refresh();
+
+                    String combo = "bundle=" + bundle + ", scoped=" + scoped + ", tracker=" + tracker;
+                    assertCascadeOrder(targetStream, combo);
+                    assertEquals(1, fakeBroadcaster.broadcastCalls.size(),
+                        combo + ": exactly one broadcast call");
+                }
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("task() increments the refresh counter")
+    void task_incrementsRefreshCount() {
+        SkinRefreshHandler.resetRefreshTaskCount();
+        refresh();
+
+        assertEquals(1, SkinRefreshHandler.getRefreshTaskCount());
+    }
+
+    /* ================================================================== */
+    /*  C. Cascade atomicity (persistence) contract                       */
+    /* ================================================================== */
+
+    @Test
+    @DisplayName("saveSkinAsync failure leaves the applied GameProfile textures untouched")
+    void saveSkinAsyncFailure_leavesProfileUntouched() throws Exception {
+        GameProfile profile = profileWithTextures(OLD_PROPERTY);
+        SkinStorage failing = mock(SkinStorage.class);
+        when(failing.getSkin(any(UUID.class))).thenReturn(NEW_SKIN);
+        doThrow(new RuntimeException("simulated disk enqueue failure"))
+                .when(failing).saveSkinAsync(any(UUID.class), any(CustomSkinProperty.class));
+        setStaticField(SkinRestorer.class, "skinStorage", failing);
+
+        long failedBefore = SkinMetrics.INSTANCE.snapshot().refreshesFailed();
+        long savesBefore = SkinMetrics.INSTANCE.snapshot().savesSubmitted();
+
+        boolean persisted = SkinRefreshHandler.applyAtomicPersistence(PLAYER_UUID, profile, NEW_SKIN);
+
+        assertFalse(persisted, "a failed enqueue must report failure");
+        Collection<Property> textures = texturesOf(profile);
+        assertEquals(1, textures.size(), "a failed save must not mutate the profile");
+        assertEquals(OLD_PROPERTY, textures.iterator().next(),
+                "the applied profile must keep the previous textures when persistence fails");
+        assertEquals(failedBefore + 1, SkinMetrics.INSTANCE.snapshot().refreshesFailed(),
+                "the partial cascade failure must be recorded");
+        assertEquals(savesBefore, SkinMetrics.INSTANCE.snapshot().savesSubmitted(),
+                "a failed enqueue must not count as a submitted save");
+        assertEquals(0, fakeBroadcaster.broadcastCalls.size(),
+            "broadcast must not run when persistence fails");
+    }
+
+    @Test
+    @DisplayName("applyAtomicPersistence with a throwing profile mutation fails soft")
+    void applyAtomicPersistence_mutateProfileThrowing_failsSoft() {
+        GameProfile profile = mock(GameProfile.class);
+        // Real PropertyMap subclass (Mockito spies on Guava Multimaps are
+        // forbidden by @DoNotMock); only removeAll throws, everything else
+        // delegates to the real backing map.
+        PropertyMap properties = new PropertyMap() {
+            @Override
+            public Collection<Property> removeAll(Object key) {
+                throw new RuntimeException("simulated profile mutation failure");
+            }
+        };
+        properties.put("textures", OLD_PROPERTY);
+        when(profile.getProperties()).thenReturn(properties);
+        storage.setSkin(PLAYER_UUID, NEW_SKIN);
+        long failedBefore = SkinMetrics.INSTANCE.snapshot().refreshesFailed();
+
+        boolean persisted = SkinRefreshHandler.applyAtomicPersistence(PLAYER_UUID, profile, NEW_SKIN);
+
+        assertFalse(persisted, "a failed profile mutation must report failure");
+        assertEquals(failedBefore + 1, SkinMetrics.INSTANCE.snapshot().refreshesFailed(),
+                "the failed mutation must be recorded");
+        Collection<Property> textures = texturesOf(profile);
+        assertEquals(1, textures.size(), "a failed mutation must leave the profile untouched");
+        assertEquals(OLD_PROPERTY, textures.iterator().next(),
+                "the applied profile must keep its previous textures");
+    }
+
+    @Test
+    @DisplayName("successful save applies the stored skin to the GameProfile")
+    void saveSkinAsyncSuccess_appliesStoredSkin() throws Exception {
+        GameProfile profile = profileWithTextures(OLD_PROPERTY);
+        storage.setSkin(PLAYER_UUID, NEW_SKIN);
+
+        long failedBefore = SkinMetrics.INSTANCE.snapshot().refreshesFailed();
+        long savesBefore = SkinMetrics.INSTANCE.snapshot().savesSubmitted();
+
+        boolean persisted = SkinRefreshHandler.applyAtomicPersistence(PLAYER_UUID, profile, NEW_SKIN);
+        skinIO.flushPending();
+
+        assertTrue(persisted, "a successful enqueue must report success");
+        Collection<Property> textures = texturesOf(profile);
+        assertEquals(1, textures.size());
+        assertEquals(NEW_SKIN.getOriginalProperty(), textures.iterator().next(),
+                "the applied profile must match the saved skin value");
+        assertEquals(failedBefore, SkinMetrics.INSTANCE.snapshot().refreshesFailed(),
+                "a successful refresh must not record a failure");
+        assertEquals(savesBefore + 1, SkinMetrics.INSTANCE.snapshot().savesSubmitted(),
+                "the cascade must enqueue exactly one save");
+    }
+
+    @Test
+    @DisplayName("restart equivalence: after the cascade the on-disk skin equals the in-memory skin")
+    void afterCascade_ondiskSkinEqualsInMemorySkin() throws Exception {
+        GameProfile profile = new GameProfile(PLAYER_UUID, "Alice");
+        storage.setSkin(PLAYER_UUID, NEW_SKIN);
+
+        boolean persisted = SkinRefreshHandler.applyAtomicPersistence(PLAYER_UUID, profile, NEW_SKIN);
+        skinIO.flushPending();
+
+        assertTrue(persisted, "the cascade must report success");
+        CustomSkinProperty fromDisk = skinIO.loadSkin(PLAYER_UUID);
+        assertNotNull(fromDisk, "the cascade must have persisted the skin to disk");
+        assertEquals(NEW_SKIN, fromDisk,
+                "the on-disk skin after the cascade must equal the stored in-memory skin");
+        assertEquals(storage.getSkin(PLAYER_UUID), fromDisk,
+                "a restart reloading from disk must reproduce the in-memory skin");
+    }
+
+    /* ================================================================== */
+    /*  D. /skin clear with no Mojang profile                                */
+    /* ================================================================== */
+
+    @Test
+    @DisplayName("clear path also invokes the broadcaster and the cascade")
+    void clearPath_invokesBroadcasterAndCascade() {
+        // Stored skin is null: drop the applied textures property and
+        // run the broadcast+cascade so observers re-learn the cleared
+        // profile and the target reverts to the default skin.
+        storage.setSkin(target.getUUID(), null);
+        refresh();
+
+        assertEquals(1, fakeBroadcaster.broadcastCalls.size(),
+            "clear path also broadcasts; calls=" + fakeBroadcaster.broadcastCalls);
+        assertEquals(1, fakeBroadcaster.trackerCalls.size(),
+            "clear path also retracks");
+        assertCascadeOrder(targetStream);
+    }
+
+    /* ================================================================== */
+    /*  E. Wire-up verification                                            */
+    /* ================================================================== */
+
+    @Test
+    @DisplayName("getBroadcaster returns the wired instance")
+    void broadcasterGetterReturnsWired() {
+        assertEquals(fakeBroadcaster, SkinRefreshHandler.getBroadcaster(),
+            "the broadcaster the handler uses must be the one we injected");
+    }
+
+    /* ================================================================== */
+    /*  F. Pure logic: tryRestoreFromMojang + deriveReason                 */
+    /* ================================================================== */
+
+    @Nested
+    @DisplayName("tryRestoreFromMojang")
+    static class TryRestoreFromMojang {
+
+        private static final String PLAYER_NAME = "Steve";
+        private static final String STORED_SOURCE = "Notch";
+        private static final String FAKE_VALUE = "validTextureValue";
+        private static final String FAKE_SIG = "validSignature";
+
+        static class FakeMojangAPI implements MojangAPI {
+            final Map<String, CustomSkinProperty> skins = new HashMap<>();
+
+            void addSkin(String name, CustomSkinProperty skin) {
+                skins.put(name.toLowerCase(), skin);
+            }
+
+            @Override
+            public Optional<MojangSkinDataResult> getSkin(String nameOrUniqueId) {
+                CustomSkinProperty skin = skins.get(nameOrUniqueId.toLowerCase());
+                if (skin == null) return Optional.empty();
+                return Optional.of(new MojangSkinDataResult(UUID.randomUUID(), skin));
+            }
+
+            @Override
+            public Optional<UUID> getUUID(String playerName) {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<CustomSkinProperty> getProfile(ProfileLookup lookup) {
+                return Optional.empty();
+            }
+        }
+
+        @Test
+        @DisplayName("returns skin when Mojang has a profile for storedSource")
+        void restoreFromStoredSource() {
+            FakeMojangAPI api = new FakeMojangAPI();
+            api.addSkin(STORED_SOURCE, new CustomSkinProperty(FAKE_VALUE, FAKE_SIG, STORED_SOURCE));
+
+            SkinRefreshHandler.MojangRestoreResult result =
+                SkinRefreshHandler.tryRestoreFromMojang(api, STORED_SOURCE, PLAYER_NAME);
+
+            assertNotNull(result);
+            assertEquals(FAKE_VALUE, result.skin.getOriginalProperty().getValue());
+            assertEquals(STORED_SOURCE, result.licensedUsername);
+        }
+
+        @Test
+        @DisplayName("uses playerName when storedSource is null")
+        void fallbackFromNullSource() {
+            FakeMojangAPI api = new FakeMojangAPI();
+            api.addSkin(PLAYER_NAME, new CustomSkinProperty(FAKE_VALUE, FAKE_SIG, PLAYER_NAME));
+
+            SkinRefreshHandler.MojangRestoreResult result =
+                SkinRefreshHandler.tryRestoreFromMojang(api, null, PLAYER_NAME);
+
+            assertNotNull(result);
+            assertEquals(FAKE_VALUE, result.skin.getOriginalProperty().getValue());
+            assertEquals(PLAYER_NAME, result.licensedUsername);
+        }
+
+        @Test
+        @DisplayName("uses playerName when storedSource is empty")
+        void fallbackFromEmptySource() {
+            FakeMojangAPI api = new FakeMojangAPI();
+            api.addSkin(PLAYER_NAME, new CustomSkinProperty(FAKE_VALUE, FAKE_SIG, PLAYER_NAME));
+
+            SkinRefreshHandler.MojangRestoreResult result =
+                SkinRefreshHandler.tryRestoreFromMojang(api, "", PLAYER_NAME);
+
+            assertNotNull(result);
+            assertEquals(FAKE_VALUE, result.skin.getOriginalProperty().getValue());
+            assertEquals(PLAYER_NAME, result.licensedUsername);
+        }
+
+        @Test
+        @DisplayName("returns null when Mojang has no profile for the username")
+        void mojangNoProfile() {
+            FakeMojangAPI api = new FakeMojangAPI();
+
+            SkinRefreshHandler.MojangRestoreResult result =
+                SkinRefreshHandler.tryRestoreFromMojang(api, STORED_SOURCE, PLAYER_NAME);
+
+            assertNull(result);
+        }
+
+        @Test
+        @DisplayName("returns null when Mojang skin isEmpty (default skin value)")
+        void mojangEmptySkin() {
+            CustomSkinProperty emptySkin = new CustomSkinProperty("textures", "", "", STORED_SOURCE);
+            FakeMojangAPI api = new FakeMojangAPI();
+            api.addSkin(STORED_SOURCE, emptySkin);
+
+            SkinRefreshHandler.MojangRestoreResult result =
+                SkinRefreshHandler.tryRestoreFromMojang(api, STORED_SOURCE, PLAYER_NAME);
+
+            assertNull(result);
+        }
+    }
+
+    @Nested
+    @DisplayName("deriveReason")
+    static class DeriveReason {
+
+        @Test
+        @DisplayName("username with no custom source uses the plain message")
+        void username_nullSource() {
+            assertEquals("No skin found", SkinRefreshHandler.deriveReason(SkinActionType.username, null));
+        }
+
+        @Test
+        @DisplayName("username with a custom source names the source")
+        void username_withSource() {
+            assertEquals("No skin found for \"Notch\"",
+                SkinRefreshHandler.deriveReason(SkinActionType.username, "Notch"));
+        }
+
+        @Test
+        @DisplayName("url with a non-namemc source reports MineSkin rejection")
+        void url_nonNameMcSource() {
+            assertEquals("MineSkin rejected the URL",
+                SkinRefreshHandler.deriveReason(SkinActionType.url, "https://example.com/skin.png"));
+        }
+
+        @Test
+        @DisplayName("url with a namemc profile source is sanitized to the username")
+        void url_nameMcProfileSource() {
+            // sanitizeSkinInput rewrites the namemc profile URL to the
+            // username; deriveReason then reports that username.
+            assertEquals("No skin found for \"Notch\"",
+                SkinRefreshHandler.deriveReason(SkinActionType.url, "https://namemc.com/profile/Notch.1"));
+        }
+
+        @Test
+        @DisplayName("random uses the no-random-username message")
+        void random() {
+            assertEquals("No random username available",
+                SkinRefreshHandler.deriveReason(SkinActionType.random, null));
+        }
+    }
+
+    /* ================================================================== */
+    /*  Fixture                                                            */
+    /* ================================================================== */
+
+    /** Runs one refresh and resets all captured streams first. */
+    private void refresh() {
+        resetStreams();
+        fakeBroadcaster.reset();
+        SkinRefreshHandler.task(target);
+    }
+
+    private void resetStreams() {
+        targetStream.clear();
+        teleportCalls.clear();
+    }
+
+    private ServerPlayerEntity newPlayer(String name, ServerWorld level) {
+        UUID uuid = UUID.randomUUID();
+        ServerPlayerEntity player = mock(ServerPlayerEntity.class);
+        when(player.getUUID()).thenReturn(uuid);
+        when(player.getGameProfile()).thenReturn(new GameProfile(uuid, name));
+        when(player.getLevel()).thenReturn(level);
+        when(player.position()).thenReturn(Vector3d.ZERO);
+        when(player.getServer()).thenReturn(server);
+
+        // Field-backed state production reads directly (mock fields are null
+        // because Mockito skips constructors).
+        ServerPlayNetHandler connection = mock(ServerPlayNetHandler.class);
+        setField(player, "connection", connection);
+        PlayerInteractionManager gameMode = mock(PlayerInteractionManager.class);
+        when(gameMode.getGameModeForPlayer()).thenReturn(GameType.SURVIVAL);
+        when(gameMode.getPreviousGameModeForPlayer()).thenReturn(GameType.SURVIVAL);
+        setField(player, "gameMode", gameMode);
+        setField(player, "abilities", new PlayerAbilities());
+        return player;
+    }
+
+    /**
+     * Ordered capture of everything sent to this player's connection.
+     * Idempotent per player: the capture doAnswer is attached once and the
+     * same list is returned on every call.
+     */
+    private List<Object> streamFor(ServerPlayerEntity player) {
+        return playerStreams.computeIfAbsent(player, p -> {
+            List<Object> stream = new ArrayList<>();
+            doAnswer(inv -> {
+                stream.add(inv.getArgument(0));
+                return null;
+            }).when(p.connection).send(any(IPacket.class));
+            doAnswer(inv -> {
+                // 1.16.5: the position packet travels inside
+                // ServerPlayNetHandler#teleport; capture its arguments and
+                // emit a stream marker in the vanilla respawn position.
+                teleportCalls.add(inv.getArguments());
+                stream.add("teleport");
+                return null;
+            }).when(p.connection).teleport(anyDouble(), anyDouble(), anyDouble(), anyFloat(), anyFloat());
+            return stream;
+        });
+    }
+
+    private static ServerWorld levelMock(RegistryKey<World> dimension) {
+        ServerWorld level = mock(ServerWorld.class);
+        when(level.dimension()).thenReturn(dimension);
+        when(level.dimensionType()).thenReturn(mock(DimensionType.class));
+        when(level.getSeed()).thenReturn(0L);
+        when(level.isDebug()).thenReturn(false);
+        when(level.isFlat()).thenReturn(false);
+        return level;
+    }
+
+    private static void assertCascadeOrder(List<Object> stream) {
+        assertCascadeOrder(stream, "");
+    }
+
+    private static void assertCascadeOrder(List<Object> stream, String combo) {
+        int respawn = indexOfType(stream, SRespawnPacket.class);
+        int teleport = indexOfType(stream, "teleport", String.class);
+        int levelInfo = indexOfType(stream, "sendLevelInfo", String.class);
+        int permission = indexOfType(stream, "sendPlayerPermissionLevel", String.class);
+        int allPlayerInfo = indexOfType(stream, "sendAllPlayerInfo", String.class);
+        int abilities = indexOfType(stream, SPlayerAbilitiesPacket.class);
+        assertTrue(respawn >= 0 && teleport > respawn && levelInfo > teleport
+                && permission > levelInfo && allPlayerInfo > permission && abilities > allPlayerInfo,
+            combo + ": expected respawn < teleport < levelInfo < permission < allPlayerInfo < abilities; stream=" + stream);
+    }
+
+    private static int indexOfType(List<?> events, Class<?> type) {
+        for (int i = 0; i < events.size(); i++) {
+            if (type.isInstance(events.get(i))) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static int indexOfType(List<?> events, Object marker, Class<?> type) {
+        for (int i = 0; i < events.size(); i++) {
+            if (type.isInstance(events.get(i)) && events.get(i).equals(marker)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static long countOfType(List<?> events, Class<?> type) {
+        return events.stream().filter(type::isInstance).count();
+    }
+
+    private static long countOfType(List<?> events, Object marker, Class<?> type) {
+        return events.stream().filter(e -> type.isInstance(e) && e.equals(marker)).count();
+    }
+
+    private static void setField(Object target, String fieldName, Object value) {
+        try {
+            Field field = ServerPlayerEntity.class.getField(fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Cannot set ServerPlayerEntity." + fieldName, e);
+        }
+    }
+
+    private static void setStaticField(Class<?> clazz, String name, Object value) throws Exception {
+        Field field = clazz.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(null, value);
+    }
+
+    private static GameProfile profileWithTextures(Property textures) {
+        GameProfile profile = new GameProfile(PLAYER_UUID, "Alice");
+        profile.getProperties().put("textures", textures);
+        return profile;
+    }
+
+    private static Collection<Property> texturesOf(GameProfile profile) {
+        return profile.getProperties().get("textures");
+    }
+}

--- a/forge-1.16.5/src/test/java/levosilimo/everlastingskins/util/I18nUtilsTest.java
+++ b/forge-1.16.5/src/test/java/levosilimo/everlastingskins/util/I18nUtilsTest.java
@@ -1,0 +1,152 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.util;
+
+import levosilimo.everlastingskins.Config;
+import com.electronwill.nightconfig.core.InMemoryCommentedFormat;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for the 1.16.5 lane's own {@link I18nUtils} — JSON locale loading,
+ * locale-code normalization, per-locale lookup, format-arg filling and the
+ * Config override chain.
+ *
+ * <p>Locales are loaded from the classpath resources
+ * {@code /assets/everlastingskins/lang/<locale>.json} via
+ * {@link I18nUtils#loadAll()}. The English file is complete; de_de carries a
+ * partial key set and falls back to English for the rest.
+ */
+class I18nUtilsTest {
+
+    @BeforeAll
+    static void loadConfigAndLocales() {
+        // Serve Config defaults so Config.LANGUAGE is readable.
+        Config.COMMON_CONFIG.setConfig(
+                InMemoryCommentedFormat.defaultInstance().createConfig(java.util.HashMap::new));
+        I18nUtils.loadAll();
+    }
+
+    @Nested
+    @DisplayName("defaultLocaleFor")
+    class DefaultLocaleFor {
+
+        @ParameterizedTest
+        @CsvSource({
+            "en_us, en",
+            "zh_cn, zh_cn",
+            "en_ud, en",
+            "EN_GB, en",
+            "ru_ru, ru",
+            "uk_ua, uk",
+            "de_de, de_de"
+        })
+        @DisplayName("Normalizes Minecraft locale codes against loaded files")
+        void normalization(String raw, String expected) {
+            assertEquals(expected, I18nUtils.defaultLocaleFor(raw));
+        }
+
+        @Test
+        @DisplayName("null locale maps to the default locale")
+        void nullLocaleMapsToDefault() {
+            assertEquals("en", I18nUtils.defaultLocaleFor(null));
+        }
+    }
+
+    @Nested
+    @DisplayName("getLocalizedString")
+    class GetLocalizedString {
+
+        @Test
+        @DisplayName("Resolves a key from the requested locale file")
+        void resolvesFromLocaleFile() {
+            String german = I18nUtils.getLocalizedString("discord_announce", "de_de");
+            assertTrue(german.contains("geändert"), "expected German text, got: " + german);
+        }
+
+        @Test
+        @DisplayName("Unsupported locale falls back to English")
+        void fallsBackToEnglish() {
+            String result = I18nUtils.getLocalizedString("discord_announce", "zz_zz");
+            assertTrue(result.contains("changed their skin"), "expected English fallback, got: " + result);
+            assertNotEquals("discord_announce", result);
+        }
+
+        @Test
+        @DisplayName("Missing key falls back to the raw key")
+        void missingKeyReturnsRawKey() {
+            assertEquals("no_such_key_ever", I18nUtils.getLocalizedString("no_such_key_ever", "en"));
+        }
+
+        @Test
+        @DisplayName("null key returns null")
+        void nullKeyReturnsNull() {
+            assertNull(I18nUtils.getLocalizedString(null, "en"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Config override chain")
+    class ConfigOverride {
+
+        @Test
+        @DisplayName("A customized messages_* entry overrides the locale files")
+        void configOverrideWins() {
+            String original = Config.MESSAGES_CHANGE.get();
+            try {
+                Config.MESSAGES_CHANGE.set("Custom change text");
+                assertEquals("Custom change text", I18nUtils.getLocalizedString("change", "en"));
+            } finally {
+                Config.MESSAGES_CHANGE.set(original);
+            }
+        }
+
+        @Test
+        @DisplayName("The canonical default is not treated as an override")
+        void canonicalDefaultNotAnOverride() {
+            // Default equals DEFAULT_ENGLISH, so the locale file still serves.
+            String result = I18nUtils.getLocalizedString("change", "en");
+            assertEquals("Skin change queued", result);
+        }
+    }
+
+    @Nested
+    @DisplayName("get / format")
+    class Get {
+
+        @Test
+        @DisplayName("Fills %s specifiers from args")
+        void fillsFormatArgs() {
+            String result = I18nUtils.get("no_skin_found", "Notch");
+            assertEquals("No skin found for \"Notch\"", result);
+        }
+
+        @Test
+        @DisplayName("Malformed admin template falls back to the raw template")
+        void malformedTemplateReturnsTemplate() {
+            String original = Config.MESSAGES_CHANGE.get();
+            try {
+                Config.MESSAGES_CHANGE.set("bad %s %d template");
+                // get() fills %s from args; the %d conversion throws and the
+                // template is returned unformatted rather than crashing.
+                String result = I18nUtils.get("change", "x");
+                assertEquals("bad %s %d template", result);
+            } finally {
+                Config.MESSAGES_CHANGE.set(original);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes the unit-test gap for the `forge-1.16.5` lane (NO-SOURCE for `:forge-1.16.5:test` per lib-12 audit finding #3): ports the relevant binding-specific unit tests from forge-1.21 and adds tests for the MC 1.16.5-specific APIs.

**96 tests** across 8 test classes + 2 test helpers, all Mockito/JUnit 5 (mock-based, no live Forge server), running locally in seconds on Java 8.

## What's covered (1.16.5 binding-specific)

- **SkinRefreshHandlerTest** (15+10): cascade order `SRespawnPacket → ServerPlayNetHandler#teleport → sendLevelInfo → sendPlayerPermissionLevel → sendAllPlayerInfo → SPlayerAbilitiesPacket`; teleport reproduces the player's position/yaw/pitch (the 1.16.5 position packet travels inside `teleport`, never built by the handler); R3 atomic-persistence contract (`applyAtomicPersistence`); broadcaster call shape across the 8-flag matrix; clear path; `tryRestoreFromMojang` + `deriveReason` (pure logic, 1.16.5 copies).
- **VanillaSkinBroadcasterTest** (10): REMOVE-before-ADD via the unified 1.16.5 `SPlayerListItemPacket`; `BROADCAST_USE_BUNDLE` documented **inert** (no bundle packet on 1.16.5); dimension scoping in both broadcast modes; entity-tracker untrack/retrack; ADD carries the profile.
- **ForgePermissionServiceTest** (12): the legacy 1.16.5 string-node `PermissionAPI` backend — online-vs-offline routing (`ServerLifecycleHooks` → PlayerList lookup vs `GameProfile` fallback), `.skin.source` **not** special-cased (1.16.5 delta vs 1.21), vanilla op-level fallback on API throw, `registerNodes` registration contract.
- **VanillaPermissionServiceTest** (12): per-command op-level logic + Java-8 `PermissionContext` validation.
- **DiscordSrvHookTest** (6): the fully-reflective 1.16.5 hook — graceful skip when DiscordSRV is absent (covers all DSRV scenarios on this lane), localized announce text, null fallbacks.
- **ConfigTest** (15): 1.16.5 `ForgeConfigSpec` defaults (language, broadcast flags, permission op levels, Mojang cache).
- **I18nUtilsTest** (14): 1.16.5 locale normalization/fallback, Config override chain, format args.

## Notable finding

The 1.21 bootstrap-flag trick does **not** translate directly: 1.16.5 has no `isBootstrapped` gate, but `World.<clinit>` → `Registry.<clinit>` → `MemoryModuleType.<clinit>` → `GlobalPos.<clinit>` re-enters `World` mid-clinit (reads `World.RESOURCE_KEY_CODEC` → NPE) when `World` starts the chain. Fix: force `Registry.<clinit>` first via `Class.forName("net.minecraft.util.registry.Registry")` in the test static block — the same order the game uses.

## Infra

- `forge-1.16.5/build.gradle.kts`: added Mockito **4.11.0** (+inline for `mockStatic`) as `testImplementation` — 4.x is required because this lane runs Java 8 (Mockito 5.x needs Java 11; the 1.21 convention plugin's 5.12.0 is not usable here). No production code touched.

## Verification

- `compileTestJava` (Java 8): pass
- `test` (Java 8): 96/96 pass
- `build` (Java 8): pass, verifyNoMixin gate green
- aislop pre-commit + root pre-push gates: clean