### PR TITLE
test(:common): promote FakeMineSkinAPI to :common (P2-12)

### DIFF
--- a/common/src/test/java/levosilimo/everlastingskins/skinchanger/FakeMineSkinAPI.java
+++ b/common/src/test/java/levosilimo/everlastingskins/skinchanger/FakeMineSkinAPI.java
@@ -4,7 +4,7 @@
  * https://github.com/Levosilimo/Everlasting-Skins
  */
 
-package levosilimo.everlastingskins.integration;
+package levosilimo.everlastingskins.skinchanger;
 
 import levosilimo.everlastingskins.enums.SkinVariant;
 import levosilimo.everlastingskins.skinchanger.MineSkinAPI;

--- a/mc1.12.2/src/test/java/levosilimo/everlastingskins/integration/MineSkinPathIT.java
+++ b/mc1.12.2/src/test/java/levosilimo/everlastingskins/integration/MineSkinPathIT.java
@@ -10,6 +10,7 @@ import levosilimo.everlastingskins.Config;
 import levosilimo.everlastingskins.enums.SkinVariant;
 import levosilimo.everlastingskins.harness.AsyncSupport;
 import levosilimo.everlastingskins.harness.TestServerContext;
+import levosilimo.everlastingskins.skinchanger.FakeMineSkinAPI;
 import levosilimo.everlastingskins.skinchanger.SkinCommandTestAccess;
 import levosilimo.everlastingskins.util.CustomSkinProperty;
 import net.minecraft.entity.player.EntityPlayerMP;


### PR DESCRIPTION
## P2-12 — Promote FakeMineSkinAPI to :common

Promotes the single, generic FakeMineSkinAPI test stub out of the mc1.12.2 lane into :common test (skinchanger package), matching the existing FakeMojangAPI convention.

**Why safe:**
- 51 LOC, self-contained, zero forge imports.
- Depends only on :common main classes (MineSkinAPI, MineSkinResponse, SkinVariant, CustomSkinProperty) + javax.annotation.Nullable (jsr305, compileOnly on :common, inherited by test classpath — @Nullable already compiles warning-free under --release 8 + -Werror across common main).
- No other lane has a copy, so no duplicate-class collision anywhere.

**Changes:**
1. NEW common/src/test/java/levosilimo/everlastingskins/skinchanger/FakeMineSkinAPI.java (verbatim body, package changed from `integration` to `skinchanger`).
2. MODIFIED mc1.12.2/.../integration/MineSkinPathIT.java — added `import levosilimo.everlastingskins.skinchanger.FakeMineSkinAPI;`.
3. DELETED mc1.12.2/.../integration/FakeMineSkinAPI.java (required — lane syncCommonTestSources copies common test tree, so the lane-local copy would now collide).

**Verification:**
- `./gradlew :common:build` passes (--release 8 + -Werror).
- `cd mc1.12.2 && JAVA_HOME=<jdk8> ./gradlew test` — MineSkinPathIT passes; no duplicate class.

**Notes:**
- The only consumer of the fake is MineSkinPathIT (forge-bound IT that stays lane-local). SkinCommandTestAccess needs no change (takes MineSkinAPI interface).
- P3-9's deferred nested FakeMineSkin is a DIFFERENT class name — no collision; P3-9 can later import the promoted FakeMineSkinAPI instead of its nested stub.