### PR TITLE
chore(publish): publish-mc1_5_2 as beta prerelease

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -604,7 +604,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           version: ${{ github.ref_name }}
           name: "Everlasting Skins ${{ github.ref_name }}"
-          version-type: release
+          version-type: beta
           loaders: forge
           game-versions: "1.5.2"
           game-version-filter: releases


### PR DESCRIPTION
User-approved: the first 1.5.2 release ships as a beta prerelease. version-type beta in publish-mc1_5_2 only; other lane publish jobs untouched.