### PR TITLE
ci: cache gradle + no-op E2E (mc1.12.2), keep required-check name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,6 +253,7 @@ jobs:
   e2e-mc1_12_2:
     name: E2E (mc1.12.2)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: lint-yaml
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
@@ -261,12 +262,19 @@ jobs:
         with:
           java-version: 21
           distribution: temurin
+      - name: Cache Gradle wrapper and caches
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5
+        with:
+          path: |
+            ~/.gradle/wrapper/dists
+            ~/.gradle/caches
+          key: gradle-${{ runner.os }}-m2-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-m2-
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
-      - name: Headless smoke placeholder
-        run: |
-          echo "headless smoke placeholder"
-          ./gradlew :forge-1.21:tasks --no-daemon --console=plain
+      - name: Headless smoke placeholder (required-check contract stub)
+        run: echo "E2E (mc1.12.2) placeholder — real HeadlessMC boot smoke runs on the mc1.12.2 fork branch"
 
   # ── GameTest on 1.21 (canonical gametest subproject) ──────────
   gametest-121:


### PR DESCRIPTION
Cut ~17 min off every CI run by turning the E2E (mc1.12.2) placeholder into a no-op echo, and pre-wire its gradle cache for the real boot smoke that lands next (P1-6).

The placeholder currently runs `./gradlew :forge-1.21:tasks`, which triggers a cold download of the forge-1.21 userdev distribution. On the 2026-08-07 run (PR #314) E2E was still running at 18 min. It's a contract stub — the real headlessmc boot smoke lives on the mc1.12.2 branch. Replacing the step with a pure echo gets the same required-check coverage at ~30 s.

- Cache step added (root-wrapper key, `gradle/wrapper/gradle-wrapper.properties` only — not the `**/` glob that would invalidate on any lane wrapper change).
- Step body reduced to `echo` (step name changed; job key and check name `E2E (mc1.12.2)` kept byte-identical — the required-check contract matches on that string).
- `timeout-minutes: 15` added to the job (ships with the replacement, not the earlier PR, to avoid two PRs editing the same job).

Confirmed: yamllint (repo config) + structure validation green; `E2E (mc1.12.2)` still resolves against the required-check contract.