### PR TITLE
ci: ensure main in trigger scope + fix aislop base ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,4 +251,8 @@ jobs:
         with:
           node-version: 20
       - name: Run aislop gate on PR changes
-        run: npx -y aislop ci --changes --base origin/integration/m2-monorepo
+        # Diff against the PR's actual base branch (github.base_ref); on
+        # push events fall back to origin/main. Replaces the hardcoded
+        # origin/integration/m2-monorepo so PRs into main are gated
+        # against main, and integration PRs keep their old behavior.
+        run: npx -y aislop ci --changes --base origin/${{ github.base_ref || 'main' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,4 +255,4 @@ jobs:
         # push events fall back to origin/main. Replaces the hardcoded
         # origin/integration/m2-monorepo so PRs into main are gated
         # against main; integration PRs keep their prior behavior.
-        run: npx -y aislop ci --changes --base origin/${{ github.base_ref || 'main' }}
+        run: npx -y aislop ci --changes --base origin/integration/m2-monorepo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,5 +254,5 @@ jobs:
         # Diff against the PR's actual base branch (github.base_ref); on
         # push events fall back to origin/main. Replaces the hardcoded
         # origin/integration/m2-monorepo so PRs into main are gated
-        # against main, and integration PRs keep their old behavior.
+        # against main; integration PRs keep their prior behavior.
         run: npx -y aislop ci --changes --base origin/${{ github.base_ref || 'main' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,4 +255,4 @@ jobs:
         # push events fall back to origin/main. Replaces the hardcoded
         # origin/integration/m2-monorepo so PRs into main are gated
         # against main; integration PRs keep their prior behavior.
-        run: npx -y aislop ci --changes --base origin/integration/m2-monorepo
+        run: npx -y aislop ci --changes --base origin/${{ github.base_ref || 'main' }}


### PR DESCRIPTION
## What

Two CI fixes for the M2 monorepo after `main` became the default branch:

1. **Trigger scope** — `main` is already present in `on.push.branches` and `on.pull_request.branches` on this branch (landed via fix-41 commit `769e03d` → merged PR #292-era integration history, and separately via #285 on main). Verified: both arrays are `["integration/m2-monorepo", "main"]`. No change needed here.
2. **aislop base ref** — the gate hardcoded `--base origin/integration/m2-monorepo`, so a PR **into main** would diff against the wrong base. Changed to:

   ```yaml
   run: npx -y aislop ci --changes --base origin/${{ github.base_ref || 'main' }}
   ```

## Why this approach (documented decision)

- `github.base_ref` is the PR's actual base branch → PRs into `main` gate against `origin/main`; PRs into `integration/m2-monorepo` keep **exactly** the previous behavior.
- On `push` events `github.base_ref` is empty, so the `|| 'main'` fallback yields `origin/main` (empty diff on pushes to main; gates the promotion diff on pushes to integration).
- **Removing `--base` entirely was rejected**: `aislop ci --changes` defaults the base to `HEAD`, producing an empty diff — that would silently disable the gate for all PRs.
- Using `origin/` prefix is required: actions/checkout (fetch-depth: 0) exposes only remote-tracking refs, so bare `main`/`integration/m2-monorepo` would not resolve in `git rev-parse`.

## Verification

- yamllint (strict, `.yamllint.yml`): clean, exit 0
- `python3` YAML load (BaseLoader): `on` key preserved, both arrays contain both branches
- `git diff --check`: clean
- Pre-commit hooks: aislop 100/100 clean, gradle verifyNoMixin BUILD SUCCESSFUL (JDK 21 toolchain)

Note: `origin/main`'s ci.yml still carries the same aislop hardcode — it will pick up this fix when lane A fast-forwards main to integration's new head.