### PR TITLE
flake: DebounceStateConsistencyIT 300ms sleep -> metric poll (FIX C)

### DIFF
--- a/mc1.12.2/src/test/java/levosilimo/everlastingskins/integration/DebounceStateConsistencyIT.java
+++ b/mc1.12.2/src/test/java/levosilimo/everlastingskins/integration/DebounceStateConsistencyIT.java
@@ -11,6 +11,7 @@ import levosilimo.everlastingskins.Config;
 import levosilimo.everlastingskins.harness.AsyncSupport;
 import levosilimo.everlastingskins.harness.PacketLog;
 import levosilimo.everlastingskins.harness.TestServerContext;
+import levosilimo.everlastingskins.metrics.PlayerSnapshot;
 import levosilimo.everlastingskins.metrics.SkinMetrics;
 import levosilimo.everlastingskins.skinchanger.SkinCommandTestAccess;
 import levosilimo.everlastingskins.util.CustomSkinProperty;
@@ -139,9 +140,18 @@ class DebounceStateConsistencyIT {
             () -> SkinMetrics.INSTANCE.snapshot().refreshesCompleted() > baseCompleted),
             "first request must complete its profile refresh");
 
-        Thread.sleep(300);
         long debouncedBefore = SkinMetrics.INSTANCE.snapshot().refreshesDebounced();
         long completedBefore = SkinMetrics.INSTANCE.snapshot().refreshesCompleted();
+        // Wait on the real signal: the per-player last refresh (set by the first
+        // request's recordRefreshCompleted, the same settle barrier awaited at L138-140)
+        // must be Config.DEBOUNCE_MILLIS old so the debounce window has elapsed
+        // before the second request. Bounded at 2s; no fixed sleep, no wall-clock race.
+        assertTrue(AsyncSupport.await(2000, () -> {
+            PlayerSnapshot ps = SkinMetrics.INSTANCE.snapshot()
+                .perPlayer().get(player.getUniqueID());
+            return ps != null
+                && System.currentTimeMillis() - ps.lastRefreshAtMs() >= Config.DEBOUNCE_MILLIS;
+        }), "debounce window must elapse before the second request");
 
         ctx.commandManager.executeCommand(player, "/skin set mojang Jeb_");
         assertTrue(AsyncSupport.await(5000,


### PR DESCRIPTION
DebounceStateConsistencyIT.expiredDebounceWindow_appliesNormally sleeps a fixed
300ms to let the 100ms debounce window pass before issuing the second request.
That is the roadmap's highest flake: it can under-wait on a fast machine (second
request lands inside the window and is wrongly debounced) or over-wait on slow CI.

Replace the sleep with a bounded poll on the real signal: the per-player
last-refresh timestamp from SkinMetrics.snapshot().perPlayer().lastRefreshAtMs()
must be >= Config.DEBOUNCE_MILLIS old. Deterministic, self-documenting, no new
dependency (reuses AsyncSupport.await already imported at L10). Adds the missing
`import levosilimo.everlastingskins.metrics.PlayerSnapshot;`.

Note: the plan's literal `await().untilAsserted(assertEquals(debouncedBefore,
refreshesDebounced()))` was rejected — a counter-equality poll passes immediately
and never proves the window elapsed; it also referenced debouncedBefore before
assignment. Polled signal verified: SkinMetrics.recordRefreshCompleted (L87-91)
sets perPlayer.lastRefreshAtMs; snapshot() (L340) exposes it via
PlayerSnapshot.lastRefreshAtMs() (public).

Verification: 38 consecutive green runs of DebounceStateConsistencyIT across 4
loops (10x each, minus 2 runs corrupted by a wrong-JAVA_HOME build state on the
first invocation — a build-task failure before the suite ran, self-healed; the
test assertions never failed). L153 counter-delta stays 0 and the 2s timeout
never triggers. Coordinates with the P3 concurrent debounce tests.