### PR TITLE
docs: post-promotion polish (README + CHANGELOG)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,7 +133,13 @@ Mixin gate, CI matrix, and forge-1.21 compat fixes.
   54.1.18, 2 API fixes; 34/34 gametests pass)
 - **#281** — feat(monorepo): forge-1.21.8 main source carry-over (Forge
   58.1.21, EventBus 7 migration; gametest dropped per MC 1.21.5 overhaul;
-  215 tests pass)
+  215 tests pass). Gametest coverage was restored by #292 below.
+- **#292** — feat(gametest): forge-1.21.8 GameTest re-introduced (post-#281)
+  using the MC 1.21.5+ data-driven test-instance framework
+  (`minecraft:test_function` / `test_instance` / `test_environment`
+  registries; `@GameTestNamespace` + `@GameTest` on a JPMS-isolated
+  `everlastingskins_gametest` mod). 34 skin-pipeline tests ported from
+  forge-1.21 + vanilla builtin `always_pass` = 35/35 required tests pass.
 
 ### Known follow-ups (next PRs)
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 Server-side persistent custom skins on pure Forge servers — no client mod required.
 
-This is the M2 multi-module monorepo (`integration/m2-monorepo` branch). It
-unifies every Forge lane of the project under one Gradle root; the 1.12.2 lane
-stays on its own wrapper out-of-band.
+This is the M2 multi-module monorepo. `main` is the default branch;
+`integration/m2-monorepo` is the live integration branch where fix/* PRs
+merge and CI runs. It unifies every Forge lane of the project under one
+Gradle root; the 1.12.2 lane stays on its own wrapper out-of-band.
 
 ## Layout
 


### PR DESCRIPTION
Post-promotion docs polish (D-1 lane).

- README.md: intro now states `main` is the default branch; `integration/m2-monorepo` is the live integration branch where fix/* PRs merge and CI runs (was stale 'M2 multi-module monorepo (integration/m2-monorepo branch)' from pre-promotion).
- CHANGELOG.md: added #292 entry documenting forge-1.21.8 GameTest re-introduction via the MC 1.21.5+ data-driven test-instance framework (34 ported skin-pipeline tests + vanilla builtin `always_pass` = 35/35), superseding the stale #281 'gametest dropped' claim.
- AGENTS.md: verified — branch-protection reference to integration/m2-monorepo remains accurate; no change needed.

Pre-commit (aislop + test-count gate + verifyNoMixin + compile) and pre-push (full unit tests + forge-1.21 gametest + aislop ci) gates passed.