### PR TITLE
test(common): SkinStorage concurrency property + FallbackChain integration (P3-7 + P3-9)

### DIFF
--- a/common/src/test/java/levosilimo/everlastingskins/skinchanger/FallbackChainIntegrationTest.java
+++ b/common/src/test/java/levosilimo/everlastingskins/skinchanger/FallbackChainIntegrationTest.java
@@ -1,0 +1,183 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import com.mojang.authlib.properties.Property;
+import levosilimo.everlastingskins.FakeHttpClient;
+import levosilimo.everlastingskins.enums.SkinVariant;
+import levosilimo.everlastingskins.skinchanger.responses.HttpResponse;
+import levosilimo.everlastingskins.skinchanger.responses.mineskin.MineSkinResponse;
+import levosilimo.everlastingskins.util.CustomSkinProperty;
+import levosilimo.everlastingskins.util.HttpClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end fall-back chain contract (Mojang-404 -> MineSkin -> default skin).
+ * <p>
+ * There is no single {@code :common} assembler that chains all three stages (the
+ * literal production chain spans forge lanes; see P3-part2 plan P3-9, lines 109-115).
+ * This test therefore composes the component fall-through contract the lanes wire up:
+ * <ol>
+ *   <li>{@link MojangApiHttpImpl} over {@link FakeHttpClient} serving 404 on the
+ *       sessionserver profile URI must return empty (chain advances past Mojang).</li>
+ *   <li>A MineSkin seam (local {@code MineSkinAPI} fake) returning null must advance
+ *       the chain past MineSkin.</li>
+ *   <li>{@link DefaultSkinResolver} must terminate at a resolved default skin.</li>
+ * </ol>
+ * A shared {@code order} list records each stage as it fires, so the exact
+ * Mojang-then-MineSkin-then-default sequence is asserted. The {@code recording}
+ * client proves the sessionserver URI was actually the first HTTP hit.
+ */
+class FallbackChainIntegrationTest {
+
+    private static final UUID PLAYER_UUID = UUID.fromString("12345678-1234-1234-1234-123456789abc");
+    private static final String NO_DASH_UUID = "12345678123412341234123456789abc";
+    private static final String IMAGE_URL = "https://example.com/skin.png";
+
+    private static final MojangEndpoints TEST_ENDPOINTS = new MojangEndpoints(
+            "http://test.local/uuid/mojang/%playerName%",
+            "http://test.local/uuid/minetools/%playerName%",
+            "http://test.local/profile/mojang/%uuid%",
+            "http://test.local/profile/minetools/%uuid%");
+
+    private final List<String> order = new ArrayList<>();
+    private FakeHttpClient httpClient;
+    private RecordingHttpClient recording;
+    private MojangApiHttpImpl mojangApi;
+    private FakeMojangAPI seed;
+
+    @BeforeEach
+    void setUp() {
+        httpClient = new FakeHttpClient();
+        recording = new RecordingHttpClient(httpClient);
+        mojangApi = new MojangApiHttpImpl(TEST_ENDPOINTS, recording);
+        // Default-skin resolver seed: a real Mojang API returns empty after a 404, so
+        // the default stage resolves through a seeded fake keyed by the entry name.
+        // FakeMojangAPI.addSkin registers by skin.getSource(), so source must be "Steve".
+        seed = new FakeMojangAPI();
+        seed.addSkin("Steve", new CustomSkinProperty("textures", "defaultValue", "defaultSig", "Steve"));
+    }
+
+    /**
+     * Mojang 404 profile -> MineSkin returns null -> DefaultSkinResolver default.
+     * Asserts the three stages fire in exactly Mojang -> MineSkin -> default order.
+     */
+    @Test
+    @DisplayName("Mojang 404 -> MineSkin empty -> default skin (order mojang, mineskin, default)")
+    void fullChainFallsThroughToDefault() {
+        URI mojangProfile = URI.create("http://test.local/profile/mojang/" + NO_DASH_UUID);
+        httpClient.addResponse(mojangProfile, 404, "");
+        // profileMineTools URI intentionally unregistered -> FakeHttpClient throws
+        // IOException (caught in fetchJson) -> getProfile returns empty.
+
+        ProfileLookup lookup = new ProfileLookup("TestPlayer", PLAYER_UUID);
+
+        // Stage 1: Mojang must come up empty on 404 AND hit the sessionserver URI first.
+        Optional<CustomSkinProperty> mojangResult = mojangApi.getProfile(lookup);
+        assertFalse(mojangResult.isPresent(), "404 profile must advance past Mojang");
+        assertEquals(mojangProfile, recording.firstUri(), "Mojang profile URI must be the first HTTP hit");
+        order.add("mojang"); // Mojang consulted and empty -> advance
+
+        // Stage 2: MineSkin seam returns null -> falls through.
+        FakeMineSkin mineskin = new FakeMineSkin();
+        MineSkinResponse msResult = mineskin.genSkin(IMAGE_URL, SkinVariant.CLASSIC);
+        assertNull(msResult, "empty MineSkin must advance past MineSkin");
+        order.add("mineskin");
+
+        // Stage 3: default skin termination.
+        Property defaultSkin = DefaultSkinResolver.resolveDefault(Collections.singletonList("Steve"), seed);
+        assertNotNull(defaultSkin, "chain must terminate at a default skin");
+        assertEquals("defaultValue", defaultSkin.getValue());
+        order.add("default");
+
+        assertEquals(Arrays.asList("mojang", "mineskin", "default"), order,
+                "fallback stages must fire in Mojang -> MineSkin -> default order");
+    }
+
+    /**
+     * A 200 Mojang profile short-circuits: MineSkin and default must NOT be reached.
+     */
+    @Test
+    @DisplayName("Mojang 200 short-circuits the chain (only Mojang is consulted)")
+    void mojangSuccessShortCircuitsChain() {
+        URI mojangProfile = URI.create("http://test.local/profile/mojang/" + NO_DASH_UUID);
+        httpClient.addResponse(mojangProfile, 200,
+                "{\"id\":\"x\",\"name\":\"x\",\"properties\":" +
+                        "[{\"name\":\"textures\",\"value\":\"v\",\"signature\":\"s\"}]}");
+
+        ProfileLookup lookup = new ProfileLookup("TestPlayer", PLAYER_UUID);
+        Optional<CustomSkinProperty> result = mojangApi.getProfile(lookup);
+
+        assertTrue(result.isPresent(), "200 profile must resolve at the Mojang stage");
+        assertEquals("v", result.get().getOriginalProperty().getValue());
+        assertEquals(mojangProfile, recording.firstUri(), "Mojang profile URI must be hit");
+        // No stage falls through on success: MineSkin and default are never reached.
+        assertTrue(order.isEmpty(),
+                "MineSkin and default must NOT fire when Mojang succeeds: " + order);
+    }
+
+    /* ================================================================== */
+    /*  Local MineSkin seam (P2-12 not yet promoted into :common)          */
+    /* ================================================================== */
+
+    /**
+     * Deterministic MineSkin stub that always returns null (empty fall-through).
+     * Kept nested and named distinctly to avoid a duplicate-class collision if P2-12
+     * later promotes {@code FakeMineSkinAPI} into the :common test tree.
+     */
+    private static final class FakeMineSkin implements MineSkinAPI {
+        @Nullable
+        @Override
+        public MineSkinResponse genSkin(String url, @Nullable SkinVariant variant) {
+            return null;
+        }
+    }
+
+    /* ================================================================== */
+    /*  Recording HttpClient: delegates to FakeHttpClient, logs call order  */
+    /* ================================================================== */
+
+    private static final class RecordingHttpClient implements HttpClient {
+        private final FakeHttpClient delegate;
+        private final List<URI> uris = new ArrayList<>();
+
+        RecordingHttpClient(FakeHttpClient delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public HttpResponse execute(URI uri, @Nullable RequestBody body, HttpType accepts,
+                String userAgent, HttpMethod method, Map<String, String> headers, int timeout)
+                throws IOException {
+            uris.add(uri);
+            return delegate.execute(uri, body, accepts, userAgent, method, headers, timeout);
+        }
+
+        URI firstUri() {
+            return uris.isEmpty() ? null : uris.get(0);
+        }
+    }
+}

--- a/common/src/test/java/levosilimo/everlastingskins/skinchanger/SkinIODeleteRaceTest.java
+++ b/common/src/test/java/levosilimo/everlastingskins/skinchanger/SkinIODeleteRaceTest.java
@@ -7,24 +7,35 @@
 package levosilimo.everlastingskins.skinchanger;
 
 import levosilimo.everlastingskins.util.CustomSkinProperty;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.From;
+import net.jqwik.api.Label;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.RepeatedTest;
-import org.junit.jupiter.api.RepetitionInfo;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Random;
+import java.util.Base64;
+import java.util.Comparator;
+import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -88,42 +99,70 @@ class SkinIODeleteRaceTest {
         }
     }
 
