### PR TITLE
build: fix mod_version for 1.16.5/1.20.1 JAR filenames

### DIFF
--- a/forge-1.16.5/gradle.properties
+++ b/forge-1.16.5/gradle.properties
@@ -11,3 +11,6 @@ loader_version_range=[36,)
 
 # Curse versions for this point release
 curse_versions=1.16.5
+
+# Mod version (JAR filename + mods.toml impl version; keep in sync with root)
+mod_version=2.1.0

--- a/forge-1.20.1/gradle.properties
+++ b/forge-1.20.1/gradle.properties
@@ -11,3 +11,6 @@ curse_versions=1.20.1
 # Run working dirs (resolved relative to this subproject)
 mc.runDir=run
 mc.runDir2=run2
+
+# Mod version (JAR filename + mods.toml impl version; keep in sync with root)
+mod_version=2.1.0


### PR DESCRIPTION
## Summary

Adds `mod_version=2.1.0` to the `forge-1.16.5` and `forge-1.20.1` lane `gradle.properties`.

## Why

Both lane `build.gradle.kts` files derive the artifact version via `findProperty("mod_version") ?: "1.0.0"`. Neither lane defined `mod_version`, so their JARs were built as `everlastingskins-1.16.5-1.0.0.jar` / `everlastingskins-1.20.1-1.0.0.jar` while the packaged `mods.toml` and the publish workflow's Modrinth version (`mc1.16.5-v2.1.0` / `mc1.20.1-v2.1.0`) say 2.1.0 — a publish blocker.

Verified locally (both lanes, `clean build`, tests + `verifyNoMixin` pass):
- `forge-1.16.5/build/libs/everlastingskins-1.16.5-2.1.0.jar` — mods.toml `version = "2.1.0"`
- `forge-1.20.1/build/libs/everlastingskins-1.20.1-2.1.0.jar` — mods.toml `version = "2.1.0"`

No other files touched.