### PR TITLE
ci(workflow): adopt gradle/actions/setup-gradle on root-wrapper jobs (P2-18, hybrid)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,15 +65,10 @@ jobs:
         with:
           java-version: ${{ matrix.java || '21' }}
           distribution: temurin
-      - name: Cache Gradle wrapper and caches
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      - name: Set up Gradle (wrapper validation + cache)
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb  # v6
         with:
-          path: |
-            ~/.gradle/wrapper/dists
-            ~/.gradle/caches
-          key: gradle-${{ runner.os }}-m2-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: |
-            gradle-${{ runner.os }}-m2-
+          cache-provider: basic
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Verify test count meets minimum
@@ -499,15 +494,10 @@ jobs:
         with:
           java-version: 21
           distribution: temurin
-      - name: Cache Gradle wrapper and caches
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      - name: Set up Gradle (wrapper validation + cache)
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb  # v6
         with:
-          path: |
-            ~/.gradle/wrapper/dists
-            ~/.gradle/caches
-          key: gradle-${{ runner.os }}-m2-gametest-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: |
-            gradle-${{ runner.os }}-m2-
+          cache-provider: basic
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Run GameTest (skin visibility packets)
@@ -540,15 +530,10 @@ jobs:
         with:
           java-version: 21
           distribution: temurin
-      - name: Cache Gradle wrapper and caches
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      - name: Set up Gradle (wrapper validation + cache)
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb  # v6
         with:
-          path: |
-            ~/.gradle/wrapper/dists
-            ~/.gradle/caches
-          key: gradle-${{ runner.os }}-m2-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: |
-            gradle-${{ runner.os }}-m2-
+          cache-provider: basic
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Run GameTest (skin visibility packets)
@@ -576,15 +561,10 @@ jobs:
         with:
           java-version: 21
           distribution: temurin
-      - name: Cache Gradle wrapper and caches
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      - name: Set up Gradle (wrapper validation + cache)
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb  # v6
         with:
-          path: |
-            ~/.gradle/wrapper/dists
-            ~/.gradle/caches
-          key: gradle-${{ runner.os }}-m2-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: |
-            gradle-${{ runner.os }}-m2-
+          cache-provider: basic
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Run GameTest (skin visibility packets)
@@ -612,15 +592,10 @@ jobs:
         with:
           java-version: 21
           distribution: temurin
-      - name: Cache Gradle wrapper and caches
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      - name: Set up Gradle (wrapper validation + cache)
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb  # v6
         with:
-          path: |
-            ~/.gradle/wrapper/dists
-            ~/.gradle/caches
-          key: gradle-${{ runner.os }}-m2-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: |
-            gradle-${{ runner.os }}-m2-
+          cache-provider: basic
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Run GameTest (skin visibility packets)
@@ -648,15 +623,10 @@ jobs:
         with:
           java-version: 25
           distribution: temurin
-      - name: Cache Gradle wrapper and caches
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      - name: Set up Gradle (wrapper validation + cache)
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb  # v6
         with:
-          path: |
-            ~/.gradle/wrapper/dists
-            ~/.gradle/caches
-          key: gradle-${{ runner.os }}-m2-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: |
-            gradle-${{ runner.os }}-m2-
+          cache-provider: basic
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Run GameTest (skin visibility packets)
@@ -684,15 +654,10 @@ jobs:
         with:
           java-version: 25
           distribution: temurin
-      - name: Cache Gradle wrapper and caches
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      - name: Set up Gradle (wrapper validation + cache)
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb  # v6
         with:
-          path: |
-            ~/.gradle/wrapper/dists
-            ~/.gradle/caches
-          key: gradle-${{ runner.os }}-m2-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: |
-            gradle-${{ runner.os }}-m2-
+          cache-provider: basic
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Run GameTest (skin visibility packets)
@@ -741,15 +706,10 @@ jobs:
         with:
           java-version: 21
           distribution: temurin
-      - name: Cache Gradle wrapper and caches
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      - name: Set up Gradle (wrapper validation + cache)
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb  # v6
         with:
-          path: |
-            ~/.gradle/wrapper/dists
-            ~/.gradle/caches
-          key: gradle-${{ runner.os }}-m2-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: |
-            gradle-${{ runner.os }}-m2-
+          cache-provider: basic
       - name: chmod +x gradlew
         run: chmod +x gradlew
       - name: Run CI Health (gradle-health.sh + dep-analysis)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -87,16 +87,10 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: temurin
-      - name: Cache Gradle
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      - name: Set up Gradle (wrapper validation + cache)
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb  # v6
         with:
-          path: |
-            ~/.gradle/wrapper/dists
-            ~/.gradle/caches
-          key: gradle-${{ runner.os }}-${{ matrix.game-version }}
-          restore-keys: |
-            gradle-${{ runner.os }}-${{ matrix.game-version }}-
-            gradle-${{ runner.os }}-
+          cache-provider: basic
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build


### PR DESCRIPTION
## P2-18: adopt `gradle/actions/setup-gradle` on root-wrapper jobs (hybrid)

Replaces the manual `actions/cache` Gradle blocks with `gradle/actions/setup-gradle@<v6 SHA> # v6` on **root-wrapper jobs only**. Out-of-band lanes keep their manual `actions/cache` steps (their wrappers/Gradle versions fall outside setup-gradle's supported envelope).

### Hybrid scope

| Adopted (setup-gradle @ v6, `cache-provider: basic`) | Keep manual `actions/cache` |
|---|---|
| `build` matrix (7 legs: common / 1.21 / 1.21.1 / 1.21.4 / 1.21.8 / 26.2 / 26.1) | `Build (mc1.12.2)` |
| `GameTest (1.21)` | `Build (forge-1.16.5)` |
| `GameTest (1.21.1)` | `Build (forge-1.8.9)` |
| `GameTest (1.21.4)` | `Build (forge-1.10.2)` |
| `GameTest (1.21.8)` | `Build (forge-1.6.4)` |
| `GameTest (26.2)` | `Build (forge-1.5.2)` |
| `GameTest (26.1)` | `Build (forge-1.4.7)` |
| `CI Health` | `Build (forge-1.20.1)` |
| `Publish` matrix (publish.yml) | `Build (forge-1.18.2)` |
| | `Build (forge-1.7.10)` |
| | `E2E (mc1.12.2)` — E2E downloads cache (`~/.cache/everlastingskins`, `~/.minecraft`, headlessmc) is not Gradle content |

### Details

- **`setup-java` retained in every job**, ordered before setup-gradle (setup-gradle does not install Java). No `cache: gradle` added to setup-java — docs warn it interferes with setup-gradle's cache.
- **`cache-provider: basic`** — MIT-licensed, stable setup-java-style key, avoids the commercial enhanced provider and git-SHA churn.
- **Wrapper validation**: left at the v4+ default (`validate-wrappers: true`) — validates all 11 wrapper jars repo-wide, oldest lane 4.4.1 (in verifiable range). First-run risk only.
- **No dependency-graph submission** (out of scope; needs `contents: write` + Gradle ≥ 5.2).
- **No job-name changes** — the 22-context required-check contract is untouched.
- SHA pin `9c971963bec38e04b3d30dcc455b5382be2fdbfb` = tag `v6` merge commit (resolved via `gh api repos/gradle/actions/git/refs/tags/v6` → dereferenced tag object).

### Validation
- `yaml.safe_load` on both workflows: pass
- `yamllint -d "{rules: {key-duplicates: enable}}"` on both: pass (matches lint-yaml gate)
- Lane jobs byte-identical (diff review); only the 9 adopted cache blocks changed
