### PR TITLE
build: graduate duplicate-class dep-analysis WARN->FAIL (forge-1.21.1/1.21.4/1.21.8/26.2 batch)

### DIFF
--- a/forge-1.21.1/gradle.properties
+++ b/forge-1.21.1/gradle.properties
@@ -6,3 +6,4 @@ forge_version_range=[52.1.16,53)
 
 # Curse versions for this point release
 curse_versions=1.21.1
+depAnalysis.graduateDuplicateClass=true

--- a/forge-1.21.4/gradle.properties
+++ b/forge-1.21.4/gradle.properties
@@ -6,3 +6,4 @@ forge_version_range=[54.1.18,55)
 
 # Curse versions for this point release
 curse_versions=1.21.4
+depAnalysis.graduateDuplicateClass=true

--- a/forge-1.21.8/gradle.properties
+++ b/forge-1.21.8/gradle.properties
@@ -6,3 +6,4 @@ forge_version_range=[58.1.21,59)
 
 # Curse versions for this point release
 curse_versions=1.21.8
+depAnalysis.graduateDuplicateClass=true

--- a/forge-26.2/gradle.properties
+++ b/forge-26.2/gradle.properties
@@ -34,3 +34,4 @@ mod_license=MIT License
 mod_authors=Levosilimo
 mod_version=2.1.0-beta.1
 mixin_id=everlastingskins
+depAnalysis.graduateDuplicateClass=true


### PR DESCRIPTION
## P2-6 PR #2 — graduate duplicate-class dep-analysis on 4 more lanes

Extends #327 (forge-1.21, merged) to the remaining active modules: forge-1.21.1, forge-1.21.4, forge-1.21.8, forge-26.2.

Each lane sets `depAnalysis.graduateDuplicateClass=true` in its `gradle.properties`; the convention (from #327) reads the property to (a) raise duplicate-class findings from WARN to FAIL and (b) wire `projectHealth` into `check`, so the required Build (X) CI cell now fails on a duplicate-class finding.

### Changes
- 4 files, 1 line each (property only — convention untouched)

### Verification (JAVA_HOME=21, --offline)
| Lane | Build | projectHealth in check |
|---|---|---|
| forge-1.21.1 | BUILD SUCCESSFUL | ran, exit 0 (zero duplicate-class) |
| forge-1.21.4 | BUILD SUCCESSFUL | ran, exit 0 (zero duplicate-class) |
| forge-1.21.8 | BUILD SUCCESSFUL | ran, exit 0 (zero duplicate-class) |
| forge-26.2 | BUILD SUCCESSFUL | ran, exit 0 (zero duplicate-class) |

### Rollback
Flip the property off in any lane's gradle.properties — both the FAIL severity and the check wiring revert together (single-property rollback per the P2-6 plan).