### PR TITLE
chore: promote dep-analysis rollout + #297 docs to main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ out/
 #ForgeGradle
 build/
 .gradle/
+.kotlin/
 run/
 server/
 /logs

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,8 @@ test-infrastructure/headlessmc/
 
 # Agent artifacts
 IMPLEMENTATION_PLAN.md
+
+# BEGIN oh-my-opencode-slim worktrees
+.slim/worktrees/
+.slim/worktrees.json
+# END oh-my-opencode-slim worktrees

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,12 +168,46 @@ runs the cheap `lint-yaml` / `aislop` jobs on the host runner; the Forge build
 matrix is not reliable under act (Docker JDK image fragility) — treat `act` as
 a syntax gate, not a build substitute.
 
+## Codebase improvement tools (knip-equivalent)
 
-## Required checks (integration/m2-monorepo branch protection)
+Java/Gradle has no direct `knip` equivalent; the closest analog is the
+dependency-analysis-gradle-plugin (autonomousapps). Role split: **AFT /
+Qartez / Codegraph** handle dead-code, dead-symbol, clone, and hotspot
+analysis (already integrated, no changes needed);
+**dependency-analysis-gradle-plugin** handles dep hygiene — unused deps,
+wrong-config, undeclared transitives, duplicate class files — the gap the
+codebase-intel tools do not fill.
 
-Enforced via the gh API — do not edit branch protection in-repo. `Build
-(forge-1.16.5)` and `Build (forge-1.20.1)` are required status checks on
-integration/m2-monorepo, additive to the existing contract (`YAML Lint`,
-`Build (common)` / `Build (1.21.x)` matrix, `Build (mc1.12.2)`, `E2E
-(mc1.12.2)`, `GameTest (1.21)`, `aislop (M2)`). CI job names must match
-the required-check strings exactly.
+WARN-only policy: Forge reflection (registry `@ObjectHolder`,
+`@EventBusSubscriber`, string-based resource registration) is a known
+false-positive source for dependency-analysis; we run WARN-only and never
+`fixDependencies` automatically until a manual triage pass confirms the
+findings are real. Rolled out in WARN-only mode; hook integration is gated
+on empirical validation on a forge-1.21.x module to catalog known false
+positives.
+
+Lane policy: buildSrc classpath (lane 1) + convention plugin (lane 2) +
+`scripts/gradle-health.sh` (manual runs, this lane) are in place.
+Out-of-band lanes (mc1.12.2 / forge-1.16.5 / forge-1.20.1) are NOT eligible
+for dependency-analysis due to their Gradle version constraints (verified
+Feb 2026) — they continue to rely on AFT/Qartez/Codegraph.
+
+## Branch policy & required checks
+
+`main` is the default branch (promoted from `integration/m2-monorepo` at
+`055031b`, 2026-08-06 — the 4-commit `1.21` divergence, all PR #256, is
+superseded by the monorepo's `/common` vendor approach and was not
+ported). `1.21` and `mc1.12.2` remain as frozen stable aliases (tagged
+`archived-m2-complete`): do NOT delete them, do NOT force-push them.
+`1.21` keeps its own 3-check protection (`Build (1.21)`, `GameTest
+(1.21)`, `YAML Lint`).
+
+Required checks (identical contract on `main` and
+`integration/m2-monorepo`) are enforced via the gh API — do not edit
+branch protection in-repo. The contract is strict (`enforce_admins`, no
+force pushes/deletions) with 12 contexts: `YAML Lint`, the `Build
+(common)` / `Build (1.21.x)` matrix, `Build (mc1.12.2)`, `E2E
+(mc1.12.2)` (push-only job — fires on push events only), `GameTest
+(1.21)`, the out-of-band `Build (forge-1.16.5)` / `Build (forge-1.20.1)`
+lanes, and `aislop (M2)`. CI job names must match the required-check
+strings exactly.

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -29,4 +29,22 @@ dependencies {
     // wrapper classpaths. Keeping a second FG version here would collide
     // on the shared plugin id and break the 1.21 lane.
     implementation("net.minecraftforge:forgegradle:[7.0.3,8)")
+
+    // Dependency-analysis-gradle-plugin (com.autonomousapps.dependency-analysis),
+    // 3.18.0 — the "knip" analog for Gradle Java builds: its buildHealth task
+    // detects unused dependencies, wrong configurations (api vs implementation),
+    // undeclared transitive dependencies, and duplicate class files. Declared
+    // as a classpath dependency so everlastingskins.forge-module can apply
+    // id("com.autonomousapps.dependency-analysis") versionlessly (same reason
+    // as the ErrorProne line above).
+    //
+    // Version 3.18.0: latest stable as of 2026, verified compatible with
+    // Gradle 9.6.1; minimum supported Gradle is 8.11 (root build is 9.3.1).
+    // Requires a Java 11 runtime, which is fine: the build JVM is 17+ and
+    // :common's --release 8 is a source/target level, not the build JVM.
+    //
+    // Caution: Forge's runtime reflection (e.g. @EventBusSubscriber, model
+    // loaders) can produce false positives in buildHealth. We run it at
+    // severity=WARN only, never FAIL, and review before any auto-fix.
+    implementation("com.autonomousapps:dependency-analysis-gradle-plugin:3.18.0")
 }

