### PR TITLE
build: jqwik activation fix (Gradle 9.3.1 compatibility)

### DIFF
--- a/buildSrc/src/main/kotlin/everlastingskins.forge-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/everlastingskins.forge-module.gradle.kts
@@ -292,13 +292,13 @@ dependencies {
     testImplementation(platform("org.junit:junit-bom:5.10.3"))
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.3")
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.10.3")
-    testImplementation("net.jqwik:jqwik-api:1.9.0")
+    testImplementation("net.jqwik:jqwik-api:1.9.3")
     testImplementation("me.clip:placeholderapi:2.12.3")
     testImplementation("org.mockito:mockito-core:5.12.0")
     testImplementation("org.mockito:mockito-junit-jupiter:5.12.0")
 
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.3")
-    testRuntimeOnly("net.jqwik:jqwik-engine:1.9.0")
+    testRuntimeOnly("net.jqwik:jqwik-engine:1.9.3")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.10.3")
 
     "gametestImplementation"(sourceSets.main.get().output)

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -59,7 +59,7 @@ dependencies {
     testImplementation(platform("org.junit:junit-bom:5.10.3"))
     testImplementation("org.junit.jupiter:junit-jupiter-api")
     testImplementation("org.junit.jupiter:junit-jupiter-params")
-    testImplementation("net.jqwik:jqwik-api:1.9.0")
+    testImplementation("net.jqwik:jqwik-api:1.9.3")
     testImplementation("org.mockito:mockito-core:5.12.0")
     // The module's main code paths use Gson/authlib/log4j at runtime too.
     testImplementation("com.google.code.gson:gson:2.8.0")
@@ -67,7 +67,7 @@ dependencies {
     testImplementation("org.apache.logging.log4j:log4j-api:2.8.1")
 
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.3")
-    testRuntimeOnly("net.jqwik:jqwik-engine:1.9.0")
+    testRuntimeOnly("net.jqwik:jqwik-engine:1.9.3")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.10.3")
     // Default log4j2 config (ERROR-only) so test output stays quiet.
     testRuntimeOnly("org.apache.logging.log4j:log4j-core:2.8.1")


### PR DESCRIPTION
## Summary

Per lib-28: bump jqwik to 1.9.1+ to restore @Property test activation under Gradle 9.3.1. Bumped **1.9.0 → 1.9.3** (latest 1.9.x) in both build files.

- `buildSrc/src/main/kotlin/everlastingskins.forge-module.gradle.kts`: jqwik-api / jqwik-engine 1.9.0 → 1.9.3
- `common/build.gradle.kts`: jqwik-api / jqwik-engine 1.9.0 → 1.9.3

## Verification

- `./gradlew :common:build` ✅ green (with jqwik 1.9.3)
- `./gradlew :common:test --tests '*SkinIOPropertyTest*'` — **8/8 jqwik properties STILL SKIPPED** ⚠️

## Root cause of the remaining skip (found during verification)

The version bump alone does **not** activate the tests. jqwik 1.9.3 (and 1.9.0 — identical bytecode) hard-skips `@Group` classes declared `static`:

```
executionSkipped(TestIdentifier ... '@Group classes must not be static')
```

`SkinIOPropertyTest` declares its six containers as `@Group static class …` — jqwik requires non-static inner classes for groups. Verified empirically: removing `static` from the six `@Group` classes makes all 8 properties **PASS** (scratch test, not committed — outside this PR's 2-file scope).

**Follow-up needed** (separate change): drop `static` from the six `@Group` classes in `common/src/test/java/.../SkinIOPropertyTest.java`. This PR keeps the dependency modernization; the activation fix is a one-word-per-class test change.