### PR TITLE
buildSrc: add dependency-analysis-gradle-plugin:3.18.0 to classpath

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -29,4 +29,22 @@ dependencies {
     // wrapper classpaths. Keeping a second FG version here would collide
     // on the shared plugin id and break the 1.21 lane.
     implementation("net.minecraftforge:forgegradle:[7.0.3,8)")
+
+    // Dependency-analysis-gradle-plugin (com.autonomousapps.dependency-analysis),
+    // 3.18.0 — the "knip" analog for Gradle Java builds: its buildHealth task
+    // detects unused dependencies, wrong configurations (api vs implementation),
+    // undeclared transitive dependencies, and duplicate class files. Declared
+    // as a classpath dependency so everlastingskins.forge-module can apply
+    // id("com.autonomousapps.dependency-analysis") versionlessly (same reason
+    // as the ErrorProne line above).
+    //
+    // Version 3.18.0: latest stable as of 2026, verified compatible with
+    // Gradle 9.6.1; minimum supported Gradle is 8.11 (root build is 9.3.1).
+    // Requires a Java 11 runtime, which is fine: the build JVM is 17+ and
+    // :common's --release 8 is a source/target level, not the build JVM.
+    //
+    // Caution: Forge's runtime reflection (e.g. @EventBusSubscriber, model
+    // loaders) can produce false positives in buildHealth. We run it at
+    // severity=WARN only, never FAIL, and review before any auto-fix.
+    implementation("com.autonomousapps:dependency-analysis-gradle-plugin:3.18.0")
 }


### PR DESCRIPTION
## Summary

Adds the dependency-analysis-gradle-plugin to the buildSrc classpath
so the new `everlastingskins.dependency-analysis` convention plugin
(PR #2) can apply dep-analysis versionlessly.

This is the Java/Gradle analog of `knip`: buildHealth reports unused
dependencies, wrong configurations, undeclared transitives, and
duplicate class files across the root build. WARN-only by convention
(see PR #2); no auto-fix is invoked.

## Why 3.18.0

- Latest stable release (2026-07-27); no newer version exists.
- Verified against Gradle 9.6.1; minimum supported Gradle is 8.11.
  Root build runs Gradle 9.3.1.
- Java 11 runtime requirement is satisfied by the root build JVM
  (17+). `:common` is compiled at `--release 8` as a source-target
  constraint only; the build JVM is still 17+.

## Risk

Forge reflection (`@ObjectHolder`, `@EventBusSubscriber`, string-based
resource registration) is a known false-positive source for
dep-analysis. The WARN-only policy in PR #2 makes this a hygiene
report, not a gate. Per AGENTS.md, hook integration is gated on
empirical validation on a forge-1.21.x module.

## Followup PRs

- #2: convention plugin (WARN-only)
- #3: forge-module workaround for the FG sourcesSets layout
- #4: apply to :common
- #5: apply to forge-1.21 / 1.21.1 / 1.21.4 / 1.21.8
- #6: wrapper script + AGENTS.md docs + .gitignore
