### PR TITLE
chore(publish): publish-mc1_5_2 without CurseForge (token not provisioned; Modrinth + GitHub Releases only)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -594,11 +594,9 @@ jobs:
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
 
-      - name: Publish to CurseForge, Modrinth, GitHub Releases
+      - name: Publish to Modrinth, GitHub Releases
         uses: Kira-NT/mc-publish@52307b03863581dec6b652b83e597aec02ebb075  # v3
         with:
-          curseforge-id: 538149
-          curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
           modrinth-id: everlasting-skins
           modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
User decision: CurseForge is not important for the 1.5.2 release. CURSEFORGE_TOKEN secret is malformed (400 on first-ever publish run); removing the CF platform from publish-mc1_5_2 so Modrinth + GitHub Releases complete. Other lane publish jobs keep their CurseForge config — they will need the secret fixed before their first publish.