### PR TITLE
test: flake-risk safe batch (FIX B + A + D — no behavior change)

### DIFF
--- a/common/src/test/java/levosilimo/everlastingskins/skinchanger/MojangProfileCacheTest.java
+++ b/common/src/test/java/levosilimo/everlastingskins/skinchanger/MojangProfileCacheTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.BooleanSupplier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -25,6 +26,16 @@ class MojangProfileCacheTest {
 
     private static final String USERNAME = "Notch";
     private static final CustomSkinProperty SKIN = new CustomSkinProperty("textures", "value", "sig", "MojangAPI");
+
+    /** No-new-dep poll: returns when cond holds, else fails after timeoutMs. */
+    private static void awaitUntil(BooleanSupplier cond, long timeoutMs) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            if (cond.getAsBoolean()) return;
+            Thread.sleep(10);
+        }
+        fail("condition not met within " + timeoutMs + "ms");
+    }
 
     @Test
     @DisplayName("a cached entry is returned immediately")
@@ -43,7 +54,7 @@ class MojangProfileCacheTest {
         MojangProfileCache cache = new MojangProfileCache(10, 100);
         cache.put(USERNAME, SKIN);
 
-        Thread.sleep(20);
+        awaitUntil(() -> cache.get(USERNAME) == null && cache.size() == 0, 1000);
 
         assertNull(cache.get(USERNAME));
         assertEquals(0, cache.size());
@@ -142,7 +153,7 @@ class MojangProfileCacheTest {
     void ttlExpiry_evictsEntriesOnPut() throws InterruptedException {
         MojangProfileCache cache = new MojangProfileCache(20, 100);
         cache.put("a", SKIN);
-        Thread.sleep(40);
+        awaitUntil(() -> cache.get("a") == null, 1000);  // wait for TTL expiry, not a fixed sleep
         cache.put("b", SKIN);            // sweep drops expired a
         assertEquals(1, cache.size());
         assertNull(cache.get("a"));

--- a/common/src/test/java/levosilimo/everlastingskins/skinchanger/SkinStorageTest.java
+++ b/common/src/test/java/levosilimo/everlastingskins/skinchanger/SkinStorageTest.java
@@ -340,11 +340,12 @@ class SkinStorageTest {
     }
     /** Polls for a file to appear (50ms debounce + load headroom, bounded 2s). */
     private static boolean awaitFile(Path file) throws InterruptedException {
-        for (int i = 0; i < 40; i++) {
-            if (Files.exists(file)) {
-                return true;
-            }
-            Thread.sleep(50);
+        long deadline = System.currentTimeMillis() + 2000;
+        long pollMs = 1;
+        while (System.currentTimeMillis() < deadline) {
+            if (Files.exists(file)) return true;
+            Thread.sleep(pollMs);
+            pollMs = Math.min(100, pollMs * 2);
         }
         return Files.exists(file);
     }

--- a/mc1.12.2/src/test/java/levosilimo/everlastingskins/harness/AsyncSupport.java
+++ b/mc1.12.2/src/test/java/levosilimo/everlastingskins/harness/AsyncSupport.java
@@ -18,14 +18,16 @@ public final class AsyncSupport {
 
     public static boolean await(long deadlineMs, BooleanSupplier condition) {
         long deadline = System.currentTimeMillis() + deadlineMs;
+        long pollMs = 1;
         while (System.currentTimeMillis() < deadline) {
             if (condition.getAsBoolean()) return true;
             try {
-                Thread.sleep(10);
+                Thread.sleep(pollMs);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 return false;
             }
+            pollMs = Math.min(100, pollMs * 2);  // 1 -> 2 -> 4 -> ... -> 100ms cap
         }
         return condition.getAsBoolean();
     }

--- a/mc1.12.2/src/test/java/levosilimo/everlastingskins/skinchanger/SkinStorageTest.java
+++ b/mc1.12.2/src/test/java/levosilimo/everlastingskins/skinchanger/SkinStorageTest.java
@@ -279,11 +279,12 @@ class SkinStorageTest {
     }
     /** Polls for a file to appear (50ms debounce + load headroom, bounded 2s). */
     private static boolean awaitFile(Path file) throws InterruptedException {
-        for (int i = 0; i < 40; i++) {
-            if (Files.exists(file)) {
-                return true;
-            }
-            Thread.sleep(50);
+        long deadline = System.currentTimeMillis() + 2000;
+        long pollMs = 1;
+        while (System.currentTimeMillis() < deadline) {
+            if (Files.exists(file)) return true;
+            Thread.sleep(pollMs);
+            pollMs = Math.min(100, pollMs * 2);
         }
         return Files.exists(file);
     }


### PR DESCRIPTION
## Safe flake fixes — no behavior change, no new dependencies

Tier 1 of the flake-risk reduction plan (see `.slim/deepwork/three-lane-expansion/plans/flake-risk-reduction-plan.md`). All three fixes are assertion-preserving and dependency-free; per AGENTS.md rule 4, no Awaitility was added (no-new-dep poll helpers instead).

### FIX B — AsyncSupport.await exponential backoff (mc1.12.2)
Replace the fixed 10ms poll with a 1→100ms exponential backoff. All 74 call sites across 17 test files benefit. Deadline contract unchanged; fast conditions still return on the first poll (~1ms). Pure CPU/wall-time reduction, no assertion change.

### FIX A — MojangProfileCacheTest TTL expiry polls (common, single shared source)
Replace the two bare `Thread.sleep(20/40)` with a bounded no-new-dep poll on the expired state. Strictly more correct: the fixed sleep could fire before the TTL elapses under a slow scheduler (the actual flake). MojangProfileCacheTest is shared into mc1.12.2 via `syncCommonTestSources` (NOT in the exclude list), so one source file covers both lanes.

### FIX D — SkinStorageTest.awaitFile backoff (common + mc1.12.2)
Already bounded at 2s and non-flaky; converts the fixed 50ms step to 1→100ms backoff as wall-time polish. SkinStorageTest IS excluded from the common test share, so both lane copies are patched.

## Verification (10x loops, all green)
- `:common:test` on `*MojangProfileCacheTest*` + `*SkinStorageTest*` ×10 — 0 failures (12 + 21 tests)
- mc1.12.2 full lane `./gradlew test` ×10 (JDK 8) — 0 failures (514 tests/run)

## Out of scope (deferred to separate PRs)
- FIX C (DebounceStateConsistencyIT) and FIX F (gametest) change test semantics and belong in their own PRs.
