### PR TITLE
forge-1.21.x: adopt dep-analysis convention plugin

### DIFF
--- a/forge-1.21.1/build.gradle.kts
+++ b/forge-1.21.1/build.gradle.kts
@@ -1,3 +1,4 @@
 plugins {
     id("everlastingskins.forge-module")
+    id("everlastingskins.dependency-analysis")
 }

--- a/forge-1.21.4/build.gradle.kts
+++ b/forge-1.21.4/build.gradle.kts
@@ -1,3 +1,4 @@
 plugins {
     id("everlastingskins.forge-module")
+    id("everlastingskins.dependency-analysis")
 }

--- a/forge-1.21.8/build.gradle.kts
+++ b/forge-1.21.8/build.gradle.kts
@@ -1,3 +1,4 @@
 plugins {
     id("everlastingskins.forge-module")
+    id("everlastingskins.dependency-analysis")
 }

--- a/forge-1.21/build.gradle.kts
+++ b/forge-1.21/build.gradle.kts
@@ -1,3 +1,4 @@
 plugins {
     id("everlastingskins.forge-module")
+    id("everlastingskins.dependency-analysis")
 }


### PR DESCRIPTION
## Summary

Four commits, one per `:forge-1.21.x` module. Each adds
`id("everlastingskins.dependency-analysis")` to the plugins block,
immediately after `everlastingskins.forge-module`. No version — it
comes from the buildSrc classpath dep added in PR #1.

## Modules

- `:forge-1.21` — reference module per AGENTS.md rule 1
- `:forge-1.21.1`, `:forge-1.21.4`, `:forge-1.21.8` — point-release
  parity per AGENTS.md rule 5

No `gradle.properties` changes; MC/Forge versions stay pinned to
their respective tags.

## Why this works

The buildSrc workaround in PR #3 (`gradle.projectsEvaluated`
wiring `processResources` into dep-analysis' analysis tasks) is
what makes `:projectHealth` runnable on Forge modules. Without it,
the implicit-dependency detection in Gradle 9.3.1 hard-fails the
plugin's bytecode/ABI analysis on the FG sourcesSets layout.

## Verification

- `:forge-1.21:projectHealth` runs to completion, exit 0, 43
  findings (3 genuine + 40 expected Forge-reflection FPs).
- Same for `:forge-1.21.1` / `:forge-1.21.4` / `:forge-1.21.8`,
  each at ~35 findings with identical category shape.

## Followup

- #6: wrapper script + AGENTS.md docs + .gitignore
- A separate triage-fixes PR is pending for the 3-5 genuine
  findings the rollout surfaced.
