### PR TITLE
ci: wire GameTest CI for forge-1.21.1 / 1.21.4 / 1.21.8 / 26.2 (informational)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,6 +304,150 @@ jobs:
             --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED
             -Dio.netty.tryReflectionSetAccessible=true"
 
+  # ── GameTest on 1.21.1 (point release) ────────────────────────
+  gametest-1211:
+    name: GameTest (1.21.1)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: lint-yaml
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
+      - name: Set up JDK 21
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961  # v5
+        with:
+          java-version: 21
+          distribution: temurin
+      - name: Cache Gradle wrapper and caches
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5
+        with:
+          path: |
+            ~/.gradle/wrapper/dists
+            ~/.gradle/caches
+          key: gradle-${{ runner.os }}-m2-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-m2-
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Run GameTest (skin visibility packets)
+        run: ./gradlew :forge-1.21.1:runGameTestServer --no-daemon --console=plain
+        timeout-minutes: 30
+        env:
+          GRADLE_OPTS: >-
+            -Dorg.gradle.jvmargs="-Dfile.encoding=UTF-8
+            --add-opens=java.base/java.lang=ALL-UNNAMED
+            --add-opens=java.base/java.nio=ALL-UNNAMED
+            --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
+            --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED
+            -Dio.netty.tryReflectionSetAccessible=true"
+
+  # ── GameTest on 1.21.4 (point release) ────────────────────────
+  gametest-1214:
+    name: GameTest (1.21.4)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: lint-yaml
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
+      - name: Set up JDK 21
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961  # v5
+        with:
+          java-version: 21
+          distribution: temurin
+      - name: Cache Gradle wrapper and caches
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5
+        with:
+          path: |
+            ~/.gradle/wrapper/dists
+            ~/.gradle/caches
+          key: gradle-${{ runner.os }}-m2-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-m2-
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Run GameTest (skin visibility packets)
+        run: ./gradlew :forge-1.21.4:runGameTestServer --no-daemon --console=plain
+        timeout-minutes: 30
+        env:
+          GRADLE_OPTS: >-
+            -Dorg.gradle.jvmargs="-Dfile.encoding=UTF-8
+            --add-opens=java.base/java.lang=ALL-UNNAMED
+            --add-opens=java.base/java.nio=ALL-UNNAMED
+            --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
+            --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED
+            -Dio.netty.tryReflectionSetAccessible=true"
+
+  # ── GameTest on 1.21.8 (point release) ────────────────────────
+  gametest-1218:
+    name: GameTest (1.21.8)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: lint-yaml
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
+      - name: Set up JDK 21
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961  # v5
+        with:
+          java-version: 21
+          distribution: temurin
+      - name: Cache Gradle wrapper and caches
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5
+        with:
+          path: |
+            ~/.gradle/wrapper/dists
+            ~/.gradle/caches
+          key: gradle-${{ runner.os }}-m2-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-m2-
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Run GameTest (skin visibility packets)
+        run: ./gradlew :forge-1.21.8:runGameTestServer --no-daemon --console=plain
+        timeout-minutes: 30
+        env:
+          GRADLE_OPTS: >-
+            -Dorg.gradle.jvmargs="-Dfile.encoding=UTF-8
+            --add-opens=java.base/java.lang=ALL-UNNAMED
+            --add-opens=java.base/java.nio=ALL-UNNAMED
+            --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
+            --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED
+            -Dio.netty.tryReflectionSetAccessible=true"
+
+  # ── GameTest on 26.2 (new MC major line) ──────────────────────
+  gametest-262:
+    name: GameTest (26.2)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: lint-yaml
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
+      - name: Set up JDK 25
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961  # v5
+        with:
+          java-version: 25
+          distribution: temurin
+      - name: Cache Gradle wrapper and caches
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5
+        with:
+          path: |
+            ~/.gradle/wrapper/dists
+            ~/.gradle/caches
+          key: gradle-${{ runner.os }}-m2-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-m2-
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Run GameTest (skin visibility packets)
+        run: ./gradlew :forge-26.2:runGameTestServer --no-daemon --console=plain
+        timeout-minutes: 30
+        env:
+          GRADLE_OPTS: >-
+            -Dorg.gradle.jvmargs="-Dfile.encoding=UTF-8
+            --add-opens=java.base/java.lang=ALL-UNNAMED
+            --add-opens=java.base/java.nio=ALL-UNNAMED
+            --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
+            --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED
+            -Dio.netty.tryReflectionSetAccessible=true"
+
   # ── aislop quality gate (same scanner as the pre-commit hook) ─
   aislop:
     name: aislop (M2)


### PR DESCRIPTION
Source GameTest code already committed in each modern lane (35-37 @GameTest methods + 68 JSON scenarios on 1.21.8/26.2). Only the CI wiring is missing. Adds 4 new informational GameTest jobs mirroring the proven forge-1.21 gametest-121. New jobs are NOT in the required-check contract (informational only) until they prove green.