### PR TITLE
ci(workflow): P1-6 mc1.12.2 real E2E + vendored harness diff-guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -395,23 +395,25 @@ jobs:
           if-no-files-found: warn
 
   # ── E2E (mc1.12.2) required-check contract ─────────────────────
-  # The old per-branch required-check contract names `E2E (mc1.12.2)`
-  # as a status context; keep that exact check name present on
-  # main (future-proofing, memory #1212). The real
-  # HeadlessMC boot smoke runs on the mc1.12.2 branch; this lane runs
-  # a minimal placeholder against forge-1.21, where the headlessmc
-  # tests live in the M2 tree.
+  # P1-6 (CI-IMPROVEMENT-ROADMAP, lib-11): the REAL mc1.12.2 E2E now runs
+  # here — the placeholder stub is retired. mc1.12.2/test-infrastructure/
+  # run-e2e.sh builds the lane, boots a real Forge 14.23.5.2847 server
+  # with the mod, launches a HeadlessMC client (TestPlayer) under xvfb,
+  # and asserts on the server log that the server booted, the client
+  # joined, and the FML handshake mod-list line names everlastingskins.
+  # Requires JDK 8 (FG 2.3.4 / Gradle 4.10.3 lane); the required-check
+  # name `E2E (mc1.12.2)` is preserved verbatim for the contract.
   e2e-mc1_12_2:
     name: E2E (mc1.12.2)
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: 45
     needs: lint-yaml
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
-      - name: Set up JDK 21
+      - name: Set up JDK 8
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961  # v5
         with:
-          java-version: 21
+          java-version: "8"
           distribution: temurin
       - name: Cache Gradle wrapper and caches
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5
@@ -419,13 +421,36 @@ jobs:
           path: |
             ~/.gradle/wrapper/dists
             ~/.gradle/caches
-          key: gradle-${{ runner.os }}-m2-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+          key: gradle-${{ runner.os }}-mc1.12.2-${{ hashFiles('**/gradle-wrapper.properties') }}
           restore-keys: |
-            gradle-${{ runner.os }}-m2-
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-      - name: Headless smoke placeholder (required-check contract stub)
-        run: echo "E2E (mc1.12.2) placeholder — real HeadlessMC boot smoke runs on the mc1.12.2 fork branch"
+            gradle-${{ runner.os }}-mc1.12.2-
+      - name: Cache E2E downloads (Forge installers, HeadlessMC, client profile)
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5
+        with:
+          path: |
+            ~/.cache/everlastingskins
+            ~/.minecraft
+            mc1.12.2/test-infrastructure/headlessmc
+          key: e2e-mc1.12.2-${{ runner.os }}
+          restore-keys: |
+            e2e-mc1.12.2-${{ runner.os }}-
+      - name: Run real mc1.12.2 E2E (server boot + headless client join)
+        run: bash mc1.12.2/test-infrastructure/run-e2e.sh mc1.12.2
+
+  # ── Vendored harness diff-guard (lib-12) ───────────────────────
+  # Fails when a vendored SpecialSource harness lane (forge-1.6.4,
+  # forge-1.5.2, future forge-1.4.7) drifts from the canonical harness
+  # beyond the allowed substitution set and the whitelisted per-lane fork
+  # lines. See scripts/ci-vendored-harness-diff-guard.sh.
+  vendored-harness-diff-guard:
+    name: Vendored harness diff-guard
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    needs: lint-yaml
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
+      - name: Run vendored harness diff-guard
+        run: bash scripts/ci-vendored-harness-diff-guard.sh
 
   # ── GameTest on 1.21 (canonical gametest subproject) ──────────
   gametest-121:

--- a/mc1.12.2/test-infrastructure/run-e2e.sh
+++ b/mc1.12.2/test-infrastructure/run-e2e.sh
@@ -29,13 +29,23 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 
+# Monorepo layout: the script lives at mc1.12.2/test-infrastructure/, so
+# PROJECT_DIR is already the lane dir and BRANCH_DIR must not be
+# re-appended. The fork layout keeps test-infrastructure/ beside the lane
+# dir; keep the legacy PROJECT_DIR/$BRANCH_DIR join for that case.
+if [ "$(basename "$PROJECT_DIR")" = "$BRANCH_DIR" ]; then
+    LANE_DIR="$PROJECT_DIR"
+else
+    LANE_DIR="$PROJECT_DIR/$BRANCH_DIR"
+fi
+
 echo "=== EverlastingSkins E2E Test ==="
 echo "Branch:    $BRANCH (MC $MC_VERSION, Forge $FORGE_VERSION)"
 echo
 
 # 1. Build the mod
 echo "[1/6] Building mod..."
-cd "$PROJECT_DIR/$BRANCH_DIR"
+cd "$LANE_DIR"
 if [ ! -x gradlew ]; then
     chmod +x gradlew
 fi

--- a/scripts/canonical/vendored-harness-normalized.txt
+++ b/scripts/canonical/vendored-harness-normalized.txt
@@ -1,116 +1,35 @@
-// forge-LANE — standalone vendored-deobf build for the Minecraft MCVER lane.
-//
-// LANE SEPARATION (out-of-band, per monorepo doctrine): this lane cannot use
-// any ForgeGradle. fix-3 (2026-08-08) verified empirically that GTNH FG
-// 1.2.11 rejects forge FORGEVER at configuration time, MCP-Archive has
-// zero MCVER channels, and de.oceanlabs.mcp:mcp:MCVER 404s on the Forge
-// maven. So the lane toolchain IS the vendored remap harness proven by the
-// 0.5-day SpecialSource spike (feature/lane-forge-LANE-vendored-spike,
-// 3d30c29): remap-only (SpecialSource 1.7.4 bytecode remapping against the
-// MCP MCPVER conf bundled in the forge src zip), no decompiler, no FG, no
-// jitpack, no archive.org. This build is its own wrapper (Gradle 4.4.1,
-// Java 8 ONLY), never included in settings.gradle.kts, no buildSrc, no
-// `everlastingskins.forge-module` convention, no dependency-analysis
-// (out-of-band policy, same as forge-1.7.10 / forge-1.8.9 / mc1.12.2).
-//
-// NAME DOMAINS (empirical, spike-verified against the piston server jar):
-//   - production runtime = OBFUSCATED. minecraft_server.MCVER.jar ships
-//     proguard names: root-package classes (`ea`, `ey`, ...) EXCEPT identity
-//     classes like net/minecraft/server/MinecraftServer which keep their
-//     names; members are always obf (MinecraftServer.F(), Packet250CustomPayload
-//     field `a`). FMLDeobfTweaker registers an empty remapper in production
-//     (identity), so the shipped mod jar MUST be reobfuscated to this domain.
-//   - MCP MCPVER conf (bundled in forge-LANE-FORGEVER-src.zip at
-//     forge/fml/conf/, version.cfg asserts MCPVersion = MCPVER): joined.srg CL
-//     lines map obf-class -> srg-class (net/minecraft/src/*); MD lines key by
-//     (obf-owner, obf-method, OBF-desc) and carry per-side #C/#S variants;
-//     FD lines key by (obf-owner, obf-field). methods.csv/fields.csv map
-//     func_/field_ -> readable deobf names.
-//   - THE UNIVERSAL JAR IS OBF-DOMAIN FOR CLASSES AND FIELDS, READABLE FOR
-//     METHODS (spike javap of the RAW jar: `Method ka.sendPacketToPlayer`,
-//     `Field jv.a`, `registerServerCommand(ab)`). The spike's separate
-//     srg->deobf pass with an EMPTY CL map therefore remapped nothing FML
-//     uses — the stub compiled only because it never touched an FML API
-//     whose signature mentions an MC type. The lane implements
-//     IPacketHandler / IConnectionHandler / ICommand, so the universal jar
-//     MUST be remapped with the same obf->deobf CL+FD map as the server jar
-//     (class refs cm/ea/ab/jv/ka/ey -> net/minecraft/src/*, field refs like
-//     jv.a -> EntityPlayerMP.playerNetServerHandler); readable method refs
-//     simply have no MD entry and pass through untouched.
-//   - dev classpath = build/deobf/merged-deobf.jar (server.jar obf->deobf +
-//     universal.jar obf->deobf, merged). Ship artifact = the mod jar
-//     reobf'd deobf->obf (composite: csv reverse + joined.srg reverse).
-
 plugins {
     id 'java'
 }
-
 version = "${mod_version}"
-group = 'levosilimo.everlastingskins'
 archivesBaseName = 'everlastingskins-LANE'
-
 sourceCompatibility = targetCompatibility = JavaVersion.VERSION_1_8
-
 repositories {
     mavenCentral()
-    // authlib is NOT on the MCVER server classpath (verified: no authlib in
-    // install_profile.json / piston-meta MCVER.json — it arrived in later MC
-    // lines) and NOT on mavenCentral; Mojang's own maven hosts it. Needed at
-    // compile time because :common's CustomSkinProperty binds authlib's
-    // Property type (compile-only; runtime caveat documented above).
     maven {
         name = 'minecraft-libraries'
         url = 'https://libraries.minecraft.net'
     }
 }
-
 configurations {
-    // SpecialSource 1.7.4 + its transitives (asm-debug-all 5.1, jopt-simple
-    // 5.0.1, guava 19.0) — resolved from mavenCentral, hash-verified by
-    // Gradle. This is the ONLY toolchain dependency; the buildscript block
-    // (and its FG/jitpack/forge-maven repos) is intentionally absent.
     specialsource
 }
