### PR TITLE
ci: job timeouts, fail-fast publish, least-privilege permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ["main"]
@@ -18,6 +21,7 @@ jobs:
   lint-yaml:
     name: YAML Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
       - name: Run yamllint
@@ -30,6 +34,7 @@ jobs:
   build:
     name: Build (${{ matrix.mc }})
     runs-on: ubuntu-latest
+    timeout-minutes: ${{ matrix.timeout || 30 }}
     needs: lint-yaml
     strategy:
       fail-fast: false
@@ -48,6 +53,7 @@ jobs:
           - module: forge-26.2
             mc: "26.2"
             java: "25"
+            timeout: 45   # heaviest: Java 25 + unobfuscated MC + FG 7.0.17
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
       - name: Set up JDK ${{ matrix.java || '21' }}
@@ -87,6 +93,7 @@ jobs:
   build-mc1_12_2:
     name: Build (mc1.12.2)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: lint-yaml
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
@@ -119,6 +126,7 @@ jobs:
   build-forge-1_16_5:
     name: Build (forge-1.16.5)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: lint-yaml
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
@@ -151,6 +159,7 @@ jobs:
   build-forge-1_8_9:
     name: Build (forge-1.8.9)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: lint-yaml
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
@@ -183,6 +192,7 @@ jobs:
   build-forge-1_20_1:
     name: Build (forge-1.20.1)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: lint-yaml
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
@@ -215,6 +225,7 @@ jobs:
   build-forge-1_7_10:
     name: Build (forge-1.7.10)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: lint-yaml
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
@@ -308,6 +319,7 @@ jobs:
   aislop:
     name: aislop (M2)
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: lint-yaml
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,7 @@ name: Publish
 
 permissions:
   contents: write
+  releases: write
 
 on:
   push:
@@ -25,6 +26,7 @@ jobs:
   publish:
     name: Publish (${{ matrix.game-version }})
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     if: startsWith(github.ref_name, matrix.prefix)
     strategy:
       fail-fast: false
@@ -96,7 +98,7 @@ jobs:
           game-version-filter: releases
           environment: server
           files: ${{ matrix.module }}/build/libs/*.jar
-          fail-mode: warn
+          fail-mode: fail
           retry-attempts: 3
           retry-delay: 15000
 
@@ -105,6 +107,7 @@ jobs:
     name: Publish (mc1.12.2)
     if: startsWith(github.ref_name, 'mc1.12.2-v')
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
@@ -150,7 +153,7 @@ jobs:
           game-version-filter: releases
           environment: server
           files: mc1.12.2/build/libs/*.jar
-          fail-mode: warn
+          fail-mode: fail
           retry-attempts: 3
           retry-delay: 15000
 
@@ -159,6 +162,7 @@ jobs:
     name: Publish (mc1.16.5)
     if: startsWith(github.ref_name, 'mc1.16.5-v')
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
@@ -204,7 +208,7 @@ jobs:
           game-version-filter: releases
           environment: server
           files: forge-1.16.5/build/libs/*.jar
-          fail-mode: warn
+          fail-mode: fail
           retry-attempts: 3
           retry-delay: 15000
 
@@ -213,6 +217,7 @@ jobs:
     name: Publish (mc1.8.9)
     if: startsWith(github.ref_name, 'mc1.8.9-v')
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
@@ -258,7 +263,7 @@ jobs:
           game-version-filter: releases
           environment: server
           files: forge-1.8.9/build/libs/*.jar
-          fail-mode: warn
+          fail-mode: fail
           retry-attempts: 3
           retry-delay: 15000
 
@@ -267,6 +272,7 @@ jobs:
     name: Publish (mc1.20.1)
     if: startsWith(github.ref_name, 'mc1.20.1-v')
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
@@ -312,7 +318,7 @@ jobs:
           game-version-filter: releases
           environment: server
           files: forge-1.20.1/build/libs/*.jar
-          fail-mode: warn
+          fail-mode: fail
           retry-attempts: 3
           retry-delay: 15000
 
@@ -321,6 +327,7 @@ jobs:
     name: Publish (mc1.7.10)
     if: startsWith(github.ref_name, 'mc1.7.10-v')
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
@@ -366,6 +373,6 @@ jobs:
           game-version-filter: releases
           environment: server
           files: forge-1.7.10/build/libs/*.jar
-          fail-mode: warn
+          fail-mode: fail
           retry-attempts: 3
           retry-delay: 15000


### PR DESCRIPTION
CI hygiene batch from the post-three-lane-expansion audits (lib-17, lib-21).

- Add `timeout-minutes` to every ci.yml/publish.yml job that lacked one
  (default is 360 min — a hung gradle/userdev/mc-publish job can burn 6h).
  Matrix build gets `${{ matrix.timeout || 30 }}`; forge-26.2 resolves to 45
  (Java 25 + unobfuscated MC + FG 7.0.17). lint-yaml/aislop capped at 5,
  out-of-band lane builds (mc1.12.2, 1.16.5, 1.8.9, 1.20.1, 1.7.10) at 30,
  all 6 publish jobs at 45. gametest-121 already had a 15-min cap (the
  15->30 raise is tracked separately, P1-8, on the back of the 2026-08-07
  cold-cache cancellation evidence).
- publish.yml `fail-mode: warn` -> `fail` on all 6 jobs (matrix + the five
  out-of-band lanes). The 2026-08-07 publish workflow died instantly with no
  logs; we already have silent failure modes — a half-publish should not be
  another one.
- ci.yml gains a top-level `permissions: contents: read` (least privilege;
  no job needs more). publish.yml gains the explicit `releases: write` scope
  it needs for mc-publish.

No required-check contract change. No behavior change to any CI job's
pass/fail on normal runs — only adds upper bounds and tightens the release
path. Verified: yaml parse green on both workflows (act unavailable locally).
