### PR TITLE
ci: CI-IMPROVEMENT-ROADMAP P0 yaml batch (test-count gate once, GameTest timeout, cache keys)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,14 +71,18 @@ jobs:
           path: |
             ~/.gradle/wrapper/dists
             ~/.gradle/caches
-          key: gradle-${{ runner.os }}-m2-${{ hashFiles('**/gradle-wrapper.properties') }}
+          key: gradle-${{ runner.os }}-m2-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: |
             gradle-${{ runner.os }}-m2-
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Verify test count meets minimum
+        # CI-IMPROVEMENT-ROADMAP P0-5: run once on the common leg instead of
+        # once per matrix leg (8 identical greps today). Regex aligned with
+        # scripts/test-count-gate.sh (@Test OR @ParameterizedTest).
+        if: matrix.mc == "common"
         run: |
-          COUNT=$(grep -r "@Test" --include="*.java" common/src forge-1.21/src 2>/dev/null | wc -l)
+          COUNT=$(grep -rE "@(Test|ParameterizedTest)\b" --include="*.java" common/src forge-1.21/src 2>/dev/null | wc -l)
           echo "Test count: $COUNT"
           if [ "$COUNT" -lt 150 ]; then
             echo "ERROR: Test count dropped below 150 (got $COUNT)"
@@ -394,7 +398,7 @@ jobs:
   gametest-121:
     name: GameTest (1.21)
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: 30
     needs: lint-yaml
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
@@ -409,14 +413,19 @@ jobs:
           path: |
             ~/.gradle/wrapper/dists
             ~/.gradle/caches
-          key: gradle-${{ runner.os }}-m2-gametest-${{ hashFiles('**/gradle-wrapper.properties') }}
+          key: gradle-${{ runner.os }}-m2-gametest-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: |
             gradle-${{ runner.os }}-m2-
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Run GameTest (skin visibility packets)
+        # CI-IMPROVEMENT-ROADMAP P1-8: 15 min is correct for a warm cache but
+        # turns a cold-cache PR run into a guaranteed red check + manual
+        # re-run (fix-10: cancelled at 15m15s on PR #314 cold cache; warm runs
+        # finish in 2.5-6 min). 30 min bounds the runaway case while
+        # tolerating cache misses.
         run: ./gradlew :forge-1.21:runGameTestServer --no-daemon --console=plain
-        timeout-minutes: 15
+        timeout-minutes: 30
         env:
           GRADLE_OPTS: >-
             -Dorg.gradle.jvmargs="-Dfile.encoding=UTF-8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
         # CI-IMPROVEMENT-ROADMAP P0-5: run once on the common leg instead of
         # once per matrix leg (8 identical greps today). Regex aligned with
         # scripts/test-count-gate.sh (@Test OR @ParameterizedTest).
-        if: matrix.mc == "common"
+        if: matrix.mc == 'common'
         run: |
           COUNT=$(grep -rE "@(Test|ParameterizedTest)\b" --include="*.java" common/src forge-1.21/src 2>/dev/null | wc -l)
           echo "Test count: $COUNT"


### PR DESCRIPTION
## Summary

Yaml-only CI batch from CI-IMPROVEMENT-ROADMAP (P0 + P1-8 evidence-backed items). Audit found P0-1/P0-2/P0-3/P0-4(ci.yml) already landed (#318); two P0 items remained, plus the P1-8 carryover.

## Changes (3 yaml edits, all in ci.yml)

1. **P0-5 — test-count gate runs once** (was: 8 identical greps, one per matrix leg)
   - `if: matrix.mc == "common"` on the Verify-test-count step
   - Regex aligned with `scripts/test-count-gate.sh`: `@(Test|ParameterizedTest)\b` (was `@Test` only; count 393 ≥ 150 verified)
2. **P1-8 — GameTest (1.21) timeout 15 → 30 min** (job + step)
   - fix-10 evidence: cancelled at 15m15s on PR #314 cold cache; warm runs finish in 2.5–6 min
3. **P1-8 — cache keys scoped to root wrapper** for build matrix + gametest-121
   - `hashFiles('**/gradle-wrapper.properties')` → `hashFiles('gradle/wrapper/gradle-wrapper.properties')`; any out-of-band lane wrapper change no longer invalidates the M2 cache for all six matrix legs
   - restore-keys (`gradle-${{ runner.os }}-m2-`) prefix-match the old keys, so existing caches remain reachable — no cold-cache regression on merge

## Explicitly NOT changed

- **publish.yml permissions** (roadmap P0-4): the prescribed `releases: write` is **not a valid key** in the Actions `permissions:` block (verified against GitHub workflow-syntax docs). Adding it would fail workflow registration and block ALL tag releases. Current `permissions: contents: write` already covers GitHub Releases — leave as-is.
- **concurrency block**: already present and correct for the push+PR trigger set (`github.ref` is unique per PR).

## Validation

- yamllint strict (repo config): PASS
- pyyaml parse: PASS
- pre-commit hooks (aislop, compile, test-count 433, verify-no-mixin): PASS
- act not available locally; CI's YAML Lint job will re-verify on the PR run

No branch-protection contract changes (no job names added/removed).
