### PR TITLE
test(common): trim redundant HttpResultTest.recordComponentAccessors (P3-5)

### DIFF
--- a/common/src/test/java/levosilimo/everlastingskins/skinchanger/HttpResultTest.java
+++ b/common/src/test/java/levosilimo/everlastingskins/skinchanger/HttpResultTest.java
@@ -45,15 +45,4 @@ class HttpResultTest {
         IllegalStateException ex = assertThrows(IllegalStateException.class, () -> result.get());
         assertSame(cause, ex.getCause());
     }
-
-    @Test
-    void recordComponentAccessors() {
-        HttpResponse resp = new HttpResponse(200, "body", EMPTY_HEADERS);
-        HttpResult.Success success = new HttpResult.Success(resp);
-        assertSame(resp, success.response());
-
-        IOException cause = new IOException("fail");
-        HttpResult.Failure failure = new HttpResult.Failure(cause);
-        assertSame(cause, failure.cause());
-    }
 }


### PR DESCRIPTION
Per lib-59 audit. The recordComponentAccessors() method tested getter round-trip on a record, which is JDK behavior — not project behavior. Redundant with the existing successIsSuccess / failureUnwrapThrows tests that cover the project's actual contracts.