-
-// Harness output paths (defined before `dependencies` so the lazy
-// `compile files(...)` reference can see them).
 def mappingDir = file("$buildDir/mappings")
 def obfToDeobfSrg = file("$mappingDir/obf-to-deobf.srg")
 def deobfToObfSrg = file("$mappingDir/deobf-to-obf.srg")
 def deobfServerJar = file("$buildDir/deobf/server-deobf.jar")
 def deobfUniversalJar = file("$buildDir/deobf/universal-deobf.jar")
 def mergedDeobfJar = file("$buildDir/deobf/merged-deobf.jar")
-
 dependencies {
     specialsource 'net.md-5:SpecialSource:1.7.4'
-
-    // :common is consumed by source-dir sharing and binds three Maven
-    // artifacts at compile time that the MCVER server does NOT ship
-    // (verified against install_profile.json + piston-meta MCVER.json —
-    // authlib and log4j2 arrived in later MC lines; gson IS on the MCVER
-    // classpath at 2.2.2). Rule-4 lane decision: declare them explicitly
-    // with the exact MCVER-era versions. Runtime note (documented in the
-    // coverage report): a deployment must add authlib + log4j-api jars to
-    // the server classpath, since the mod (like every lane) stores
-    // :common's authlib-backed CustomSkinProperty.
-    compile 'com.google.code.findbugs:jsr305:3.0.2'          // :common @Nullable (not on MCVER classpath)
-    compile 'com.google.code.gson:gson:2.2.2'                // :common SkinIO/JsonUtils (exact MCVER version)
-    compile 'com.mojang:authlib:1.5.16'                      // :common CustomSkinProperty (hosted on libraries.minecraft.net)    compile 'org.apache.logging.log4j:log4j-api:2.8.1'       // :common LogManager (not on MCVER classpath)
-
-    // The merged-deobf jar (MC + FML + Forge) is produced by deobfClasspath;
-    // `compile files(...)` resolves lazily, after the producing task runs.
+    compile 'com.google.code.findbugs:jsr305:3.0.2'
+    compile 'com.google.code.gson:gson:2.2.2'
+    compile 'com.mojang:authlib:1.5.16'
+    compile 'org.apache.logging.log4j:log4j-api:2.8.1'
     compile files(mergedDeobfJar)
-
-    // Rule 4 lane decision: JUnit 4.13.2 + mockito-core 2.28.2, mirroring
-    // forge-1.7.10 (Gradle 4.4.1 floor; 4.4.1 lanes use JUnit 4).
     testCompile 'junit:junit:4.13.2'
     testCompile 'org.mockito:mockito-core:2.28.2'
 }
