### PR TITLE
ci(diff-guard): handle MCP version letter suffix (e.g. 7.26a) in sed normalization

### DIFF
--- a/scripts/ci-vendored-harness-diff-guard.sh
+++ b/scripts/ci-vendored-harness-diff-guard.sh
@@ -48,9 +48,9 @@ normalize() {
         -e 's/forge-1\.(6\.4|5\.2|4\.7)/forge-LANE/g' \
         -e 's/1\.(6\.4|5\.2|4\.7)/MCVER/g' \
         -e 's/[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/FORGEVER/g' \
-        -e 's/mcp[0-9]+/mcpMCP/g' \
-        -e 's/MCPVersion ?= ?[0-9.]+/MCPVersion = MCPVER/g' \
-        -e 's/MCP [0-9.]+ conf/MCP MCPVER conf/g' \
+        -e 's/mcp[0-9]+[a-z]?/mcpMCP/g' \
+        -e 's/MCPVersion ?= ?[0-9.]+[a-z]?/MCPVersion = MCPVER/g' \
+        -e 's/MCP [0-9.]+[a-z]? conf/MCP MCPVER conf/g' \
         -e 's/forge[0-9]+/forgePKG/g' \
         -e "s/archivesBaseName = '[^']*'/archivesBaseName = 'everlastingskins-LANE'/" \
         -e "s/digest: '[0-9a-fA-F]{16,64}'/digest: 'DIGEST'/g" \


### PR DESCRIPTION
Fixes the vendored-harness diff-guard CI to handle MCP versions with trailing letters (e.g. 7.26a for forge-1.4.7). Without this fix, the 1.4.7 lane PR will fail the guard because mcp726a normalizes to mcpMCPa instead of mcpMCP. Verified locally: 3 sed rules with [a-z]? suffix allow 1.6.4 (8.11), 1.5.2 (7.51), and 1.4.7 (7.26a) all to PASS without regenerating the canonical (digit-only lanes' normalized output is byte-identical).