### PR TITLE
build: graduate duplicate-class dep-analysis WARN->FAIL (forge-1.21 first; gates via depAnalysis.graduateDuplicateClass property)

### DIFF
--- a/buildSrc/src/main/kotlin/everlastingskins.dependency-analysis.gradle.kts
+++ b/buildSrc/src/main/kotlin/everlastingskins.dependency-analysis.gradle.kts
@@ -25,6 +25,8 @@
 // project once any module applies this convention.
 
 import com.autonomousapps.DependencyAnalysisSubExtension
+import com.autonomousapps.tasks.AbiAnalysisTask
+import com.autonomousapps.tasks.ClassListExploderTask
 import com.autonomousapps.tasks.ProjectHealthTask
 
 plugins {
@@ -42,10 +44,28 @@ plugins {
 // 'DependencyAnalysisExtension' does not exist"). The per-project issues{}
 // handler is ProjectIssueHandler, which has onAny directly (no all{} wrapper
 // — that lives on the root IssueHandler).
+// P2-6: one per-lane gate controls BOTH the FAIL severity and the check
+// wiring, so graduation and its CI wiring roll back together by flipping one
+// property. :common and not-yet-graduated lanes never set it, so they stay
+// WARN-only and unwired.
+val graduateDuplicateClass = project.findProperty("depAnalysis.graduateDuplicateClass")
+    ?.toString()?.toBoolean() == true
+
 extensions.configure<DependencyAnalysisSubExtension> {
     issues {
         onAny {
             severity("warn")
+        }
+        // P2-6: graduate ONLY the duplicate-class category to FAIL, gated
+        // per-lane. The plugin's per-issue override takes precedence over
+        // onAny, so warn remains in force for every other category
+        // (Forge-reflection FPs stay non-blocking). duplicate-class-file is
+        // the zero-FP category; jsr305 split-package is neutralized by
+        // forge-module's compileOnly/testImplementation excludes.
+        if (graduateDuplicateClass) {
+            onDuplicateClassWarnings {
+                severity("fail")
+            }
         }
     }
 }
@@ -58,4 +78,32 @@ extensions.configure<DependencyAnalysisSubExtension> {
 // fails with "Task with name 'projectHealth' not found".
 tasks.withType<ProjectHealthTask>().configureEach {
     consoleReport.set(layout.buildDirectory.file("reports/dependency-analysis/project-health-report.txt"))
+}
+
+// P2-6: wire projectHealth into check ONLY for graduated lanes, so `build`
+// (hence the required Build (X) CI cell) fails on a duplicate-class finding.
+// Must run inside projectsEvaluated: the plugin registers projectHealth
+// conditionally/deferred, so a named() lookup at apply time fails. This
+// composes with forge-module's #960 workaround (ClassListExploderTask /
+// AbiAnalysisTask dependsOn processResources). :common never sets the
+// property, so it is skipped entirely.
+if (graduateDuplicateClass) {
+    gradle.projectsEvaluated {
+        tasks.matching { it.name == "check" }.configureEach {
+            dependsOn(tasks.withType<ProjectHealthTask>())
+        }
+        // #960 sibling for the test variant: explodeByteCodeSourceTest /
+        // abiAnalysisTest read build/sourcesSets/test (produced by
+        // processTestResources) without declaring the edge — forge-module's
+        // #960 workaround wires only the main variant (processResources).
+        // The violation only surfaces once check runs projectHealth in the
+        // same graph as test, i.e. only on graduated lanes, so the fix is
+        // gated on the same property and rolls back with it.
+        tasks.withType<ClassListExploderTask>().configureEach {
+            dependsOn("processTestResources")
+        }
+        tasks.withType<AbiAnalysisTask>().configureEach {
+            dependsOn("processTestResources")
+        }
+    }
 }

--- a/forge-1.21/gradle.properties
+++ b/forge-1.21/gradle.properties
@@ -12,4 +12,8 @@ mc.runDir=run
 mc.runDir2=run2
 gametestNamespace=everlastingskins
 
+# P2-6: graduate duplicate-class dep-analysis to FAIL and wire projectHealth
+# into check (gates the Build (1.21) CI cell on duplicate-class findings).
+depAnalysis.graduateDuplicateClass=true
+
 # M2: :common is canonical; this module consumes it (gate default).


### PR DESCRIPTION
## P2-6 (PR #1): graduate duplicate-class dep-analysis on forge-1.21

Per lib-43 Option A / the P2-6 plan: wire `projectHealth` into `check` and graduate ONLY the duplicate-class category to FAIL, both gated on one per-lane property so graduation and its CI wiring roll back together by flipping a single property.

### Changes

- **`buildSrc/.../everlastingskins.dependency-analysis.gradle.kts`**
  - New per-lane gate: `depAnalysis.graduateDuplicateClass` (absent/false everywhere by default).
  - Inside `issues {}`: `onDuplicateClassWarnings { severity("fail") }` when gated — every other category stays WARN (Forge-reflection FPs remain non-blocking).
  - `gradle.projectsEvaluated` wiring when gated: `check` → `dependsOn(projectHealth)`, so the existing required `Build (1.21)` CI cell becomes the gate — zero new CI jobs, zero branch-protection changes.
  - Bonus fix surfaced by the wiring: the #960 workaround in forge-module only covers the main-variant analysis tasks; `explodeByteCodeSourceTest`/`abiAnalysisTest` read `build/sourcesSets/test` without declaring `processTestResources`, which Gradle 9.3.1 strict implicit-dep detection hard-fails once check and projectHealth share a graph. Test-variant edges added here, gated on the same property.
- **`forge-1.21/gradle.properties`**: `depAnalysis.graduateDuplicateClass=true`.

### Verification

- `./gradlew :forge-1.21:build --offline` — PASS (projectHealth runs inside check).
- `./gradlew :forge-1.21:projectHealth --offline` — PASS (zero duplicate-class findings today).
- **Positive control**: temporarily added `com.google.code.findbugs:jsr305:3.0.2` + `com.google.code.findbugs:annotations:3.0.1` (annotations fat-jars the same `javax/annotation/Nullable`) → `:forge-1.21:build` FAILED on `:forge-1.21:projectHealth` with duplicate-class findings on compile and runtime classpaths; reverted the deps, clean build re-verified. Note: jsr305 alone cannot trip the finding — forge-module's `compileOnly` exclude (inherited by compileClasspath) filters it and Gradle version unification collapses the runtime to one jar.

### Rollback

Flip `depAnalysis.graduateDuplicateClass` to absent/false in forge-1.21/gradle.properties — FAIL severity, check-wiring, and the test-variant edges all revert together. No branch-protection PATCH needed (12-context contract unchanged).

PR #2 (forge-1.21.1/1.21.4/1.21.8) lands after one green cycle.