### PR TITLE
flake: fix GameTest packet-arrival race via shared PacketAssert helper

### DIFF
--- a/buildSrc/src/main/kotlin/everlastingskins.forge-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/everlastingskins.forge-module.gradle.kts
@@ -121,6 +121,14 @@ sourceSets {
     create("gametest") {
         compileClasspath += sourceSets.main.get().output
         runtimeClasspath += output + sourceSets.main.get().output
+        // Shared GameTest helper (lib-47 packet-arrival flake): PacketAssert
+        // lives in its own package dir under forge-test-shared so this share
+        // pulls in only version-independent classes. It imports only
+        // net.minecraft.gametest.framework.* (stable across 1.21.x and 26.2)
+        // — unlike I18nUtilsTest/ConfigTest it has no forge21.* imports, so
+        // the share is NOT gated on minecraft.unobfuscated like the test
+        // source-set share below.
+        java.srcDir("$rootDir/forge-test-shared/src/test/java/levosilimo/everlastingskins/gametest")
     }
     // Shared LuckPerms API test stubs live in :common's test source-set
     // (canonical copy; the forge lanes deleted their duplicates).

--- a/forge-1.21.4/src/gametest/java/levosilimo/everlastingskins/gametest/SkinVisibilityTest.java
+++ b/forge-1.21.4/src/gametest/java/levosilimo/everlastingskins/gametest/SkinVisibilityTest.java
@@ -1537,7 +1537,7 @@ public class SkinVisibilityTest {
         }
     }
 
