### PR TITLE
ci: activate lefthook as the git hook manager

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -23,7 +23,11 @@ pre-commit:
   parallel: false
   commands:
     aislop:
-      run: bash -c 'if command -v bunx >/dev/null 2>&1; then RUNNER=bunx; elif command -v npx >/dev/null 2>&1; then RUNNER=npx; else echo "[aislop] neither bunx nor npx found on PATH; skipping scan" >&2; exit 0; fi; $RUNNER aislop scan --staged'
+      run: >-
+        bash -c 'if command -v bunx >/dev/null 2>&1; then RUNNER=bunx;
+        elif command -v npx >/dev/null 2>&1; then RUNNER=npx; else
+        echo "[aislop] neither bunx nor npx found on PATH; skipping scan" >&2;
+        exit 0; fi; $RUNNER aislop scan --staged'
     test-count:
       run: bash scripts/test-count-gate.sh
     verify-no-mixin:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,24 +1,29 @@
 # lefthook.yml — Go-binary git hook manager (no Python/Node runtime).
-# STATUS: documented, NOT yet adopted. `.githooks/` (via `git config
-# core.hooksPath .githooks`) remains the active path; this file is the
-# intended replacement so behavior stays identical when adopted (same
-# scripts, same order).
+# STATUS: ACTIVE. `lefthook install` writes .git/hooks/pre-commit + pre-push;
+# `git config core.hooksPath` is unset (default git-managed hooks), and the
+# former `.githooks/` path is retired so the two cannot drift.
 #
-# Adopt (operational, not part of this repo):
-#   brew install lefthook            # or: go install github.com/evilmartians/lefthook@latest
-#   lefthook install                 # writes .git/hooks/pre-commit + pre-push
-#   git config --unset core.hooksPath
-#   # follow up: delete .githooks/ so the two paths cannot drift
+# Reinstall after clone:
+#   lefthook install
 #
 # Pre-commit stays sequential (fail-fast tier, <30s); pre-push runs in
 # parallel (heavy tier, 5-10 min). Note: the two gradle jobs in pre-push
 # serialize on the project lock; aislop-ci is the true parallel win.
+#
+# Runtime parity with the retired .githooks scripts (verified on lefthook
+# 2.1.9):
+#   - empty-staged fast-exit: lefthook natively skips pre-commit commands
+#     when nothing is staged (no config needed).
+#   - aislop runner fallback: bunx -> npx; pre-commit skips the scan when
+#     neither runner is on PATH, matching the old script. Pre-push requires
+#     one of them.
+#   - skip one push with: git push --no-verify
 
 pre-commit:
   parallel: false
   commands:
     aislop:
-      run: bunx aislop scan --staged
+      run: bash -c 'if command -v bunx >/dev/null 2>&1; then RUNNER=bunx; elif command -v npx >/dev/null 2>&1; then RUNNER=npx; else echo "[aislop] neither bunx nor npx found on PATH; skipping scan" >&2; exit 0; fi; $RUNNER aislop scan --staged'
     test-count:
       run: bash scripts/test-count-gate.sh
     verify-no-mixin:
@@ -34,4 +39,4 @@ pre-push:
     gametest:
       run: forge-1.21/test-infrastructure/run-gametest-local.sh
     aislop-ci:
-      run: npx -y aislop ci --changes --base origin/main
+      run: bash -c 'if command -v bunx >/dev/null 2>&1; then bunx aislop ci --changes --base origin/main; else npx -y aislop ci --changes --base origin/main; fi'


### PR DESCRIPTION
## What

Activates [lefthook](https://github.com/evilmartians/lefthook) (v2.1.9) as the git hook manager, replacing the `.githooks/` + `core.hooksPath` setup. `lefthook.yml` already inlined every `.githooks/` command; this PR applies the two runtime-parity gaps and updates the status docs.

## Changes (lefthook.yml only)

- **Runner fallback parity**: `aislop` now uses the same `bunx -> npx` fallback as the retired scripts (pre-commit skips the scan when neither runner is on PATH; pre-push requires one).
- **Empty-staged fast-exit**: the old script exited early when nothing was staged. Verified empirically on lefthook 2.1.9 that the pre-commit group is natively skipped when nothing is staged (including `--allow-empty`), so no config is needed — noted in the header docs.
- **Docs**: removed the "NOT yet adopted" block; documents the active status, reinstall command, and parity notes.

## Operational steps applied (not part of this PR)

- `lefthook install --reset-hooks-path` — wrote `.git/hooks/pre-commit` + `.git/hooks/pre-push`, unset `core.hooksPath` (verified empty).
- Removed `.githooks/` so the two paths cannot drift. Rollback: `git config core.hooksPath .githooks`.

## Verification

- `lefthook validate` — "All good"
- `lefthook check-install` — not a command in 2.1.9; verified via hooks present in `.git/hooks` + `core.hooksPath` empty
- Single-commit smoke test through the live pre-commit: aislop / test-count / verifyNoMixin / compile all passed (commit then reset)
- Real commit `3abeb48` ran the same four checks through lefthook successfully