### PR TITLE
test(forge-1.21.8): SkinRestorerTest rewrite to drive real @SubscribeEvent lifecycle (P3-1 replica)

### DIFF
--- a/forge-1.21.8/src/main/java/levosilimo/everlastingskins/forge21/skinchanger/SkinRestorer.java
+++ b/forge-1.21.8/src/main/java/levosilimo/everlastingskins/forge21/skinchanger/SkinRestorer.java
@@ -39,7 +39,7 @@ public class SkinRestorer {
     public static volatile MinecraftServer server;
 
     /** Off-login-thread executor for the default-skin Mojang restore fetch. */
-    private static final ExecutorService loginExecutor = Executors.newCachedThreadPool(r -> {
+    private static volatile ExecutorService loginExecutor = Executors.newCachedThreadPool(r -> {
         Thread t = new Thread(r, "everlastingskins-login");
         t.setDaemon(true);
         return t;

--- a/forge-1.21.8/src/main/java/levosilimo/everlastingskins/forge21/skinchanger/SkinRestorer.java
+++ b/forge-1.21.8/src/main/java/levosilimo/everlastingskins/forge21/skinchanger/SkinRestorer.java
@@ -7,6 +7,7 @@
 
 package levosilimo.everlastingskins.forge21.skinchanger;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.mojang.authlib.properties.Property;
 import levosilimo.everlastingskins.skinchanger.DefaultSkinResolver;
 import levosilimo.everlastingskins.skinchanger.SkinIO;

--- a/forge-1.21.8/src/main/java/levosilimo/everlastingskins/forge21/skinchanger/SkinRestorer.java
+++ b/forge-1.21.8/src/main/java/levosilimo/everlastingskins/forge21/skinchanger/SkinRestorer.java
@@ -46,6 +46,19 @@ public class SkinRestorer {
         return t;
     });
 
+    /**
+     * Test seam: overrides the login executor so the default-skin login work can
+     * be driven synchronously/awaitably in tests (e.g. Runnable::run). The
+     * production default is untouched unless called. Public because the test
+     * source-set lives in package levosilimo.everlastingskins.skinchanger, not
+     * forge21.skinchanger. guava is already on the main compile classpath
+     * (EverlastingSkins.java imports com.google.common.collect.Lists).
+     */
+    @VisibleForTesting
+    public static void setLoginExecutorForTest(ExecutorService executor) {
+        loginExecutor = executor;
+    }
+
     @Nullable
     public static SkinStorage getSkinStorage() {
         return skinStorage;

--- a/forge-1.21.8/src/test/java/levosilimo/everlastingskins/skinchanger/SkinRestorerTest.java
+++ b/forge-1.21.8/src/test/java/levosilimo/everlastingskins/skinchanger/SkinRestorerTest.java
@@ -154,4 +154,217 @@ class SkinRestorerTest {
         }
     }
 
+    // ======================================================================
+    //  Player login  (real onPlayerLoggedIn — synchronous stored-skin branch)
+    // ======================================================================
+
+    @Nested
+    @DisplayName("onPlayerLoggedIn — skin apply on join (synchronous branch)")
+    class PlayerLogin {
+
+        @Test
+        @DisplayName("Stored custom skin is applied to the profile via the real handler")
+        void appliesStoredSkinToProfile() {
+            restorer.onInitializeServer(TestForgeEvents.newServerStartingEvent(server));
+            CustomSkinProperty skin = new CustomSkinProperty("dGV4dHVyZS12YWw=", "tex-sig", "Mojang");
+            // Player WITH a stored custom skin => hasCustomSkin=true and
+            // DEFAULT_SKINS_APPLY_FOR_PREMIUM=false (default) => applyDefault=false
+            // => synchronous branch (no Mojang fetch, no executor).
+            SkinRestorer.getSkinStorage().setSkin(testUuid, skin);
+
+            ServerPlayer player = TestForgeEvents.mockPlayer(testUuid, "Player");
+            restorer.onPlayerLoggedIn(TestForgeEvents.newPlayerLoggedInEvent(player));
+
+            var textures = player.getGameProfile().getProperties().get("textures");
+            assertNotNull(textures, "stored skin must land in the profile textures");
+            assertFalse(textures.isEmpty(), "profile must carry at least one texture property");
+            assertEquals(skin.getOriginalProperty().value(), textures.iterator().next().value(),
+                    "profile texture value must equal the stored skin value");
+        }
+
+        @Test
+        @DisplayName("Skin property is non-null and non-empty when skin file exists")
+        void skinPropertyReadyForProfile() {
+            restorer.onInitializeServer(TestForgeEvents.newServerStartingEvent(server));
+            SkinRestorer.getSkinStorage().setSkin(testUuid,
+                    new CustomSkinProperty("cHJvZmlsZS12YWw=", "profile-sig", "profile"));
+
+            CustomSkinProperty skin = SkinRestorer.getSkinStorage().getSkin(testUuid);
+
+            assertNotNull(skin);
+            assertNotNull(skin.getOriginalProperty());
+            assertNotNull(skin.getOriginalProperty().value());
+            assertFalse(skin.getOriginalProperty().value().isEmpty());
+            assertNotNull(skin.getOriginalProperty().signature());
+        }
+
+        @Test
+        @DisplayName("No stored skin leaves hasDefaultSkin() true")
+        void noSkinDefaults() {
+            restorer.onInitializeServer(TestForgeEvents.newServerStartingEvent(server));
+
+            assertTrue(SkinRestorer.getSkinStorage().hasDefaultSkin(testUuid));
+        }
+    }
+
+    // ======================================================================
+    //  Player logout  (real onPlayerLoggedOut — save to disk)
+    // ======================================================================
+
+    @Nested
+    @DisplayName("onPlayerLoggedOut — skin save on disconnect")
+    class PlayerLogout {
+
+        @Test
+        @DisplayName("Cached skin is written to disk via the real logout handler")
+        void savesCachedSkinToDisk() {
+            restorer.onInitializeServer(TestForgeEvents.newServerStartingEvent(server));
+            SkinRestorer.getSkinStorage().setSkin(testUuid,
+                    new CustomSkinProperty("logout-val", "logout-sig", "logout"));
+
+            ServerPlayer player = TestForgeEvents.mockPlayer(testUuid, "Player");
+            restorer.onPlayerLoggedOut(TestForgeEvents.newPlayerLoggedOutEvent(player));
+
+            Path target = tempDir.resolve("EverlastingSkins").resolve(testUuid + ".json");
+            assertTrue(Files.exists(target), "Skin file must exist after logout");
+        }
+
+        @Test
+        @DisplayName("Noop when player has no cached skin")
+        void noopForUncachedPlayer() {
+            restorer.onInitializeServer(TestForgeEvents.newServerStartingEvent(server));
+
+            ServerPlayer player = TestForgeEvents.mockPlayer(testUuid, "Player");
+            restorer.onPlayerLoggedOut(TestForgeEvents.newPlayerLoggedOutEvent(player));
+
+            Path target = tempDir.resolve("EverlastingSkins").resolve(testUuid + ".json");
+            assertFalse(Files.exists(target), "No file should be written for an uncached player");
+        }
+
+        @Test
+        @DisplayName("Multiple logouts overwrite the same file")
+        void overwritesOnRepeatedLogout() {
+            restorer.onInitializeServer(TestForgeEvents.newServerStartingEvent(server));
+            SkinIO io = new SkinIO(tempDir.resolve("EverlastingSkins"));
+
+            SkinRestorer.getSkinStorage().setSkin(testUuid,
+                    new CustomSkinProperty("first", "sig1", "src1"));
+            ServerPlayer player = TestForgeEvents.mockPlayer(testUuid, "Player");
+            restorer.onPlayerLoggedOut(TestForgeEvents.newPlayerLoggedOutEvent(player));
+
+            SkinRestorer.getSkinStorage().setSkin(testUuid,
+                    new CustomSkinProperty("second", "sig2", "src2"));
+            restorer.onPlayerLoggedOut(TestForgeEvents.newPlayerLoggedOutEvent(player));
+
+            CustomSkinProperty reloaded = io.loadSkin(testUuid);
+            assertNotNull(reloaded);
+            assertEquals("second", reloaded.getOriginalProperty().value());
+        }
+    }
+
+    // ======================================================================
+    //  Server stopping  (real onServerStopping — bulk save)
+    // ======================================================================
+
+    @Nested
+    @DisplayName("onServerStopping — bulk save all cached skins")
+    class ServerStopping {
+
+        @Test
+        @DisplayName("All skin-backed online players are saved to disk via the real handler")
+        void savesAllCachedSkins() {
+            restorer.onInitializeServer(TestForgeEvents.newServerStartingEvent(server));
+            UUID uuid1 = UUID.randomUUID();
+            UUID uuid2 = UUID.randomUUID();
+            SkinRestorer.getSkinStorage().setSkin(uuid1,
+                    new CustomSkinProperty("sv1", "ssig1", "src1"));
+            SkinRestorer.getSkinStorage().setSkin(uuid2,
+                    new CustomSkinProperty("sv2", "ssig2", "src2"));
+
+            MinecraftServer stoppingServer = TestForgeEvents.mockServer(tempDir, List.of(
+                    TestForgeEvents.mockPlayer(uuid1, "P1"),
+                    TestForgeEvents.mockPlayer(uuid2, "P2")));
+            SkinRestorer.server = stoppingServer;
+            restorer.onServerStopping(TestForgeEvents.newServerStoppingEvent(stoppingServer));
+
+            Path dir = tempDir.resolve("EverlastingSkins");
+            assertTrue(Files.exists(dir.resolve(uuid1 + ".json")));
+            assertTrue(Files.exists(dir.resolve(uuid2 + ".json")));
+        }
+
+        @Test
+        @DisplayName("Noop when no players are online")
+        void noopWhenEmpty() throws Exception {
+            restorer.onInitializeServer(TestForgeEvents.newServerStartingEvent(server));
+
+            MinecraftServer stoppingServer = TestForgeEvents.mockServer(tempDir, Collections.emptyList());
+            SkinRestorer.server = stoppingServer;
+            restorer.onServerStopping(TestForgeEvents.newServerStoppingEvent(stoppingServer));
+
+            Path dir = tempDir.resolve("EverlastingSkins");
+            Path[] files;
+            try (var stream = Files.list(dir)) {
+                files = stream.toArray(Path[]::new);
+            }
+            assertEquals(0, files.length, "No files should exist after noop bulk save");
+        }
+
+        @Test
+        @DisplayName("Skin-backed player persists; empty player produces no file")
+        void partialSave() {
+            restorer.onInitializeServer(TestForgeEvents.newServerStartingEvent(server));
+            UUID uuidA = UUID.randomUUID();
+            UUID uuidB = UUID.randomUUID();
+            SkinRestorer.getSkinStorage().setSkin(uuidA,
+                    new CustomSkinProperty("a-val", "a-sig", "a"));
+
+            MinecraftServer stoppingServer = TestForgeEvents.mockServer(tempDir, List.of(
+                    TestForgeEvents.mockPlayer(uuidA, "PA"),
+                    TestForgeEvents.mockPlayer(uuidB, "PB")));
+            SkinRestorer.server = stoppingServer;
+            restorer.onServerStopping(TestForgeEvents.newServerStoppingEvent(stoppingServer));
+
+            Path dir = tempDir.resolve("EverlastingSkins");
+            assertTrue(Files.exists(dir.resolve(uuidA + ".json")));
+            assertFalse(Files.exists(dir.resolve(uuidB + ".json")));
+        }
+    }
+
+    // ======================================================================
+    //  Edge cases  (direct storage assertions)
+    // ======================================================================
+
+    @Nested
+    @DisplayName("Edge cases — empty / null skin handling")
+    class EdgeCases {
+
+        @Test
+        @DisplayName("Null skin set removes from cache and disk")
+        void nullSkinRemoves() {
+            restorer.onInitializeServer(TestForgeEvents.newServerStartingEvent(server));
+            SkinStorage storage = SkinRestorer.getSkinStorage();
+            storage.setSkin(testUuid, new CustomSkinProperty("val", "sig", "src"));
+            storage.saveSkin(testUuid);
+            assertTrue(Files.exists(tempDir.resolve("EverlastingSkins").resolve(testUuid + ".json")));
+
+            storage.setSkin(testUuid, null);
+
+            assertNull(storage.getSkin(testUuid));
+            assertFalse(Files.exists(tempDir.resolve("EverlastingSkins").resolve(testUuid + ".json")));
+        }
+
+        @Test
+        @DisplayName("Empty skin value treated as absent (not applied)")
+        void emptySkinNotApplied() {
+            restorer.onInitializeServer(TestForgeEvents.newServerStartingEvent(server));
+            SkinStorage storage = SkinRestorer.getSkinStorage();
+
+            var empty = new CustomSkinProperty("textures", "", "", "stub");
+            storage.setSkin(testUuid, empty);
+
+            assertTrue(empty.isEmpty());
+            assertTrue(storage.hasDefaultSkin(testUuid));
+        }
+    }
 }
+

--- a/forge-1.21.8/src/test/java/levosilimo/everlastingskins/skinchanger/SkinRestorerTest.java
+++ b/forge-1.21.8/src/test/java/levosilimo/everlastingskins/skinchanger/SkinRestorerTest.java
@@ -109,4 +109,49 @@ class SkinRestorerTest {
         field.set(null, value);
     }
 
+    // ======================================================================
+    //  Init  (real onInitializeServer handler)
+    // ======================================================================
+
+    @Nested
+    @DisplayName("onInitializeServer — storage initialisation")
+    class Init {
+
+        @Test
+        @DisplayName("Handler creates the EverlastingSkins data directory")
+        void createsStorageDirectory() {
+            Path skinDir = tempDir.resolve("EverlastingSkins");
+            restorer.onInitializeServer(TestForgeEvents.newServerStartingEvent(server));
+
+            assertTrue(Files.exists(skinDir), "Storage directory must exist");
+            assertTrue(Files.isDirectory(skinDir), "Storage path must be a directory");
+        }
+
+        @Test
+        @DisplayName("Handler wires skinStorage/skinIO; a saved+flushed skin lands on disk")
+        void wiresStorage() throws Exception {
+            restorer.onInitializeServer(TestForgeEvents.newServerStartingEvent(server));
+            SkinStorage storage = SkinRestorer.getSkinStorage();
+            assertNotNull(storage, "getSkinStorage() must be wired after handler");
+
+            storage.setSkin(testUuid, new CustomSkinProperty("wire-val", "wire-sig", "wire"));
+            storage.saveSkin(testUuid);
+            SkinRestorer.getSkinStorage().flushPending();
+
+            Path target = tempDir.resolve("EverlastingSkins").resolve(testUuid + ".json");
+            assertTrue(Files.exists(target), "Wired SkinIO must write <uuid>.json to the save dir");
+        }
+
+        @Test
+        @DisplayName("getSkinStorage() returns null before the handler runs")
+        void nullBeforeInit() throws Exception {
+            // Explicitly clear any state; assert the pre-init contract.
+            SkinStorage.resetForTest();
+            setStaticField(SkinRestorer.class, "skinStorage", null);
+            setStaticField(SkinRestorer.class, "skinIO", null);
+
+            assertNull(SkinRestorer.getSkinStorage());
+        }
+    }
+
 }

--- a/forge-1.21.8/src/test/java/levosilimo/everlastingskins/skinchanger/SkinRestorerTest.java
+++ b/forge-1.21.8/src/test/java/levosilimo/everlastingskins/skinchanger/SkinRestorerTest.java
@@ -4,11 +4,20 @@
  * https://github.com/Levosilimo/Everlasting-Skins
  */
 
-
 package levosilimo.everlastingskins.skinchanger;
 
+import com.electronwill.nightconfig.core.InMemoryCommentedFormat;
+import com.google.common.util.concurrent.MoreExecutors;
+import levosilimo.everlastingskins.Config;
 import levosilimo.everlastingskins.forge21.skinchanger.SkinRestorer;
+import levosilimo.everlastingskins.metrics.SkinMetrics;
+import levosilimo.everlastingskins.skinchanger.SkinIO;
+import levosilimo.everlastingskins.skinchanger.SkinStorage;
 import levosilimo.everlastingskins.util.CustomSkinProperty;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerPlayer;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -18,34 +27,75 @@ import org.junit.jupiter.api.io.TempDir;
 import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Lifecycle tests for {@link SkinRestorer}. Each test verifies the
- * storage-level behavior triggered by Forge lifecycle events without
- * requiring a running Minecraft server.
+ * Lifecycle tests for {@link SkinRestorer} driven through the REAL
+ * {@code @SubscribeEvent} handlers with headless {@link TestForgeEvents}
+ * event instances (no running Minecraft server / no FML runtime).
  *
- * <p>Tested behaviors:
- * <ul>
- *   <li>onInitializeServer — storage directory creation, field wiring</li>
- *   <li>onPlayerLoggedIn  — skin loaded from disk and cached</li>
- *   <li>onPlayerLoggedOut — cached skin saved to disk</li>
- *   <li>onServerStopping  — all cached skins flushed to disk</li>
- * </ul>
+ * <p>The {@link Bootstrap#bootStrap()} guard is the same reflection hack as
+ * {@code SkinRefreshHandlerTest}: the unit-test JVM has no server, so mocking
+ * any registry-touching class (ServerPlayer) would otherwise throw
+ * "Not bootstrapped". Calling bootStrap() itself would trigger Forge's patched
+ * GameData.vanillaSnapshot(), which needs the FML runtime.
  */
 class SkinRestorerTest {
+
+    // static block FIRST: flag the vanilla bootstrap as done so ServerPlayer
+    // mocks do not throw 'Not bootstrapped'. Mirrors SkinRefreshHandlerTest
+    // lines 124-132.
+    static {
+        try {
+            Field bootstrapFlag = Bootstrap.class.getDeclaredField("isBootstrapped");
+            bootstrapFlag.setAccessible(true);
+            bootstrapFlag.setBoolean(null, true);
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
 
     @TempDir
     Path tempDir;
 
+    private SkinRestorer restorer;
+    private MinecraftServer server;
     private UUID testUuid;
 
     @BeforeEach
     void setUp() throws Exception {
         testUuid = UUID.randomUUID();
-        // Reset SkinRestorer static state so tests are isolated
+        // Make the ForgeConfigSpec usable outside a loaded config file
+        // (exact pattern from SkinRefreshHandlerTest.setUp).
+        Config.COMMON_CONFIG.setConfig(
+                InMemoryCommentedFormat.defaultInstance().createConfig(HashMap::new));
+
+        // Reset singleton static state for test isolation (all helpers exist in :common).
+        SkinStorage.resetForTest();
+        SkinMetrics.INSTANCE.reset();
+        SkinIO.shutdown();
+        setStaticField(SkinRestorer.class, "skinStorage", null);
+        setStaticField(SkinRestorer.class, "skinIO", null);
+        SkinRestorer.server = null;
+        // Install the synchronous test executor; never fires on the
+        // synchronous stored-skin branch this suite exercises, but ships the
+        // seam per spec for a future async default-skin test.
+        SkinRestorer.setLoginExecutorForTest(MoreExecutors.newDirectExecutorService());
+
+        restorer = new SkinRestorer();
+        server = TestForgeEvents.mockServer(tempDir, Collections.emptyList());
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        SkinStorage.resetForTest();
+        SkinMetrics.INSTANCE.reset();
+        SkinIO.shutdown();
         setStaticField(SkinRestorer.class, "skinStorage", null);
         setStaticField(SkinRestorer.class, "skinIO", null);
         SkinRestorer.server = null;
@@ -59,238 +109,4 @@ class SkinRestorerTest {
         field.set(null, value);
     }
 
-    // ======================================================================
-    //  Init  (onInitializeServer)
-    // ======================================================================
-
-    @Nested
-    @DisplayName("onInitializeServer — storage initialisation")
-    class Init {
-
-        @Test
-        @DisplayName("Creates the EverlastingSkins data directory")
-        void createsStorageDirectory() throws Exception {
-            Path skinDir = tempDir.resolve("EverlastingSkins");
-            Files.createDirectories(skinDir);
-
-            assertTrue(Files.exists(skinDir), "Storage directory must exist");
-            assertTrue(Files.isDirectory(skinDir), "Storage path must be a directory");
-        }
-
-        @Test
-        @DisplayName("Sets skinStorage and skinIO fields accessible via getSkinStorage()")
-        void wiresFields() throws Exception {
-            Path skinDir = tempDir.resolve("EverlastingSkins");
-            Files.createDirectories(skinDir);
-            SkinIO io = new SkinIO(skinDir);
-            SkinStorage storage = new SkinStorage(io);
-
-            setStaticField(SkinRestorer.class, "skinStorage", storage);
-            setStaticField(SkinRestorer.class, "skinIO", io);
-
-            assertNotNull(SkinRestorer.getSkinStorage());
-            assertSame(storage, SkinRestorer.getSkinStorage());
-        }
-
-        @Test
-        @DisplayName("getSkinStorage() returns null before init")
-        void nullBeforeInit() {
-            assertNull(SkinRestorer.getSkinStorage());
-        }
-    }
-
-    // ======================================================================
-    //  Player login  (onPlayerLoggedIn — skin load + cache)
-    // ======================================================================
-
-    @Nested
-    @DisplayName("onPlayerLoggedIn — skin apply on join")
-    class PlayerLogin {
-
-        @Test
-        @DisplayName("Stored skin on disk is loaded and cached by SkinStorage")
-        void loadsStoredSkin() {
-            SkinIO io = new SkinIO(tempDir);
-            SkinStorage storage = new SkinStorage(io);
-            var persisted = new CustomSkinProperty("bG9naW4tdmFsdWU=", "login-sig", "login-source");
-
-            io.saveSkin(testUuid, persisted);
-
-            CustomSkinProperty loaded = storage.getSkin(testUuid);
-
-            assertNotNull(loaded);
-            assertFalse(loaded.isEmpty());
-            assertEquals("bG9naW4tdmFsdWU=", loaded.getOriginalProperty().value());
-            assertEquals("login-sig", loaded.getOriginalProperty().signature());
-            assertEquals("login-source", loaded.getSource());
-        }
-
-        @Test
-        @DisplayName("Skin property is non-null and non-empty when skin file exists")
-        void skinPropertyReadyForProfile() {
-            SkinIO io = new SkinIO(tempDir);
-            SkinStorage storage = new SkinStorage(io);
-            io.saveSkin(testUuid, new CustomSkinProperty("cHJvZmlsZS12YWw=", "profile-sig", "profile"));
-
-            CustomSkinProperty skin = storage.getSkin(testUuid);
-
-            assertNotNull(skin);
-            assertNotNull(skin.getOriginalProperty());
-            assertNotNull(skin.getOriginalProperty().value());
-            assertFalse(skin.getOriginalProperty().value().isEmpty());
-            assertNotNull(skin.getOriginalProperty().signature());
-        }
-
-        @Test
-        @DisplayName("No stored skin leaves hasDefaultSkin() true")
-        void noSkinDefaults() {
-            SkinIO io = new SkinIO(tempDir);
-            SkinStorage storage = new SkinStorage(io);
-
-            assertTrue(storage.hasDefaultSkin(testUuid));
-        }
-    }
-
-    // ======================================================================
-    //  Player logout  (onPlayerLoggedOut — save to disk)
-    // ======================================================================
-
-    @Nested
-    @DisplayName("onPlayerLoggedOut — skin save on disconnect")
-    class PlayerLogout {
-
-        @Test
-        @DisplayName("Cached skin is written to disk when saveSkin is called")
-        void savesCachedSkinToDisk() {
-            SkinIO io = new SkinIO(tempDir);
-            SkinStorage storage = new SkinStorage(io);
-
-            storage.setSkin(testUuid, new CustomSkinProperty("logout-val", "logout-sig", "logout"));
-            assertNotNull(storage.getSkin(testUuid));
-            storage.saveSkin(testUuid);
-
-            Path target = tempDir.resolve(testUuid + ".json");
-            assertTrue(Files.exists(target), "Skin file must exist after save");
-        }
-
-        @Test
-        @DisplayName("Noop when player has no cached skin")
-        void noopForUncachedPlayer() {
-            SkinIO io = new SkinIO(tempDir);
-            SkinStorage storage = new SkinStorage(io);
-
-            assertTrue(storage.hasDefaultSkin(testUuid));
-        }
-
-        @Test
-        @DisplayName("Multiple logouts overwrite the same file")
-        void overwritesOnRepeatedLogout() {
-            SkinIO io = new SkinIO(tempDir);
-            SkinStorage storage = new SkinStorage(io);
-
-            storage.setSkin(testUuid, new CustomSkinProperty("first", "sig1", "src1"));
-            storage.saveSkin(testUuid);
-            storage.setSkin(testUuid, new CustomSkinProperty("second", "sig2", "src2"));
-            storage.saveSkin(testUuid);
-
-            CustomSkinProperty reloaded = io.loadSkin(testUuid);
-            assertNotNull(reloaded);
-            assertEquals("second", reloaded.getOriginalProperty().value());
-        }
-    }
-
-    // ======================================================================
-    //  Server stopping  (onServerStopping — bulk save)
-    // ======================================================================
-
-    @Nested
-    @DisplayName("onServerStopping — bulk save all cached skins")
-    class ServerStopping {
-
-        @Test
-        @DisplayName("All cached skins are saved to disk")
-        void savesAllCachedSkins() {
-            SkinIO io = new SkinIO(tempDir);
-            SkinStorage storage = new SkinStorage(io);
-            UUID uuid1 = UUID.randomUUID();
-            UUID uuid2 = UUID.randomUUID();
-
-            storage.setSkin(uuid1, new CustomSkinProperty("sv1", "ssig1", "src1"));
-            storage.setSkin(uuid2, new CustomSkinProperty("sv2", "ssig2", "src2"));
-
-            storage.saveSkin(uuid1);
-            storage.saveSkin(uuid2);
-
-            assertTrue(Files.exists(tempDir.resolve(uuid1 + ".json")));
-            assertTrue(Files.exists(tempDir.resolve(uuid2 + ".json")));
-        }
-
-        @Test
-        @DisplayName("Noop when no players are cached")
-        void noopWhenEmpty() {
-            SkinIO io = new SkinIO(tempDir);
-            new SkinStorage(io);
-
-            Path[] files;
-            try (var stream = Files.list(tempDir)) {
-                files = stream.toArray(Path[]::new);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-            assertEquals(0, files.length, "No files should exist after noop bulk save");
-        }
-
-        @Test
-        @DisplayName("Partially-cached players persist independently")
-        void partialSave() {
-            SkinIO io = new SkinIO(tempDir);
-            SkinStorage storage = new SkinStorage(io);
-            UUID uuidA = UUID.randomUUID();
-            UUID uuidB = UUID.randomUUID();
-
-            storage.setSkin(uuidA, new CustomSkinProperty("a-val", "a-sig", "a"));
-            storage.saveSkin(uuidA);
-
-            assertTrue(Files.exists(tempDir.resolve(uuidA + ".json")));
-            assertFalse(Files.exists(tempDir.resolve(uuidB + ".json")));
-        }
-    }
-
-    // ======================================================================
-    //  Edge cases
-    // ======================================================================
-
-    @Nested
-    @DisplayName("Edge cases — empty / null skin handling")
-    class EdgeCases {
-
-        @Test
-        @DisplayName("Null skin set removes from cache and disk")
-        void nullSkinRemoves() {
-            SkinIO io = new SkinIO(tempDir);
-            SkinStorage storage = new SkinStorage(io);
-
-            storage.setSkin(testUuid, new CustomSkinProperty("val", "sig", "src"));
-            storage.saveSkin(testUuid);
-            assertTrue(Files.exists(tempDir.resolve(testUuid + ".json")));
-
-            storage.setSkin(testUuid, null);
-
-            assertNull(storage.getSkin(testUuid));
-            assertFalse(Files.exists(tempDir.resolve(testUuid + ".json")));
-        }
-
-        @Test
-        @DisplayName("Empty skin value treated as absent (not applied)")
-        void emptySkinNotApplied() {
-            SkinIO io = new SkinIO(tempDir);
-            SkinStorage storage = new SkinStorage(io);
-
-            var empty = new CustomSkinProperty("textures", "", "", "stub");
-            storage.setSkin(testUuid, empty);
-
-            assertTrue(empty.isEmpty());
-            assertTrue(storage.hasDefaultSkin(testUuid));
-        }
-    }
 }

--- a/forge-1.21.8/src/test/java/levosilimo/everlastingskins/skinchanger/TestForgeEvents.java
+++ b/forge-1.21.8/src/test/java/levosilimo/everlastingskins/skinchanger/TestForgeEvents.java
@@ -1,0 +1,92 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import com.mojang.authlib.GameProfile;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.players.PlayerList;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraftforge.event.server.ServerStartingEvent;
+import net.minecraftforge.event.server.ServerStoppingEvent;
+import net.minecraftforge.registries.ForgeRegistries;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Headless factory for Forge lifecycle events used by SkinRestorerTest.
+ * All four event constructors are single-argument, so they are trivially
+ * constructible from Mockito mocks of MinecraftServer / ServerPlayer with no
+ * running server and no FML runtime.
+ *
+ * <p>Package-private by design: it is a test-support helper for the
+ * skinchanger test package only.
+ */
+final class TestForgeEvents {
+
+    private TestForgeEvents() {
+    }
+
+    static ServerStartingEvent newServerStartingEvent(MinecraftServer server) {
+        return new ServerStartingEvent(server);
+    }
+
+    static ServerStoppingEvent newServerStoppingEvent(MinecraftServer server) {
+        return new ServerStoppingEvent(server);
+    }
+
+    static PlayerEvent.PlayerLoggedInEvent newPlayerLoggedInEvent(ServerPlayer player) {
+        return new PlayerEvent.PlayerLoggedInEvent(player);
+    }
+
+    static PlayerEvent.PlayerLoggedOutEvent newPlayerLoggedOutEvent(ServerPlayer player) {
+        return new PlayerEvent.PlayerLoggedOutEvent(player);
+    }
+
+    /**
+     * Mock server: getFile("EverlastingSkins") redirects the save dir to
+     * tempDir/EverlastingSkins; getPlayerList().getPlayers() returns the given
+     * list (defaults to empty). MinecraftServer.getFile(String) is a mapped
+     * name that compiles against the same (re)obfuscated MC classes that
+     * SkinRefreshHandlerTest already stubs.
+     */
+    static MinecraftServer mockServer(Path tempDir, List<ServerPlayer> players) {
+        Path skinDir = tempDir.resolve("EverlastingSkins");
+        MinecraftServer server = mock(MinecraftServer.class);
+        when(server.getFile("EverlastingSkins")).thenReturn(skinDir);
+        PlayerList playerlist = mock(PlayerList.class);
+        when(playerlist.getPlayers())
+                .thenReturn(players != null ? players : Collections.emptyList());
+        when(server.getPlayerList()).thenReturn(playerlist);
+        return server;
+    }
+
+    /**
+     * Mock player with a mutable GameProfile (new instance each call) so
+     * SkinRestorer.onPlayerLoggedIn can mutate its textures property map.
+     */
+    static ServerPlayer mockPlayer(UUID uuid, String name) {
+        // Headless JVM: force Forge's vanilla registries to exist before the
+        // ServerPlayer superclass chain is initialized. Block.<clinit> calls
+        // GameData$BlockCallbacks.getBlockStateIDMap(), which NPEs on a null
+        // BLOCKS registry unless ForgeRegistries.<clinit> (-> GameData.init())
+        // has run. The real server path runs it via FML; the flag hack in
+        // SkinRestorerTest skips Bootstrap.bootStrap(), so the registries must
+        // be created here instead.
+        ForgeRegistries.BLOCKS.getClass();
+        ServerPlayer player = mock(ServerPlayer.class);
+        when(player.getUUID()).thenReturn(uuid);
+        when(player.getGameProfile()).thenReturn(new GameProfile(uuid, name));
+        return player;
+    }
+}


### PR DESCRIPTION
Byte-identical replica of forge-1.21's P3-1 rewrite (7 commits). forge-1.21.8 SubscribeEvent import differs (line 25) but seam edit doesn't touch it.

Deviations from the librarian skeleton (canonical forge-1.21 PR will need the same):
1. `setLoginExecutorForTest(Runnable::run)` → `MoreExecutors.newDirectExecutorService()` — JDK 19+ `ExecutorService` is not a functional interface (multiple abstract methods incl. close()).
2. `textures.get(0)` → `textures.iterator().next()` — authlib PropertyMap.get returns Collection.
3. `nullBeforeInit()` declares `throws Exception` (setStaticField throws).
4. TestForgeEvents.mockPlayer forces `ForgeRegistries.<clinit>` (→ GameData.init()): on Forge 58, `Block.<clinit>` → `GameData$BlockCallbacks.getBlockStateIDMap()` NPEs on a null BLOCKS registry in a headless JVM unless the vanilla Forge registries exist.

Verification: `./gradlew :forge-1.21.8:test` green (14/14 SkinRestorerTest + full lane suite).