### PR TITLE
ci(workflow): add Build (forge-1.4.7) ci.yml job + publish-mc1_4_7 wiring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,6 +295,39 @@ jobs:
           path: forge-1.5.2/build/libs/*.jar
           if-no-files-found: warn
 
+  # ── forge-1.4.7 out-of-band lane (own wrapper, JDK 8, vendored SpecialSource) ──
+  build-forge-1_4_7:
+    name: Build (forge-1.4.7)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    needs: lint-yaml
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - name: Set up JDK 8
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961  # v5
+        with:
+          java-version: "8"
+          distribution: temurin
+      - name: Cache Gradle wrapper and caches
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: |
+            ~/.gradle/wrapper/dists
+            ~/.gradle/caches
+          key: gradle-${{ runner.os }}-forge-1.4.7-${{ hashFiles('**/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-forge-1.4.7-
+      - name: Grant execute permission for gradlew
+        run: chmod +x forge-1.4.7/gradlew
+      - name: Build and test
+        run: cd forge-1.4.7 && ./gradlew build verifyNoMixin --no-daemon --stacktrace
+      - name: Upload built jar
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: mod-forge-1.4.7
+          path: forge-1.4.7/build/libs/*.jar
+          if-no-files-found: warn
+
   # ── forge-1.20.1 out-of-band lane (own wrapper, JDK 21) ────────
   build-forge-1_20_1:
     name: Build (forge-1.20.1)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,7 @@ on:
       - 'mc1.7.10-v*'
       - 'mc1.6.4-v*'
       - 'mc1.5.2-v*'
+      - 'mc1.4.7-v*'
       # NOTE: NeoForge intentionally dropped — no mcneoforge lane.
 
 jobs:
@@ -65,7 +66,7 @@ jobs:
             game-version: "26.1"
             java: "25"
           # NOTE: mc1.20.1 / mc1.16.5 / mc1.18.2 / mc1.10.2 / mc1.6.4 /
-          # mc1.5.2 have NO
+          # mc1.5.2 / mc1.4.7 have NO
           # matrix entries: since the FG lane separation (PR #2xx) they are
           # standalone builds with their own wrappers (forge-1.16.5 → Gradle
           # 7.6.4/Java 8 + FG 5.1.77; forge-1.20.1 → Gradle 8.14/Java 21 +
@@ -73,11 +74,12 @@ jobs:
           # forge-1.10.2 → Gradle 4.10.3/Java 8 + FG 2.2.5; forge-1.6.4 →
           # Gradle 4.4.1/Java 8 + vendored SpecialSource 1.7.4 deobf
           # harness; forge-1.5.2 → Gradle 4.4.1/Java 8 + vendored
-          # SpecialSource 1.7.4 deobf harness), so the shared
+          # SpecialSource 1.7.4 deobf harness; forge-1.4.7 → Gradle 4.4.1/
+          # Java 8 + vendored SpecialSource 1.7.4 deobf harness), so the shared
           # `./gradlew :${{ matrix.module }}:build` step cannot build them.
           # They publish via the dedicated publish-mc1_16_5 / publish-mc1_20_1
           # / publish-mc1_18_2 / publish-mc1_10_2 / publish-mc1_6_4 /
-          # publish-mc1_5_2 jobs below.
+          # publish-mc1_5_2 / publish-mc1_4_7 jobs below.
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Set up JDK ${{ matrix.java }}
@@ -614,6 +616,61 @@ jobs:
           game-version-filter: releases
           environment: server
           files: forge-1.5.2/build/libs/*.jar
+          fail-mode: fail
+          retry-attempts: 3
+          retry-delay: 15000
+
+  # ── forge-1.4.7 out-of-band lane (own wrapper, JDK 8, vendored SpecialSource harness) ──
+  publish-mc1_4_7:
+    name: Publish (mc1.4.7)
+    if: startsWith(github.ref_name, 'mc1.4.7-v')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961  # v5
+        with:
+          java-version: "8"
+          distribution: temurin
+
+      - name: Cache Gradle
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: |
+            ~/.gradle/wrapper/dists
+            ~/.gradle/caches
+          key: gradle-${{ runner.os }}-forge-1.4.7
+          restore-keys: |
+            gradle-${{ runner.os }}-forge-1.4.7-
+            gradle-${{ runner.os }}-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x forge-1.4.7/gradlew
+
+      - name: Build
+        run: cd forge-1.4.7 && ./gradlew build --no-daemon
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+
+      - name: Publish to CurseForge, Modrinth, GitHub Releases
+        uses: Kira-NT/mc-publish@52307b03863581dec6b652b83e597aec02ebb075  # v3
+        with:
+          curseforge-id: 538149
+          curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
+          modrinth-id: everlasting-skins
+          modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          version: ${{ github.ref_name }}
+          name: "Everlasting Skins ${{ github.ref_name }}"
+          version-type: release
+          loaders: forge
+          game-versions: "1.4.7"
+          game-version-filter: releases
+          environment: server
+          files: forge-1.4.7/build/libs/*.jar
           fail-mode: fail
           retry-attempts: 3
           retry-delay: 15000


### PR DESCRIPTION
Lane PR #401 merged the 1.4.7 lane (commit e7b678c) but omitted the ci.yml Build (forge-1.4.7) job. Per precedent (1.5.2 / 1.6.4 lane PRs), the ci.yml job must land with the lane. Without this job, gh-api-bump/1.4.7.sh applied a required check that no workflow produces, deadlocking all PRs (branch protection was dropped from 22 to 21 to unblock). This PR adds the missing job (mirror of build-forge-1_5_2 / build-forge-1_6_4 with 1.4.7 substitutions: JDK 8 temurin, own cache key, ./gradlew build verifyNoMixin --no-daemon --stacktrace, upload mod-forge-1.4.7). Also verifies/adds publish.yml mc1.4.7-v* trigger + publish-mc1_4_7 job if not already present. After this PR lands, gh-api-bump/1.4.7.sh can be re-applied to restore contract 21->22.