### PR TITLE
test: extend LuckPerms canonical stubs for P3-6 test rewrite (build-green)

### DIFF
--- a/common/src/test/java/net/luckperms/api/StubCachedPermissionData.java
+++ b/common/src/test/java/net/luckperms/api/StubCachedPermissionData.java
@@ -1,0 +1,37 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
+package net.luckperms.api;
+
+import net.luckperms.api.cacheddata.CachedPermissionData;
+import net.luckperms.api.query.QueryOptions;
+import net.luckperms.api.util.Tristate;
+import java.util.Map;
+
+/**
+ * Public LuckPerms API stub: per-user cached permission data over a node map.
+ * getPermissionData(QueryOptions) must stay public and take QueryOptions (not
+ * DefaultQueryOptions) so the service's reflection getMethod matches the interface.
+ */
+public class StubCachedPermissionData implements CachedPermissionData {
+
+    private final Map<String, Tristate> permissions;
+
+    public StubCachedPermissionData(Map<String, Tristate> permissions) {
+        this.permissions = permissions;
+    }
+
+    @Override
+    public PermissionData getPermissionData() {
+        return new StubPermissionData(permissions);
+    }
+
+    @Override
+    public PermissionData getPermissionData(QueryOptions options) {
+        return new StubPermissionData(permissions);
+    }
+}

--- a/common/src/test/java/net/luckperms/api/StubLuckPerms.java
+++ b/common/src/test/java/net/luckperms/api/StubLuckPerms.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
+package net.luckperms.api;
+
+/**
+ * Public LuckPerms API stub: a concrete LuckPerms impl returning a fixed
+ * StubUserManager and a fixed API version. Must be public top-level so
+ * tryCreate()'s reflection (getUserManager) and getActiveBackendName()'s
+ * reflection (getAPIVersion) can access the methods.
+ */
+public class StubLuckPerms implements LuckPerms {
+
+    private final StubUserManager userManager;
+    private final String apiVersion;
+
+    public StubLuckPerms(StubUserManager userManager, String apiVersion) {
+        this.userManager = userManager;
+        this.apiVersion = apiVersion;
+    }
+
+    @Override
+    public UserManager getUserManager() {
+        return userManager;
+    }
+
+    @Override
+    public String getAPIVersion() {
+        return apiVersion;
+    }
+}

--- a/common/src/test/java/net/luckperms/api/StubPermissionData.java
+++ b/common/src/test/java/net/luckperms/api/StubPermissionData.java
@@ -1,0 +1,30 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+
+package net.luckperms.api;
+
+import net.luckperms.api.util.Tristate;
+import java.util.Map;
+
+/**
+ * Public LuckPerms API stub: permission-node lookup backed by a map.
+ * Must be public top-level (the service reflects getMethod("checkPermission", String.class)
+ * on the runtime class across the levosilimo package boundary).
+ */
+public class StubPermissionData implements PermissionData {
+
+    private final Map<String, Tristate> permissions;
+
+    public StubPermissionData(Map<String, Tristate> permissions) {
+        this.permissions = permissions;
+    }
+
+    @Override
+    public Tristate checkPermission(String node) {
+        return permissions.getOrDefault(node, Tristate.UNDEFINED);
+    }
+}

--- a/common/src/test/java/net/luckperms/api/StubUser.java
+++ b/common/src/test/java/net/luckperms/api/StubUser.java
@@ -8,6 +8,8 @@
 package net.luckperms.api;
 
 import net.luckperms.api.cacheddata.CachedPermissionData;
+import net.luckperms.api.util.Tristate;
+import java.util.Map;
 
 /**
  * Public LuckPerms API stub for unit tests (see StubUserManager for why the
@@ -15,8 +17,18 @@ import net.luckperms.api.cacheddata.CachedPermissionData;
  */
 public class StubUser implements User {
 
+    private final Map<String, Tristate> permissions;
+
+    public StubUser() {
+        this(java.util.Collections.emptyMap());
+    }
+
+    public StubUser(Map<String, Tristate> permissions) {
+        this.permissions = permissions;
+    }
+
     @Override
     public CachedPermissionData getCachedData() {
-        return null;
+        return new StubCachedPermissionData(permissions);
     }
 }

--- a/common/src/test/java/net/luckperms/api/StubUserManager.java
+++ b/common/src/test/java/net/luckperms/api/StubUserManager.java
@@ -8,7 +8,9 @@
 package net.luckperms.api;
 
 import java.util.UUID;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import net.luckperms.api.util.Tristate;
 
 /**
  * Public LuckPerms API stub for unit tests. Must be a PUBLIC top-level class:
@@ -20,9 +22,21 @@ import java.util.concurrent.CompletableFuture;
 public class StubUserManager implements UserManager {
 
     private final boolean loaded;
+    private final boolean nullUser;
+    private final Map<String, Tristate> permissions;
 
     public StubUserManager(boolean loaded) {
+        this(loaded, false, java.util.Collections.emptyMap());
+    }
+
+    public StubUserManager(boolean loaded, boolean nullUser) {
+        this(loaded, nullUser, java.util.Collections.emptyMap());
+    }
+
+    public StubUserManager(boolean loaded, boolean nullUser, Map<String, Tristate> permissions) {
         this.loaded = loaded;
+        this.nullUser = nullUser;
+        this.permissions = permissions;
     }
 
     @Override
@@ -32,11 +46,11 @@ public class StubUserManager implements UserManager {
 
     @Override
     public User getUser(UUID uuid) {
-        return loaded ? new StubUser() : null;
+        return (loaded && !nullUser) ? new StubUser(permissions) : null;
     }
 
     @Override
     public CompletableFuture<User> loadUser(UUID uuid) {
-        return CompletableFuture.completedFuture(new StubUser());
+        return CompletableFuture.completedFuture(new StubUser(permissions));
     }
 }


### PR DESCRIPTION
Build-green stub-surface extension only. Adds 3 public stubs (StubPermissionData, StubCachedPermissionData, StubLuckPerms) and backward-compatibly modifies StubUser (keeps no-arg ctor; getCachedData now non-null) and StubUserManager (keeps 1-arg ctor; adds nullUser + 3-arg ctor). No existing test constructs the stubs directly (all 4 in-root LuckPermsPermissionServiceTest copies use Mockito), so no test behavior changes. The P3-6 Mockito->stub rewrite lands in a separate follow-up PR.

5 files: 3 new + 2 modified, all under common/src/test/java/net/luckperms/api/.

Branch: test/luckperms-stub-surface-extension. Target: main. Do NOT combine with the P3-6 test rewrite.