### PR TITLE
ci: pin runner to ubuntu-24.04 (reproducibility over rolling-latest)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
   # ── Lint all YAML files once ───────────────────────────────────
   lint-yaml:
     name: YAML Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
@@ -33,7 +33,7 @@ jobs:
   # ── Build matrix over the M2 modules (JDK 21) ──────────────────
   build:
     name: Build (${{ matrix.mc }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: ${{ matrix.timeout || 30 }}
     needs: lint-yaml
     strategy:
@@ -92,7 +92,7 @@ jobs:
   # ── mc1.12.2 out-of-band lane (own wrapper, JDK 8) ─────────────
   build-mc1_12_2:
     name: Build (mc1.12.2)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     needs: lint-yaml
     steps:
@@ -125,7 +125,7 @@ jobs:
   # ── forge-1.16.5 out-of-band lane (own wrapper, JDK 8) ────────
   build-forge-1_16_5:
     name: Build (forge-1.16.5)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     needs: lint-yaml
     steps:
@@ -158,7 +158,7 @@ jobs:
   # ── forge-1.8.9 out-of-band lane (own wrapper, JDK 8) ────────
   build-forge-1_8_9:
     name: Build (forge-1.8.9)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     needs: lint-yaml
     steps:
@@ -191,7 +191,7 @@ jobs:
   # ── forge-1.20.1 out-of-band lane (own wrapper, JDK 21) ────────
   build-forge-1_20_1:
     name: Build (forge-1.20.1)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     needs: lint-yaml
     steps:
@@ -224,7 +224,7 @@ jobs:
   # ── forge-1.7.10 out-of-band lane (own wrapper, JDK 8, GTNH FG 1.2.11) ──
   build-forge-1_7_10:
     name: Build (forge-1.7.10)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     needs: lint-yaml
     steps:
@@ -263,7 +263,7 @@ jobs:
   # tests live in the M2 tree.
   e2e-mc1_12_2:
     name: E2E (mc1.12.2)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     needs: lint-yaml
     steps:
@@ -290,7 +290,7 @@ jobs:
   # ── GameTest on 1.21 (canonical gametest subproject) ──────────
   gametest-121:
     name: GameTest (1.21)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     needs: lint-yaml
     steps:
@@ -470,7 +470,7 @@ jobs:
   # ── aislop quality gate (same scanner as the pre-commit hook) ─
   aislop:
     name: aislop (M2)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     needs: lint-yaml
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
   # ── Per-tag module routing: tag prefix -> Gradle subproject ────
   publish:
     name: Publish (${{ matrix.game-version }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 45
     if: startsWith(github.ref_name, matrix.prefix)
     strategy:
@@ -106,7 +106,7 @@ jobs:
   publish-mc1_12_2:
     name: Publish (mc1.12.2)
     if: startsWith(github.ref_name, 'mc1.12.2-v')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 45
 
     steps:
@@ -161,7 +161,7 @@ jobs:
   publish-mc1_16_5:
     name: Publish (mc1.16.5)
     if: startsWith(github.ref_name, 'mc1.16.5-v')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 45
 
     steps:
@@ -216,7 +216,7 @@ jobs:
   publish-mc1_8_9:
     name: Publish (mc1.8.9)
     if: startsWith(github.ref_name, 'mc1.8.9-v')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 45
 
     steps:
@@ -271,7 +271,7 @@ jobs:
   publish-mc1_20_1:
     name: Publish (mc1.20.1)
     if: startsWith(github.ref_name, 'mc1.20.1-v')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 45
 
     steps:
@@ -326,7 +326,7 @@ jobs:
   publish-mc1_7_10:
     name: Publish (mc1.7.10)
     if: startsWith(github.ref_name, 'mc1.7.10-v')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 45
 
     steps:


### PR DESCRIPTION
Per P2-11 plan. All 16 occurrences of `ubuntu-latest` across ci.yml + publish.yml replaced with `ubuntu-24.04` (current LTS). Zero behavior change today (24.04 IS what latest resolves to); reproducibility + deprecation-survivability win. JDK 8 lanes (mc1.12.2, forge-1.16.5) verified to run on 24.04. No contract change.