### PR TITLE
forge-module: wire processResources into dep-analysis analysis tasks

### DIFF
--- a/buildSrc/src/main/kotlin/everlastingskins.forge-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/everlastingskins.forge-module.gradle.kts
@@ -1,6 +1,8 @@
 // everlastingskins.forge-module — convention plugin for the ForgeGradle 7+
 // (Java 21 toolchain) modules: forge-1.21 and the 1.21.x point releases.
 
+import com.autonomousapps.tasks.AbiAnalysisTask
+import com.autonomousapps.tasks.ClassListExploderTask
 import java.text.SimpleDateFormat
 import java.util.Date
 
@@ -322,4 +324,23 @@ sourceSets.all {
     val dir = layout.buildDirectory.dir("sourcesSets/${name}")
     output.setResourcesDir(dir.get().asFile)
     java.destinationDirectory = dir
+}
+
+// Workaround for dependency-analysis-gradle-plugin #960:
+// FG redirects every sourceSet's classes+resources output to
+// build/sourcesSets/<name> (this convention's lines 321-325). The
+// plugin's explodeByteCodeSourceMain + abiAnalysisMain tasks read
+// build/sourcesSets/<name> but don't declare dependsOn processResources,
+// so Gradle 9.3.1's strict implicit-dependency detection hard-fails
+// :<module>:projectHealth. Maintainer-verified fix per #960: inject
+// the missing wiring at projectsEvaluated time. Only fires when the
+// dep-analysis plugin is actually applied to this module — its tasks
+// won't exist otherwise and `withType` is a no-op.
+gradle.projectsEvaluated {
+    tasks.withType<ClassListExploderTask>().configureEach {
+        dependsOn("processResources")
+    }
+    tasks.withType<AbiAnalysisTask>().configureEach {
+        dependsOn("processResources")
+    }
 }


### PR DESCRIPTION
## Summary

Wires `dependsOn("processResources")` onto dep-analysis'
`ClassListExploderTask` and `AbiAnalysisTask` instances at
`gradle.projectsEvaluated` time. Without this, `:forge-1.21:projectHealth`
(and any Forge module that adopts the dep-analysis convention)
fails with a Gradle 9.3.1 implicit-dependency hard error.

## Why

FG redirects every sourceSet's classes+resources output to
`build/sourcesSets/<name>` for the obfuscation layout
(`everlastingskins.forge-module.gradle.kts:321-325`). dep-analysis'
analysis tasks read that directory without declaring an explicit
`dependsOn` on `processResources`. Gradle 9.3.1 promotes implicit-
dependency detection to a hard error; Gradle 8 only warned.

This is the maintainer-verified workaround for upstream
autonomousapps/dependency-analysis-gradle-plugin#960.

## Verification

- `:forge-1.21:projectHealth` runs to completion (exit 0, 43
  findings: 3 genuine + 40 expected Forge-reflection FPs).
- Same fix applies to all four `:forge-1.21.x` modules via the
  shared convention plugin.

## Followup

The 5 dep-analysis triage findings (api/implementation promotion,
spigot-api drop, junit-jupiter-api placement, jsr305 excludes)
were triaged and shipped as uncommitted working-tree state pending
a separate decision on whether to fold them into a downstream PR.
This PR contains only the buildSrc-side workaround.

## Followup PRs

- #4: apply convention to :common
- #5: apply convention to forge-1.21 / 1.21.1 / 1.21.4 / 1.21.8
- #6: wrapper script + AGENTS.md docs + .gitignore
