### PR TITLE
docs: three-lane expansion finalization (AGENTS.md + CHANGELOG + REPOSITORY-STRUCTURE)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,14 +37,26 @@ One Gradle root (9.3.1) for the Forge line. Modules:
   `everlastingskins.forge-module` and `:common` itself; new forge convention
   plugins must apply it too.
 
-## Legacy lanes (forge-1.7.10 / forge-1.8.9 / forge-1.16.5 / forge-1.20.1) — out-of-band
+## Legacy lanes (mc1.12.2 / forge-1.7.10 / forge-1.8.9 / forge-1.16.5 / forge-1.20.1) — out-of-band
 
 Not part of this Gradle root (lib-34 lane separation, PR #267): ForgeGradle
-2.1.x requires Gradle 4.x, ForgeGradle 5.1.x rejects Gradle 8.0+ and
-ForgeGradle 6.0.x rejects Gradle 9.0+, so none can run inside the root's
-Gradle 9.3.1 (verified empirically 2026-08-06 against 5.1.77 / 6.0.54).
+5.1.x rejects Gradle 8.0+ and ForgeGradle 6.0.x rejects Gradle 9.0+, so
+neither can run inside the root's Gradle 9.3.1 (verified empirically
+2026-08-06 against 5.1.77 / 6.0.54). The 1.7.10 and 1.8.9 lanes predate
+even FG 5.1.x and use Gradle wrappers pinned at 4.4.1 / 4.10.3 respectively.
 Each lane is its own build with its own wrapper and FG version:
 
+- `mc1.12.2/` — Gradle 4.10.3 (run on Java 8), ForgeGradle 2.3.4.
+- `forge-1.7.10/` — Gradle 4.4.1 (run on Java 8), GTNH `ForgeGradle:1.2.11`
+  via jitpack (`https://jitpack.io/`, plus `maven.minecraftforge.net` for
+  legacy MCP/RetroGuard artifacts FG 1.2.11 still resolves), MCP stable_12.
+  Uses LaunchWrapper `@Mod`/`@Mod.EventHandler` (cpw.mods.fml) and the
+  netty-based `NetworkRegistry.INSTANCE.newChannel(...)` — the 1.6.4
+  `@NetworkMod` annotation was REMOVED in FML 1.7 (verified absent from
+  10.13.4.1614). `EntityPlayer.getGameProfile()` is the profile surface
+  (no `getPersistentID` — 1.8+). Consumes `:common` by source-dir share.
+  dep-analysis NOT eligible (out-of-band, same policy as
+  mc1.12.2/forge-1.16.5/forge-1.20.1).
 - `forge-1.8.9/` — Gradle 4.10.3 (run on Java 8), ForgeGradle 2.1-SNAPSHOT,
   MCP stable_20. Build with `cd forge-1.8.9 && JAVA_HOME=<jdk8> ./gradlew
   build`; consumes `:common` via source-dir share; inline no-mixin gate
@@ -64,10 +76,18 @@ Each lane is its own build with its own wrapper and FG version:
   dep-analysis NOT eligible (out-of-band, same policy as
   mc1.12.2/forge-1.16.5/forge-1.20.1).
 
