### PR TITLE
ci: fix publish.yml workflow file issue

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,6 @@ name: Publish
 
 permissions:
   contents: write
-  releases: write
 
 on:
   push:
@@ -27,7 +26,10 @@ jobs:
     name: Publish (${{ matrix.game-version }})
     runs-on: ubuntu-24.04
     timeout-minutes: 45
-    if: startsWith(github.ref_name, matrix.prefix)
+    # NOTE: the tag gate lives on the steps, NOT the job: GitHub's
+    # context-availability table excludes `matrix` from jobs.<job_id>.if,
+    # and a matrix ref there rejects the whole file at registration
+    # ("workflow file issue"). Step-level if supports matrix.
     strategy:
       fail-fast: false
       matrix:
@@ -79,10 +81,12 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build
+        if: startsWith(github.ref_name, matrix.prefix)
         run: ./gradlew :${{ matrix.module }}:build --no-daemon
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
       - name: Publish to CurseForge, Modrinth, GitHub Releases
+        if: startsWith(github.ref_name, matrix.prefix)
         uses: Kira-NT/mc-publish@52307b03863581dec6b652b83e597aec02ebb075  # v3
         with:
           curseforge-id: 538149


### PR DESCRIPTION
## Summary

Fixes the publish workflow failing with **"This run likely failed because of a workflow file issue"** on every push (zero jobs created, workflow name unparsed by GitHub).

## Root cause

The matrix job's job-level condition used the `matrix` context:

```yaml
if: startsWith(github.ref_name, matrix.prefix)
```

GitHub's [context-availability table](https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability) excludes `matrix` from `jobs.<job_id>.if` — a matrix reference there rejects the entire workflow file at registration. Introduced in the M2 rework (d396eb6, 2026-08-05); the pre-M2 file used separate jobs with literal prefixes and validated fine. Every publish.yml run since (incl. the pre-#318 promote branch, run 31221357015) failed identically.

## Changes

- **Moved the tag gate onto the Build and Publish steps** (`if: startsWith(github.ref_name, matrix.prefix)`) where `matrix` is a valid context; removed the job-level `if`. Routing behavior unchanged: only the matrix combo whose prefix matches the pushed tag builds and publishes.
- **Dropped `releases: write`** from `permissions` — restores the known-good pre-M2 set (`contents: write` alone covers mc-publish GitHub Releases). The scope was added in #318 but postdates the break and is unverified.

## Verification

- yamllint clean; YAML parses
- Branch push produced **no** "workflow file issue" run (previously every branch/main push surfaced one)
- All lefthook gates green (aislop, compile, test-count 433, verify-no-mixin, unit-tests)