### PR TITLE
common: adopt dep-analysis convention plugin

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     id("no-mixin")
     // ErrorProne static analysis (buildSrc): hooks every JavaCompile.
     id("everlastingskins.errorprone")
+    id("everlastingskins.dependency-analysis")
 }
 
 java {

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -52,7 +52,6 @@ dependencies {
     testImplementation("com.google.code.gson:gson:2.8.0")
     testImplementation("com.mojang:authlib:1.5.25")
     testImplementation("org.apache.logging.log4j:log4j-api:2.8.1")
-    testImplementation("com.google.code.findbugs:jsr305:3.0.2")
 
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.10.3")
     // Default log4j2 config (ERROR-only) so test output stays quiet.


### PR DESCRIPTION
## Summary

Two-commit change to `common/build.gradle.kts`:

1. **Adopt the dep-analysis convention plugin.** `:common` is the
   cheapest consumer (no Forge dep, no userdev download) and
   provides the cleanest empirical baseline for the WARN-only
   rollout.
2. **Drop unused `testImplementation("com.google.code.findbugs:jsr305:3.0.2")`.**
   dep-analysis found zero `javax.annotation` references across
   the test sources. The `compileOnly` jsr305 marker is unchanged
   (genuinely used by main source). gson pulls jsr305 transitively,
   so the test classpath is unaffected.

## Verification

- `:common:test` BUILD SUCCESSFUL after commit 2 (gson transitive
  jsr305 covers test runtime).
- `:common:projectHealth` runs to completion, exit 0, WARN-only.
  Findings dropped from 7 to 6 (the test-jsr305 finding is gone);
  the remaining 6 are aggregate-jar quirks from junit-jupiter /
  jqwik that are governed by the existing junit-bom.

## Followup PRs

- #5: apply convention to forge-1.21 / 1.21.1 / 1.21.4 / 1.21.8
- #6: wrapper script + AGENTS.md docs + .gitignore
