### PR TITLE
ci: cut wall time via configure-on-demand (root-config userdev skip)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
             exit 1
           fi
       - name: Build module
-        run: ./gradlew :${{ matrix.module }}:build --no-daemon --stacktrace
+        run: ./gradlew :${{ matrix.module }}:build --no-daemon --stacktrace --configure-on-demand
       - name: Upload built jar
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
@@ -506,7 +506,7 @@ jobs:
         # re-run (fix-10: cancelled at 15m15s on PR #314 cold cache; warm runs
         # finish in 2.5-6 min). 30 min bounds the runaway case while
         # tolerating cache misses.
-        run: ./gradlew :forge-1.21:runGameTestServer --no-daemon --console=plain
+        run: ./gradlew :forge-1.21:runGameTestServer --no-daemon --console=plain --configure-on-demand
         timeout-minutes: 30
         env:
           GRADLE_OPTS: >-
@@ -537,7 +537,7 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Run GameTest (skin visibility packets)
-        run: ./gradlew :forge-1.21.1:runGameTestServer --no-daemon --console=plain
+        run: ./gradlew :forge-1.21.1:runGameTestServer --no-daemon --console=plain --configure-on-demand
         timeout-minutes: 30
         env:
           GRADLE_OPTS: >-
@@ -568,7 +568,7 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Run GameTest (skin visibility packets)
-        run: ./gradlew :forge-1.21.4:runGameTestServer --no-daemon --console=plain
+        run: ./gradlew :forge-1.21.4:runGameTestServer --no-daemon --console=plain --configure-on-demand
         timeout-minutes: 30
         env:
           GRADLE_OPTS: >-
@@ -599,7 +599,7 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Run GameTest (skin visibility packets)
-        run: ./gradlew :forge-1.21.8:runGameTestServer --no-daemon --console=plain
+        run: ./gradlew :forge-1.21.8:runGameTestServer --no-daemon --console=plain --configure-on-demand
         timeout-minutes: 30
         env:
           GRADLE_OPTS: >-
@@ -630,7 +630,7 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Run GameTest (skin visibility packets)
-        run: ./gradlew :forge-26.2:runGameTestServer --no-daemon --console=plain
+        run: ./gradlew :forge-26.2:runGameTestServer --no-daemon --console=plain --configure-on-demand
         timeout-minutes: 30
         env:
           GRADLE_OPTS: >-
@@ -661,7 +661,7 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Run GameTest (skin visibility packets)
-        run: ./gradlew :forge-26.1:runGameTestServer --no-daemon --console=plain
+        run: ./gradlew :forge-26.1:runGameTestServer --no-daemon --console=plain --configure-on-demand
         timeout-minutes: 30
         env:
           GRADLE_OPTS: >-

--- a/scripts/gradle-health.sh
+++ b/scripts/gradle-health.sh
@@ -40,7 +40,7 @@ for c in "${CONSUMERS[@]}"; do
         continue
     fi
     echo "[gradle-health] ${c}:projectHealth..."
-    ./gradlew --no-daemon --offline "${c}:projectHealth" || true
+    ./gradlew --no-daemon --offline --configure-on-demand "${c}:projectHealth" || true
     case "$c" in
         :common) report="common/build/reports/dependency-analysis/project-health-report.txt" ;;
         *) report="${c#:}/build/reports/dependency-analysis/project-health-report.txt" ;;


### PR DESCRIPTION
Per CI-runtime research (lib-2): all root jobs pay ForgeGradle userdev configuration for all 7 forge modules even when building :common (Build (common) = 21.8m; every leg clusters 15-23m; wall bounded by GameTest (1.21.1) at 23.45m).

--configure-on-demand (CI-only flag on the root-build command lines) makes Gradle configure only the target project + its project deps, skipping the other 6 forge modules' ForgeGradle userdev/mappings resolution at configuration time.

Local validation (Gradle 9.7.0, sdkman JDK 21.0.2-tem):
- Config-phase evidence: `time ./gradlew :common:help` (no flag) = 7m19s -> `--configure-on-demand` = 6.7s (65x)
- `./gradlew --configure-on-demand :common:build --no-daemon --offline` -> BUILD SUCCESSFUL in 1m (was 21.8m in CI)
- `./gradlew --configure-on-demand :forge-1.21:compileJava --no-daemon --offline` -> BUILD SUCCESSFUL in 14s (forge module + transitive :common dep configure correctly)

Scope (step-level only, no job names touched — 22-context contract intact):
- build-matrix leg: :${{ matrix.module }}:build
- 6 GameTest legs: :forge-X:runGameTestServer
- ci-health via scripts/gradle-health.sh projectHealth loop

Expected ci.yml wall ~23m -> ~6-8m. First CI run is the gate: if any required check fails on configuration, revert and report.