-
-// :common is consumed by source-dir sharing: this is a standalone build and
-// cannot use project(":common"). Classes that also exist under src/main/java
-// must be deleted from the lane — javac fails on the duplicate via the share
-// (Rule 1; :common is canonical).
 sourceSets {
     main {
         java {
@@ -123,30 +42,20 @@ sourceSets {
         }
     }
 }
-
-// ---------------------------------------------------------------------------
-// Vendored inputs (resolveVendored)
-// ---------------------------------------------------------------------------
-// Cache dir mirrors the forge-1.7.10 jitpack vendor-fallback pattern: files
-// land outside the repo (under the Gradle user home) and can be pre-seeded
-// for offline builds. Override with -Pvendored.dir=<path>; force offline
-// with -Pvendored.offline (fails instead of downloading).
 def vendoredDir = project.hasProperty('vendored.dir')
     ? file(project.property('vendored.dir'))
     : file("${gradle.gradleUserHomeDir}/everlastingskins-vendored/MCVER")
-
 def vendoredInputs = [
     [name: 'forge-LANE-FORGEVER-src.zip',
      url: 'https://maven.minecraftforge.net/net/minecraftforge/forge/MCVER-FORGEVER/forge-LANE-FORGEVER-src.zip',
      algo: 'MD5', digest: 'DIGEST'],
-    [name: 'forge-LANE-FORGEVER-universal.jar',
-     url: 'https://maven.minecraftforge.net/net/minecraftforge/forge/MCVER-FORGEVER/forge-LANE-FORGEVER-universal.jar',
+    [name: 'forge-LANE-FORGEVER-universal.ART',
+     url: 'https://maven.minecraftforge.net/net/minecraftforge/forge/MCVER-FORGEVER/forge-LANE-FORGEVER-universal.ART',
      algo: 'MD5', digest: 'DIGEST'],
     [name: 'minecraft_server.MCVER.jar',
-     url: 'https://piston-data.mojang.com/v1/objects/SHA1/server.jar',
+     url: 'https://MOJANG_HOST/v1/objects/SHA1/server.jar',
      algo: 'SHA-1', digest: 'DIGEST'],
 ]
-
 def digestOf = { File f, String algo ->
     def md = java.security.MessageDigest.getInstance(algo)
     f.withInputStream { is ->
@@ -156,10 +65,7 @@ def digestOf = { File f, String algo ->
     }
     md.digest().collect { String.format('%02x', it) }.join('')
 }
-
 task resolveVendored {
-    group = 'everlastingskins'
-    description = 'Download + checksum-verify the 3 vendored inputs (forge src zip, forge universal jar, vanilla MCVER server jar) into a cache dir; pre-seed the dir or pass -Pvendored.offline for offline builds.'
     outputs.dir vendoredDir
     doLast {
         def offline = project.hasProperty('vendored.offline')
@@ -188,15 +94,8 @@ task resolveVendored {
         }
     }
 }
-
-// ---------------------------------------------------------------------------
-// MCP MCPVER conf extraction (extractMcpConf)
-// ---------------------------------------------------------------------------
 def mcpConfDir = file("$buildDir/mcpMCP")
-
 task extractMcpConf(dependsOn: resolveVendored) {
-    group = 'everlastingskins'
-    description = 'Extract the bundled MCP MCPVER conf (forge/fml/conf/*) from the forge src zip and assert MCPVersion = MCPVER'
     inputs.file { new File(vendoredDir, 'forge-LANE-FORGEVER-src.zip') }
     outputs.dir mcpConfDir
     doLast {
@@ -207,14 +106,12 @@ task extractMcpConf(dependsOn: resolveVendored) {
                 include(name: 'forge/fml/conf/**')
             }
         }
-        // Flatten the forge/fml/conf/ nesting so consumers see plain files.
         def nested = new File(mcpConfDir, 'forge/fml/conf')
         if (!nested.isDirectory()) {
             throw new GradleException("extractMcpConf: no forge/fml/conf/ in ${srcZip.name}")
         }
         nested.listFiles().each { f -> f.renameTo(new File(mcpConfDir, f.name)) }
         delete new File(mcpConfDir, 'forge')
-
         ['joined.srg', 'methods.csv', 'fields.csv', 'params.csv', 'packages.csv', 'version.cfg'].each { name ->
             if (!new File(mcpConfDir, name).isFile()) {
                 throw new GradleException("extractMcpConf: missing ${name} after extraction")
@@ -227,12 +124,6 @@ task extractMcpConf(dependsOn: resolveVendored) {
         logger.lifecycle('extractMcpConf: MCP MCPVER conf extracted and asserted (MCPVersion = MCPVER, MCVER)')
     }
 }
-
-// ---------------------------------------------------------------------------
-// MCP conf parsers (shared by the mapping builders)
-// ---------------------------------------------------------------------------
-// methods.csv/fields.csv rows: searge,name,side,desc — the desc column is
-// quoted and may contain commas; only the first two fields are needed.
 def parseCsvMappings = { File csv ->
     def map = [:]
     csv.eachLine('UTF-8') { line, idx ->
@@ -244,17 +135,11 @@ def parseCsvMappings = { File csv ->
     }
     map
 }
-
-// joined.srg lines (tokens after the ':' separator; trailing '#C'/'#S' side
-// tags are dropped):
-//   CL: <obfClass> <srgClass>
-//   MD: <obfOwner>/<obfMethod> <OBF-desc> <srgOwner>/<funcName> <srg-desc>
-//   FD: <obfOwner>/<obfField> <srgOwner>/<fieldName>
 def parseJoinedSrg = { File srg ->
-    def cl = [:]      // obf class -> srg class
-    def clRev = [:]   // srg class -> obf class
-    def md = [:]      // [obfOwner, obfMethod, obfDesc] -> [srgOwner, funcName, srgDesc]
-    def fd = [:]      // [obfOwner, obfField] -> [srgOwner, srgField]
+    def cl = [:]
+    def clRev = [:]
+    def md = [:]
+    def fd = [:]
     srg.eachLine('UTF-8') { line ->
         line = line.trim()
         if (line.isEmpty() || line.startsWith('#')) return
@@ -283,7 +168,6 @@ def parseJoinedSrg = { File srg ->
     }
     [cl: cl, clRev: clRev, md: md, fd: fd]
 }
-
 def writeSrgMapping = { File out, Map clMap, Map mdMap, Map fdMap ->
     def w = out.newWriter('UTF-8')
     try {
@@ -294,15 +178,12 @@ def writeSrgMapping = { File out, Map clMap, Map mdMap, Map fdMap ->
         w.close()
     }
 }
-
-// Rewrite every class reference in a descriptor to the obf domain.
 def obfifyDesc = { String desc, Map clRev ->
     desc.replaceAll(/L([^;]+);/) { m ->
         def obf = clRev[m[1]]
         obf ? "L${obf};" : m[0]
     }
 }
-
 def runSpecialSource = { String inJar, String outJar, String srgIn ->
     javaexec {
         classpath = configurations.specialsource
@@ -310,19 +191,87 @@ def runSpecialSource = { String inJar, String outJar, String srgIn ->
         args '-i', inJar, '-o', outJar, '-m', srgIn, '-q'
     }
 }
-
-// ---------------------------------------------------------------------------
-// Deobf classpath (deobfClasspath): compose the obf->deobf mapping, run
-// SpecialSource on the server jar AND the universal jar (both are
-// obf-domain for classes/fields), merge into build/deobf/merged-deobf.jar.
-// ---------------------------------------------------------------------------
+    def hier = [:]
+    new java.util.zip.ZipFile(jar).withCloseable { zf ->
+        zf.entries().each { entry ->
+            if (!entry.name.endsWith('.class')) return
+            byte[] bytes = zf.getInputStream(entry).bytes
+            def pos = 8
+            def cpCount = ((bytes[pos] & 0xFF) << 8) | (bytes[pos + 1] & 0xFF)
+            pos += 2
+            def utf8 = [:]
+            def classNames = [:]
+            def i = 1
+            while (i < cpCount) {
+                def tag = bytes[pos] & 0xFF
+                pos += 1
+                switch (tag) {
+                    case 1:
+                        def len = ((bytes[pos] & 0xFF) << 8) | (bytes[pos + 1] & 0xFF)
+                        pos += 2
+                        utf8[i] = new String(bytes, pos, len, 'UTF-8')
+                        pos += len
+                        break
+                    case 7:
+                        classNames[i] = ((bytes[pos] & 0xFF) << 8) | (bytes[pos + 1] & 0xFF)
+                        pos += 2
+                        break
+                    case 5: case 6:
+                        pos += 8
+                        i += 1
+                        break
+                    case 15:
+                        pos += 3
+                        break
+                    case 8: case 16:
+                        pos += 2
+                        break
+                    default:
+                        pos += 4
+                        break
+                }
+                i += 1
+            }
+            pos += 2
+            def thisIdx = ((bytes[pos] & 0xFF) << 8) | (bytes[pos + 1] & 0xFF)
+            def superIdx = ((bytes[pos + 2] & 0xFF) << 8) | (bytes[pos + 3] & 0xFF)
+            def thisName = utf8[classNames[thisIdx]]
+            if (thisName != null) {
+                hier[thisName] = superIdx == 0 ? null : utf8[classNames[superIdx]]
+            }
+        }
+    }
+    hier
+}
+    def subclasses = [:]
+    hier.each { name, superName ->
+        if (superName != null) {
+            def list = subclasses.get(superName, [])
+            list << name
+            subclasses[superName] = list
+        }
+    }
+    def extra = [:]
+    mdMapC.each { key, value ->
+        def owner = key[0]
+        def queue = new ArrayList(subclasses.get(owner, []) ?: [])
+        def seen = [(owner): true]
+        while (!queue.isEmpty()) {
+            def sub = queue.remove(0)
+            if (seen[sub]) continue
+            seen[sub] = true
+            def obfSub = clRevMap[sub] ?: sub
+            extra[[sub, key[1], key[2]]] = [obfSub, value[1], value[2]]
+            queue.addAll(new ArrayList(subclasses.get(sub, []) ?: []))
+        }
+    }
+    extra.each { k, v -> mdMapC[k] = v }
+}
 task deobfClasspath(dependsOn: extractMcpConf) {
-    group = 'everlastingskins'
-    description = 'Compose the obf->deobf mapping from the MCP MCPVER conf, run SpecialSource on the server jar AND the FML universal jar (both reference MC classes/fields by obf names), and merge them into build/deobf/merged-deobf.jar — the FG "minecraft" classpath equivalent.'
     inputs.dir mcpConfDir
     inputs.files {
         [new File(vendoredDir, 'minecraft_server.MCVER.jar'),
-         new File(vendoredDir, 'forge-LANE-FORGEVER-universal.jar')]
+         new File(vendoredDir, 'forge-LANE-FORGEVER-universal.ART')]
     }
     outputs.files mergedDeobfJar, deobfServerJar, deobfUniversalJar, obfToDeobfSrg, deobfToObfSrg
     doLast {
@@ -330,11 +279,6 @@ task deobfClasspath(dependsOn: extractMcpConf) {
         def fields = parseCsvMappings(new File(mcpConfDir, 'fields.csv'))
         def srg = parseJoinedSrg(new File(mcpConfDir, 'joined.srg'))
         mappingDir.mkdirs()
-
-        // --- obf -> deobf (server jar + universal jar) -------------------
-        // Bytecode refs: (obfOwner, obfMethod, OBF-desc) + (obfOwner, obfField).
-        // The conf MD input side already carries the OBF desc; the owner is
-        // obf (identity classes map to themselves via clRev fallback).
         def clMap = [:]
         def mdMap = [:]
         def fdMap = [:]
@@ -348,43 +292,14 @@ task deobfClasspath(dependsOn: extractMcpConf) {
         srg.fd.each { key, value ->
             def readable = fields[value[1]]
             if (readable == null) return
-            fdMap[[key[0], key[1]]] = [value[0], readable] // key = (obfOwner, obfField)
+            fdMap[[key[0], key[1]]] = [value[0], readable]
         }
         writeSrgMapping(obfToDeobfSrg, clMap, mdMap, fdMap)
-
-        // --- deobf -> obf (mod jar reobf, composite reverse) ------------
-        // Bytecode refs after compiling against merged-deobf.jar:
-        // (srgOwner, readable, srg-desc) + (srgOwner, readableField).
-        // Reverse each conf line through the csvs; identity classes keep
-        // their names, so they are excluded from the CL reverse map.
-        def clRevMap = [:]
-        srg.clRev.each { srgName, obf -> if (srgName != obf) clRevMap[srgName] = obf }
-        def mdMapC = [:]
-        def fdMapC = [:]
-        srg.md.each { key, value ->
-            def readable = methods[value[1]]
-            if (readable == null) return
-            def obfOwner = clRevMap[value[0]] ?: value[0]
-            mdMapC[[value[0], readable, value[2]]] = [obfOwner, key[1], obfifyDesc(value[2], clRevMap)]
-        }
-        srg.fd.each { key, value ->
-            def readable = fields[value[1]]
-            if (readable == null) return
-            def obfOwner = clRevMap[value[0]] ?: value[0]
-            fdMapC[[value[0], readable]] = [obfOwner, key[1]]
-        }
-        writeSrgMapping(deobfToObfSrg, clRevMap, mdMapC, fdMapC)
-
-        // --- remap + merge -------------------------------------------------
         new File("$buildDir/deobf").mkdirs()
         runSpecialSource(new File(vendoredDir, 'minecraft_server.MCVER.jar').absolutePath,
             deobfServerJar.absolutePath, obfToDeobfSrg.absolutePath)
-        runSpecialSource(new File(vendoredDir, 'forge-LANE-FORGEVER-universal.jar').absolutePath,
+        runSpecialSource(new File(vendoredDir, 'forge-LANE-FORGEVER-universal.ART').absolutePath,
             deobfUniversalJar.absolutePath, obfToDeobfSrg.absolutePath)
-
-        // Merge: server-deobf first, universal-deobf on top. The two jars are
-        // disjoint by construction (server: net/minecraft + leftover obf
-        // classes; universal: cpw.mods.fml + net.minecraftforge).
         def seen = new HashSet()
         mergedDeobfJar.withOutputStream { os ->
             def zos = new java.util.zip.ZipOutputStream(os)
@@ -402,49 +317,46 @@ task deobfClasspath(dependsOn: extractMcpConf) {
                 zos.close()
             }
         }
-        logger.lifecycle("deobfClasspath: ${mergedDeobfJar.name} built (server obf->deobf + universal obf->deobf)")
+        def clRevMap = [:]
+        srg.clRev.each { srgName, obf -> if (srgName != obf) clRevMap[srgName] = obf }
+        def mdMapC = [:]
+        def fdMapC = [:]
+        srg.md.each { key, value ->
+            def readable = methods[value[1]]
+            if (readable == null) return
+            def obfOwner = clRevMap[value[0]] ?: value[0]
+            mdMapC[[value[0], readable, value[2]]] = [obfOwner, key[1], obfifyDesc(value[2], clRevMap)]
+        }
+        srg.fd.each { key, value ->
+            def readable = fields[value[1]]
+            if (readable == null) return
+            def obfOwner = clRevMap[value[0]] ?: value[0]
+            fdMapC[[value[0], readable]] = [obfOwner, key[1]]
+        }
+        writeSrgMapping(deobfToObfSrg, clRevMap, mdMapC, fdMapC)
     }
 }
-
-// ---------------------------------------------------------------------------
-// Compile (compileJava): javac against merged-deobf.jar + declared deps.
-// ---------------------------------------------------------------------------
 compileJava {
     dependsOn deobfClasspath
     options.encoding = 'UTF-8'
 }
-
-// ---------------------------------------------------------------------------
-// @Mod version constant (generateVersionSource)
-// ---------------------------------------------------------------------------
-// The @Mod annotation needs a compile-time version constant; without FG's
-// `replace` token, a generated source keeps @Mod's version in sync with
-// gradle.properties mod_version (mcmod.info is expanded separately in
-// processResources).
 def versionSourceDir = file("$buildDir/generated/version")
-
 task generateVersionSource {
-    group = 'everlastingskins'
-    description = 'Generate ModVersion.VERSION from gradle.properties mod_version (no FG replace on this harness).'
     outputs.dir versionSourceDir
     doLast {
         def f = new File(versionSourceDir, 'levosilimo/everlastingskins/forgePKG/ModVersion.java')
         f.parentFile.mkdirs()
         f.text = """package levosilimo.everlastingskins.forgePKG;
-
 /** Generated from gradle.properties mod_version — keeps @Mod's version in sync. */
 public final class ModVersion {
     public static final String VERSION = "${project.version}";
-
     private ModVersion() {}
 }
 """
     }
 }
-
 sourceSets.main.java.srcDir versionSourceDir
 compileJava.dependsOn generateVersionSource
-
 jar {
     manifest {
         attributes([
@@ -457,7 +369,6 @@ jar {
         ])
     }
 }
-
 processResources {
     from(sourceSets.main.resources.srcDirs) {
         include 'mcmod.info'
@@ -467,13 +378,7 @@ processResources {
         exclude 'mcmod.info'
     }
 }
-
-// ---------------------------------------------------------------------------
-// Reobf (reobf): composite deobf->obf remap of the mod jar, in place.
-// ---------------------------------------------------------------------------
 task reobf(dependsOn: [jar, deobfClasspath]) {
-    group = 'everlastingskins'
-    description = 'Reobfuscate the mod jar deobf->obf (csv reverse + joined.srg reverse) with SpecialSource — production runs obfuscated, so the ship artifact must be obf-named.'
     inputs.file jar.archivePath
     inputs.file deobfToObfSrg
     outputs.file jar.archivePath
@@ -486,13 +391,7 @@ task reobf(dependsOn: [jar, deobfClasspath]) {
         logger.lifecycle("reobf: ${inJar.name} remapped deobf->obf")
     }
 }
-
-// ---------------------------------------------------------------------------
-// Self-check (assertNameDomain): javap the reobf'd mod jar and fail on any
-// leaked srg/deobf MC reference.
-// ---------------------------------------------------------------------------
 task assertNameDomain(dependsOn: reobf) {
-    group = 'verification'
     doLast {
         def jarFile = jar.archivePath
         def classes = []
@@ -504,11 +403,9 @@ task assertNameDomain(dependsOn: reobf) {
             }
         }
         if (classes.isEmpty()) throw new GradleException("assertNameDomain: no classes in ${jarFile}")
-
         def javapBin = new File(System.getProperty('java.home'), 'bin/javap')
         if (!javapBin.isFile()) javapBin = new File(System.getProperty('java.home'), '../bin/javap')
         if (!javapBin.isFile()) throw new GradleException("assertNameDomain: javap not found (${javapBin})")
-
         def out = new ByteArrayOutputStream()
         def javapArgs = [javapBin.absolutePath, '-c', '-p', '-classpath', jarFile.absolutePath] + classes
         exec {
@@ -517,12 +414,12 @@ task assertNameDomain(dependsOn: reobf) {
             errorOutput = out
         }
         def text = out.toString('UTF-8')
-
-        // Leaked-domain tokens. net/minecraft/src/ is the renamed-class srg
-        // package (any such ref is a missed CL remap); func_/field_ are srg
-        // member names; the owner-qualified MC member surfaces must be obf
-        // .channel -> a). FML API names (getServer, registerChannel) are
-        // never obfuscated and are excluded by the owner qualification.
+                         'getCommandSenderName',
+                         'getConfigurationManager',
+                         'net/minecraft/server/MinecraftServer.getFile',
+                         'playerNetServerHandler',
+                         'netManager',
+                         'playerEntityList']
         if (!offenders.isEmpty()) {
             throw new GradleException(
                 "assertNameDomain FAILED: leaked srg/deobf references in ${jarFile.name}: ${offenders.join(', ')}\n" +
@@ -532,23 +429,15 @@ task assertNameDomain(dependsOn: reobf) {
         logger.lifecycle("assertNameDomain: ${jarFile.name} is fully obf-named (no func_, field_, or net/minecraft/src/ refs)")
     }
 }
-
-// ---------------------------------------------------------------------------
-// no-mixin gate (inlined from buildSrc no-mixin.gradle.kts via the
-// forge-1.7.10/build.gradle:135-209 template, which this standalone build
-// cannot reference)
-// ---------------------------------------------------------------------------
 def bannedLiterals = [
     [label: 'mixingradle coordinate', literal: 'org.spongepowered' + ':mixingradle'],
     [label: 'mixin plugin id', literal: 'org.spongepowered' + '.mixin'],
     [label: 'mixin config bundling', literal: 'everlastingskins' + '.mixins.json'],
 ]
-
 def bannedPatterns = [
     [label: 'Mixin annotation', pattern: java.util.regex.Pattern.compile('@' + 'Mixin' + '\\b')],
     [label: 'mixin block', pattern: java.util.regex.Pattern.compile('^\\s*' + 'mixin' + '\\s*\\{')],
 ]
-
 def scanFile = { File file, List<String> offenders ->
     if (!file.isFile()) return
     def text = file.getText('UTF-8')
@@ -565,14 +454,9 @@ def scanFile = { File file, List<String> offenders ->
         }
     }
 }
-
 task verifyNoMixin {
-    group = 'verification'
-    description = 'Fails the build if any Mixin usage is detected: annotations, mixingradle, the mixin plugin id, mixin {} blocks, or mixins.json bundling.'
-
     doLast {
         def offenders = []
-
         def sourceRoots = []
         sourceSets.each { ss ->
             ss.allSource.srcDirs.each { dir ->
@@ -586,12 +470,10 @@ task verifyNoMixin {
                 }
             }
         }
-
         ['build.gradle', 'settings.gradle', 'gradle.properties'].each { name ->
             def f = new File(projectDir, name)
             if (f.isFile()) scanFile(f, offenders)
         }
-
         if (!offenders.isEmpty()) {
             throw new GradleException(
                 "Mixin policy violated:\n" +
@@ -604,11 +486,9 @@ task verifyNoMixin {
         logger.lifecycle('Mixin check passed: zero Mixin annotations, zero mixingradle references.')
     }
 }
-
 test {
     testLogging {
         events "passed", "skipped", "failed"
     }
 }
-
 build.dependsOn verifyNoMixin, assertNameDomain

--- a/scripts/canonical/vendored-harness-normalized.txt
+++ b/scripts/canonical/vendored-harness-normalized.txt
@@ -1,0 +1,614 @@
+// forge-LANE — standalone vendored-deobf build for the Minecraft MCVER lane.
+//
+// LANE SEPARATION (out-of-band, per monorepo doctrine): this lane cannot use
+// any ForgeGradle. fix-3 (2026-08-08) verified empirically that GTNH FG
+// 1.2.11 rejects forge FORGEVER at configuration time, MCP-Archive has
+// zero MCVER channels, and de.oceanlabs.mcp:mcp:MCVER 404s on the Forge
+// maven. So the lane toolchain IS the vendored remap harness proven by the
+// 0.5-day SpecialSource spike (feature/lane-forge-LANE-vendored-spike,
+// 3d30c29): remap-only (SpecialSource 1.7.4 bytecode remapping against the
+// MCP MCPVER conf bundled in the forge src zip), no decompiler, no FG, no
+// jitpack, no archive.org. This build is its own wrapper (Gradle 4.4.1,
+// Java 8 ONLY), never included in settings.gradle.kts, no buildSrc, no
+// `everlastingskins.forge-module` convention, no dependency-analysis
+// (out-of-band policy, same as forge-1.7.10 / forge-1.8.9 / mc1.12.2).
+//
+// NAME DOMAINS (empirical, spike-verified against the piston server jar):
+//   - production runtime = OBFUSCATED. minecraft_server.MCVER.jar ships
+//     proguard names: root-package classes (`ea`, `ey`, ...) EXCEPT identity
+//     classes like net/minecraft/server/MinecraftServer which keep their
+//     names; members are always obf (MinecraftServer.F(), Packet250CustomPayload
+//     field `a`). FMLDeobfTweaker registers an empty remapper in production
+//     (identity), so the shipped mod jar MUST be reobfuscated to this domain.
+//   - MCP MCPVER conf (bundled in forge-LANE-FORGEVER-src.zip at
+//     forge/fml/conf/, version.cfg asserts MCPVersion = MCPVER): joined.srg CL
+//     lines map obf-class -> srg-class (net/minecraft/src/*); MD lines key by
+//     (obf-owner, obf-method, OBF-desc) and carry per-side #C/#S variants;
+//     FD lines key by (obf-owner, obf-field). methods.csv/fields.csv map
+//     func_/field_ -> readable deobf names.
+//   - THE UNIVERSAL JAR IS OBF-DOMAIN FOR CLASSES AND FIELDS, READABLE FOR
+//     METHODS (spike javap of the RAW jar: `Method ka.sendPacketToPlayer`,
+//     `Field jv.a`, `registerServerCommand(ab)`). The spike's separate
+//     srg->deobf pass with an EMPTY CL map therefore remapped nothing FML
+//     uses — the stub compiled only because it never touched an FML API
+//     whose signature mentions an MC type. The lane implements
+//     IPacketHandler / IConnectionHandler / ICommand, so the universal jar
+//     MUST be remapped with the same obf->deobf CL+FD map as the server jar
+//     (class refs cm/ea/ab/jv/ka/ey -> net/minecraft/src/*, field refs like
+//     jv.a -> EntityPlayerMP.playerNetServerHandler); readable method refs
+//     simply have no MD entry and pass through untouched.
+//   - dev classpath = build/deobf/merged-deobf.jar (server.jar obf->deobf +
+//     universal.jar obf->deobf, merged). Ship artifact = the mod jar
+//     reobf'd deobf->obf (composite: csv reverse + joined.srg reverse).
+
+plugins {
+    id 'java'
+}
+
+version = "${mod_version}"
+group = 'levosilimo.everlastingskins'
+archivesBaseName = 'everlastingskins-LANE'
+
+sourceCompatibility = targetCompatibility = JavaVersion.VERSION_1_8
+
+repositories {
+    mavenCentral()
+    // authlib is NOT on the MCVER server classpath (verified: no authlib in
+    // install_profile.json / piston-meta MCVER.json — it arrived in later MC
+    // lines) and NOT on mavenCentral; Mojang's own maven hosts it. Needed at
+    // compile time because :common's CustomSkinProperty binds authlib's
+    // Property type (compile-only; runtime caveat documented above).
+    maven {
+        name = 'minecraft-libraries'
+        url = 'https://libraries.minecraft.net'
+    }
+}
+
+configurations {
+    // SpecialSource 1.7.4 + its transitives (asm-debug-all 5.1, jopt-simple
+    // 5.0.1, guava 19.0) — resolved from mavenCentral, hash-verified by
+    // Gradle. This is the ONLY toolchain dependency; the buildscript block
+    // (and its FG/jitpack/forge-maven repos) is intentionally absent.
+    specialsource
+}
+
+// Harness output paths (defined before `dependencies` so the lazy
+// `compile files(...)` reference can see them).
+def mappingDir = file("$buildDir/mappings")
+def obfToDeobfSrg = file("$mappingDir/obf-to-deobf.srg")
+def deobfToObfSrg = file("$mappingDir/deobf-to-obf.srg")
+def deobfServerJar = file("$buildDir/deobf/server-deobf.jar")
+def deobfUniversalJar = file("$buildDir/deobf/universal-deobf.jar")
+def mergedDeobfJar = file("$buildDir/deobf/merged-deobf.jar")
+
+dependencies {
+    specialsource 'net.md-5:SpecialSource:1.7.4'
+
+    // :common is consumed by source-dir sharing and binds three Maven
+    // artifacts at compile time that the MCVER server does NOT ship
+    // (verified against install_profile.json + piston-meta MCVER.json —
+    // authlib and log4j2 arrived in later MC lines; gson IS on the MCVER
+    // classpath at 2.2.2). Rule-4 lane decision: declare them explicitly
+    // with the exact MCVER-era versions. Runtime note (documented in the
+    // coverage report): a deployment must add authlib + log4j-api jars to
+    // the server classpath, since the mod (like every lane) stores
+    // :common's authlib-backed CustomSkinProperty.
+    compile 'com.google.code.findbugs:jsr305:3.0.2'          // :common @Nullable (not on MCVER classpath)
+    compile 'com.google.code.gson:gson:2.2.2'                // :common SkinIO/JsonUtils (exact MCVER version)
+    compile 'com.mojang:authlib:1.5.16'                      // :common CustomSkinProperty (hosted on libraries.minecraft.net)    compile 'org.apache.logging.log4j:log4j-api:2.8.1'       // :common LogManager (not on MCVER classpath)
+
+    // The merged-deobf jar (MC + FML + Forge) is produced by deobfClasspath;
+    // `compile files(...)` resolves lazily, after the producing task runs.
+    compile files(mergedDeobfJar)
+
+    // Rule 4 lane decision: JUnit 4.13.2 + mockito-core 2.28.2, mirroring
+    // forge-1.7.10 (Gradle 4.4.1 floor; 4.4.1 lanes use JUnit 4).
+    testCompile 'junit:junit:4.13.2'
+    testCompile 'org.mockito:mockito-core:2.28.2'
+}
+
+// :common is consumed by source-dir sharing: this is a standalone build and
+// cannot use project(":common"). Classes that also exist under src/main/java
+// must be deleted from the lane — javac fails on the duplicate via the share
+// (Rule 1; :common is canonical).
+sourceSets {
+    main {
+        java {
+            srcDir 'src/main/java'
+            srcDir '../common/src/main/java'
+        }
+        resources {
+            srcDir 'src/main/resources'
+            srcDir '../common/src/main/resources'
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Vendored inputs (resolveVendored)
+// ---------------------------------------------------------------------------
+// Cache dir mirrors the forge-1.7.10 jitpack vendor-fallback pattern: files
+// land outside the repo (under the Gradle user home) and can be pre-seeded
+// for offline builds. Override with -Pvendored.dir=<path>; force offline
+// with -Pvendored.offline (fails instead of downloading).
+def vendoredDir = project.hasProperty('vendored.dir')
+    ? file(project.property('vendored.dir'))
+    : file("${gradle.gradleUserHomeDir}/everlastingskins-vendored/MCVER")
+
+def vendoredInputs = [
+    [name: 'forge-LANE-FORGEVER-src.zip',
+     url: 'https://maven.minecraftforge.net/net/minecraftforge/forge/MCVER-FORGEVER/forge-LANE-FORGEVER-src.zip',
+     algo: 'MD5', digest: 'DIGEST'],
+    [name: 'forge-LANE-FORGEVER-universal.jar',
+     url: 'https://maven.minecraftforge.net/net/minecraftforge/forge/MCVER-FORGEVER/forge-LANE-FORGEVER-universal.jar',
+     algo: 'MD5', digest: 'DIGEST'],
+    [name: 'minecraft_server.MCVER.jar',
+     url: 'https://piston-data.mojang.com/v1/objects/SHA1/server.jar',
+     algo: 'SHA-1', digest: 'DIGEST'],
+]
+
+def digestOf = { File f, String algo ->
+    def md = java.security.MessageDigest.getInstance(algo)
+    f.withInputStream { is ->
+        byte[] buf = new byte[8192]
+        int n
+        while ((n = is.read(buf)) > 0) md.update(buf, 0, n)
+    }
+    md.digest().collect { String.format('%02x', it) }.join('')
+}
+
+task resolveVendored {
+    group = 'everlastingskins'
+    description = 'Download + checksum-verify the 3 vendored inputs (forge src zip, forge universal jar, vanilla MCVER server jar) into a cache dir; pre-seed the dir or pass -Pvendored.offline for offline builds.'
+    outputs.dir vendoredDir
+    doLast {
+        def offline = project.hasProperty('vendored.offline')
+        vendoredInputs.each { input ->
+            def target = new File(vendoredDir, input.name)
+            if (target.isFile() && digestOf(target, input.algo).equalsIgnoreCase(input.digest)) {
+                logger.lifecycle("resolveVendored: ${input.name} present and verified (${input.algo} ${input.digest})")
+                return
+            }
+            if (offline) {
+                throw new GradleException("vendored input missing in offline mode: ${target} — pre-seed the cache dir or drop -Pvendored.offline")
+            }
+            target.parentFile.mkdirs()
+            def part = new File(target.parentFile, target.name + '.part')
+            logger.lifecycle("resolveVendored: downloading ${input.url}")
+            new URL(input.url).withInputStream { is ->
+                part.withOutputStream { os -> os << is }
+            }
+            def actual = digestOf(part, input.algo)
+            if (!actual.equalsIgnoreCase(input.digest)) {
+                part.delete()
+                throw new GradleException("checksum mismatch for ${input.name}: expected ${input.digest}, got ${actual}")
+            }
+            part.renameTo(target)
+            logger.lifecycle("resolveVendored: ${input.name} downloaded and verified (${input.algo} ${input.digest})")
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MCP MCPVER conf extraction (extractMcpConf)
+// ---------------------------------------------------------------------------
+def mcpConfDir = file("$buildDir/mcpMCP")
+
+task extractMcpConf(dependsOn: resolveVendored) {
+    group = 'everlastingskins'
+    description = 'Extract the bundled MCP MCPVER conf (forge/fml/conf/*) from the forge src zip and assert MCPVersion = MCPVER'
+    inputs.file { new File(vendoredDir, 'forge-LANE-FORGEVER-src.zip') }
+    outputs.dir mcpConfDir
+    doLast {
+        def srcZip = new File(vendoredDir, 'forge-LANE-FORGEVER-src.zip')
+        delete mcpConfDir
+        ant.unzip(src: srcZip, dest: mcpConfDir) {
+            patternset {
+                include(name: 'forge/fml/conf/**')
+            }
+        }
+        // Flatten the forge/fml/conf/ nesting so consumers see plain files.
+        def nested = new File(mcpConfDir, 'forge/fml/conf')
+        if (!nested.isDirectory()) {
+            throw new GradleException("extractMcpConf: no forge/fml/conf/ in ${srcZip.name}")
+        }
+        nested.listFiles().each { f -> f.renameTo(new File(mcpConfDir, f.name)) }
+        delete new File(mcpConfDir, 'forge')
+
+        ['joined.srg', 'methods.csv', 'fields.csv', 'params.csv', 'packages.csv', 'version.cfg'].each { name ->
+            if (!new File(mcpConfDir, name).isFile()) {
+                throw new GradleException("extractMcpConf: missing ${name} after extraction")
+            }
+        }
+        def versionCfg = new File(mcpConfDir, 'version.cfg').getText('UTF-8')
+        if (!versionCfg.contains('MCPVersion = MCPVER')) {
+            throw new GradleException("extractMcpConf: version.cfg does not assert MCPVersion = MCPVER:\n${versionCfg}")
+        }
+        logger.lifecycle('extractMcpConf: MCP MCPVER conf extracted and asserted (MCPVersion = MCPVER, MCVER)')
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MCP conf parsers (shared by the mapping builders)
+// ---------------------------------------------------------------------------
+// methods.csv/fields.csv rows: searge,name,side,desc — the desc column is
+// quoted and may contain commas; only the first two fields are needed.
+def parseCsvMappings = { File csv ->
+    def map = [:]
+    csv.eachLine('UTF-8') { line, idx ->
+        if (idx == 0 || line.trim().isEmpty()) return
+        int c1 = line.indexOf(',')
+        int c2 = line.indexOf(',', c1 + 1)
+        if (c1 < 0 || c2 < 0) return
+        map[line.substring(0, c1).trim()] = line.substring(c1 + 1, c2).trim()
+    }
+    map
+}
+
+// joined.srg lines (tokens after the ':' separator; trailing '#C'/'#S' side
+// tags are dropped):
+//   CL: <obfClass> <srgClass>
+//   MD: <obfOwner>/<obfMethod> <OBF-desc> <srgOwner>/<funcName> <srg-desc>
+//   FD: <obfOwner>/<obfField> <srgOwner>/<fieldName>
+def parseJoinedSrg = { File srg ->
+    def cl = [:]      // obf class -> srg class
+    def clRev = [:]   // srg class -> obf class
+    def md = [:]      // [obfOwner, obfMethod, obfDesc] -> [srgOwner, funcName, srgDesc]
+    def fd = [:]      // [obfOwner, obfField] -> [srgOwner, srgField]
+    srg.eachLine('UTF-8') { line ->
+        line = line.trim()
+        if (line.isEmpty() || line.startsWith('#')) return
+        def tok = line.split('\\s+').findAll { !it.startsWith('#') }
+        if (tok.size() < 3) return
+        switch (tok[0]) {
+            case 'CL:':
+                cl[tok[1]] = tok[2]
+                clRev[tok[2]] = tok[1]
+                break
+            case 'MD:':
+                def inOwner = tok[1].substring(0, tok[1].lastIndexOf('/'))
+                def inName = tok[1].substring(tok[1].lastIndexOf('/') + 1)
+                def outOwner = tok[3].substring(0, tok[3].lastIndexOf('/'))
+                def outName = tok[3].substring(tok[3].lastIndexOf('/') + 1)
+                md[[inOwner, inName, tok[2]]] = [outOwner, outName, tok[4]]
+                break
+            case 'FD:':
+                def inOwner = tok[1].substring(0, tok[1].lastIndexOf('/'))
+                def inName = tok[1].substring(tok[1].lastIndexOf('/') + 1)
+                def outOwner = tok[2].substring(0, tok[2].lastIndexOf('/'))
+                def outName = tok[2].substring(tok[2].lastIndexOf('/') + 1)
+                fd[[inOwner, inName]] = [outOwner, outName]
+                break
+        }
+    }
+    [cl: cl, clRev: clRev, md: md, fd: fd]
+}
+
+def writeSrgMapping = { File out, Map clMap, Map mdMap, Map fdMap ->
+    def w = out.newWriter('UTF-8')
+    try {
+        clMap.each { k, v -> w.println("CL: ${k} ${v}") }
+        mdMap.each { key, value -> w.println("MD: ${key[0]}/${key[1]} ${key[2]} ${value[0]}/${value[1]} ${value[2]}") }
+        fdMap.each { key, value -> w.println("FD: ${key[0]}/${key[1]} ${value[0]}/${value[1]}") }
+    } finally {
+        w.close()
+    }
+}
+
+// Rewrite every class reference in a descriptor to the obf domain.
+def obfifyDesc = { String desc, Map clRev ->
+    desc.replaceAll(/L([^;]+);/) { m ->
+        def obf = clRev[m[1]]
+        obf ? "L${obf};" : m[0]
+    }
+}
+
+def runSpecialSource = { String inJar, String outJar, String srgIn ->
+    javaexec {
+        classpath = configurations.specialsource
+        main = 'net.md_5.specialsource.SpecialSource'
+        args '-i', inJar, '-o', outJar, '-m', srgIn, '-q'
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Deobf classpath (deobfClasspath): compose the obf->deobf mapping, run
+// SpecialSource on the server jar AND the universal jar (both are
+// obf-domain for classes/fields), merge into build/deobf/merged-deobf.jar.
+// ---------------------------------------------------------------------------
+task deobfClasspath(dependsOn: extractMcpConf) {
+    group = 'everlastingskins'
+    description = 'Compose the obf->deobf mapping from the MCP MCPVER conf, run SpecialSource on the server jar AND the FML universal jar (both reference MC classes/fields by obf names), and merge them into build/deobf/merged-deobf.jar — the FG "minecraft" classpath equivalent.'
+    inputs.dir mcpConfDir
+    inputs.files {
+        [new File(vendoredDir, 'minecraft_server.MCVER.jar'),
+         new File(vendoredDir, 'forge-LANE-FORGEVER-universal.jar')]
+    }
+    outputs.files mergedDeobfJar, deobfServerJar, deobfUniversalJar, obfToDeobfSrg, deobfToObfSrg
+    doLast {
+        def methods = parseCsvMappings(new File(mcpConfDir, 'methods.csv'))
+        def fields = parseCsvMappings(new File(mcpConfDir, 'fields.csv'))
+        def srg = parseJoinedSrg(new File(mcpConfDir, 'joined.srg'))
+        mappingDir.mkdirs()
+
+        // --- obf -> deobf (server jar + universal jar) -------------------
+        // Bytecode refs: (obfOwner, obfMethod, OBF-desc) + (obfOwner, obfField).
+        // The conf MD input side already carries the OBF desc; the owner is
+        // obf (identity classes map to themselves via clRev fallback).
+        def clMap = [:]
+        def mdMap = [:]
+        def fdMap = [:]
+        srg.cl.each { obf, srgName -> clMap[obf] = srgName }
+        srg.md.each { key, value ->
+            def readable = methods[value[1]]
+            if (readable == null) return
+            def obfOwner = srg.clRev[key[0]] ?: key[0]
+            mdMap[[obfOwner, key[1], key[2]]] = [value[0], readable, value[2]]
+        }
+        srg.fd.each { key, value ->
+            def readable = fields[value[1]]
+            if (readable == null) return
+            fdMap[[key[0], key[1]]] = [value[0], readable] // key = (obfOwner, obfField)
+        }
+        writeSrgMapping(obfToDeobfSrg, clMap, mdMap, fdMap)
+
+        // --- deobf -> obf (mod jar reobf, composite reverse) ------------
+        // Bytecode refs after compiling against merged-deobf.jar:
+        // (srgOwner, readable, srg-desc) + (srgOwner, readableField).
+        // Reverse each conf line through the csvs; identity classes keep
+        // their names, so they are excluded from the CL reverse map.
+        def clRevMap = [:]
+        srg.clRev.each { srgName, obf -> if (srgName != obf) clRevMap[srgName] = obf }
+        def mdMapC = [:]
+        def fdMapC = [:]
+        srg.md.each { key, value ->
+            def readable = methods[value[1]]
+            if (readable == null) return
+            def obfOwner = clRevMap[value[0]] ?: value[0]
+            mdMapC[[value[0], readable, value[2]]] = [obfOwner, key[1], obfifyDesc(value[2], clRevMap)]
+        }
+        srg.fd.each { key, value ->
+            def readable = fields[value[1]]
+            if (readable == null) return
+            def obfOwner = clRevMap[value[0]] ?: value[0]
+            fdMapC[[value[0], readable]] = [obfOwner, key[1]]
+        }
+        writeSrgMapping(deobfToObfSrg, clRevMap, mdMapC, fdMapC)
+
+        // --- remap + merge -------------------------------------------------
+        new File("$buildDir/deobf").mkdirs()
+        runSpecialSource(new File(vendoredDir, 'minecraft_server.MCVER.jar').absolutePath,
+            deobfServerJar.absolutePath, obfToDeobfSrg.absolutePath)
+        runSpecialSource(new File(vendoredDir, 'forge-LANE-FORGEVER-universal.jar').absolutePath,
+            deobfUniversalJar.absolutePath, obfToDeobfSrg.absolutePath)
+
+        // Merge: server-deobf first, universal-deobf on top. The two jars are
+        // disjoint by construction (server: net/minecraft + leftover obf
+        // classes; universal: cpw.mods.fml + net.minecraftforge).
+        def seen = new HashSet()
+        mergedDeobfJar.withOutputStream { os ->
+            def zos = new java.util.zip.ZipOutputStream(os)
+            try {
+                    new java.util.zip.ZipFile(jar).withCloseable { zf ->
+                        zf.entries().each { entry ->
+                            if (entry.isDirectory() || !seen.add(entry.name)) return
+                            zos.putNextEntry(new java.util.zip.ZipEntry(entry.name))
+                            zf.getInputStream(entry).withCloseable { ins -> zos << ins }
+                            zos.closeEntry()
+                        }
+                    }
+                }
+            } finally {
+                zos.close()
+            }
+        }
+        logger.lifecycle("deobfClasspath: ${mergedDeobfJar.name} built (server obf->deobf + universal obf->deobf)")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Compile (compileJava): javac against merged-deobf.jar + declared deps.
+// ---------------------------------------------------------------------------
+compileJava {
+    dependsOn deobfClasspath
+    options.encoding = 'UTF-8'
+}
+
+// ---------------------------------------------------------------------------
+// @Mod version constant (generateVersionSource)
+// ---------------------------------------------------------------------------
+// The @Mod annotation needs a compile-time version constant; without FG's
+// `replace` token, a generated source keeps @Mod's version in sync with
+// gradle.properties mod_version (mcmod.info is expanded separately in
+// processResources).
+def versionSourceDir = file("$buildDir/generated/version")
+
+task generateVersionSource {
+    group = 'everlastingskins'
+    description = 'Generate ModVersion.VERSION from gradle.properties mod_version (no FG replace on this harness).'
+    outputs.dir versionSourceDir
+    doLast {
+        def f = new File(versionSourceDir, 'levosilimo/everlastingskins/forgePKG/ModVersion.java')
+        f.parentFile.mkdirs()
+        f.text = """package levosilimo.everlastingskins.forgePKG;
+
+/** Generated from gradle.properties mod_version — keeps @Mod's version in sync. */
+public final class ModVersion {
+    public static final String VERSION = "${project.version}";
+
+    private ModVersion() {}
+}
+"""
+    }
+}
+
+sourceSets.main.java.srcDir versionSourceDir
+compileJava.dependsOn generateVersionSource
+
+jar {
+    manifest {
+        attributes([
+            'Specification-Title': archivesBaseName,
+            'Specification-Vendor': 'Levosilimo',
+            'Specification-Version': project.version,
+            'Implementation-Title': project.name,
+            'Implementation-Version': project.version,
+            'Implementation-Vendor': 'Levosilimo'
+        ])
+    }
+}
+
+processResources {
+    from(sourceSets.main.resources.srcDirs) {
+        include 'mcmod.info'
+        expand 'version': project.version, 'mcversion': "${minecraft_version}"
+    }
+    from(sourceSets.main.resources.srcDirs) {
+        exclude 'mcmod.info'
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Reobf (reobf): composite deobf->obf remap of the mod jar, in place.
+// ---------------------------------------------------------------------------
+task reobf(dependsOn: [jar, deobfClasspath]) {
+    group = 'everlastingskins'
+    description = 'Reobfuscate the mod jar deobf->obf (csv reverse + joined.srg reverse) with SpecialSource — production runs obfuscated, so the ship artifact must be obf-named.'
+    inputs.file jar.archivePath
+    inputs.file deobfToObfSrg
+    outputs.file jar.archivePath
+    doLast {
+        def inJar = jar.archivePath
+        def tmpJar = file("${inJar.parentFile}/${inJar.name}.reobf")
+        runSpecialSource(inJar.absolutePath, tmpJar.absolutePath, deobfToObfSrg.absolutePath)
+        if (!inJar.delete()) throw new GradleException("reobf: could not delete ${inJar}")
+        if (!tmpJar.renameTo(inJar)) throw new GradleException("reobf: could not replace ${inJar} with the reobf'd jar")
+        logger.lifecycle("reobf: ${inJar.name} remapped deobf->obf")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Self-check (assertNameDomain): javap the reobf'd mod jar and fail on any
+// leaked srg/deobf MC reference.
+// ---------------------------------------------------------------------------
+task assertNameDomain(dependsOn: reobf) {
+    group = 'verification'
+    doLast {
+        def jarFile = jar.archivePath
+        def classes = []
+        new java.util.zip.ZipFile(jarFile).withCloseable { zf ->
+            zf.entries().each { e ->
+                if (e.name.endsWith('.class') && !e.name.startsWith('META-INF/')) {
+                    classes << e.name.substring(0, e.name.length() - 6).replace('/', '.')
+                }
+            }
+        }
+        if (classes.isEmpty()) throw new GradleException("assertNameDomain: no classes in ${jarFile}")
+
+        def javapBin = new File(System.getProperty('java.home'), 'bin/javap')
+        if (!javapBin.isFile()) javapBin = new File(System.getProperty('java.home'), '../bin/javap')
+        if (!javapBin.isFile()) throw new GradleException("assertNameDomain: javap not found (${javapBin})")
+
+        def out = new ByteArrayOutputStream()
+        def javapArgs = [javapBin.absolutePath, '-c', '-p', '-classpath', jarFile.absolutePath] + classes
+        exec {
+            commandLine javapArgs
+            standardOutput = out
+            errorOutput = out
+        }
+        def text = out.toString('UTF-8')
+
+        // Leaked-domain tokens. net/minecraft/src/ is the renamed-class srg
+        // package (any such ref is a missed CL remap); func_/field_ are srg
+        // member names; the owner-qualified MC member surfaces must be obf
+        // .channel -> a). FML API names (getServer, registerChannel) are
+        // never obfuscated and are excluded by the owner qualification.
+        if (!offenders.isEmpty()) {
+            throw new GradleException(
+                "assertNameDomain FAILED: leaked srg/deobf references in ${jarFile.name}: ${offenders.join(', ')}\n" +
+                "The deobf->obf reobf chain did not fully remap the MC surface (see deobf-to-obf.srg)."
+            )
+        }
+        logger.lifecycle("assertNameDomain: ${jarFile.name} is fully obf-named (no func_, field_, or net/minecraft/src/ refs)")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// no-mixin gate (inlined from buildSrc no-mixin.gradle.kts via the
+// forge-1.7.10/build.gradle:135-209 template, which this standalone build
+// cannot reference)
+// ---------------------------------------------------------------------------
+def bannedLiterals = [
+    [label: 'mixingradle coordinate', literal: 'org.spongepowered' + ':mixingradle'],
+    [label: 'mixin plugin id', literal: 'org.spongepowered' + '.mixin'],
+    [label: 'mixin config bundling', literal: 'everlastingskins' + '.mixins.json'],
+]
+
+def bannedPatterns = [
+    [label: 'Mixin annotation', pattern: java.util.regex.Pattern.compile('@' + 'Mixin' + '\\b')],
+    [label: 'mixin block', pattern: java.util.regex.Pattern.compile('^\\s*' + 'mixin' + '\\s*\\{')],
+]
+
+def scanFile = { File file, List<String> offenders ->
+    if (!file.isFile()) return
+    def text = file.getText('UTF-8')
+    bannedLiterals.each { entry ->
+        if (text.contains(entry.literal)) {
+            offenders << "${project.relativePath(file)}: ${entry.label} reference ('${entry.literal}')"
+        }
+    }
+    bannedPatterns.each { entry ->
+        def matcher = entry.pattern.matcher(text)
+        while (matcher.find()) {
+            def lineNo = text.substring(0, matcher.start()).count('\n') + 1
+            offenders << "${project.relativePath(file)}: ${entry.label} at line ${lineNo}"
+        }
+    }
+}
+
+task verifyNoMixin {
+    group = 'verification'
+    description = 'Fails the build if any Mixin usage is detected: annotations, mixingradle, the mixin plugin id, mixin {} blocks, or mixins.json bundling.'
+
+    doLast {
+        def offenders = []
+
+        def sourceRoots = []
+        sourceSets.each { ss ->
+            ss.allSource.srcDirs.each { dir ->
+                if (dir.exists()) sourceRoots << dir
+            }
+        }
+        sourceRoots.each { root ->
+            root.eachFileRecurse(groovy.io.FileType.FILES) { f ->
+                if (f.name.endsWith('.java') || f.name.endsWith('.json') || f.name.endsWith('.properties')) {
+                    scanFile(f, offenders)
+                }
+            }
+        }
+
+        ['build.gradle', 'settings.gradle', 'gradle.properties'].each { name ->
+            def f = new File(projectDir, name)
+            if (f.isFile()) scanFile(f, offenders)
+        }
+
+        if (!offenders.isEmpty()) {
+            throw new GradleException(
+                "Mixin policy violated:\n" +
+                offenders.join('\n') +
+                "\n\nMixin policy: the lane contains ZERO Mixin usage. " +
+                "If a lane requires Mixin support, fork the lane - it is a sign " +
+                "that should not happen in the shared core."
+            )
+        }
+        logger.lifecycle('Mixin check passed: zero Mixin annotations, zero mixingradle references.')
+    }
+}
+
+test {
+    testLogging {
+        events "passed", "skipped", "failed"
+    }
+}
+
+build.dependsOn verifyNoMixin, assertNameDomain

--- a/scripts/ci-vendored-harness-diff-guard.sh
+++ b/scripts/ci-vendored-harness-diff-guard.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Vendored SpecialSource harness diff-guard (lib-12).
+#
+# The forge-1.6.4 / forge-1.5.2 / (future) forge-1.4.7 out-of-band lanes
+# keep the vendored SpecialSource remap harness as copy-paste per the
+# lane-separation doctrine (research-vendored-harness-abstraction.json,
+# option C). Copy-paste already diverged once (the subclass-owner reobf
+# fix landed in 1.5.2 but not 1.6.4), so this guard fails CI when a lane's
+# build.gradle drifts from the canonical harness beyond the allowed
+# substitution set and the whitelisted per-lane fork lines.
+#
+# Mechanics:
+#   1. sed-normalize each lane's build.gradle: strip the allowed
+#      substitution set (MC version, forge version, MCP version, mcp* conf
+#      dir, forge* package, archivesBaseName, vendored artifact digests).
+#   2. Drop lines matching the whitelisted per-lane fork patterns
+#      (scripts/vendored-harness-fork-lines.txt) from BOTH sides.
+#   3. diff against the checked-in canonical expected-normalized pattern
+#      (scripts/canonical/vendored-harness-normalized.txt), generated from
+#      forge-1.6.4 via --update. Any residual divergence fails the build.
+#
+# Regenerate the canonical pattern after a deliberate harness-wide
+# evolution (and only then):
+#   bash scripts/ci-vendored-harness-diff-guard.sh --update
+#
+# Usage: bash scripts/ci-vendored-harness-diff-guard.sh [--update]
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_NAME="$(basename "$0")"
+CANONICAL="$ROOT/scripts/canonical/vendored-harness-normalized.txt"
+FORK_LINES="$ROOT/scripts/vendored-harness-fork-lines.txt"
+
+# Vendored-harness lanes, oldest first. The first lane present is the
+# canonical reference; later lanes must match it modulo the substitution
+# set and the fork whitelist. Missing lanes are skipped (forge-1.5.2 and
+# forge-1.4.7 do not exist in the monorepo yet; the guard picks them up
+# automatically when they land).
+LANES=(forge-1.6.4 forge-1.5.2 forge-1.4.7)
+
+# sed-normalize a build.gradle: strip the allowed substitution set.
+normalize() {
+    sed -E \
+        -e 's/forge-1\.(6\.4|5\.2|4\.7)/forge-LANE/g' \
+        -e 's/1\.(6\.4|5\.2|4\.7)/MCVER/g' \
+        -e 's/[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/FORGEVER/g' \
+        -e 's/mcp[0-9]+/mcpMCP/g' \
+        -e 's/MCPVersion ?= ?[0-9.]+/MCPVersion = MCPVER/g' \
+        -e 's/MCP [0-9.]+ conf/MCP MCPVER conf/g' \
+        -e 's/forge[0-9]+/forgePKG/g' \
+        -e "s/archivesBaseName = '[^']*'/archivesBaseName = 'everlastingskins-LANE'/" \
+        -e "s/digest: '[0-9a-fA-F]{16,64}'/digest: 'DIGEST'/g" \
+        -e 's/[0-9a-f]{40}/SHA1/g' \
+        "$1"
+}
+
+# Whitelisted per-lane fork patterns, one ERE per non-comment line.
+fork_patterns() {
+    grep -vE '^[[:space:]]*(#|$)' "$FORK_LINES" | paste -sd'|' -
+}
+
+# Normalize $1 then drop whitelisted fork lines.
+filter() {
+    local pat
+    pat="$(fork_patterns)"
+    normalize "$1" | grep -vE "$pat" || true
+}
+
+if [ "${1:-}" = "--update" ]; then
+    canonical_lane=""
+    for lane in "${LANES[@]}"; do
+        if [ -f "$ROOT/$lane/build.gradle" ]; then
+            canonical_lane="$lane"
+            break
+        fi
+    done
+    if [ -z "$canonical_lane" ]; then
+        echo "ERROR: no vendored-harness lane found (looked for: ${LANES[*]})" >&2
+        exit 1
+    fi
+    mkdir -p "$(dirname "$CANONICAL")"
+    filter "$ROOT/$canonical_lane/build.gradle" > "$CANONICAL"
+    echo "Updated canonical harness pattern from $canonical_lane/build.gradle: $CANONICAL"
+    exit 0
+fi
+
+if [ ! -f "$CANONICAL" ]; then
+    echo "ERROR: canonical pattern missing: $CANONICAL" >&2
+    echo "Generate it: bash $SCRIPT_NAME --update" >&2
+    exit 1
+fi
+
+FAILED=0
+for lane in "${LANES[@]}"; do
+    f="$ROOT/$lane/build.gradle"
+    if [ ! -f "$f" ]; then
+        echo "SKIP: $lane (lane not present yet)"
+        continue
+    fi
+    tmp="$(mktemp)"
+    filter "$f" > "$tmp"
+    if ! diff -u "$CANONICAL" "$tmp" > "$tmp.diff"; then
+        FAILED=1
+        echo "FAIL: $lane/build.gradle diverges from the canonical harness (first 60 diff lines):" >&2
+        sed -n '1,60p' "$tmp.diff" >&2
+    else
+        echo "PASS: $lane/build.gradle matches the canonical harness"
+    fi
+    rm -f "$tmp" "$tmp.diff"
+done
+
+if [ "$FAILED" -eq 1 ]; then
+    echo "ERROR: vendored harness drift detected. Harness-wide changes must regenerate" >&2
+    echo "the canonical pattern deliberately: bash $SCRIPT_NAME --update" >&2
+    exit 1
+fi
+
+echo "Vendored harness diff-guard OK"

--- a/scripts/ci-vendored-harness-diff-guard.sh
+++ b/scripts/ci-vendored-harness-diff-guard.sh
@@ -12,7 +12,10 @@
 # Mechanics:
 #   1. sed-normalize each lane's build.gradle: strip the allowed
 #      substitution set (MC version, forge version, MCP version, mcp* conf
-#      dir, forge* package, archivesBaseName, vendored artifact digests).
+#      dir, forge* package, archivesBaseName, vendored artifact digests,
+#      artifact extension jar/zip, mojang download host) and strip prose
+#      that carries no build logic (comment lines, trailing comments,
+#      group/description metadata lines).
 #   2. Drop lines matching the whitelisted per-lane fork patterns
 #      (scripts/vendored-harness-fork-lines.txt) from BOTH sides.
 #   3. diff against the checked-in canonical expected-normalized pattern
@@ -34,12 +37,12 @@ FORK_LINES="$ROOT/scripts/vendored-harness-fork-lines.txt"
 
 # Vendored-harness lanes, oldest first. The first lane present is the
 # canonical reference; later lanes must match it modulo the substitution
-# set and the fork whitelist. Missing lanes are skipped (forge-1.5.2 and
-# forge-1.4.7 do not exist in the monorepo yet; the guard picks them up
-# automatically when they land).
+# set and the fork whitelist. Missing lanes are skipped (the guard picks
+# them up automatically when they land).
 LANES=(forge-1.6.4 forge-1.5.2 forge-1.4.7)
 
-# sed-normalize a build.gradle: strip the allowed substitution set.
+# sed-normalize a build.gradle: strip the allowed substitution set, then
+# strip prose (comments, group/description metadata).
 normalize() {
     sed -E \
         -e 's/forge-1\.(6\.4|5\.2|4\.7)/forge-LANE/g' \
@@ -52,7 +55,29 @@ normalize() {
         -e "s/archivesBaseName = '[^']*'/archivesBaseName = 'everlastingskins-LANE'/" \
         -e "s/digest: '[0-9a-fA-F]{16,64}'/digest: 'DIGEST'/g" \
         -e 's/[0-9a-f]{40}/SHA1/g' \
-        "$1"
+        -e 's/universal\.(jar|zip)/universal.ART/g' \
+        -e 's/piston-data\.mojang\.com|launcher\.mojang\.com/MOJANG_HOST/g' \
+        "$1" | strip_prose
+}
+
+# Quote-aware comment strip (a '//' inside a quoted URL must survive) +
+# drop group/description metadata lines (prose, no build logic).
+strip_prose() {
+    awk '
+{
+    line = $0
+    inq = 0
+    for (i = 1; i <= length(line); i++) {
+        c = substr(line, i, 1)
+        if (c == "\x27") inq = !inq
+        else if (c == "/" && substr(line, i+1, 1) == "/" && !inq) {
+            line = substr(line, 1, i-1)
+            break
+        }
+    }
+    sub(/[[:space:]]+$/, "", line)
+    if (line != "" && line !~ /^[[:space:]]*(group|description) = /) print line
+}'
 }
 
 # Whitelisted per-lane fork patterns, one ERE per non-comment line.

--- a/scripts/vendored-harness-fork-lines.txt
+++ b/scripts/vendored-harness-fork-lines.txt
@@ -1,0 +1,13 @@
+# Vendored SpecialSource harness per-lane fork lines (lib-12,
+# research-vendored-harness-abstraction.json). Lines matching these EREs
+# are dropped from BOTH sides of the diff-guard comparison: they are the
+# documented behavioral forks that legitimately differ between lanes.
+# Any other divergence fails the guard.
+# Fork 1: merge order in deobfClasspath (server-first vs universal-first).
+\[deobfServerJar, deobfUniversalJar\]\.each|\[deobfUniversalJar, deobfServerJar\]\.each
+# Fork 2: subclass-owner expansion (scanHierarchy / expandSubclassMethods).
+scanHierarchy|expandSubclassMethods|subclassOwner
+# Fork 3: assertNameDomain forbidden-token set (per-MC-version surface).
+forbidden|MinecraftServer\.getServer|Packet250CustomPayload\.channel
+# Fork 4: test-runtime dependency (1.5.2 adds log4j-core for authlib-beta).
+log4j-core

--- a/scripts/vendored-harness-fork-lines.txt
+++ b/scripts/vendored-harness-fork-lines.txt
@@ -3,8 +3,9 @@
 # are dropped from BOTH sides of the diff-guard comparison: they are the
 # documented behavioral forks that legitimately differ between lanes.
 # Any other divergence fails the guard.
-# Fork 1: merge order in deobfClasspath (server-first vs universal-first).
-\[deobfServerJar, deobfUniversalJar\]\.each|\[deobfUniversalJar, deobfServerJar\]\.each
+# Fork 1: merge order in deobfClasspath (server-first vs universal-first),
+# including the lifecycle line that documents the universal-wins behavior.
+\[deobfServerJar, deobfUniversalJar\]\.each|\[deobfUniversalJar, deobfServerJar\]\.each|deobfClasspath: \$\{mergedDeobfJar\.name\} built
 # Fork 2: subclass-owner expansion (scanHierarchy / expandSubclassMethods).
 scanHierarchy|expandSubclassMethods|subclassOwner
 # Fork 3: assertNameDomain forbidden-token set (per-MC-version surface).


### PR DESCRIPTION
Two remaining CI-IMPROVEMENT-ROADMAP items.

**P1-6 (lib-11): real mc1.12.2 E2E.** The `E2E (mc1.12.2)` job was a placeholder stub; it now runs the real boot-smoke runner (`mc1.12.2/test-infrastructure/run-e2e.sh mc1.12.2`) on JDK 8: builds the lane, boots a real Forge 14.23.5.2847 server with the mod, launches a HeadlessMC client (TestPlayer) under xvfb, and asserts on the server log that the server booted, the client joined, and the FML handshake mod-list line names everlastingskins. The required-check name is preserved verbatim. The runner's lane-dir resolution was fixed for the monorepo layout (script now lives inside `mc1.12.2/`, so `PROJECT_DIR` is already the lane dir).

**Vendored harness diff-guard (lib-12).** New `Vendored harness diff-guard` CI job + `scripts/ci-vendored-harness-diff-guard.sh`: sed-normalizes each vendored SpecialSource harness lane's build.gradle (forge-1.6.4, forge-1.5.2, future forge-1.4.7 — strips MC version, forge version, MCP version, mcp* dir, forge* package, archivesBaseName, artifact digests) and diffs against the checked-in canonical expected-normalized pattern (`scripts/canonical/vendored-harness-normalized.txt`, generated from forge-1.6.4). Fails on divergence beyond the allowed substitution set and the whitelisted per-lane fork lines (`scripts/vendored-harness-fork-lines.txt` — merge order, subclass-owner expansion, assertNameDomain token sets, test-runtime dep). Catches harness drift mechanically per lib-12's recommendation; harness-wide evolution regenerates the canonical deliberately via `--update`.