### PR TITLE
test(mc1.12.2): port SkinCommandTabCompleteTest fix from main

### DIFF
--- a/mc1.12.2/src/test/java/levosilimo/everlastingskins/skinchanger/SkinCommandTabCompleteTest.java
+++ b/mc1.12.2/src/test/java/levosilimo/everlastingskins/skinchanger/SkinCommandTabCompleteTest.java
@@ -7,6 +7,7 @@
 package levosilimo.everlastingskins.skinchanger;
 
 import levosilimo.everlastingskins.Config;
+import levosilimo.everlastingskins.permission.PermissionTestSupport;
 import levosilimo.everlastingskins.util.CompletionSources;
 import levosilimo.everlastingskins.util.CustomSkinProperty;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -50,6 +51,9 @@ class SkinCommandTabCompleteTest {
         Config.MINESKIN_ENABLED = false;
         Config.permissionsOpLevelMetrics = 2;
         Config.permissionsOpLevelMetricsReset = 2;
+        // :common's manager registers no backend by itself (fail-closed); the
+        // per-version bootstrap registers these — tests mirror the bootstrap.
+        PermissionTestSupport.installVanilla();
         CompletionSources.setMojangProfileCache(new MojangProfileCache());
 
         server = mock(MinecraftServer.class);
@@ -63,6 +67,7 @@ class SkinCommandTabCompleteTest {
         Config.MINESKIN_ENABLED = false;
         Config.permissionsOpLevelMetrics = 2;
         Config.permissionsOpLevelMetricsReset = 2;
+        PermissionTestSupport.uninstall();
     }
 
     @Test


### PR DESCRIPTION
Ports the SkinCommandTabCompleteTest fix from main (#285, d04608a) to integration to clear the red `Build (mc1.12.2)` required check.

**Cause**: The shared PermissionServiceManager is fail-closed without a registered backend, but SkinCommandTabCompleteTest exercised permission gates without installing one. It only passed when another test class happened to run first and leak the backend (order-dependent) — 4 of 8 tests failed in isolation (permission-gated: subcommand filter, random cascade, clear/source targets, metrics reset filter), all `expected: <[set, clear, source]> but was: <[]>` style assertion failures.

**Fix** (test-only, byte-identical to #285): install/uninstall the vanilla permission backend via PermissionTestSupport in @BeforeEach/@AfterEach, mirroring SkinCommandPermissionTest and the 1.20.1 lane.

**Verified locally**: targeted test 8/8 PASSED; full suite 514/514 PASSED; `./gradlew build` BUILD SUCCESSFUL.