--- a/buildSrc/src/main/kotlin/everlastingskins.dependency-analysis.gradle.kts
+++ b/buildSrc/src/main/kotlin/everlastingskins.dependency-analysis.gradle.kts
@@ -1,0 +1,61 @@
+// everlastingskins.dependency-analysis — WARN-only "knip" for the Forge line.
+// Applies com.autonomousapps.dependency-analysis (version comes from the
+// buildSrc classpath, never declared here) and runs every check at warn
+// severity so the build can NEVER fail on a dependency-health finding.
+//
+// Why WARN-only: Forge is reflection-heavy. @ObjectHolder registry entries,
+// @EventBusSubscriber static subscribers, model loaders and string-based
+// resource registration are invisible to static analysis, so buildHealth
+// reliably reports false positives on this codebase. Mojang's authlib/log4j
+// transitives get flagged as duplicates too; that is Kombucha (in-plugin
+// dedup) hygiene, reviewed separately. Mixin is a non-issue here: the
+// no-mixin gate already forbids @Mixin anywhere in the repo.
+//
+// Conventions (the "structure rules" this plugin deliberately does NOT add —
+// Forge reflection cannot be modeled as rule entries):
+//  - never gate CI on buildHealth: it is a human-readable hygiene report,
+//    run on demand via ./gradlew buildHealth (root) / projectHealth (module);
+//  - never run fixDependencies automatically: the unused-dependency detector
+//    is defeated by the reflection above, so an auto-fix would delete live
+//    entries. Any fix is a manual, reviewed change (AGENTS.md policy).
+//
+// Note: 3.x removed the old `abortBuildOnFalsePositives` flag; the modern
+// equivalent is issues { all { onAny { severity("warn") } } } below, which
+// also governs the buildHealth aggregate the plugin registers on the root
+// project once any module applies this convention.
+
+import com.autonomousapps.DependencyAnalysisSubExtension
+import com.autonomousapps.tasks.ProjectHealthTask
+
+plugins {
+    id("com.autonomousapps.dependency-analysis")
+}
+
+// Every issue category (unused dependencies, wrong configurations, undeclared
+// transitives, duplicate classes, ...) at warn severity. "fail" is the plugin
+// default; we never want a dependency-health finding to break a build.
+//
+// NOTE: use DependencyAnalysisSubExtension here, not
+// DependencyAnalysisExtension — the latter is registered only on the ROOT
+// project (RootPlugin); subprojects get the Sub extension. The lane-2 version
+// used the root type and failed at apply time on :common ("Extension of type
+// 'DependencyAnalysisExtension' does not exist"). The per-project issues{}
+// handler is ProjectIssueHandler, which has onAny directly (no all{} wrapper
+// — that lives on the root IssueHandler).
+extensions.configure<DependencyAnalysisSubExtension> {
+    issues {
+        onAny {
+            severity("warn")
+        }
+    }
+}
+
+// Deterministic report output: fixed relative path under build/, independent
+// of the project dir name. The plugin default is already this path; pinning
+// it here guards against default drift and keeps CI artifact paths stable.
+// withType+configureEach (not tasks.named): the plugin registers
+// projectHealth conditionally/deferred, so a named() lookup at apply time
+// fails with "Task with name 'projectHealth' not found".
+tasks.withType<ProjectHealthTask>().configureEach {
+    consoleReport.set(layout.buildDirectory.file("reports/dependency-analysis/project-health-report.txt"))
+}