-    @RepeatedTest(20)
-    @DisplayName("randomized save/delete/flush sequences never resurrect a deleted file")
-    void randomizedSequencesNeverResurrectDeletedFile(RepetitionInfo repetition) throws Exception {
-        UUID u = UUID.randomUUID();
-        Path target = tempDir.resolve(u + ".json");
-        Random rnd = new Random(0x5eedL + repetition.getCurrentRepetition() * 7919L);
-        String lastPayload = null;
-        Op lastOp = null;
+    /**
+     * P3-7 rewrite of the old {@code @RepeatedTest(20) + rnd.nextInt(3) +
+     * Thread.sleep} loop: a jqwik {@code @Property} over an
+     * {@code Arbitrary<List<Op>>} (SAVE/DELETE/FLUSH). The Thread.sleep
+     * (the flake source lib-21 flagged) is replaced by flushPending() as the
+     * deterministic barrier. Same last-op contract:
+     *   lastOp==DELETE -> file absent
+     *   lastOp==SAVE   -> file present with the last payload
+     *
+     * <p>Per-try isolation uses newTempDir()+deleteRecursively()+resetForTest()+
+     * METRICS_LOCK (the established SkinIOPropertyTest pattern) instead of the
+     * shared {@code @TempDir} field, because jqwik + @TempDir injection is
+     * unreliable and files would accumulate across tries.
+     */
+    @Property(tries = 100)
+    @Label("randomized save/delete/flush sequences never resurrect a deleted file")
+    void randomizedSequencesNeverResurrectDeletedFile(@ForAll @From("saveDeleteFlushSequences") List<Op> ops)
+            throws IOException {
+        synchronized (METRICS_LOCK) {
+            SkinStorage.resetForTest();
+            Path dir = newTempDir();
+            try {
+                SkinIO io = new SkinIO(dir);
+                SkinStorage isolated = new SkinStorage(io);
+                UUID u = UUID.randomUUID();
+                Path target = dir.resolve(u + ".json");
+                OpType lastOp = null;
+                String lastPayload = null;
+                for (Op op : ops) {
+                    switch (op.type) {
+                        case SAVE:
+                            lastPayload = op.payload;
+                            lastOp = OpType.SAVE;
+                            CompletableFuture<Void> unused = isolated.saveSkinAsync(u, skin(op.payload));
+                            break;
+                        case DELETE:
+                            isolated.removeSkin(u);
+                            lastOp = OpType.DELETE;
+                            break;
+                        case FLUSH:
+                            isolated.flushPending(); // barrier replaces the old Thread.sleep window
+                            break;
+                        default:
+                            throw new IllegalStateException("unknown op " + op.type);
+                    }
+                }
+                isolated.flushPending();
 
-        for (int i = 0; i < 15; i++) {
-            switch (rnd.nextInt(3)) {
-                case 0:
-                    lastPayload = "payload-" + rnd.nextInt(100000);
-                    CompletableFuture<Void> unused = storage.saveSkinAsync(u, skin(lastPayload));
-                    lastOp = Op.SAVE;
-                    break;
-                case 1:
-                    storage.removeSkin(u);
-                    lastOp = Op.DELETE;
-                    break;
-                default:
-                    storage.flushPending();
+                if (lastOp == OpType.DELETE) {
+                    assertFalse(Files.exists(target),
+                            "stale write resurrected a deleted skin");
+                } else if (lastOp == OpType.SAVE) {
+                    // Compare the deserialized value, NOT raw file text: Gson
+                    // escapes base64 padding chars on write ("YQ==" becomes
+                    // "YQ\u003d\u003d"), so a text contains() match on the
+                    // payload is wrong for base64 payloads.
+                    CustomSkinProperty loaded = io.loadSkin(u);
+                    assertNotNull(loaded, "last save was lost: " + target);
+                    assertEquals(lastPayload, loaded.getValue(),
+                            "stale payload won over the last save");
+                }
+            } finally {
+                deleteRecursively(dir);
             }
-            Thread.sleep(rnd.nextInt(3));
-        }
-        storage.flushPending();
-
-        if (lastOp == Op.DELETE) {
-            assertFalse(Files.exists(target),
-                    "repetition " + repetition.getCurrentRepetition() + ": stale write resurrected a deleted skin");
-        } else if (lastOp == Op.SAVE) {
-            assertTrue(Files.exists(target),
-                    "repetition " + repetition.getCurrentRepetition() + ": last save was lost");
-            String content = new String(Files.readAllBytes(target), StandardCharsets.UTF_8);
-            assertTrue(content.contains(lastPayload),
-                    "repetition " + repetition.getCurrentRepetition() + ": stale payload won over the last save");
         }
     }
 
@@ -162,8 +201,60 @@ class SkinIODeleteRaceTest {
         return new CustomSkinProperty(value, "sig", "src");
     }
 
-    private enum Op {
-        SAVE, DELETE
+    private enum OpType { SAVE, DELETE, FLUSH }
+
+    private static final class Op {
+        final OpType type;
+        final String payload;
+
+        Op(OpType type, String payload) {
+            this.type = type;
+            this.payload = payload;
+        }
+
+        @Override
+        public String toString() {
+            return type + (payload == null ? "" : "(" + payload + ")");
+        }
+    }
+
+    @Provide
+    Arbitrary<String> payloads() {
+        return Arbitraries.strings().withCharRange('a', 'z').ofMinLength(1).ofMaxLength(16)
+                .map(s -> Base64.getEncoder().encodeToString(s.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Provide
+    Arbitrary<List<Op>> saveDeleteFlushSequences() {
+        return Combinators.combine(
+                Arbitraries.of(OpType.SAVE, OpType.DELETE, OpType.FLUSH),
+                payloads())
+                .as(Op::new)
+                .list().ofMinSize(1).ofMaxSize(15);
+    }
+
+    private static final Object METRICS_LOCK = new Object();
+
+    private static Path newTempDir() {
+        try {
+            return Files.createTempDirectory("skiniodelete-race-");
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static void deleteRecursively(Path dir) {
+        try (Stream<Path> stream = Files.walk(dir)) {
+            stream.sorted(Comparator.reverseOrder()).forEach(path -> {
+                try {
+                    Files.deleteIfExists(path);
+                } catch (IOException ignored) {
+                    // best-effort temp cleanup
+                }
+            });
+        } catch (IOException ignored) {
+            // best-effort temp cleanup
+        }
     }
 
     /** SkinIO whose drain write blocks until the test releases it. */

--- a/common/src/test/java/levosilimo/everlastingskins/skinchanger/SkinStorageConcurrencyTest.java
+++ b/common/src/test/java/levosilimo/everlastingskins/skinchanger/SkinStorageConcurrencyTest.java
@@ -1,0 +1,219 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import levosilimo.everlastingskins.metrics.SkinMetrics;
+import levosilimo.everlastingskins.util.CustomSkinProperty;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.From;
+import net.jqwik.api.Label;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Concurrent cache-access property test for {@link SkinStorage}.
+ *
+ * <p>N worker threads hammer the (static) {@code skinMap} plus the shared
+ * {@link SkinIO} coalescing writer concurrently. Each worker owns a disjoint
+ * slice of the UUID pool, so the per-UUID "last write wins" model is
+ * deterministic: after all workers join and {@code flushPending()} drains the
+ * writer, {@code getSkin} must return exactly the last value that worker set
+ * for that UUID (or null/absent if the worker's last op was a remove) — never
+ * an older overwritten value, and never a value from another UUID.
+ *
+ * <p>Deadlock safety: every worker future is awaited with a timeout, so a real
+ * deadlock in SkinStorage/SkinIO fails the try with TimeoutException instead
+ * of hanging the suite. No-exception invariant: any worker-thrown Throwable is
+ * collected and rethrown after join, and the future.get() propagates it.
+ *
+ * <p>The whole body is synchronized on METRICS_LOCK (jqwik may re-run/shrink a
+ * failing property on a background thread concurrently with other tries) and
+ * calls SkinStorage.resetForTest() + SkinMetrics.INSTANCE.reset() per try so
+ * the static map never bleeds across tries or test classes.
+ */
+class SkinStorageConcurrencyTest {
+
+    /** Fences property bodies against jqwik's concurrent shrink re-runs. */
+    private static final Object METRICS_LOCK = new Object();
+
+    private static final int WORKERS = 8;
+    private static final int OPS_PER_WORKER = 50;
+    private static final long AWAIT_SECONDS = 10L;
+
+    /** Base64 payloads so any disk reload path (getSkin on a map miss) stays loadable. */
+    @Provide
+    Arbitrary<String> payloads() {
+        return Arbitraries.strings().withCharRange('a', 'z').ofMinLength(1).ofMaxLength(16)
+                .map(s -> Base64.getEncoder().encodeToString(s.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    /** How many UUIDs each worker owns; a worker's slice is workerId * slice .. +slice. */
+    @Provide
+    Arbitrary<Integer> uuidsPerWorker() {
+        return Arbitraries.integers().between(1, 4);
+    }
+
+    @Property(tries = 25)
+    @Label("concurrent set/get/remove/hasDefault/save/flush: no exceptions, no lost updates")
+    void concurrentAccessNeverLosesLastWrite(@ForAll @From("payloads") String payload,
+                                             @ForAll @From("uuidsPerWorker") int slice)
+            throws Exception {
+        synchronized (METRICS_LOCK) {
+            SkinMetrics.INSTANCE.reset();
+            SkinStorage.resetForTest();
+            Path dir = newTempDir();
+            try {
+                SkinStorage storage = new SkinStorage(new SkinIO(dir));
+                UUID[] uuids = new UUID[WORKERS * slice];
+                for (int i = 0; i < uuids.length; i++) {
+                    uuids[i] = UUID.randomUUID();
+                }
+                // Model: the last skin the owning worker set for each UUID.
+                Map<UUID, CustomSkinProperty> expected = new ConcurrentHashMap<>();
+                AtomicReference<Throwable> failure = new AtomicReference<>();
+                ExecutorService pool = Executors.newFixedThreadPool(WORKERS);
+                CyclicBarrier start = new CyclicBarrier(WORKERS);
+                try {
+                    Future<?>[] futures = new Future<?>[WORKERS];
+                    for (int w = 0; w < WORKERS; w++) {
+                        final int workerId = w;
+                        futures[w] = pool.submit(() ->
+                                runWorker(workerId, slice, uuids, payload, storage, expected, start, failure));
+                    }
+                    for (Future<?> f : futures) {
+                        // Timeout => real deadlock in the store under test.
+                        f.get(AWAIT_SECONDS, TimeUnit.SECONDS);
+                    }
+                } finally {
+                    pool.shutdownNow();
+                }
+                if (failure.get() != null) {
+                    throw new AssertionError("worker threw", failure.get());
+                }
+                storage.flushPending();
+                assertModel(storage, uuids, expected);
+            } finally {
+                deleteRecursively(dir);
+            }
+        }
+    }
+
+    private static void runWorker(int workerId, int slice, UUID[] uuids, String payload,
+                                  SkinStorage storage, Map<UUID, CustomSkinProperty> expected,
+                                  CyclicBarrier start, AtomicReference<Throwable> failure) {
+        try {
+            start.await(); // release all workers at the same instant for genuine contention
+            Random rnd = new Random(0xdeadbeefL + workerId * 104729L);
+            for (int i = 0; i < OPS_PER_WORKER; i++) {
+                UUID uuid = uuids[workerId * slice + (i % slice)];
+                switch (rnd.nextInt(6)) {
+                    case 0: // setSkin
+                    case 1:
+                        CustomSkinProperty skin = skin(payload, workerId, i);
+                        storage.setSkin(uuid, skin);
+                        expected.put(uuid, skin);
+                        break;
+                    case 2: // getSkin (harmless read, exercises map/disk read)
+                        storage.getSkin(uuid);
+                        break;
+                    case 3: // removeSkin
+                        storage.removeSkin(uuid);
+                        expected.remove(uuid);
+                        break;
+                    case 4: // hasDefaultSkin
+                        storage.hasDefaultSkin(uuid);
+                        break;
+                    case 5: // saveSkinAsync (coalescing async write)
+                        // setSkin first keeps the map and the model warm: a bare
+                        // async save would leave a map miss + on-disk hit, which
+                        // getSkin() would reload and assertModel would misread as
+                        // a "resurrected" uuid. The async write itself still lands
+                        // on the shared writer thread after flushPending().
+                        CustomSkinProperty asyncSkin = skin(payload, workerId, i);
+                        storage.setSkin(uuid, asyncSkin);
+                        expected.put(uuid, asyncSkin);
+                        storage.saveSkinAsync(uuid, asyncSkin);
+                        break;
+                    default:
+                        throw new IllegalStateException("unknown op");
+                }
+            }
+        } catch (Throwable t) {
+            failure.compareAndSet(null, t);
+        }
+    }
+
+    /** For every pool UUID: live => getSkin equals the owning worker's last set; else absent. */
+    private static void assertModel(SkinStorage storage, UUID[] uuids,
+                                    Map<UUID, CustomSkinProperty> expected) {
+        for (UUID uuid : uuids) {
+            CustomSkinProperty want = expected.get(uuid);
+            CustomSkinProperty got = storage.getSkin(uuid);
+            if (want == null) {
+                // Removed / never-set: getSkin must be absent (map miss + no disk file).
+                assertNull(got, "deleted/never-set uuid resurrected: " + uuid);
+            } else {
+                assertNotNull(got, "no skin for live uuid " + uuid);
+                // Compare the payload, NOT equals(): CustomSkinProperty.equals is source-only.
+                assertEquals(want.getValue(), got.getValue(), "lost update for " + uuid);
+            }
+        }
+    }
+
+    private static CustomSkinProperty skin(String payload, int worker, int i) {
+        String value = Base64.getEncoder().encodeToString(
+                (payload + "-" + worker + "-" + i).getBytes(StandardCharsets.UTF_8));
+        return new CustomSkinProperty(value, "sig", "concurrency-test");
+    }
+
+    private static Path newTempDir() {
+        try {
+            return Files.createTempDirectory("skinstorage-concurrency-");
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static void deleteRecursively(Path dir) {
+        try (Stream<Path> stream = Files.walk(dir)) {
+            stream.sorted(Comparator.reverseOrder()).forEach(path -> {
+                try {
+                    Files.deleteIfExists(path);
+                } catch (IOException ignored) {
+                    // best-effort temp cleanup
+                }
+            });
+        } catch (IOException ignored) {
+            // best-effort temp cleanup
+        }
+    }
+}


### PR DESCRIPTION
P3-7 + P3-9, `:common` test tree only (runs under the `Build (common)` CI gate; in-root lanes unaffected).

**P3-7 — concurrent cache-access property test**
- Add `SkinStorageConcurrencyTest`: jqwik `@Property` (25 tries) spawning 8 worker threads doing concurrent `setSkin`/`getSkin`/`removeSkin`/`hasDefaultSkin`/`saveSkinAsync` against one `SkinStorage` (`SkinIO` on a temp dir). Each worker owns a disjoint UUID slice so per-UUID last-write-wins is deterministic; every future is awaited with a 10s timeout so a real deadlock fails the try instead of hanging the suite. No-exception invariant via an `AtomicReference` + future propagation. After `flushPending()`, per UUID: `getSkin` payload equals the last `setSkin` value, or null for removed/never-set uuids (compare `getValue()`, since `CustomSkinProperty.equals` is source-only). Per-try `resetForTest()` + `SkinMetrics.reset()` + `METRICS_LOCK` for static-state and shrink isolation; `newTempDir()`+`deleteRecursively()` instead of `@TempDir`.
- Rewrite `SkinIODeleteRaceTest.randomizedSequencesNeverResurrectDeletedFile` from `@RepeatedTest(20) + rnd.nextInt(3) + Thread.sleep` to a jqwik `@Property` (100 tries) over `Arbitrary<List<Op>>` (SAVE/DELETE/FLUSH), replacing the sleep flake source with `flushPending()` as the deterministic barrier. Same last-op contract (DELETE -> file absent, SAVE -> file present with the last payload). Two fixes over the raw skeleton, both found by running the suite:
  - the SAVE assertion compares the deserialized value via `io.loadSkin`, not raw file text — Gson escapes base64 padding chars on write (`YQ==` -> `YQ\u003d\u003d`), so `contains()` on the raw payload fails;
  - async-save ops keep the map/model warm (`setSkin` before `saveSkinAsync`) so a bare disk-only write cannot be misread by `assertModel` as a resurrected uuid.

**P3-9 — fallback-chain integration test**
- Add `FallbackChainIntegrationTest` asserting the component fall-through contract the lanes compose: Mojang-404 profile (via `FakeHttpClient` + `RecordingHttpClient`) advances past Mojang (asserting the sessionserver URI is the first HTTP hit); a nested `FakeMineSkin` seam returning null advances past MineSkin (kept local and distinctly named, P2-12-agnostic); `DefaultSkinResolver` seeded via `FakeMojangAPI.addSkin` terminates at the default property. A shared `order` list asserts stages fire in exactly mojang -> mineskin -> default; a 200-success test asserts the chain short-circuits (order == [mojang]).

Verification: `./gradlew :common:build` and targeted `:common:test` for the three classes — both green.
Scope: `:common` test tree only (3 files). Java 8 + `-Werror` compatible (no `List.of`/`var`).