### PR TITLE
ci: add GameTest (26.1) job (parity with 26.2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -471,6 +471,42 @@ jobs:
             --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED
             -Dio.netty.tryReflectionSetAccessible=true"
 
+  # ── GameTest on 26.1 (new MC major line) ──────────────────────
+  gametest-261:
+    name: GameTest (26.1)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: lint-yaml
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
+      - name: Set up JDK 25
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961  # v5
+        with:
+          java-version: 25
+          distribution: temurin
+      - name: Cache Gradle wrapper and caches
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5
+        with:
+          path: |
+            ~/.gradle/wrapper/dists
+            ~/.gradle/caches
+          key: gradle-${{ runner.os }}-m2-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-m2-
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Run GameTest (skin visibility packets)
+        run: ./gradlew :forge-26.1:runGameTestServer --no-daemon --console=plain
+        timeout-minutes: 30
+        env:
+          GRADLE_OPTS: >-
+            -Dorg.gradle.jvmargs="-Dfile.encoding=UTF-8
+            --add-opens=java.base/java.lang=ALL-UNNAMED
+            --add-opens=java.base/java.nio=ALL-UNNAMED
+            --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
+            --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED
+            -Dio.netty.tryReflectionSetAccessible=true"
+
   # ── aislop quality gate (same scanner as the pre-commit hook) ─
   aislop:
     name: aislop (M2)


### PR DESCRIPTION
Mirrors gametest-262 for the new forge-26.1 lane (Java 25, timeout 30). NOT a required context — informational parity job.