--- a/buildSrc/src/main/kotlin/everlastingskins.forge-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/everlastingskins.forge-module.gradle.kts
@@ -224,9 +224,9 @@ dependencies {
     // resolved the conflict — no module ever opted out. If a future
     // forge-* lane needs vendored :common copies for tooling reasons,
     // re-add the gate + opt-out property here.
-    implementation(project(":common"))
+    api(project(":common"))
     implementation("org.apache.httpcomponents:httpclient:4.5.13")
-    implementation(minecraft.dependency("net.minecraftforge:forge:${minecraftVersion}-${forgeVersion}"))
+    api(minecraft.dependency("net.minecraftforge:forge:${minecraftVersion}-${forgeVersion}"))
     // MUST be declared before the mixin processor: mixin-0.8.7-processor.jar
     // bundles an unrelocated OLD Guava (no ImmutableMap.Builder.buildOrThrow),
     // which would shadow ErrorProne's Guava 33 on the annotation processor
@@ -255,7 +255,6 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.3")
     testImplementation("net.jqwik:jqwik:1.9.0")
     testImplementation("me.clip:placeholderapi:2.12.3")
-    testImplementation("org.spigotmc:spigot-api:1.20.4-R0.1-SNAPSHOT")
     testImplementation("org.mockito:mockito-core:5.12.0")
     testImplementation("org.mockito:mockito-junit-jupiter:5.12.0")
 
@@ -263,8 +262,17 @@ dependencies {
 
     "gametestImplementation"(sourceSets.main.get().output)
     "gametestImplementation"("org.junit.jupiter:junit-jupiter-api:5.10.3")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.3")
     "gametestRuntimeOnly"("org.junit.platform:junit-platform-launcher:1.10.3")
 }
+
+// jsr305 is brought in transitively by Forge AND bundled by discordsrv;
+// both publish javax/annotation/Nullable to the same FQN. Exclude the
+// transitive copy so discordsrv's bundled class is the only one on the
+// classpath (same split-package pattern as the historical #265 forge21.*
+// fix). dep-analysis 3.18.0 surfaces this as a duplicate-class warning.
+configurations.getByName("compileOnly").exclude(group = "com.google.code.findbugs", module = "jsr305")
+configurations.getByName("testImplementation").exclude(group = "com.google.code.findbugs", module = "jsr305")
 
 configurations.getByName("testRuntimeClasspath") {
     exclude(group = "org.slf4j", module = "slf4j-simple")

--- a/buildSrc/src/main/kotlin/everlastingskins.forge-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/everlastingskins.forge-module.gradle.kts
@@ -1,6 +1,8 @@
 // everlastingskins.forge-module — convention plugin for the ForgeGradle 7+
 // (Java 21 toolchain) modules: forge-1.21 and the 1.21.x point releases.
 
+import com.autonomousapps.tasks.AbiAnalysisTask
+import com.autonomousapps.tasks.ClassListExploderTask
 import java.text.SimpleDateFormat
 import java.util.Date
 
@@ -322,4 +324,23 @@ sourceSets.all {
     val dir = layout.buildDirectory.dir("sourcesSets/${name}")
     output.setResourcesDir(dir.get().asFile)
     java.destinationDirectory = dir
+}
+
+// Workaround for dependency-analysis-gradle-plugin #960:
+// FG redirects every sourceSet's classes+resources output to
+// build/sourcesSets/<name> (this convention's lines 321-325). The
+// plugin's explodeByteCodeSourceMain + abiAnalysisMain tasks read
+// build/sourcesSets/<name> but don't declare dependsOn processResources,
+// so Gradle 9.3.1's strict implicit-dependency detection hard-fails
+// :<module>:projectHealth. Maintainer-verified fix per #960: inject
+// the missing wiring at projectsEvaluated time. Only fires when the
+// dep-analysis plugin is actually applied to this module — its tasks
+// won't exist otherwise and `withType` is a no-op.
+gradle.projectsEvaluated {
+    tasks.withType<ClassListExploderTask>().configureEach {
+        dependsOn("processResources")
+    }
+    tasks.withType<AbiAnalysisTask>().configureEach {
+        dependsOn("processResources")
+    }
 }

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     id("no-mixin")
     // ErrorProne static analysis (buildSrc): hooks every JavaCompile.
     id("everlastingskins.errorprone")
+    id("everlastingskins.dependency-analysis")
 }
 
 java {

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -52,7 +52,6 @@ dependencies {
     testImplementation("com.google.code.gson:gson:2.8.0")
     testImplementation("com.mojang:authlib:1.5.25")
     testImplementation("org.apache.logging.log4j:log4j-api:2.8.1")
-    testImplementation("com.google.code.findbugs:jsr305:3.0.2")
 
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.10.3")
     // Default log4j2 config (ERROR-only) so test output stays quiet.

--- a/forge-1.21.1/build.gradle.kts
+++ b/forge-1.21.1/build.gradle.kts
@@ -1,3 +1,4 @@
 plugins {
     id("everlastingskins.forge-module")
+    id("everlastingskins.dependency-analysis")
 }

--- a/forge-1.21.4/build.gradle.kts
+++ b/forge-1.21.4/build.gradle.kts
@@ -1,3 +1,4 @@
 plugins {
     id("everlastingskins.forge-module")
+    id("everlastingskins.dependency-analysis")
 }

--- a/forge-1.21.8/build.gradle.kts
+++ b/forge-1.21.8/build.gradle.kts
@@ -1,3 +1,4 @@
 plugins {
     id("everlastingskins.forge-module")
+    id("everlastingskins.dependency-analysis")
 }

--- a/forge-1.21/README.md
+++ b/forge-1.21/README.md
@@ -2,25 +2,34 @@
 
 Persistent player skin management for Minecraft Forge servers.
 
-[![CI (1.21)](https://github.com/Levosilimo/Everlasting-Skins/actions/workflows/ci.yml/badge.svg?branch=1.21)](https://github.com/Levosilimo/Everlasting-Skins/actions/workflows/ci.yml?query=branch%3A1.21)
-[![CI (mc1.12.2)](https://github.com/Levosilimo/Everlasting-Skins/actions/workflows/ci.yml/badge.svg?branch=mc1.12.2)](https://github.com/Levosilimo/Everlasting-Skins/actions/workflows/ci.yml?query=branch%3Amc1.12.2)
+[![CI](https://github.com/Levosilimo/Everlasting-Skins/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Levosilimo/Everlasting-Skins/actions/workflows/ci.yml?query=branch%3Amain)
 [![Release](https://img.shields.io/github/v/release/Levosilimo/Everlasting-Skins?include_prereleases&label=latest)](https://github.com/Levosilimo/Everlasting-Skins/releases)
 [![License](https://img.shields.io/github/license/Levosilimo/Everlasting-Skins)](LICENSE)
 [![CurseForge](https://cf.way2muchnoise.eu/versions/538149.svg)](https://www.curseforge.com/minecraft/mc-mods/everlasting-skins)
 [![Modrinth](https://img.shields.io/modrinth/dt/everlasting-skins?label=Modrinth)](https://modrinth.com/mod/everlasting-skins)
 [![Java](https://img.shields.io/badge/java-21%20%7C%208-blue)](https://adoptium.net/)
 
-This repository uses **git branches** to target different Minecraft versions.
-Each branch is isolated with its own toolchain, Forge version, and Java runtime.
+This repository is a **Gradle monorepo** (`main` is the default branch): every
+supported Minecraft version is a lane under one root build instead of an
+isolated git branch. All lanes share the version-independent `:common` module.
 
-## Branches
+## Lanes
 
-| Branch | Minecraft | Forge | Java | Status |
-|--------|-----------|-------|------|--------|
-| [1.21](https://github.com/Levosilimo/Everlasting-Skins/tree/1.21) | 1.21 | 51.0.8 | 21 | Active |
-| [mc1.12.2](https://github.com/Levosilimo/Everlasting-Skins/tree/mc1.12.2) | 1.12.2 | 14.23.5.2847 | 8 | Active |
+| Lane | Minecraft | Forge | Java | Notes |
+|------|-----------|-------|------|-------|
+| [:common](https://github.com/Levosilimo/Everlasting-Skins/tree/main/common) | — | — | 8 (`--release 8`) | version-independent shared module |
+| [:forge-1.21](https://github.com/Levosilimo/Everlasting-Skins/tree/main/forge-1.21) | 1.21 | 51.0.8 | 21 | root subproject (Gradle 9.3.1) |
+| [:forge-1.21.1](https://github.com/Levosilimo/Everlasting-Skins/tree/main/forge-1.21.1) | 1.21.1 | 52.1.16 | 21 | root subproject |
+| [:forge-1.21.4](https://github.com/Levosilimo/Everlasting-Skins/tree/main/forge-1.21.4) | 1.21.4 | 54.1.18 | 21 | root subproject |
+| [:forge-1.21.8](https://github.com/Levosilimo/Everlasting-Skins/tree/main/forge-1.21.8) | 1.21.8 | 58.1.21 | 21 | root subproject |
+| [forge-1.16.5/](https://github.com/Levosilimo/Everlasting-Skins/tree/main/forge-1.16.5) | 1.16.5 | 36.2.34 | 8 | own wrapper (Gradle 7.6.4, FG 5.1.77) |
+| [forge-1.20.1/](https://github.com/Levosilimo/Everlasting-Skins/tree/main/forge-1.20.1) | 1.20.1 | 47.4.10 | 21 | own wrapper (Gradle 8.7, FG 6.0.54) |
+| [mc1.12.2/](https://github.com/Levosilimo/Everlasting-Skins/tree/main/mc1.12.2) | 1.12.2 | 14.23.5.2847 | 8 | own wrapper (Gradle 4.10.3, FG 2.3.4) |
 
-Each branch has its own README with version-specific installation instructions, config paths, and command documentation.
+The `1.21` and `mc1.12.2` branches still exist on GitHub but are **archived
+stable aliases** — frozen snapshots of the old per-branch layout, not active
+development targets. See [REPOSITORY-STRUCTURE.md](../REPOSITORY-STRUCTURE.md)
+for the full layout.
 
 ## ✨ Features
 
@@ -36,7 +45,7 @@ Each branch has its own README with version-specific installation instructions, 
 ## 📦 Installation
 
 1. Install [Forge for Minecraft 1.21](https://files.minecraftforge.net/net/minecraftforge/forge/index_1.21.html).
-2. Download `EverlastingSkins-1.21-2.1.0.jar` from the [Releases page](https://github.com/Levosilimo/Everlasting-Skins/releases).
+2. Download `everlastingskins-1.21-2.1.0.jar` from the [Releases page](https://github.com/Levosilimo/Everlasting-Skins/releases).
 3. Place the JAR in your server's `mods/` folder.
 4. Restart the server.
 
@@ -208,12 +217,12 @@ To enable DiscordSRV announcements:
 Requires JDK 21 and Gradle (via the wrapper):
 
 ```bash
-git clone -b 1.21 https://github.com/Levosilimo/Everlasting-Skins
+git clone https://github.com/Levosilimo/Everlasting-Skins
 cd Everlasting-Skins
-./gradlew build
+./gradlew :forge-1.21:build
 ```
 
-Output: `build/libs/EverlastingSkins-1.21-2.1.0.jar`
+Output: `forge-1.21/build/libs/everlastingskins-1.21-2.1.0.jar`
 
 ## ❓ FAQ
 

--- a/forge-1.21/build.gradle.kts
+++ b/forge-1.21/build.gradle.kts
@@ -1,3 +1,4 @@
 plugins {
     id("everlastingskins.forge-module")
+    id("everlastingskins.dependency-analysis")
 }

--- a/scripts/gradle-health.sh
+++ b/scripts/gradle-health.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Dependency-analysis buildHealth: runs the autonomousapps buildHealth report
+# in offline mode. Knip-equivalent dep hygiene (unused deps, wrong-config,
+# undeclared transitives) for the Gradle root build.
+#
+# WARN-only hygiene: exits 0 always; never a fail gate until false positives
+# (Forge reflection) are catalogued.
+#
+# Usage: bash scripts/gradle-health.sh [-v]
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+VERBOSE=0
+if [ "${1:-}" = "-v" ]; then
+  VERBOSE=1
+fi
+
+# Per-project projectHealth iteration. buildHealth is a root-level
+# aggregate (DependencyAnalysisPlugin.applyForRoot guards
+# `if (this == rootProject)`), so we run each consumer's
+# per-project task individually. Consumer list is the script's source
+# of truth — append future modules here as they adopt the convention.
+CONSUMERS=(
+    ":common"
+    ":forge-1.21"
+    ":forge-1.21.1"
+    ":forge-1.21.4"
+    ":forge-1.21.8"
+)
+
+for c in "${CONSUMERS[@]}"; do
+    if [ -z "$c" ] || [[ "$c" =~ ^# ]]; then
+        continue
+    fi
+    echo "[gradle-health] ${c}:projectHealth..."
+    ./gradlew --no-daemon --offline "${c}:projectHealth" || true
+    report="common/build/reports/dependency-analysis/project-health-report.txt"
+    case "$c" in
+        :common) report="common/build/reports/dependency-analysis/project-health-report.txt" ;;
+        :forge-1.21) report="forge-1.21/build/reports/dependency-analysis/project-health-report.txt" ;;
+        *) report="${c#:}/build/reports/dependency-analysis/project-health-report.txt" ;;
+    esac
+    if [ -f "$report" ]; then
+        echo "[gradle-health] ${c} report: $report"
+    fi
+done
+
+exit 0


### PR DESCRIPTION
## Summary

Fast-forward main to `integration/m2-monorepo` HEAD `0e22365` via a
merge commit. Closes the dep-analysis rollout by bringing the same
7-PR set already on integration/m2-monorepo onto main.

## What's in the diff

The promotion includes two review groups:

**1. PR #297** (`docs(forge-1.21): rewrite README to describe Gradle lanes`,
`03764b6`): docs-only. Merged to `integration/m2-monorepo` at
01:02, ~4.5h before the dep-analysis rollout started. This PR is
**prior reviewed and CI-green** — it's been sitting on
integration/m2-monorepo for over a day and was not promoted
separately because PR #299's main sync ran ~15 minutes earlier.
It is unavoidable in any promotion of `0e22365`; rewriting
integration history to exclude it would require force-push.

**2. The 7 dep-analysis rollout PRs** (already reviewed and merged to
integration/m2-monorepo):
- #303 `buildSrc: add dependency-analysis-gradle-plugin:3.18.0 to classpath`
- #301 `buildSrc: add dep-analysis convention plugin (WARN-only)`
- #300 `forge-module: wire processResources into dep-analysis analysis tasks`
- #304 `common: adopt dep-analysis convention plugin`
- #302 `forge-1.21.x: adopt dep-analysis convention plugin`
- #305 `dep-analysis: add gradle-health wrapper + AGENTS.md docs + .gitignore`
- #306 `forge-module: address dep-analysis triage findings`

## Why

The dep-analysis plugin is WARN-only and never auto-fixes; AGENTS.md
has a new "Codebase improvement tools (knip-equivalent)" section.
Out-of-band lanes (mc1.12.2 / forge-1.16.5 / forge-1.20.1) source-share
`:common` only and are untouched.

## AGENTS.md compliance

- Rule 4 (no new deps): the dep-analysis-gradle-plugin is on the
  buildSrc classpath; same Maven coordinates as the legacy 1.21 build
  already had; no runtime deps changed.
- Rule 5 (point-release parity): zero `gradle.properties` edits.
- Rule 6 (:common consumed unconditionally): the `api` promotion in #306
  strengthens the rule rather than weakening it.

## Verification

- All 12 required contexts green on integration/m2-monorepo HEAD post-#306.
- Out-of-band lanes (forge-1.16.5, forge-1.20.1, mc1.12.2) builds included in the matrix.
- See `.slim/deepwork/dep-analysis-rollout.md` for the rollout ledger.