-    @GameTest(template = "everlastingskins:empty", batch = "skinSet_selfReceivesBroadcast", timeoutTicks = 200)
+    @GameTest(template = "everlastingskins:empty", batch = "skinSet_selfReceivesBroadcast", timeoutTicks = 60000)
     public void skinSet_selfReceivesBroadcast(GameTestHelper helper) {
         FakeMojangAPI fake = installFakeMojangAPI(true);
         SkinStorage storage = ensureStorage(helper);
@@ -1545,6 +1545,13 @@ public class SkinVisibilityTest {
         ServerPlayer playerA = mockPlayer(helper, "SelfRecvPlayer");
         makeOp(playerA);
         UUID playerId = playerA.getUUID();
+
+        // Real-time budget for the async pipeline — see
+        // ASYNC_PIPELINE_DEADLINE_NANOS. timeoutTicks=60000 above is only a
+        // backstop; the deadline below is the actual bound (lib-47: the tick
+        // budget alone raced the broadcast on loaded CI runners).
+        PacketAssert.Deadline packetDeadline =
+                PacketAssert.deadline(TimeUnit.NANOSECONDS.toMillis(ASYNC_PIPELINE_DEADLINE_NANOS));
 
         try {
             placePlayer(helper, playerA);
@@ -1555,15 +1562,22 @@ public class SkinVisibilityTest {
             helper.assertTrue(result == 1, "command should report 1 target, got " + result);
 
             helper.succeedWhen(() -> {
+                PacketAssert.checkDeadline(helper, packetDeadline, "self-reception broadcast");
                 CustomSkinProperty stored = storage.getSkin(playerId);
                 if (stored == null || !SkinActionCommand.SOURCE_MOJANG.equals(stored.getSource())) {
                     throw new GameTestAssertException("waiting for source=" + SkinActionCommand.SOURCE_MOJANG + " (got "
                             + (stored == null ? "null" : stored.getSource()) + ")");
                 }
-                long selfCount = countAddPlayerUpdatesWithTextures(drain(playerA), playerId);
-                if (selfCount < 1) {
-                    throw new GameTestAssertException("target player must receive at least 1 ADD_PLAYER (self-reception), got " + selfCount);
-                }
+                // Packet-arrival phase: retry every tick while the deadline
+                // holds; fail at the deadline instead of racing the tick
+                // budget (lib-47: transient "got 0" surfaced as the failure
+                // when the 200-tick budget ran out on loaded runners).
+                PacketAssert.assertEventually(helper, packetDeadline, () -> {
+                    long selfCount = countAddPlayerUpdatesWithTextures(drain(playerA), playerId);
+                    if (selfCount < 1) {
+                        throw new GameTestAssertException("target player must receive at least 1 ADD_PLAYER (self-reception), got " + selfCount);
+                    }
+                });
                 removeQuietly(server, playerA);
             });
         } catch (RuntimeException e) {

--- a/forge-1.21/src/gametest/java/levosilimo/everlastingskins/gametest/SkinVisibilityTest.java
+++ b/forge-1.21/src/gametest/java/levosilimo/everlastingskins/gametest/SkinVisibilityTest.java
@@ -1537,7 +1537,7 @@ public class SkinVisibilityTest {
         }
     }
 
-    @GameTest(template = "everlastingskins:empty", batch = "skinSet_selfReceivesBroadcast", timeoutTicks = 200)
+    @GameTest(template = "everlastingskins:empty", batch = "skinSet_selfReceivesBroadcast", timeoutTicks = 60000)
     public void skinSet_selfReceivesBroadcast(GameTestHelper helper) {
         FakeMojangAPI fake = installFakeMojangAPI(true);
         SkinStorage storage = ensureStorage(helper);
@@ -1545,6 +1545,13 @@ public class SkinVisibilityTest {
         ServerPlayer playerA = mockPlayer(helper, "SelfRecvPlayer");
         makeOp(playerA);
         UUID playerId = playerA.getUUID();
+
+        // Real-time budget for the async pipeline — see
+        // ASYNC_PIPELINE_DEADLINE_NANOS. timeoutTicks=60000 above is only a
+        // backstop; the deadline below is the actual bound (lib-47: the tick
+        // budget alone raced the broadcast on loaded CI runners).
+        PacketAssert.Deadline packetDeadline =
+                PacketAssert.deadline(TimeUnit.NANOSECONDS.toMillis(ASYNC_PIPELINE_DEADLINE_NANOS));
 
         try {
             placePlayer(helper, playerA);
@@ -1555,15 +1562,22 @@ public class SkinVisibilityTest {
             helper.assertTrue(result == 1, "command should report 1 target, got " + result);
 
             helper.succeedWhen(() -> {
+                PacketAssert.checkDeadline(helper, packetDeadline, "self-reception broadcast");
                 CustomSkinProperty stored = storage.getSkin(playerId);
                 if (stored == null || !SkinActionCommand.SOURCE_MOJANG.equals(stored.getSource())) {
                     throw new GameTestAssertException("waiting for source=" + SkinActionCommand.SOURCE_MOJANG + " (got "
                             + (stored == null ? "null" : stored.getSource()) + ")");
                 }
-                long selfCount = countAddPlayerUpdatesWithTextures(drain(playerA), playerId);
-                if (selfCount < 1) {
-                    throw new GameTestAssertException("target player must receive at least 1 ADD_PLAYER (self-reception), got " + selfCount);
-                }
+                // Packet-arrival phase: retry every tick while the deadline
+                // holds; fail at the deadline instead of racing the tick
+                // budget (lib-47: transient "got 0" surfaced as the failure
+                // when the 200-tick budget ran out on loaded runners).
+                PacketAssert.assertEventually(helper, packetDeadline, () -> {
+                    long selfCount = countAddPlayerUpdatesWithTextures(drain(playerA), playerId);
+                    if (selfCount < 1) {
+                        throw new GameTestAssertException("target player must receive at least 1 ADD_PLAYER (self-reception), got " + selfCount);
+                    }
+                });
                 removeQuietly(server, playerA);
             });
         } catch (RuntimeException e) {

--- a/forge-26.2/src/gametest/java/levosilimo/everlastingskins/gametest/SkinVisibilityTest.java
+++ b/forge-26.2/src/gametest/java/levosilimo/everlastingskins/gametest/SkinVisibilityTest.java
@@ -1465,8 +1465,12 @@ public class SkinVisibilityTest {
 
         // Real-time budget for the async pipeline — see
         // ASYNC_PIPELINE_DEADLINE_NANOS. timeoutTicks=60000 above is only a
-        // backstop; the deadline below is the actual bound.
-        long deadlineNanos = System.nanoTime() + ASYNC_PIPELINE_DEADLINE_NANOS;
+        // backstop; the deadline below is the actual bound. The deadline must
+        // fail HARD (lib-47: GameTestAssertException-based deadlines are
+        // swallowed by the framework's per-tick retry, so the tick budget
+        // won the race and surfaced transient "got 0" messages).
+        PacketAssert.Deadline packetDeadline =
+                PacketAssert.deadline(TimeUnit.NANOSECONDS.toMillis(ASYNC_PIPELINE_DEADLINE_NANOS));
 
         try {
             placePlayer(helper, playerA);
@@ -1499,7 +1503,7 @@ public class SkinVisibilityTest {
             // futures inside succeedWhen instead: the server keeps ticking, so
             // queued broadcasts land and drain() observes them.
             helper.succeedWhen(() -> {
-                throwIfPastDeadline(deadlineNanos, "concurrent skin set");
+                PacketAssert.checkDeadline(helper, packetDeadline, "concurrent skin set");
                 if (!futureA.isDone() || !futureB.isDone()) {
                     throw new GameTestAssertException(Component.literal("waiting for concurrent dispatches to complete"), -1);
                 }
@@ -1513,14 +1517,20 @@ public class SkinVisibilityTest {
                     throw new GameTestAssertException(Component.literal("waiting for playerB to store the Mojang skin (got "
                             + (skinB == null ? "null" : skinB.getSource()) + ")"), -1);
                 }
-                long obsCountA = countAddPlayerUpdatesWithTextures(drain(observerA), uuidA);
-                long obsCountB = countAddPlayerUpdatesWithTextures(drain(observerB), uuidB);
-                if (obsCountA != 1) {
-                    throw new GameTestAssertException(Component.literal("observerA expected 1 packet, got " + obsCountA), -1);
-                }
-                if (obsCountB != 1) {
-                    throw new GameTestAssertException(Component.literal("observerB expected 1 packet, got " + obsCountB), -1);
-                }
+                // Packet-arrival phase: retry every tick while the deadline
+                // holds; fail at the deadline instead of racing the tick
+                // budget (lib-47: transient "expected 1 packet, got 0"
+                // surfaced as the failure on loaded runners).
+                PacketAssert.assertEventually(helper, packetDeadline, () -> {
+                    long obsCountA = countAddPlayerUpdatesWithTextures(drain(observerA), uuidA);
+                    long obsCountB = countAddPlayerUpdatesWithTextures(drain(observerB), uuidB);
+                    if (obsCountA != 1) {
+                        throw new GameTestAssertException(Component.literal("observerA expected 1 packet, got " + obsCountA), -1);
+                    }
+                    if (obsCountB != 1) {
+                        throw new GameTestAssertException(Component.literal("observerB expected 1 packet, got " + obsCountB), -1);
+                    }
+                });
                 removeQuietly(server, playerA);
                 removeQuietly(server, playerB);
                 removeQuietly(server, observerA);

--- a/forge-test-shared/src/test/java/levosilimo/everlastingskins/gametest/PacketAssert.java
+++ b/forge-test-shared/src/test/java/levosilimo/everlastingskins/gametest/PacketAssert.java
@@ -1,0 +1,127 @@
+package levosilimo.everlastingskins.gametest;
+
+import java.util.concurrent.TimeUnit;
+import net.minecraft.gametest.framework.GameTestAssertException;
+import net.minecraft.gametest.framework.GameTestHelper;
+
+/**
+ * Shared polling assertion for GameTest packet-arrival waits (lib-47).
+ *
+ * <p>The GameTest framework runs succeedWhen/runAtEveryTick runnables once per
+ * server tick and SWALLOWS {@link GameTestAssertException} (GameTestInfo's
+ * sequence tick path catches it and retries next tick), so a throwing
+ * assertion is the idiom for "keep waiting". The framework only converts that
+ * swallow into a test failure when the TICK budget (timeoutTicks/maxTicks)
+ * runs out — at which point the strict timeout path reports the last
+ * transient assertion message ("target player must receive at least 1
+ * ADD_PLAYER ..., got 0") as the failure. Wall-clock deadlines implemented
+ * with plain GameTestAssertException are equally ineffective: they are
+ * swallowed too. That let packet-arrival asserts race the tick budget instead
+ * of a wall-clock deadline (skinset_selfreceivesbroadcast on forge-1.21 /
+ * 1.21.4, concurrent_skin_set_two_players on forge-26.2, all on loaded CI
+ * runners).
+ *
+ * <p>This helper fixes the deadline side. Create ONE {@link Deadline} outside
+ * the succeedWhen lambda and use it for the whole wait:
+ *
+ * <pre>{@code
+ * PacketAssert.Deadline deadline = PacketAssert.deadline(20_000);
+ * helper.succeedWhen(() -> {
+ *     PacketAssert.checkDeadline(helper, deadline, "self-reception packet");
+ *     ...
+ *     PacketAssert.assertEventually(helper, deadline, () -> {
+ *         long count = countAddPlayerUpdatesWithTextures(drain(playerA), playerId);
+ *         if (count < 1) {
+ *             throw new GameTestAssertException("... got " + count);
+ *         }
+ *     });
+ * });
+ * }</pre>
+ *
+ * <p>While the deadline holds, failures rethrow as
+ * {@link GameTestAssertException} (swallowed, re-polled next tick); once it
+ * passes, the helper fails the test via {@link GameTestHelper#fail(String)} —
+ * the framework's own failure channel — so the test fails AT the wall-clock
+ * deadline with a clear timeout message instead of surfacing a transient
+ * "got 0" from a race the framework would have tolerated a tick later.
+ */
+public final class PacketAssert {
+
+    private PacketAssert() {
+    }
+
+    /** Wall-clock deadline for a packet-arrival wait. Create once, reuse across polls. */
+    public static Deadline deadline(long timeoutMs) {
+        return new Deadline(timeoutMs);
+    }
+
+    /**
+     * Runs {@code assertion} once. On {@link GameTestAssertException} with time
+     * remaining, rethrows it so the framework's per-tick swallow path re-polls
+     * next tick; when the deadline has passed, fails the test via the helper
+     * instead. MUST be called from the server thread (test body or a
+     * succeedWhen poll) and share a single {@link Deadline} across polls —
+     * a fresh deadline per poll would never expire.
+     */
+    public static void assertEventually(GameTestHelper helper, Deadline deadline, Runnable assertion) {
+        try {
+            assertion.run();
+        } catch (GameTestAssertException failure) {
+            if (deadline.expired()) {
+                helper.fail("timed out after " + deadline.timeoutMs + "ms waiting: " + failure.getMessage());
+            } else {
+                throw failure;
+            }
+        }
+    }
+
+    /**
+     * Fails the test via the helper once the deadline has passed; no-op
+     * otherwise. Call at the top of a succeedWhen poll so the whole wait —
+     * not just the packet phase — is bounded by the wall-clock deadline.
+     */
+    public static void checkDeadline(GameTestHelper helper, Deadline deadline, String what) {
+        if (deadline.expired()) {
+            helper.fail("timed out after " + deadline.timeoutMs + "ms waiting for " + what);
+        }
+    }
+
+    /**
+     * One-shot convenience (no helper, no cross-poll state): runs the
+     * assertion once and rethrows {@link GameTestAssertException} while the
+     * deadline holds, or throws {@link AssertionError} once it expires. The
+     * framework's swallow path only catches GameTestAssertException, so the
+     * AssertionError surfaces as a failure even from inside a succeedWhen
+     * poll. Do NOT call this repeatedly from a succeedWhen lambda with a
+     * fresh timeout each poll — the deadline would never expire; use
+     * {@link #deadline(long)} + {@link #assertEventually(GameTestHelper,
+     * Deadline, Runnable)} instead.
+     */
+    public static void assertEventually(Runnable assertion, long timeoutMs) {
+        Deadline deadline = deadline(timeoutMs);
+        try {
+            assertion.run();
+        } catch (GameTestAssertException failure) {
+            if (deadline.expired()) {
+                throw new AssertionError(
+                        "timed out after " + timeoutMs + "ms waiting: " + failure.getMessage(), failure);
+            }
+            throw failure;
+        }
+    }
+
+    /** Shared wall-clock deadline; created by {@link #deadline(long)}. */
+    public static final class Deadline {
+        private final long timeoutMs;
+        private final long deadlineNanos;
+
+        private Deadline(long timeoutMs) {
+            this.timeoutMs = timeoutMs;
+            this.deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMs);
+        }
+
+        boolean expired() {
+            return System.nanoTime() > deadlineNanos;
+        }
+    }
+}


### PR DESCRIPTION
## What

lib-47: systemic GameTest packet-arrival flake — 4 failures across 3 lanes:
- `skinSet_selfReceivesBroadcast` (forge-1.21, forge-1.21.4)
- `concurrentSkinSet_twoPlayers` (forge-26.2)

Failure: "target player must receive at least 1 ADD_PLAYER (self-reception), got 0" / "observerA expected 1 packet, got 0".

## Root cause (verified against vanilla 1.21 GameTestInfo bytecode)

- The framework's per-tick sequence path **swallows GameTestAssertException** (retries next tick) — that's why the throw-to-poll idiom works.
- But when the **tick budget** (timeoutTicks/maxTicks) runs out, the strict timeout path runs the sequence once more with fail-on-exception — surfacing the **last transient assertion message** instead of a timeout.
- Wall-clock deadlines implemented as GameTestAssertException (`throwIfPastDeadline`) are **swallowed too** — the deadline was a no-op; the tick budget always won.
- `skinSet_selfReceivesBroadcast` had only `timeoutTicks=200` (~0.5s at CPU-speed ticks) for an async fetch + server.execute broadcast + netty flush chain → raced on loaded CI runners.

## Fix

- **NEW** `forge-test-shared/.../gametest/PacketAssert.java`: shared wait-for-packet helper with a wall-clock deadline. While the deadline holds, failures rethrow as GameTestAssertException (swallowed → re-polled next tick); at the deadline it fails the test via `helper.fail(...)` — the framework's own failure channel, so the test fails AT the deadline with a clear timeout message.
- Convention: gametest source set shares the PacketAssert package dir (version-independent — no forge21.* imports, so not gated on `minecraft.unobfuscated` like the test-source-set share).
- `skinSet_selfReceivesBroadcast` (1.21 + 1.21.4): `timeoutTicks` 200 → 60000 + 20s PacketAssert deadline.
- `concurrentSkinSet_twoPlayers` (26.2): `throwIfPastDeadline` replaced with fail-hard `PacketAssert.checkDeadline`; packet-count phase wrapped in `PacketAssert.assertEventually`.

## Verification

- forge-1.21: 34/34 gametests passed, **10x loop all green**
- forge-1.21.4: 34/34 passed
- forge-26.2: 35/35 passed (includes concurrent_skin_set_two_players)