### PR TITLE
fix(junit): pin root build to JUnit 5.14.4 + Dependabot ignore for org.junit major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,14 @@ updates:
       - "dependencies"
       - "ci"
     open-pull-requests-limit: 10
+    # JUnit 6.x requires JVM 17+ and would break :common's --release 8
+    # freeze (AGENTS.md rule 1). Root build is pinned to the newest
+    # Java-8-compatible 5.x (5.14.4 / platform 1.14.4); ignore all
+    # org.junit* major bumps >= 6.0 (covers org.junit, org.junit.jupiter,
+    # org.junit.platform, org.junit.vintage).
+    ignore:
+      - dependency-name: "org.junit*"
+        versions: [">=6"]
 
   # GitHub Actions: .github/workflows.
   - package-ecosystem: "github-actions"

--- a/buildSrc/src/main/kotlin/everlastingskins.forge-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/everlastingskins.forge-module.gradle.kts
@@ -307,21 +307,21 @@ dependencies {
     testImplementation("io.papermc.paper:paper-api:1.20.4-R0.1-SNAPSHOT")
     compileOnly("org.spigotmc:spigot-api:1.20.4-R0.1-SNAPSHOT")
 
-    testImplementation(platform("org.junit:junit-bom:5.10.3"))
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.3")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:5.10.3")
+    testImplementation(platform("org.junit:junit-bom:5.14.4"))
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.14.4")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:5.14.4")
     testImplementation("net.jqwik:jqwik-api:1.9.3")
     testImplementation("me.clip:placeholderapi:2.12.3")
     testImplementation("org.mockito:mockito-core:5.12.0")
     testImplementation("org.mockito:mockito-junit-jupiter:5.12.0")
 
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.3")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.14.4")
     testRuntimeOnly("net.jqwik:jqwik-engine:1.9.3")
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.10.3")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.14.4")
 
     "gametestImplementation"(sourceSets.main.get().output)
-    "gametestImplementation"("org.junit.jupiter:junit-jupiter-api:5.10.3")
-    "gametestRuntimeOnly"("org.junit.platform:junit-platform-launcher:1.10.3")
+    "gametestImplementation"("org.junit.jupiter:junit-jupiter-api:5.14.4")
+    "gametestRuntimeOnly"("org.junit.platform:junit-platform-launcher:1.14.4")
 }
 
 // jsr305 is brought in transitively by Forge AND bundled by discordsrv;

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -56,7 +56,7 @@ dependencies {
     compileOnly("com.google.code.findbugs:jsr305:3.0.2")
 
     // --- test: standalone verification of the module ---
-    testImplementation(platform("org.junit:junit-bom:5.10.3"))
+    testImplementation(platform("org.junit:junit-bom:5.14.4"))
     testImplementation("org.junit.jupiter:junit-jupiter-api")
     testImplementation("org.junit.jupiter:junit-jupiter-params")
     testImplementation("net.jqwik:jqwik-api:1.10.1")
@@ -66,9 +66,9 @@ dependencies {
     testImplementation("com.mojang:authlib:1.5.25")
     testImplementation("org.apache.logging.log4j:log4j-api:2.26.1")
 
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.3")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.14.4")
     testRuntimeOnly("net.jqwik:jqwik-engine:1.10.1")
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.10.3")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.14.4")
     // Default log4j2 config (ERROR-only) so test output stays quiet.
     testRuntimeOnly("org.apache.logging.log4j:log4j-core:2.26.1")
 }


### PR DESCRIPTION
## Summary

Resolves the JUnit 6.x Dependabot block (#387 junit-platform-launcher, #389 junit-bom, #390 junit-jupiter-engine — all proposing 6.1.2).

JUnit 6.x requires JVM 17+, which breaks `:common` (frozen at `--release 8` per AGENTS.md rule 1). Per the tracked decision on those PRs, this pins the root build to the newest JUnit 5.x that still supports Java 8 and adds a Dependabot ignore rule for org.junit* major bumps.

## Changes

- **`buildSrc/src/main/kotlin/everlastingskins.forge-module.gradle.kts`**: junit-bom / junit-jupiter-api / junit-jupiter-params / junit-jupiter-engine `5.10.3` → `5.14.4`; junit-platform-launcher `1.10.3` → `1.14.4` (test + gametest configs). mockito / jqwik untouched.
- **`common/build.gradle.kts`**: same bump (bom 5.14.4, engine 5.14.4, launcher 1.14.4).
- **`.github/dependabot.yml`**: `ignore: dependency-name "org.junit*"` with `versions: [">=6"]` on the gradle entry — suppresses all org.junit major bumps (org.junit, junit.jupiter, junit.platform, junit.vintage) while still allowing 5.x patch updates.

## Version verification (Maven Central)

- `org.junit.jupiter:junit-jupiter-engine:5.14.4` — runtime class bytecode **major 52 (Java 8)** ✓
- `org.junit.platform:junit-platform-launcher:1.14.4` — runtime class bytecode **major 52 (Java 8)** ✓
- `org.junit:junit-bom:5.14.4` exists (HTTP 200); engine POM parents to bom 5.14.4 / platform 1.14.4
- 6.x line confirmed present (6.1.3 newest); requires JVM 17+
- Out-of-band lanes untouched (their own build.gradle pins remain).

## Validation

- `./gradlew :common:build` — BUILD SUCCESSFUL (frozen `--release 8` module compiled + full test suite green on 5.14.4)
- `python3 yaml.safe_load` on dependabot.yml — OK
- Pre-commit hooks green: aislop, compile, test-count, verify-no-mixin