### PR TITLE
test: remove static from jqwik @Group classes (SkinIOPropertyTest 8 properties now run)

### DIFF
--- a/common/src/test/java/levosilimo/everlastingskins/skinchanger/SkinIOPropertyTest.java
+++ b/common/src/test/java/levosilimo/everlastingskins/skinchanger/SkinIOPropertyTest.java
@@ -277,7 +277,7 @@ class SkinIOPropertyTest {
     }
 
     @Group
-    static class DrainIdempotence {
+    class DrainIdempotence {
 
         /**
          * Model: the drain latch and per-UUID coalescing guarantee at most one
@@ -322,7 +322,7 @@ class SkinIOPropertyTest {
 
 
     @Group
-    static class DeleteBeatsWrite {
+    class DeleteBeatsWrite {
 
         /**
          * Model: a delete is a tombstone that beats any earlier write, so a
@@ -411,7 +411,7 @@ class SkinIOPropertyTest {
 
 
     @Group
-    static class SerializeLoadRoundTrip {
+    class SerializeLoadRoundTrip {
 
         /**
          * Model: the wire format is the state, so serialize -> load ->
@@ -457,7 +457,7 @@ class SkinIOPropertyTest {
 
 
     @Group
-    static class RestartAfterDelete {
+    class RestartAfterDelete {
 
         /**
          * Model: a tombstone must survive a restart, so a fresh store over the
@@ -491,7 +491,7 @@ class SkinIOPropertyTest {
 
 
     @Group
-    static class ModelEquivalence {
+    class ModelEquivalence {
 
         /**
          * Model: the full specification. A random concurrent op script (async
@@ -538,7 +538,7 @@ class SkinIOPropertyTest {
 
 
     @Group
-    static class LatestWins {
+    class LatestWins {
 
         /**
          * Model: the map is latest-wins, so a sequence of async saves for one


### PR DESCRIPTION
## Summary

Follow-up to fix-25 / PR #344 (jqwik 1.9.0 → 1.9.3): the version bump alone did not activate the 8 `@Property` tests in `SkinIOPropertyTest` — jqwik hard-skips `static` `@Group` classes ("@Group classes must not be static").

This PR removes `static` from the six `@Group` class declarations, making them inner classes, which is what jqwik requires for container discovery.

## Verification

- `./gradlew :common:build` — BUILD SUCCESSFUL (full test suite)
- `./gradlew :common:test --tests '*SkinIOPropertyTest*'` — **tests=8, failures=0, errors=0, skipped=0** (previously 8 skipped)
- Pre-push hook: full unit suite + GameTest (1.21) + aislop ci — all passed