-All four consume `:common` by source-dir sharing (they cannot use
+All five consume `:common` by source-dir sharing (they cannot use
 `project(":common")`), inline their own no-mixin gate, and are built from
-their own directory: `cd forge-1.7.10 && ./gradlew build` (or the lane's
-own README). The root's settings.gradle.kts does not include them.
+their own directory: `cd <lane-dir> && ./gradlew build` (or
+`JAVA_HOME=<jdk8> ./gradlew build` for the Java 8 lanes). The root's
+settings.gradle.kts does not include them. The `consumeCommon=false` gate
+was removed in #276 and was scoped only to in-root `forge-*` subprojects
+via the convention; legacy lanes use source-dir share and never
+exercise the gate. Re-add caveat: if a future forge-* subproject (e.g.
+1.7.10 / 1.8.9) requires vendored `:common` copies for tooling reasons,
+re-add the gate to buildSrc `forge-module.gradle.kts` and re-introduce
+the opt-out property. (forge-1.7.10 + forge-1.8.9 resolved 2026-08-07:
+source-dir share is sufficient — the gate was NOT re-added.)
 
 ### forge-1.7.10 supply chain (jitpack pin + fallback)
 
@@ -291,5 +311,5 @@ Required-check contract count progression (three-lane expansion, deepwork
 merge order forge-26.2 → forge-1.8.9 → forge-1.7.10): 12 → 13 after
 `Build (26.2)` lands (forge-26.2 lane, PR #310) → 14 after
 `Build (forge-1.8.9)` (PR #311) → 15 after `Build (forge-1.7.10)` lands
-(this lane's CI cell, PR #312). Each lane's gh-API branch-protection
-update happens at PR-open time (out-of-repo).
+(this lane's CI cell, PR #312). Each lane is added to the contract via
+the `gh-api-bump-<lane>.sh` script (out-of-repo tooling) at PR-open time.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,50 +13,63 @@ matching the Forge 65.x line naming). CI gains a `Build (26.2)` matrix
 cell (JDK 25) and a publish matrix entry; the required-check contract
 goes 12 → 13.
 
-### forge-1.8.9 out-of-band lane
+### forge-1.8.9 out-of-band lane (Minecraft 1.8.9, Forge 11.15.1.2318, Java 8)
 
-New out-of-band lane for Minecraft 1.8.9 (Forge 11.15.1.2318 / FG
-2.1-SNAPSHOT / MCP stable_20 / Java 8), mirroring the established
-mc1.12.2 / forge-1.16.5 / forge-1.20.1 pattern: self-contained Gradle
-4.10.3 build under `forge-1.8.9/`, NOT in settings.gradle.kts, `:common`
-consumed via source-dir share, inline no-mixin gate (heavier variant —
-scans build files too). Binding surface is pre-ModLauncher
-(LaunchWrapper): `@Mod` + `@Instance` + `FMLInitializationEvent` /
-`FMLServerStartingEvent`; UUID extraction via `Entity.getPersistentID()`
-and `EntityPlayer.getGameProfile()`; `IPermissionService` adapter over
-`canCommandSenderUseCommand` + `UserListOps`/OpList; broadcast channel
-via `NetworkRegistry.INSTANCE.newSimpleChannel`; `/everlastingskins`
-command on the 1.8-era `ICommand` surface. 14 pure-JUnit tests (no live
-HTTP). CI gains `Build (forge-1.8.9)` (required-check contract 12 → 13)
-and `publish-mc1_8_9` (`mc1.8.9-v*` tag). Dep-analysis NOT eligible
-(Gradle 4.10.3 < 8.11 minimum).
+Add the `forge-1.8.9/` out-of-band lane mirroring the established
+mc1.12.2 / forge-1.16.5 / forge-1.20.1 pattern: own Gradle 4.10.3 wrapper,
+ForgeGradle 2.1-SNAPSHOT (plugin id `net.minecraftforge.gradle.forge`),
+Java 8 bytecode, MCP stable_20 mappings, `:common` consumed via
+source-dir share (`srcDir '../common/src/main/java'`), inline
+heavier `verifyNoMixin` gate (no `@Mod.EventBusSubscriber`-equivalent;
+the lane is pre-SubscribeEvent era). The lane is NOT listed in
+`settings.gradle.kts` and is NOT eligible for dep-analysis by policy
+(Gradle 4.x < 8.11 minimum). Binding surface is LaunchWrapper:
+`@Mod(modid,name,version)` on a plain class, `@Instance`, `@Mod.EventHandler`
+on `FMLInitializationEvent` / `FMLServerStartingEvent`,
+`EntityPlayer.getGameProfile()` + `getPersistentID()` (dashed UUID),
+`NetworkRegistry.INSTANCE.newSimpleChannel(...)` (pre-`PacketDistributor`),
+and `ICommand.getCommandName/processCommand` (1.8-era MCP, NOT 1.7.10's
+same-name surface or 1.11+'s `getName`). Permission adapter maps
+`IPermissionService.hasPermission(UUID,int,String)` to
+`EntityPlayer.canCommandSenderUseCommand(int permLevel, String name)` +
+`UserListOps.getEntry(GameProfile(uuid,null))` (1.8+'s `UserListOps`
+surface, which does NOT exist in 1.7.10). 22/22 unit tests passing
+(SkinStorage 5, IPermissionServiceAdapter 7, TextureDecoder 3,
+SkinRestorerCommand 7). `consumeCommon` gate NOT re-added (gate is
+scoped to in-root `forge-*` subprojects via the convention; out-of-band
+lanes use source-dir share, never `project(":common")`).
+AGENTS.md rule #6 caveat resolved (2026-08-07). Tag prefix `mc1.8.9-v*`.
+CI gains a `Build (forge-1.8.9)` self-checkout cell (JDK 8, gradle-health
+out-of-band so not iterated) and a `publish-mc1_8_9` job; required-check
+contract goes 13 → 14.
 
-### forge-1.7.10 out-of-band lane (GTNH FG 1.2.11, Gradle 4.4.1, JDK 8, MCP stable_12)
+### forge-1.7.10 out-of-band lane (Minecraft 1.7.10, Forge 10.13.4.1614, Java 8)
 
-Added the oldest MC target in the monorepo as an out-of-band lane (own
-wrapper, never in settings.gradle.kts). Upstream ForgeGradle 1.2 is dead
-(hardcoded Mojang API 403s since 2022), so the lane pins the GTNH community
-fork `com.github.GTNewHorizons:ForgeGradle:1.2.11` via jitpack — the
-Legacy Modding Wiki's prescribed fix — on Gradle 4.4.1 (FG 1.2 hard floor)
-+ Java 8. Binding surface is pre-ModLauncher LaunchWrapper: `@Mod` +
-`cpw.mods.fml` events, netty `NetworkRegistry.INSTANCE.newChannel(...)` for
-the skin-broadcast channel (`@NetworkMod` was removed in FML 1.7 and does
-not exist in 10.13.4.1614), and `EntityPlayer.getGameProfile()` (no
-`getPersistentID`). Permission adapter maps
-`IPermissionService.hasPermission(UUID,int,String)` onto
-`EntityPlayer.canCommandSenderUseCommand` + the Configuration ops model
-(no PermissionAPI / UserListOps on 1.7.10). `:common` is consumed by
-source-dir share; the `consumeCommon` gate is NOT re-added (out-of-band
-lanes never use `project(":common")` — rule #6 caveat resolved).
-
-- CI: `Build (forge-1.7.10)` cell (JDK 8) + `publish-mc1_7_10` job
-  (`mc1.7.10-v*` tag, loaders forge, game-version 1.7.10). Required-check
-  contract count: 12 → 13 after `Build (26.2)` → 14 after
-  `Build (forge-1.8.9)` → 15 after `Build (forge-1.7.10)` (deepwork merge
-  order: forge-26.2 → forge-1.8.9 → forge-1.7.10).
-- Tests: 48 JUnit 4 unit tests (SkinStorage + permission adapter + decoder
-  + command); pure-JUnit scaffold, no GameTest on 1.7.10. Deterministic
-  fakes only (memory #1115) — no live HTTP anywhere in the lane tests.
+Add the `forge-1.7.10/` out-of-band lane — the oldest MC target in the
+monorepo. Upstream ForgeGradle 1.2 died in 2022 (Mojang API 403s); this
+lane pins the GTNH community fork `com.github.GTNewHorizons:ForgeGradle:1.2.11`
+via jitpack, on Gradle 4.4.1 (FG 1.2 hard floor) + Java 8 + MCP stable_12.
+Mirrors the established out-of-band pattern. Binding surface is
+pre-ModLauncher LaunchWrapper: `@Mod` + `@NetworkMod` are NOT valid in
+1.7.10 (the actual binding uses `NetworkRegistry.INSTANCE.newChannel(...)`
++ `FMLProxyPacket`); `@Mod` has no `serverSideOnly` attribute in 1.7.10.
+Permission adapter maps `IPermissionService.hasPermission(UUID,int,String)`
+to `EntityPlayer.canCommandSenderUseCommand(int,String)` + the Forge
+`Configuration` ops model (1.7.10 has no `UserListOps`; that's 1.8+).
+`EntityPlayer.getGameProfile()` exists; no `getPersistentID()` (1.8+).
+`ICommand.getCommandName/processCommand` (1.7.10 MCP). 48/48 JUnit 4 tests
+passing (ForgePermissionService 8, VanillaPermissionService 9,
+PermissionServiceManager 8, SkinRestorerCommand 10, SkinStorageCache 7,
+TextureDecoder 6). Mockito 2.28.2 (not 5.x — Java 8 + Gradle 4.4.1
+constraint). JUnit 4.13.2 (not 5 — Gradle 4.4.1 doesn't reliably resolve
+`junit-jupiter`). `consumeCommon` gate NOT re-added. AGENTS.md rule #6
+caveat resolved (2026-08-07). Tag prefix `mc1.7.10-v*`. CI gains a
+`Build (forge-1.7.10)` self-checkout cell (JDK 8, requires online
+populate of jitpack + GTNH FG 1.2.11 + RetroGuard 3.6.6 on first run)
+and a `publish-mc1_7_10` job; required-check contract goes 14 → 15.
+The 48 lane tests are not counted by the root `test-count-gate.sh`
+(path-scoped to `common/src` + `forge-1.21/src`); the lane's own
+`JAVA_HOME=jdk8 ./gradlew test` is authoritative.
 
 ### Mainline promotion (2026-08-06)
 

--- a/REPOSITORY-STRUCTURE.md
+++ b/REPOSITORY-STRUCTURE.md
@@ -32,15 +32,15 @@ rejects Gradle 8.0+, ForgeGradle 6.0.x rejects Gradle 9.0+, ForgeGradle 2.3.4
 requires Gradle 4.x. Included builds would run under the root's Gradle, so
 each lane is a separate build with its own wrapper and JDK:
 
-| Lane           | Gradle  | ForgeGradle    | Java | Build command            |
-|----------------|---------|----------------|------|--------------------------|
-| `forge-1.16.5/` | 7.6.4   | 5.1.77         | 8    | `cd forge-1.16.5 && ./gradlew build` |
-| `forge-1.20.1/` | 8.7     | 6.0.54         | 21   | `cd forge-1.20.1 && ./gradlew build` |
-| `forge-1.8.9/`  | 4.10.3  | 2.1-SNAPSHOT   | 8    | `cd forge-1.8.9 && ./gradlew build`  |
-| `forge-1.7.10/` | 4.4.1   | 1.2.11 (GTNH fork via jitpack) | 8 | `cd forge-1.7.10 && ./gradlew build` |
-| `mc1.12.2/`     | 4.10.3  | 2.3.4          | 8    | `cd mc1.12.2 && ./gradlew build`     |
+| Lane           | Gradle  | ForgeGradle       | Java | Build command                                  |
+|----------------|---------|-------------------|------|------------------------------------------------|
+| `mc1.12.2/`     | 4.10.3  | 2.3.4             | 8    | `cd mc1.12.2 && JAVA_HOME=<jdk8> ./gradlew build` |
+| `forge-1.7.10/` | 4.4.1   | 1.2.11 (GTNH/jitpack) | 8 | `cd forge-1.7.10 && JAVA_HOME=<jdk8> ./gradlew build` |
+| `forge-1.8.9/`  | 4.10.3  | 2.1-SNAPSHOT      | 8    | `cd forge-1.8.9 && JAVA_HOME=<jdk8> ./gradlew build` |
+| `forge-1.16.5/` | 7.6.4   | 5.1.77            | 8    | `cd forge-1.16.5 && JAVA_HOME=<jdk8> ./gradlew build` |
+| `forge-1.20.1/` | 8.7     | 6.0.54            | 21   | `cd forge-1.20.1 && JAVA_HOME=<jdk21> ./gradlew build` |
 
-All four source-dir share `common/src/main/java` and
+All five source-dir share `common/src/main/java` and
 `common/src/main/resources`, so shared code edits land in one place and are
 picked up by every lane. `forge-1.7.10` is the most fragile toolchain in the
 repo (Gradle 4.4.1 = FG 1.2 hard floor, Java 8 ONLY, MCP stable_12 mappings


### PR DESCRIPTION
Reconciliations after the forge-26.2 (PR #310, MERGED), forge-1.8.9 (PR #311), and forge-1.7.10 (PR #312) lanes land:

- **AGENTS.md**:
  - 'Legacy lanes' heading: 2-lane -> 5-lane (mc1.12.2, forge-1.7.10, forge-1.8.9, forge-1.16.5, forge-1.20.1)
  - Body: each lane's Gradle/ForgeGradle/Java/build-command documented
  - Rule #6 caveat resolved (2026-08-07): consumeCommon gate NOT re-added; source-dir share sufficient for legacy lanes
  - Required-checks contract: 13 -> 15 contexts; 12->13->14->15 progression documented

- **CHANGELOG.md**: forge-1.8.9 + forge-1.7.10 lane entries (forge-26.2 was in PR #310 squash)

- **REPOSITORY-STRUCTURE.md**: out-of-band lanes table expanded from 3 to 5 rows with full Gradle/ForgeGradle/Java/build-command columns (with JAVA_HOME hints for the Java 8 lanes)

This PR is docs-only (no source/test changes). The forge-26.2 + forge-1.8.9 + forge-1.7.10 merges carried their own source changes; this PR reconciles the documentation that landed separately across the three lane PRs.