### PR TITLE
buildSrc: add dep-analysis convention plugin (WARN-only)

### DIFF
--- a/buildSrc/src/main/kotlin/everlastingskins.dependency-analysis.gradle.kts
+++ b/buildSrc/src/main/kotlin/everlastingskins.dependency-analysis.gradle.kts
@@ -1,0 +1,61 @@
+// everlastingskins.dependency-analysis — WARN-only "knip" for the Forge line.
+// Applies com.autonomousapps.dependency-analysis (version comes from the
+// buildSrc classpath, never declared here) and runs every check at warn
+// severity so the build can NEVER fail on a dependency-health finding.
+//
+// Why WARN-only: Forge is reflection-heavy. @ObjectHolder registry entries,
+// @EventBusSubscriber static subscribers, model loaders and string-based
+// resource registration are invisible to static analysis, so buildHealth
+// reliably reports false positives on this codebase. Mojang's authlib/log4j
+// transitives get flagged as duplicates too; that is Kombucha (in-plugin
+// dedup) hygiene, reviewed separately. Mixin is a non-issue here: the
+// no-mixin gate already forbids @Mixin anywhere in the repo.
+//
+// Conventions (the "structure rules" this plugin deliberately does NOT add —
+// Forge reflection cannot be modeled as rule entries):
+//  - never gate CI on buildHealth: it is a human-readable hygiene report,
+//    run on demand via ./gradlew buildHealth (root) / projectHealth (module);
+//  - never run fixDependencies automatically: the unused-dependency detector
+//    is defeated by the reflection above, so an auto-fix would delete live
+//    entries. Any fix is a manual, reviewed change (AGENTS.md policy).
+//
+// Note: 3.x removed the old `abortBuildOnFalsePositives` flag; the modern
+// equivalent is issues { all { onAny { severity("warn") } } } below, which
+// also governs the buildHealth aggregate the plugin registers on the root
+// project once any module applies this convention.
+
+import com.autonomousapps.DependencyAnalysisSubExtension
+import com.autonomousapps.tasks.ProjectHealthTask
+
+plugins {
+    id("com.autonomousapps.dependency-analysis")
+}
+
+// Every issue category (unused dependencies, wrong configurations, undeclared
+// transitives, duplicate classes, ...) at warn severity. "fail" is the plugin
+// default; we never want a dependency-health finding to break a build.
+//
+// NOTE: use DependencyAnalysisSubExtension here, not
+// DependencyAnalysisExtension — the latter is registered only on the ROOT
+// project (RootPlugin); subprojects get the Sub extension. The lane-2 version
+// used the root type and failed at apply time on :common ("Extension of type
+// 'DependencyAnalysisExtension' does not exist"). The per-project issues{}
+// handler is ProjectIssueHandler, which has onAny directly (no all{} wrapper
+// — that lives on the root IssueHandler).
+extensions.configure<DependencyAnalysisSubExtension> {
+    issues {
+        onAny {
+            severity("warn")
+        }
+    }
+}
+
+// Deterministic report output: fixed relative path under build/, independent
+// of the project dir name. The plugin default is already this path; pinning
+// it here guards against default drift and keeps CI artifact paths stable.
+// withType+configureEach (not tasks.named): the plugin registers
+// projectHealth conditionally/deferred, so a named() lookup at apply time
+// fails with "Task with name 'projectHealth' not found".
+tasks.withType<ProjectHealthTask>().configureEach {
+    consoleReport.set(layout.buildDirectory.file("reports/dependency-analysis/project-health-report.txt"))
+}


### PR DESCRIPTION
## Summary

New buildSrc convention plugin `everlastingskins.dependency-analysis`
that applies dep-analysis versionlessly to every module that opts
in. Severity is hard-coded to "warn" because Forge reflection
produces false positives on registry entries, event subscribers,
and string-based resource registration. `fixDependencies` is never
invoked — findings are a human-readable report, not a gate.

## Why a convention plugin

The plugin coordinates that need it (`:common`, plus the four
`:forge-1.21.x` modules — see PRs #4 and #5) apply the convention
by id; version comes from the buildSrc classpath dep added in PR #1.

## DSL notes (vs the deprecated 3.x API)

- `extensions.configure<DependencyAnalysisSubExtension> { ... }`
  instead of `the<...>().configure { ... }`. The sub-extension type
  extends `AbstractExtension`, not `ExtensionAware`, so the direct
  `configure` wrapper has no applicable candidate.
- `issues { onAny { severity("warn") } }` instead of the removed
  `abortBuildOnFalsePositives` flag (3.x removed it; the issues-severity
  DSL is the modern equivalent).
- `tasks.withType<ProjectHealthTask>().configureEach { consoleReport.set(...) }`
  instead of `tasks.named("projectHealth") { ... }`. The task is
  registered conditionally, so eager `named()` throws at apply time
  on subprojects; `configureEach` is lazy.

## Followup PRs

- #3: forge-module workaround for the FG sourcesSets layout
  (required for projectHealth to run on Forge modules)
- #4: apply convention to :common
- #5: apply convention to forge-1.21.x modules
- #6: wrapper script + AGENTS.md docs + .gitignore
