### PR TITLE
dep-analysis: cosmetics (Gradle citation + gradle-health.sh dedupe)

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
     // as the ErrorProne line above).
     //
     // Version 3.18.0: latest stable as of 2026, verified compatible with
-    // Gradle 9.6.1; minimum supported Gradle is 8.11 (root build is 9.3.1).
+    // Gradle 9.3.1; minimum supported Gradle is 8.11 (root build is 9.3.1).
     // Requires a Java 11 runtime, which is fine: the build JVM is 17+ and
     // :common's --release 8 is a source/target level, not the build JVM.
     //

--- a/scripts/gradle-health.sh
+++ b/scripts/gradle-health.sh
@@ -37,10 +37,8 @@ for c in "${CONSUMERS[@]}"; do
     fi
     echo "[gradle-health] ${c}:projectHealth..."
     ./gradlew --no-daemon --offline "${c}:projectHealth" || true
-    report="common/build/reports/dependency-analysis/project-health-report.txt"
     case "$c" in
         :common) report="common/build/reports/dependency-analysis/project-health-report.txt" ;;
-        :forge-1.21) report="forge-1.21/build/reports/dependency-analysis/project-health-report.txt" ;;
         *) report="${c#:}/build/reports/dependency-analysis/project-health-report.txt" ;;
     esac
     if [ -f "$report" ]; then


### PR DESCRIPTION
## Summary

Two-commit cosmetics follow-up to the dep-analysis rollout
(#303–#307). Both items were identified by the mid-rollout audit
(oracle P3, not gated to ship) and live as uncommitted
working-tree changes in the main checkout.

## Changes

1. **buildSrc: align Gradle citation** — the dep-analysis classpath
   dep comment cited Gradle 9.6.1; the root wrapper pins 9.3.1.
   Aligns the comment to the actual pinned version.

2. **scripts/gradle-health.sh: dedupe** — removed the default
   `report=` assignment (overwritten by every arm) and the explicit
   `:forge-1.21)` case arm (identical to what the `*)` wildcard
   produces via `${c#:}/...`). The wildcard is now the sole
   resolver; the script's behavior is unchanged.

## Verification

- `./gradlew --no-daemon :buildSrc:compileKotlin` green
  (post-F2 Gradle citation change invalidates buildSrc's config
  cache; expected).
- `bash -n scripts/gradle-health.sh` exit 0.
- `bash scripts/gradle-health.sh` exit 0, all 5 consumers' reports
  produced.
