### PR TITLE
build: remove unused deps, replace aggregate test deps with api-scoped, add mc1.12.2 verifyNoMixin

### DIFF
--- a/buildSrc/src/main/kotlin/everlastingskins.forge-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/everlastingskins.forge-module.gradle.kts
@@ -40,7 +40,6 @@ val forgeVersion: String = requireNotNull(project.findProperty("forge_version")?
 val modVersion: String = project.findProperty("mod_version")?.toString() ?: "1.0.0"
 val modName: String = project.findProperty("mod_name")?.toString() ?: "EverlastingSkins"
 val modVendor: String = project.findProperty("mod_vendor")?.toString() ?: "Levosilimo"
-val mixinId: String = project.findProperty("mixin_id")?.toString() ?: "everlastingskins"
 val toolchainVersion: Int = project.findProperty("java.toolchain.version")?.toString()?.toInt() ?: 21
 val mcRunDir: String = project.findProperty("mc.runDir")?.toString() ?: "run"
 val mcRunDir2: String = project.findProperty("mc.runDir2")?.toString() ?: "run2"
@@ -264,19 +263,10 @@ dependencies {
     // forge-* lane needs vendored :common copies for tooling reasons,
     // re-add the gate + opt-out property here.
     api(project(":common"))
-    implementation("org.apache.httpcomponents:httpclient:4.5.13")
     api(minecraft.dependency("net.minecraftforge:forge:${minecraftVersion}-${forgeVersion}"))
-    // MUST be declared before the mixin processor: mixin-0.8.7-processor.jar
-    // bundles an unrelocated OLD Guava (no ImmutableMap.Builder.buildOrThrow),
-    // which would shadow ErrorProne's Guava 33 on the annotation processor
-    // path and crash it with NoSuchMethodError (ErrorProne integration).
+    // Guava on the annotation processor path keeps ErrorProne stable (it
+    // previously shadowed the OLD Guava bundled in mixin-0.8.7-processor.jar).
     annotationProcessor("com.google.guava:guava:33.5.0-jre")
-    annotationProcessor("org.spongepowered:mixin:0.8.7:processor")
-    // Hack fix for now, force jopt-simple to be exactly 5.0.4 because Mojang
-    // ships that version, but some transitive dependencies request 6.0+.
-    implementation("net.sf.jopt-simple:jopt-simple:5.0.4") {
-        version { strictly("5.0.4") }
-    }
 
     compileOnly("net.luckperms:api:5.5")
     compileOnly("me.clip:placeholderapi:2.12.3")
@@ -291,17 +281,20 @@ dependencies {
     testImplementation("io.papermc.paper:paper-api:1.20.4-R0.1-SNAPSHOT")
     compileOnly("org.spigotmc:spigot-api:1.20.4-R0.1-SNAPSHOT")
 
-    testImplementation("org.junit.jupiter:junit-jupiter:5.10.3")
-    testImplementation("net.jqwik:jqwik:1.9.0")
+    testImplementation(platform("org.junit:junit-bom:5.10.3"))
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.3")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:5.10.3")
+    testImplementation("net.jqwik:jqwik-api:1.9.0")
     testImplementation("me.clip:placeholderapi:2.12.3")
     testImplementation("org.mockito:mockito-core:5.12.0")
     testImplementation("org.mockito:mockito-junit-jupiter:5.12.0")
 
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.3")
+    testRuntimeOnly("net.jqwik:jqwik-engine:1.9.0")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.10.3")
 
     "gametestImplementation"(sourceSets.main.get().output)
     "gametestImplementation"("org.junit.jupiter:junit-jupiter-api:5.10.3")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.3")
     "gametestRuntimeOnly"("org.junit.platform:junit-platform-launcher:1.10.3")
 }
 
@@ -319,6 +312,9 @@ configurations.getByName("testRuntimeClasspath") {
 
 configurations.all {
     resolutionStrategy.eachDependency {
+        if (requested.group == "net.sf.jopt-simple") {
+            useVersion("5.0.4")
+        }
         if (requested.group == "org.slf4j") {
             useVersion("2.0.9")
         }
@@ -355,10 +351,7 @@ tasks.jar {
             "Implementation-Vendor" to modVendor,
             "Implementation-Timestamp" to SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").format(Date()),
             "Built-On-Java" to "${System.getProperty("java.vm.version")} (${System.getProperty("java.vm.vendor")})",
-            "Built-On" to forgeVersion,
-            "TweakClass" to "org.spongepowered.asm.launch.MixinTweaker",
-            "TweakOrder" to 0,
-            "MixinConfigs" to "${mixinId}.mixins.json"
+            "Built-On" to forgeVersion
         )
     }
 }

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -45,14 +45,17 @@ dependencies {
 
     // --- test: standalone verification of the module ---
     testImplementation(platform("org.junit:junit-bom:5.10.3"))
-    testImplementation("org.junit.jupiter:junit-jupiter")
-    testImplementation("net.jqwik:jqwik:1.9.0")
+    testImplementation("org.junit.jupiter:junit-jupiter-api")
+    testImplementation("org.junit.jupiter:junit-jupiter-params")
+    testImplementation("net.jqwik:jqwik-api:1.9.0")
     testImplementation("org.mockito:mockito-core:5.12.0")
     // The module's main code paths use Gson/authlib/log4j at runtime too.
     testImplementation("com.google.code.gson:gson:2.8.0")
     testImplementation("com.mojang:authlib:1.5.25")
     testImplementation("org.apache.logging.log4j:log4j-api:2.8.1")
 
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.3")
+    testRuntimeOnly("net.jqwik:jqwik-engine:1.9.0")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.10.3")
     // Default log4j2 config (ERROR-only) so test output stays quiet.
     testRuntimeOnly("org.apache.logging.log4j:log4j-core:2.8.1")

--- a/mc1.12.2/build.gradle
+++ b/mc1.12.2/build.gradle
@@ -127,3 +127,7 @@ jar {
         ])
     }
 }
