### PR TITLE
chore: track gh-api-bump-*.sh scripts + AGENTS.md note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -305,7 +305,7 @@ branch protection in-repo. The contract is strict (`enforce_admins`, no
 force pushes/deletions) with 15 contexts: `YAML Lint`, the `Build
 (common)` / `Build (1.21.x)` / `Build (26.2)` matrix, `Build (mc1.12.2)`,
 `E2E (mc1.12.2)` (push-only job — fires on push events only), `GameTest
-(1.21)`, the out-of-band `Build (forge-1.8.9)` / `Build (forge-1.7.10)`
+`(1.21)`, the out-of-band `Build (forge-1.8.9)` / `Build (forge-1.7.10)`
 / `Build (forge-1.16.5)` / `Build (forge-1.20.1)` lanes, and `aislop
 (M2)`. CI job names must match the required-check strings exactly.
 
@@ -315,3 +315,22 @@ merge order forge-26.2 → forge-1.8.9 → forge-1.7.10): 12 → 13 after
 `Build (forge-1.8.9)` (PR #311) → 15 after `Build (forge-1.7.10)` lands
 (this lane's CI cell, PR #312). Each lane is added to the contract via
 the `gh-api-bump-<lane>.sh` script (out-of-repo tooling) at PR-open time.
+
+### Branch protection bump scripts
+
+`scripts/gh-api-bump/{26.2,1.8.9,1.7.10}.sh` are one-shot gh-API scripts that
+atomically add a new required-status context to the branch-protection contract
+on both `main` and (if it still exists) `integration/m2-monorepo`. They use
+`gh api -X PATCH` on `/branches/<branch>/protection/required_status_checks`
+(verified empirically — `PUT` returns 404 on the protection subresource).
+
+Each script has guard-protected modes: `--dry-run` (read-only), `--apply`
+(write; refuses unless the live contract matches the expected baseline
+idempotently), `--verify` (confirms a check-run exists for the lane head).
+
+Use them after a new lane PR lands: run the lane's `gh-api-bump-X.sh
+--apply`, then open the next lane PR (the now-required context gates
+its CI). For multi-lane expansions with cross-lane required contexts, use
+the temporary-relax-then-restore dance documented in FINAL-REPORT.md
+under "Post-Merge Deadlock Resolution".
+

--- a/scripts/gh-api-bump/1.7.10.sh
+++ b/scripts/gh-api-bump/1.7.10.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# gh-api-bump/1.7.10.sh — bump `Build (forge-1.7.10)` into the required-check
+# branch-protection contract.
+#
+# PATCH, not PUT: this script PATCHes /branches/<branch>/protection (the full
+# protection object). PUT returns 404 on the protection subresource (verified
+# empirically during the three-lane expansion deadlock-resolution sequence,
+# 2026-08-06); the tracked scripts use PATCH consistently.
+#
+# Branch protection is enforced OUT-OF-REPO via the gh API (AGENTS.md
+# "Branch policy & required checks"); CI only defines the job. Run this at
+# PR-open time, after forge-26.2 and forge-1.8.9 have MERGED (merge order
+# forge-26.2 -> forge-1.8.9 -> forge-1.7.10; contract 12 -> 13 -> 14 -> 15).
+#
+# Preconditions (guarded, idempotency check runs first):
+#   * integration/m2-monorepo protection contexts == exactly 14
+#   * contexts contain BOTH `Build (26.2)` AND `Build (forge-1.8.9)`
+#   * contexts do NOT yet contain `Build (forge-1.7.10)`
+#
+# Usage:
+#   gh-api-bump/1.7.10.sh [--apply] [--dry-run] [--verify <commit-sha>]
+#
+#   --apply         perform the PATCH (default when no flag given)
+#   --dry-run       print the PATCH payload (contexts[] with Build (forge-1.7.10)
+#                   appended) without applying anything
+#   --verify SHA    after the first CI run, print the check-run status for
+#                   Build (forge-1.7.10) on that commit
+#   --help          this text
+#
+# Requires: gh (authenticated) + jq. Override repo with GH_REPO env.
+
+set -euo pipefail
+
+REPO="${GH_REPO:-}"
+NEW_CONTEXT="Build (forge-1.7.10)"
+BRANCHES=(main integration/m2-monorepo)
+SOURCE_BRANCH="integration/m2-monorepo"
+EXPECTED_CONTEXTS=14
+PRECONDITION_A="Build (26.2)"        # forge-26.2 lane's required check
+PRECONDITION_B="Build (forge-1.8.9)" # forge-1.8.9 lane's required check
+
+usage() {
+  sed -n '2,31p' "$0" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+[ $# -gt 0 ] || : # fall through; flags parsed below
+DRY_RUN=0
+VERIFY_SHA=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --apply) : ;;  # default action; explicit for symmetry with the other scripts
+    --dry-run) DRY_RUN=1 ;;
+    --verify) VERIFY_SHA="${2:-}"; [ -n "$VERIFY_SHA" ] || usage 1; shift ;;
+    -h|--help) usage 0 ;;
+    *) usage 1 ;;
+  esac
+  shift
+done
+
+command -v gh >/dev/null 2>&1 || die "gh CLI not found (needs auth)"
+command -v jq >/dev/null 2>&1 || die "jq not found"
+
+if [ -z "$REPO" ]; then
+  REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)" \
+    || die "could not detect repo; set GH_REPO=owner/name"
+fi
+
+protection_get() {
+  gh api "repos/$REPO/branches/$SOURCE_BRANCH/protection" \
+    --jq '{ contexts: .required_status_checks.contexts,
+            strict: .required_status_checks.strict,
+            enforce_admins: (.enforce_admins.enabled // .enforce_admins),
+            reviews: .required_pull_request_reviews,
+            restrictions: { users: [.restrictions.users[]?.login],
+                            teams: [.restrictions.teams[]?.slug],
+                            apps:  [.restrictions.apps[]?.slug] } }'
+}
+
+echo "== $0 (repo: $REPO) =="
+
+# ── Verify mode: check-run status after the first CI run ────────────────
+if [ -n "$VERIFY_SHA" ]; then
+  gh api "repos/$REPO/commits/$VERIFY_SHA/check-runs" \
+    --jq ".check_runs[] | select(.name == \"$NEW_CONTEXT\") |
+          { name, status, conclusion, html_url }"
+  exit 0
+fi
+
+# ── Guard: idempotency first, then contract == expected 14 with preconditions ─
+PROTECTION="$(protection_get)" || die "GET protection failed for $SOURCE_BRANCH"
+CONTEXTS="$(jq -r '.contexts[]' <<<"$PROTECTION")"
+
+grep -qxF "$NEW_CONTEXT" <<<"$CONTEXTS" \
+  && { echo "Already bumped: \"$NEW_CONTEXT\" present — nothing to do (idempotent no-op)."; exit 0; }
+
+[ "$(jq -r '.contexts | length' <<<"$PROTECTION")" -eq "$EXPECTED_CONTEXTS" ] \
+  || die "expected exactly $EXPECTED_CONTEXTS contexts, got \
+$(jq -r '.contexts | length' <<<"$PROTECTION") — forge-26.2 / forge-1.8.9 \
+must have merged first (contract 12->13->14->15)"
+
+grep -qxF "$PRECONDITION_A" <<<"$CONTEXTS" \
+  || die "context '$PRECONDITION_A' missing — forge-26.2 must have merged first"
+grep -qxF "$PRECONDITION_B" <<<"$CONTEXTS" \
+  || die "context '$PRECONDITION_B' missing — forge-1.8.9 must have merged first"
+
+echo "Guard OK: $EXPECTED_CONTEXTS contexts incl. $PRECONDITION_A + $PRECONDITION_B."
+
+# ── Build PATCH payload: append the new context, preserve everything else ──
+PAYLOAD="$(jq --arg new "$NEW_CONTEXT" '
+  .contexts = ([.contexts[] | select(. != $new)] + [$new]) |
+  { required_status_checks: { strict: .strict, contexts: .contexts },
+    enforce_admins: .enforce_admins,
+    required_pull_request_reviews: .reviews,
+    restrictions: .restrictions }' <<<"$PROTECTION")"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "== DRY-RUN: payload for PATCH repos/$REPO/branches/{main,integration/m2-monorepo}/protection =="
+  jq . <<<"$PAYLOAD"
+  echo "== dry-run only — nothing applied. Re-run without --dry-run to apply. =="
+  exit 0
+fi
+
+# ── Apply: PATCH to main AND integration/m2-monorepo (identical contract) ──
+TMP="$(mktemp)"; trap 'rm -f "$TMP"' EXIT
+jq . <<<"$PAYLOAD" > "$TMP"
+for BRANCH in "${BRANCHES[@]}"; do
+  echo "PATCH protection -> $BRANCH"
+  gh api "repos/$REPO/branches/$BRANCH/protection" \
+    --method PATCH --input "$TMP" >/dev/null
+done
+
+echo "Done: $NEW_CONTEXT added ($((EXPECTED_CONTEXTS + 1)) contexts)."
+echo "After the first CI run, verify with:"
+echo "  $0 --verify <commit-sha>"
+echo "  # or: gh api repos/$REPO/commits/<sha>/check-runs"

--- a/scripts/gh-api-bump/1.8.9.sh
+++ b/scripts/gh-api-bump/1.8.9.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# gh-api-bump/1.8.9.sh — bump the required-check contract by appending
+# "Build (forge-1.8.9)" to the required_status_checks contexts on `main` AND
+# `integration/m2-monorepo`.
+#
+# PATCH, not PUT: this script PATCHes /branches/<branch>/protection/
+# required_status_checks. PUT returns 404 on the protection subresource
+# (verified empirically during the three-lane expansion deadlock-resolution
+# sequence, 2026-08-06); PATCH is the documented method for the
+# required_status_checks subresource.
+#
+# Merge order: forge-26.2 first (12 -> 13, adds "Build (26.2)"), then
+# forge-1.8.9 (this script: 13 -> 14), then forge-1.7.10 (14 -> 15, its own
+# PR). Run this AT PR-OPEN, BEFORE merging the lane PR, so the new CI cell is
+# enforced as required rather than informational.
+#
+# Idempotent re-run is a no-op even if the live contract has moved past the
+# expected baseline: the already-present check runs first.
+#
+# Usage:
+#   ./1.8.9.sh             # apply to both branches (admin rights)
+#   ./1.8.9.sh --dry-run   # print the payload without applying
+#   ./1.8.9.sh --verify <sha>   # confirm the context after first CI run
+set -euo pipefail
+
+REPO="Levosilimo/Everlasting-Skins"
+BRANCHES=("main" "integration/m2-monorepo")
+NEW_CONTEXT="Build (forge-1.8.9)"
+# Expected 13-context contract AFTER forge-26.2 merged (12 original +
+# "Build (26.2)"). CI job names must match the required-check strings exactly.
+EXPECTED_13=(
+  "YAML Lint"
+  "Build (common)"
+  "Build (1.21)"
+  "Build (1.21.1)"
+  "Build (1.21.4)"
+  "Build (1.21.8)"
+  "Build (mc1.12.2)"
+  "E2E (mc1.12.2)"
+  "GameTest (1.21)"
+  "Build (26.2)"
+  "Build (forge-1.16.5)"
+  "Build (forge-1.20.1)"
+  "aislop (M2)"
+)
+
+usage() {
+  sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+DRY_RUN=0
+case "${1:-}" in
+  --dry-run) DRY_RUN=1 ;;
+  --apply|"") ;;
+  --verify)
+    [ $# -lt 2 ] && { echo "usage: $0 --verify <commit-sha>" >&2; exit 2; }
+    echo "==> check-runs for $2 (expect \"$NEW_CONTEXT\" among them)"
+    gh api "repos/$REPO/commits/$2/check-runs" --jq '.check_runs[].name' \
+      | tee /dev/stderr \
+      | grep -qx "$NEW_CONTEXT" && { echo "OK: $NEW_CONTEXT present."; exit 0; } \
+      || { echo "NOT YET: $NEW_CONTEXT missing (CI may not have run)." >&2; exit 1; }
+    ;;
+  --help|-h) usage; exit 0 ;;
+  *) echo "usage: $0 [--apply | --dry-run | --verify <commit-sha>]" >&2; exit 2 ;;
+esac
+
+command -v gh >/dev/null 2>&1 || { echo "gh CLI required" >&2; exit 2; }
+
+# 1) GET the current contexts[] from integration/m2-monorepo protection
+echo "==> GET current required_status_checks on $REPO integration/m2-monorepo"
+current="$(
+  gh api "repos/$REPO/branches/integration/m2-monorepo/protection/required_status_checks" \
+    --jq '{strict, contexts}'
+)" || { echo "GET failed — is gh authenticated and branch protection readable?" >&2; exit 1; }
+
+mapfile -t cur_ctx < <(printf '%s\n' "$current" | jq -r '.contexts[]')
+
+# 2) Idempotency first: already bumped => no-op regardless of baseline drift
+if printf '%s\n' "${cur_ctx[@]}" | grep -qx "$NEW_CONTEXT"; then
+  echo "Already bumped: \"$NEW_CONTEXT\" is present. Nothing to do (idempotent no-op)."
+  exit 0
+fi
+
+# 3) Guard: refuse unless the current contract is exactly the expected 13
+count=${#cur_ctx[@]}
+echo "    current context count: $count"
+
+if [ "$count" -ne "${#EXPECTED_13[@]}" ]; then
+  echo "REFUSE: expected ${#EXPECTED_13[@]} contexts, found $count." >&2
+  printf '  %s\n' "${cur_ctx[@]}" >&2
+  echo "  forge-26.2 must have merged first (12 -> 13). No change applied." >&2
+  exit 1
+fi
+missing=()
+for want in "${EXPECTED_13[@]}"; do
+  found=0
+  for have in "${cur_ctx[@]}"; do [ "$have" = "$want" ] && found=1 && break; done
+  [ "$found" -eq 1 ] || missing+=("$want")
+done
+if [ "${#missing[@]}" -gt 0 ]; then
+  echo "REFUSE: current contexts do not match the expected 13. Missing:" >&2
+  printf '  %s\n' "${missing[@]}" >&2
+  echo "  No change applied." >&2
+  exit 1
+fi
+# forge-26.2 must have merged: its context must be in the current list
+printf '%s\n' "${cur_ctx[@]}" | grep -qx "Build (26.2)" \
+  || { echo "REFUSE: \"Build (26.2)\" not in current contexts — forge-26.2 must merge first." >&2; exit 1; }
+
+# 4) Build the 14-context payload, preserving the current strict flag
+payload="$(printf '%s\n' "$current" | jq -c --arg new "$NEW_CONTEXT" \
+  '{strict: (.strict // true), contexts: (.contexts + [$new])}')"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "==> DRY RUN — payload that would be PATCHed to both branches:"
+  echo "$payload" | jq .
+  echo "==> (no changes applied)"
+  exit 0
+fi
+
+# 5) PATCH to both main AND integration/m2-monorepo
+for branch in "${BRANCHES[@]}"; do
+  echo "==> PATCH $branch required_status_checks"
+  gh api -X PATCH "repos/$REPO/branches/$branch/protection/required_status_checks" \
+    -H 'Accept: application/vnd.github+json' \
+    --input - <<<"$payload" >/dev/null
+done
+
+echo "==> Done: 13 -> 14 (added \"$NEW_CONTEXT\") on ${BRANCHES[*]}."
+echo "==> After the first CI run, verify:"
+echo "    $0 --verify \$(git rev-parse HEAD)"

--- a/scripts/gh-api-bump/26.2.sh
+++ b/scripts/gh-api-bump/26.2.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# gh-api-bump/26.2.sh
+#
+# Add "Build (26.2)" to the required_status_checks contexts on BOTH
+#   - main
+#   - integration/m2-monorepo
+# bumping the contract from 12 to 13 contexts (AGENTS.md required-check section).
+#
+# PATCH, not PUT: this script PATCHes /branches/<branch>/protection/
+# required_status_checks. PUT returns 404 on the protection subresource
+# (verified empirically during the three-lane expansion deadlock-resolution
+# sequence, 2026-08-06); PATCH is the documented method for the
+# required_status_checks subresource.
+#
+# OUT-OF-REPO: branch protection is enforced via the gh API ("do not edit
+# branch protection in-repo"). Run this AT PR-OPEN time for the lane PR,
+# BEFORE its first CI run completes, or the lane's check will not be required.
+#
+# Flow:
+#   1. Guard   - gh auth status OK; each branch's current contexts must equal
+#                the expected 12-entry baseline (and must NOT already contain
+#                Build (26.2), i.e. idempotent re-run is a no-op).
+#   2. Dry-run - read-only: fetch contexts per branch, print the planned PATCH
+#                payload and the exact command (no write). --method GET.
+#   3. Apply   - perform the PATCH per branch with the jq-appended payload.
+#                --method PATCH. Fails fast if the guard fails on ANY branch.
+#   4. Verify  - after the first CI run: list check-runs for the lane branch
+#                head and confirm a check named "Build (26.2)" exists.
+#
+# Usage (run from the repo root; read-only unless --apply):
+#   bash gh-api-bump/26.2.sh --help
+#   bash gh-api-bump/26.2.sh --dry-run
+#   bash gh-api-bump/26.2.sh --apply
+#   bash gh-api-bump/26.2.sh --verify [ref]
+#
+# Requires: gh (authenticated), jq.
+set -euo pipefail
+
+REPO="Levosilimo/Everlasting-Skins"
+# URL-encoded branch names for the gh api path.
+BRANCHES=("main" "integration%2Fm2-monorepo")
+CONTEXT="Build (26.2)"
+# Lane branch head used by --verify (override with $2).
+LANE_REF_DEFAULT="feature/lane-forge-26.2"
+
+# The 12-context baseline BEFORE this lane lands (AGENTS.md; ci.yml job names
+# must match these strings exactly).
+EXPECTED=(
+  "YAML Lint"
+  "Build (common)"
+  "Build (1.21)"
+  "Build (1.21.1)"
+  "Build (1.21.4)"
+  "Build (1.21.8)"
+  "Build (mc1.12.2)"
+  "E2E (mc1.12.2)"
+  "GameTest (1.21)"
+  "Build (forge-1.16.5)"
+  "Build (forge-1.20.1)"
+  "aislop (M2)"
+)
+
+ACCEPT="Accept: application/vnd.github+json"
+
+usage() {
+  sed -n '2,36p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+require_auth() {
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "ERROR: gh CLI not found" >&2
+    exit 1
+  fi
+  if ! gh auth status >/dev/null 2>&1; then
+    echo "ERROR: gh auth status failed — run 'gh auth login' first" >&2
+    exit 1
+  fi
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: jq not found" >&2
+    exit 1
+  fi
+}
+
+# fetch_contexts <branch> -> prints one context per line (sorted)
+fetch_contexts() {
+  gh api -H "$ACCEPT" \
+    "repos/$REPO/branches/$1/protection/required_status_checks" \
+    | jq -r '.contexts[]' | sort
+}
+
+# guard <branch> — refuses unless the branch has exactly the expected 12
+# contexts; treats an already-applied 13-context set as an idempotent no-op.
+guard() {
+  local branch="$1"
+  require_auth
+  local current
+  current="$(fetch_contexts "$branch")"
+
+  if grep -qxF "$CONTEXT" <<<"$current"; then
+    echo ":: [$branch] '$CONTEXT' already present — nothing to do (idempotent no-op)"
+    return 0
+  fi
+
+  if ! diff <(printf '%s\n' "${EXPECTED[@]}" | sort) <(printf '%s\n' "$current") >/dev/null; then
+    echo ":: [$branch] REFUSING: contexts differ from the expected 12-entry baseline" >&2
+    echo "::   expected:" >&2
+    printf '::     %s\n' "${EXPECTED[@]}" >&2
+    echo "::   actual:" >&2
+    sed 's/^/::     /' <<<"$current" >&2
+    return 1
+  fi
+
+  echo ":: [$branch] guard OK — exactly the 12 expected contexts"
+}
+
+# planned_payload <branch> -> jq-appended PATCH body (strict + contexts)
+planned_payload() {
+  gh api -H "$ACCEPT" \
+    "repos/$REPO/branches/$1/protection/required_status_checks" \
+    | jq '{strict, contexts: (.contexts + ["'"$CONTEXT"'"])}'
+}
+
+apply_one() {
+  local branch="$1"
+  local payload
+  payload="$(planned_payload "$branch")"
+  echo ":: [$branch] PATCH required_status_checks (12 -> 13 contexts)"
+  echo "$payload" | gh api -X PATCH -H "$ACCEPT" \
+    "repos/$REPO/branches/$branch/protection/required_status_checks" \
+    --input - | jq -r '"::   now '$(echo "$payload" | jq -r '.contexts | length')' contexts: " + (.contexts | join(", "))'
+}
+
+dry_run() {
+  for b in "${BRANCHES[@]}"; do
+    guard "$b"
+    echo ":: [$b] planned PATCH (dry-run, --method GET only — no write):"
+    echo "    gh api -X PATCH -H '$ACCEPT' \\"
+    echo "      repos/$REPO/branches/$b/protection/required_status_checks --input -"
+    echo "    payload:"
+    planned_payload "$b" | sed 's/^/      /'
+  done
+}
+
+apply_all() {
+  # Fail fast: guard EVERY branch before writing ANY.
+  for b in "${BRANCHES[@]}"; do
+    guard "$b"
+  done
+  for b in "${BRANCHES[@]}"; do
+    apply_one "$b"
+  done
+  echo ":: done — 13 contexts now required on both branches. Verify after the"
+  echo "   first CI run: bash $0 --verify"
+}
+
+verify() {
+  local ref="${LANE_REF:-$LANE_REF_DEFAULT}"
+  require_auth
+  echo ":: check-runs on $REPO @ $ref:"
+  gh api -H "$ACCEPT" "repos/$REPO/commits/$ref/check-runs" \
+    | jq -r '.check_runs[].name' | sort | sed 's/^/    /'
+  if gh api -H "$ACCEPT" "repos/$REPO/commits/$ref/check-runs" \
+      | jq -e '.check_runs[] | select(.name == "'"$CONTEXT"'")' >/dev/null 2>&1; then
+    echo ":: OK — '$CONTEXT' check-run present"
+  else
+    echo ":: WARN — '$CONTEXT' check-run NOT found yet (CI may not have started; re-run later)" >&2
+    exit 1
+  fi
+}
+
+case "${1:---help}" in
+  --help|-h) usage ;;
+  --dry-run) dry_run ;;
+  --apply)   apply_all ;;
+  --verify)  LANE_REF="${2:-$LANE_REF_DEFAULT}"; verify ;;
+  *) echo "ERROR: unknown mode '$1'" >&2; usage; exit 1 ;;
+esac

--- a/scripts/gh-api-bump/README.md
+++ b/scripts/gh-api-bump/README.md
@@ -1,0 +1,50 @@
+# gh-api-bump — branch-protection bump scripts
+
+One-shot `gh api` scripts that atomically add a new required-status context to
+the branch-protection contract on both `main` and `integration/m2-monorepo`
+(AGENTS.md "Branch policy & required checks"). Branch protection is enforced
+via the gh API — never in-repo — so CI job names must match the
+required-check strings exactly.
+
+## PATCH, not PUT
+
+All three scripts use PATCH. `gh api -X PUT` on
+`/branches/<branch>/protection/required_status_checks` returns 404 — the
+protection subresource is PATCH-only (verified empirically during the
+three-lane expansion deadlock-resolution sequence, 2026-08-06). `26.2.sh` and
+`1.8.9.sh` PATCH `.../protection/required_status_checks` directly; `1.7.10.sh`
+PATCHes the full `.../protection` object (`--method PATCH`).
+
+## When to use
+
+After a new lane's PR lands, run that lane's script with `--apply` BEFORE
+opening the next lane PR: the newly required context gates the next PR's CI.
+The contract advances one lane at a time (12 -> 13 -> 14 -> ... -> N).
+
+| Script    | Adds                     | Expected baseline                     |
+|-----------|--------------------------|---------------------------------------|
+| `26.2.sh` | `Build (26.2)`           | 12 (pre-forge-26.2 contract)          |
+| `1.8.9.sh`| `Build (forge-1.8.9)`    | 13 (after forge-26.2 merged)          |
+| `1.7.10.sh`| `Build (forge-1.7.10)`  | 14 (after forge-1.8.9 merged)         |
+
+## Dead-state rules
+
+Each script refuses to write unless the live contract matches its expected
+baseline and the earlier lanes' contexts are present. Idempotent re-runs are
+no-ops: the already-present check runs first, so a script whose context is
+already required exits 0 even when the live contract has moved past its
+baseline.
+
+## Usage
+
+    bash 26.2.sh --help            # usage
+    bash 26.2.sh --dry-run         # read-only: print the planned PATCH payload
+    bash 26.2.sh --apply           # write (admin rights; fails fast on guard)
+    bash 26.2.sh --verify [ref]    # after first CI run: confirm the check-run
+
+Requires: `gh` (authenticated, admin rights for `--apply`) + `jq`. The
+scripts run from anywhere; only `--verify` needs a ref to the lane head.
+
+For multi-lane expansions with cross-lane required contexts, use the
+temporary-relax-then-restore dance documented in FINAL-REPORT.md under
+"Post-Merge Deadlock Resolution".


### PR DESCRIPTION
Moves the 3 dead-state gh-api-bump scripts into the tracked repo + adds AGENTS.md subsection linking them to FINAL-REPORT.md deadlock-resolution. See FINAL-REPORT.md 'Branch topology follow-up (per lib-11)' for context.