### PR TITLE
test: deterministic UUIDs in SkinMetricsTest + SkinIOPropertyTest (FIX G)

### DIFF
--- a/common/src/test/java/levosilimo/everlastingskins/metrics/SkinMetricsTest.java
+++ b/common/src/test/java/levosilimo/everlastingskins/metrics/SkinMetricsTest.java
@@ -25,7 +25,7 @@ class SkinMetricsTest {
     @DisplayName("recordRefreshStarted increments the initiated counter")
     void recordRefreshStarted_incrementsCounter() {
         SkinMetrics m = freshMetrics();
-        UUID uuid = UUID.randomUUID();
+        UUID uuid = UUID.fromString("00000000-0000-0000-0000-000000000001");
 
         m.recordRefreshStarted(uuid);
         m.recordRefreshStarted(uuid);
@@ -38,7 +38,7 @@ class SkinMetricsTest {
     @DisplayName("recordRefreshCompleted populates histograms and per-player state")
     void recordRefreshCompleted_populatesAllHistograms() {
         SkinMetrics m = freshMetrics();
-        UUID uuid = UUID.randomUUID();
+        UUID uuid = UUID.fromString("00000000-0000-0000-0000-000000000002");
 
         m.recordRefreshCompleted(uuid, System.nanoTime(), 1_000_000L, 200_000L, 500_000L);
 
@@ -60,7 +60,7 @@ class SkinMetricsTest {
         // Buckets: 1, 5, 10, 50, 100, 500us ... (see LATENCY_BUCKETS_US).
         // Record 10 samples of 100us each and 10 samples of 500us each.
         SkinMetrics m = freshMetrics();
-        UUID uuid = UUID.randomUUID();
+        UUID uuid = UUID.fromString("00000000-0000-0000-0000-000000000003");
         long start = System.nanoTime();
         for (int i = 0; i < 10; i++) {
             m.recordRefreshCompleted(uuid, start, 100_000L, 0, 0);
@@ -82,7 +82,7 @@ class SkinMetricsTest {
     @DisplayName("snapshot is readable under concurrent recording")
     void snapshot_isThreadSafe() {
         SkinMetrics m = freshMetrics();
-        UUID uuid = UUID.randomUUID();
+        UUID uuid = UUID.fromString("00000000-0000-0000-0000-000000000004");
         Thread[] threads = new Thread[8];
         for (int t = 0; t < threads.length; t++) {
             threads[t] = new Thread(() -> {
@@ -111,7 +111,7 @@ class SkinMetricsTest {
     @DisplayName("skipped/debounced/rate-limited use separate counters")
     void recordRefreshSkippedDebouncedRateLimited_separateCounters() {
         SkinMetrics m = freshMetrics();
-        UUID uuid = UUID.randomUUID();
+        UUID uuid = UUID.fromString("00000000-0000-0000-0000-000000000005");
 
         m.recordRefreshSkipped(uuid);
         m.recordRefreshSkipped(uuid);
@@ -130,7 +130,7 @@ class SkinMetricsTest {
     @DisplayName("reset zeroes all counters and histograms")
     void reset_zerosAllCountersAndHistograms() {
         SkinMetrics m = freshMetrics();
-        UUID uuid = UUID.randomUUID();
+        UUID uuid = UUID.fromString("00000000-0000-0000-0000-000000000006");
 
         m.recordRefreshStarted(uuid);
         m.recordRefreshCompleted(uuid, System.nanoTime(), 1_000_000L, 200_000L, 500_000L);
@@ -177,7 +177,7 @@ class SkinMetricsTest {
     @DisplayName("command total and task duration latencies are separate histograms")
     void commandTotalLatency_andTaskDuration_areSeparate() {
         SkinMetrics m = freshMetrics();
-        UUID uuid = UUID.randomUUID();
+        UUID uuid = UUID.fromString("00000000-0000-0000-0000-000000000007");
 
         m.recordRefreshCompleted(uuid, System.nanoTime(), 100_000L, 0, 0);  // sub-ms command span
         m.recordTaskDuration(TimeUnit.MILLISECONDS.toNanos(200));           // 200ms task
@@ -192,7 +192,7 @@ class SkinMetricsTest {
     @DisplayName("timed-out refreshes count separately from failures")
     void recordTimedOut_separateFromFailed() {
         SkinMetrics m = freshMetrics();
-        UUID uuid = UUID.randomUUID();
+        UUID uuid = UUID.fromString("00000000-0000-0000-0000-000000000008");
 
         m.recordRefreshFailed(uuid);
         m.recordTimedOut(uuid);

--- a/common/src/test/java/levosilimo/everlastingskins/skinchanger/SkinIOPropertyTest.java
+++ b/common/src/test/java/levosilimo/everlastingskins/skinchanger/SkinIOPropertyTest.java
@@ -303,7 +303,7 @@ class SkinIOPropertyTest {
                 try {
                     SkinIO io = new SkinIO(dir);
                     SkinStorage storage = new SkinStorage(io);
-                    UUID uuid = UUID.randomUUID();
+                    UUID uuid = UUID.fromString("00000000-0000-0000-0000-000000000101");
                     for (String value : burst) {
                         CompletableFuture<Void> unused = storage.saveSkinAsync(uuid, skin(value));
                     }
@@ -339,7 +339,7 @@ class SkinIOPropertyTest {
                 try {
                     SkinIO io = new SkinIO(dir);
                     SkinStorage storage = new SkinStorage(io);
-                    UUID uuid = UUID.randomUUID();
+                    UUID uuid = UUID.fromString("00000000-0000-0000-0000-000000000102");
                     CompletableFuture<Void> unused = storage.saveSkinAsync(uuid, skin(value));
                     storage.removeSkin(uuid);
                     storage.flushPending();
@@ -374,7 +374,7 @@ class SkinIOPropertyTest {
                 try {
                     BlockingSkinIO blockingIO = new BlockingSkinIO(dir);
                     SkinStorage storage = new SkinStorage(blockingIO);
-                    UUID uuid = UUID.randomUUID();
+                    UUID uuid = UUID.fromString("00000000-0000-0000-0000-000000000103");
                     Path target = dir.resolve(uuid + ".json");
 
                     CompletableFuture<Void> unused = storage.saveSkinAsync(uuid, skin(value));
@@ -432,7 +432,7 @@ class SkinIOPropertyTest {
                 try {
                     SkinIO io = new SkinIO(dir);
                     SkinStorage storage = new SkinStorage(io);
-                    UUID uuid = UUID.randomUUID();
+                    UUID uuid = UUID.fromString("00000000-0000-0000-0000-000000000104");
                     CustomSkinProperty skin = new CustomSkinProperty(value, signature, source);
                     io.saveSkin(uuid, skin);
                     String serialized = JsonUtils.toJson(skin);
@@ -475,7 +475,7 @@ class SkinIOPropertyTest {
                 try {
                     SkinIO io = new SkinIO(dir);
                     SkinStorage storage = new SkinStorage(io);
-                    UUID uuid = UUID.randomUUID();
+                    UUID uuid = UUID.fromString("00000000-0000-0000-0000-000000000105");
                     CompletableFuture<Void> unused = storage.saveSkinAsync(uuid, skin(value));
                     storage.removeSkin(uuid);
                     storage.flushPending();
@@ -554,7 +554,7 @@ class SkinIOPropertyTest {
                 try {
                     SkinIO io = new SkinIO(dir);
                     SkinStorage storage = new SkinStorage(io);
-                    UUID uuid = UUID.randomUUID();
+                    UUID uuid = UUID.fromString("00000000-0000-0000-0000-000000000106");
                     for (String value : values) {
                         CompletableFuture<Void> unused = storage.saveSkinAsync(uuid, skin(value));
                     }
@@ -582,7 +582,7 @@ class SkinIOPropertyTest {
                 try {
                     SkinIO io = new SkinIO(dir);
                     SkinStorage storage = new SkinStorage(io);
-                    UUID uuid = UUID.randomUUID();
+                    UUID uuid = UUID.fromString("00000000-0000-0000-0000-000000000107");
                     CyclicBarrier start = new CyclicBarrier(2);
                     AtomicReference<Throwable> failure = new AtomicReference<>();
                     Thread threadA = new Thread(() -> {


### PR DESCRIPTION
SkinMetricsTest and SkinIOPropertyTest use `UUID.randomUUID()` as map keys;
the randomness does not change outcomes (per-test, single-thread, fresh instance
/ temp dir) but makes jqwik property-failure replay non-reproducible.

Replace with fixed `UUID.fromString("0000...-N")` values (distinct suffix per
occurrence: `...0001..0008` in SkinMetricsTest, `...0101..0107` in SkinIOPropertyTest)
so a failed property run replays exactly. Pure hygiene: no behavior change, no
new dependency.

Scope decision (per lib-72): mc1.12.2 lane-local copies of both tests are
NOT touched in this PR — they remain lane-local (excluded from the :common test
share via mc1.12.2/build.gradle L46 + L50) and can take the same 15-line change
in a follow-up if replay determinism is wanted there.

Verification: 10x forced re-execution loop (`cleanTest` per iteration) of
`:common:test --tests '*SkinMetricsTest*' --tests '*SkinIOPropertyTest*'` — 10/10
green, no failures.

Pre-existing finding surfaced (not caused by this PR, verified via stash on
pristine main): all 8 jqwik `@Property` tests in SkinIOPropertyTest report
SKIPPED and never execute under this build (Gradle 9.3.1 + jqwik 1.9.0 +
junit-platform 1.10.3; engine loads, classpath clean, Jupiter tests run fine).
Same on main before this change. Out of scope here; flagging for a separate
jqwik-vs-Gradle-9 fix.