+
+// Mixin-usage gate (Groovy port of the root buildSrc no-mixin.gradle.kts;
+// Gradle 4.10.3 cannot compile the Kotlin-DSL convention).
+apply from: 'gradle/verify-no-mixin.gradle'

--- a/mc1.12.2/gradle/verify-no-mixin.gradle
+++ b/mc1.12.2/gradle/verify-no-mixin.gradle
@@ -1,0 +1,26 @@
+tasks.register('verifyNoMixin') {
+    description = 'Fails the build if any @Mixin annotations, mixingradle, mixin plugin id, mixins.json bundling, or @Mixin classes are detected in source or build files.'
+    doLast {
+        def sourceRoots = sourceSets.main.allSource.srcDirs.collect{ it.toString() }
+        def buildFiles = [buildFile.path]
+        def violations = []
+        sourceRoots.each { root ->
+            fileTree(root).matching { include '**/*.java' }.each { f ->
+                def text = f.text
+                if (text.contains('@Mixin')) violations << "${f}: contains @Mixin annotation"
+            }
+        }
+        buildFiles.each { f ->
+            def text = new File(f).text
+            if (text.contains('mixingradle')) violations << "${f}: references mixingradle"
+            if (text.contains("'mixin'") || text.contains('"mixin"')) violations << "${f}: references mixin plugin"
+        }
+        fileTree(projectDir).matching { include '**/mixins.json' }.each { f ->
+            violations << "${f}: mixins.json bundling detected"
+        }
+        if (!violations.isEmpty()) {
+            throw new GradleException("verifyNoMixin failed:\n  - " + violations.join("\n  - "))
+        }
+    }
+}
+build.dependsOn 'verifyNoMixin'


### PR DESCRIPTION
## What
- Remove the Mixin annotation processor from the forge-module convention and strip the dead `MixinConfigs`/`TweakClass` manifest attrs (no `mixins.json` exists in any module).
- Remove the unused `httpclient:4.5.13` from the convention (used only by mc1.12.2, which keeps it).
- Move `jopt-simple` from a phantom module dependency to a `resolutionStrategy` constraint (same resolution, clears the finding).
- Split aggregate test deps: `junit-jupiter` → api+params+engine (via BOM), `net.jqwik:jqwik` → `jqwik-api` + `jqwik-engine`, in both the convention and `:common`. **The engine is re-added explicitly — dropping the aggregate otherwise removes the test engine and silently disables JUnit/jqwik tests.**
- Add a Groovy `verifyNoMixin` gate to the mc1.12.2 lane (Gradle 4.10.3 cannot use the Kotlin-DSL buildSrc convention); wire via `build.dependsOn`.

## Why
Roadmap P1-3/4/5. Clears ~12 dependency-analysis findings; adds the mixin enforcement AGENTS.md claimed the lane already had.

## Verification
- [x] `./gradlew :common:compileJava` (main compiles; full `:common:build` blocked in shared worktree by FIXER-F's in-flight TestConfigSupport)
- [x] `./gradlew :forge-1.21:compileJava` (ErrorProne green without mixin AP)
- [x] `:common` testRuntimeClasspath contains junit-jupiter-engine + jqwik-engine
- [x] `cd mc1.12.2 && JAVA_HOME=<jdk8> ./gradlew verifyNoMixin` — passes; negative test (@Mixin probe) fails the gate as expected