### PR TITLE
AGENTS.md: surface dep-hygiene script in Verification section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,7 @@ registers backends).
 ./gradlew :common:build        # fast gate after :common changes
 ./gradlew :forge-1.21:build    # full forge module (slow; downloads userdev)
 ./gradlew build                # whole Forge line
+bash scripts/gradle-health.sh  # dep-hygiene sweep (manual, WARN-only; per-consumer :projectHealth)
 ```
 
 CI (`ci.yml`) is a per-module matrix (PR #260): lint-yaml → `build` over


### PR DESCRIPTION
## Summary

Surfaces `bash scripts/gradle-health.sh` in AGENTS.md's Verification
section. The wrapper was previously mentioned only in the
lane-policy prose at L190 — adding it to the canonical Verification
block makes the knip-equivalent hygiene run discoverable alongside
the existing `./gradlew build` commands.

## Change

Single line added to the Verification section, matching the
surrounding format/style. No other sections modified.
