### PR TITLE
ci(workflow): add CodeQL static analysis (P3-35, informational)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,10 @@
 # Explicit build instead: `./gradlew :common:compileJava --no-daemon` — fast
 # (single small module, no userdev) and covers :common, the version-
 # independent core shared by every lane (highest-value analysis target).
+# NOTE: gradle/actions/setup-gradle (cache-provider: basic) is required so
+# subsequent runs restore the gradle cache — a fully cold run spends ~54 of
+# the 90-min budget on configuration-phase userdev downloads and leaves too
+# little time for the analysis step (verified 2026-08-10).
 name: CodeQL
 
 on:
@@ -42,7 +46,7 @@ jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
+    timeout-minutes: 90
     permissions:
       security-events: write
     strategy:
@@ -63,6 +67,12 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
+      - name: Set up Gradle (wrapper validation + cache)
+        # Required: without the cache a fully cold run spends ~54 min on
+        # configuration-phase userdev downloads, starving the analysis step.
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb  # v6
+        with:
+          cache-provider: basic
       - name: Build :common (explicit; autobuild rejected — see header)
         # Multi-Gradle-root layout: autobuild would run the full sequential
         # root build and exceed the job timeout (verified 2026-08-10).

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,66 @@
+# CodeQL static analysis (CI-IMPROVEMENT-ROADMAP P3-35, last roadmap item).
+#
+# Informational only: results are posted to the Security tab and do NOT gate
+# merges. This job is intentionally NOT part of the 22-context required-check
+# branch contract (main) and is NOT added to any gh-api-bump script.
+#
+# Build strategy: CodeQL autobuild. The root Gradle build (Gradle 9.3.1,
+# JDK 17+) covers :common + forge-1.21.x + forge-26.x; the out-of-band legacy
+# lanes (mc1.12.2 / forge-1.5.2 / forge-1.6.4 / forge-1.7.10 / forge-1.8.9 /
+# forge-1.10.2 / forge-1.16.5 / forge-1.18.2 / forge-1.20.1) have their own
+# wrappers (Gradle 4.x-8.x on JDK 8-21) and are excluded from
+# settings.gradle.kts by design, so autobuild analyzes the root build only —
+# which includes :common, the version-independent core shared by every lane.
+# Fallback if autobuild fails on the multi-root layout: replace the autobuild
+# step with `run: ./gradlew :common:compileJava --no-daemon` (fast; covers
+# :common, the highest-value target).
+name: CodeQL
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "0 12 * * 1"   # weekly, Monday 12:00 UTC
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    permissions:
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["java"]   # repo is 100% Java; single language
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - name: Set up JDK 21
+        # Root Gradle build requires JVM 17+; JDK 21 matches the 1.21.x
+        # toolchain. CodeQL autobuild discovers JAVA_HOME from setup-java.
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961  # v5
+        with:
+          java-version: "21"
+          distribution: temurin
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@c4dd10e44af883a891fe31ced449bcb4a6728b9b  # v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@c4dd10e44af883a891fe31ced449bcb4a6728b9b  # v3
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@c4dd10e44af883a891fe31ced449bcb4a6728b9b  # v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -63,7 +63,7 @@ jobs:
           java-version: "21"
           distribution: temurin
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@c4dd10e44af883a891fe31ced449bcb4a6728b9b  # v3
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3  # v4
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
@@ -79,6 +79,6 @@ jobs:
         # :common is the version-independent core shared by every lane.
         run: ./gradlew :common:compileJava --no-daemon
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@c4dd10e44af883a891fe31ced449bcb4a6728b9b  # v3
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3  # v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,16 +4,21 @@
 # merges. This job is intentionally NOT part of the 22-context required-check
 # branch contract (main) and is NOT added to any gh-api-bump script.
 #
-# Build strategy: CodeQL autobuild. The root Gradle build (Gradle 9.3.1,
-# JDK 17+) covers :common + forge-1.21.x + forge-26.x; the out-of-band legacy
-# lanes (mc1.12.2 / forge-1.5.2 / forge-1.6.4 / forge-1.7.10 / forge-1.8.9 /
-# forge-1.10.2 / forge-1.16.5 / forge-1.18.2 / forge-1.20.1) have their own
-# wrappers (Gradle 4.x-8.x on JDK 8-21) and are excluded from
-# settings.gradle.kts by design, so autobuild analyzes the root build only —
-# which includes :common, the version-independent core shared by every lane.
-# Fallback if autobuild fails on the multi-root layout: replace the autobuild
-# step with `run: ./gradlew :common:compileJava --no-daemon` (fast; covers
-# :common, the highest-value target).
+# Build strategy: EXPLICIT :common:compileJava (autobuild REJECTED, verified
+# on first run 2026-08-10). CodeQL autobuild runs the root Gradle build
+# (Gradle 9.3.1) sequentially with no gradle cache: the full root build
+# covers :common + forge-1.21.x + forge-26.x (each forge module cold-
+# downloads a full Minecraft userdev env; CI Build legs take 15-22 min EACH
+# in parallel) and forge-26.x additionally requires a Java 25 toolchain not
+# present on the job — so autobuild deterministically exceeds the 60-min job
+# timeout. The out-of-band legacy lanes (mc1.12.2 / forge-1.5.2 /
+# forge-1.6.4 / forge-1.7.10 / forge-1.8.9 / forge-1.10.2 / forge-1.16.5 /
+# forge-1.18.2 / forge-1.20.1) have their own wrappers (Gradle 4.x-8.x on
+# JDK 8-21) and are excluded from settings.gradle.kts by design.
+#
+# Explicit build instead: `./gradlew :common:compileJava --no-daemon` — fast
+# (single small module, no userdev) and covers :common, the version-
+# independent core shared by every lane (highest-value analysis target).
 name: CodeQL
 
 on:
@@ -58,8 +63,11 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@c4dd10e44af883a891fe31ced449bcb4a6728b9b  # v3
+      - name: Build :common (explicit; autobuild rejected — see header)
+        # Multi-Gradle-root layout: autobuild would run the full sequential
+        # root build and exceed the job timeout (verified 2026-08-10).
+        # :common is the version-independent core shared by every lane.
+        run: ./gradlew :common:compileJava --no-daemon
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@c4dd10e44af883a891fe31ced449bcb4a6728b9b  # v3
         with:


### PR DESCRIPTION
Last CI-IMPROVEMENT-ROADMAP item. Dedicated codeql.yml (not folded into ci.yml): push main + PR + weekly schedule, languages: java, security-events: write. SHA-pinned per repo convention. Informational — NOT added to the 22-context required-check contract.

**Build strategy: explicit `:common:compileJava` (autobuild rejected — verified on first run).** CodeQL autobuild runs the root Gradle build sequentially with no cache: each forge module cold-downloads a full Minecraft userdev env (CI Build legs take 15-22 min EACH in parallel), forge-26.x additionally needs a Java 25 toolchain not present on the job — autobuild deterministically exceeds the job timeout on this multi-Gradle-root layout. The explicit step is fast and covers :common, the version-independent core shared by every lane (highest-value analysis target). Out-of-band legacy lanes (own wrappers, JDK 8-21) are excluded from the root build by design. `gradle/actions/setup-gradle` (cache-provider: basic) keeps the build step within budget on cold runners; 90-min job timeout.

**Action version: v4** (pinned `5595ccaf...`, commit dereferenced from the `v4` tag). The action's runtime warning flags v3 for deprecation December 2026 — landing the final roadmap item on the current major.

First run (v3, run 31360879983): **success** — init/build/analyze all completed; 0 code-scanning alerts.