### PR TITLE
ci: add CI Health job (gradle-health.sh + dep-analysis; informational)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,3 +321,33 @@ jobs:
         # Diff against the PR's actual base branch (github.base_ref); on
         # push events fall back to origin/main.
         run: npx -y aislop ci --changes --base origin/${{ github.base_ref || 'main' }}
+
+  # ── CI Health: gradle-health.sh + dep-analysis projectHealth ──
+  # Informational (WARN-only policy) — NOT in the required-check
+  # contract until it proves green (see plans/P2-part2-implementation-plan.md).
+  ci-health:
+    name: CI Health
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: lint-yaml
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
+      - name: Set up JDK 21
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961  # v5
+        with:
+          java-version: 21
+          distribution: temurin
+      - name: Cache Gradle wrapper and caches
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5
+        with:
+          path: |
+            ~/.gradle/wrapper/dists
+            ~/.gradle/caches
+          key: gradle-${{ runner.os }}-m2-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-m2-
+      - name: chmod +x gradlew
+        run: chmod +x gradlew
+      - name: Run CI Health (gradle-health.sh + dep-analysis)
+        # WARN-only: script exits 0 always; sweeps :common + the in-root forge modules.
+        run: bash scripts/gradle-health.sh --offline


### PR DESCRIPTION
Per P2-15 plan. New job runs scripts/gradle-health.sh across :common + the in-root forge modules with --offline (WARN-only dep-analysis policy preserved). Job is INFORMATIONAL — NOT in the required-check contract until it proves green. After 1 successful CI cycle, consider adding 'CI Health' to the contract via scripts/gh-api-bump/CI-health.sh (deadlock-safe post-merge).