### PR TITLE
feat(commands): share MojangProfileCache with tab completion (modern lanes)

### DIFF
--- a/common/src/main/java/levosilimo/everlastingskins/skinchanger/MojangApiHttpImpl.java
+++ b/common/src/main/java/levosilimo/everlastingskins/skinchanger/MojangApiHttpImpl.java
@@ -46,7 +46,7 @@ public class MojangApiHttpImpl implements MojangAPI {
     private final MojangEndpoints endpoints;
     private final HttpClient httpClient;
     private final boolean profileCacheEnabled;
-    private final MojangProfileCache cache = new MojangProfileCache();
+    private final MojangProfileCache cache;
 
     public MojangApiHttpImpl() {
         this(MojangEndpoints.DEFAULT, new HttpsUrlConnectionHttpClient(), true);
@@ -61,9 +61,20 @@ public class MojangApiHttpImpl implements MojangAPI {
     }
 
     public MojangApiHttpImpl(MojangEndpoints endpoints, HttpClient httpClient, boolean profileCacheEnabled) {
+        this(endpoints, httpClient, profileCacheEnabled, new MojangProfileCache());
+    }
+
+    /**
+     * Full constructor. The cache is caller-owned so one instance can back both
+     * the Mojang API path and tab completion (CompletionSources); a null cache
+     * falls back to a fresh default one.
+     */
+    public MojangApiHttpImpl(MojangEndpoints endpoints, HttpClient httpClient, boolean profileCacheEnabled,
+            MojangProfileCache cache) {
         this.endpoints = endpoints;
         this.httpClient = httpClient;
         this.profileCacheEnabled = profileCacheEnabled;
+        this.cache = cache != null ? cache : new MojangProfileCache();
     }
 
     @Override

--- a/forge-1.16.5/src/main/java/levosilimo/everlastingskins/skinchanger/SkinCommand.java
+++ b/forge-1.16.5/src/main/java/levosilimo/everlastingskins/skinchanger/SkinCommand.java
@@ -12,6 +12,7 @@ import com.mojang.brigadier.arguments.BoolArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
+import levosilimo.everlastingskins.Config;
 import levosilimo.everlastingskins.enums.SkinActionType;
 import levosilimo.everlastingskins.enums.SkinVariant;
 import levosilimo.everlastingskins.permission.PermissionContext;
@@ -19,6 +20,7 @@ import levosilimo.everlastingskins.permission.PermissionServiceManager;
 import levosilimo.everlastingskins.skinchanger.command.SkinActionCommand;
 import levosilimo.everlastingskins.skinchanger.command.SkinMetricsCommand;
 import levosilimo.everlastingskins.util.CompletionSources;
+import levosilimo.everlastingskins.util.HttpsUrlConnectionHttpClient;
 import levosilimo.everlastingskins.util.I18nUtils;
 import net.minecraft.command.CommandSource;
 import net.minecraft.command.Commands;
@@ -51,7 +53,11 @@ public class SkinCommand {
 
     public static MojangAPI getMojangAPI() {
         if (mojangAPIInstance == null) {
-            mojangAPIInstance = new MojangApiHttpImpl();
+            MojangProfileCache sharedCache = new MojangProfileCache(
+                    Config.MOJANG_CACHE_TTL_MS.get(), Config.MOJANG_CACHE_MAX_SIZE.get());
+            mojangAPIInstance = new MojangApiHttpImpl(MojangEndpoints.DEFAULT, new HttpsUrlConnectionHttpClient(),
+                    true, sharedCache);
+            CompletionSources.setMojangProfileCache(sharedCache);
         }
         return mojangAPIInstance;
     }

--- a/forge-1.18.2/src/main/java/levosilimo/everlastingskins/skinchanger/SkinCommand.java
+++ b/forge-1.18.2/src/main/java/levosilimo/everlastingskins/skinchanger/SkinCommand.java
@@ -62,7 +62,10 @@ public class SkinCommand {
 
     public static MojangAPI getMojangAPI() {
         if (mojangAPIInstance == null) {
-            mojangAPIInstance = new MojangApiHttpImpl(MojangEndpoints.DEFAULT, new JavaHttpClient());
+            MojangProfileCache sharedCache = new MojangProfileCache(
+                    Config.MOJANG_CACHE_TTL_MS.get(), Config.MOJANG_CACHE_MAX_SIZE.get());
+            mojangAPIInstance = new MojangApiHttpImpl(MojangEndpoints.DEFAULT, new JavaHttpClient(), true, sharedCache);
+            CompletionSources.setMojangProfileCache(sharedCache);
         }
         return mojangAPIInstance;
     }

--- a/forge-1.20.1/src/main/java/levosilimo/everlastingskins/skinchanger/SkinCommand.java
+++ b/forge-1.20.1/src/main/java/levosilimo/everlastingskins/skinchanger/SkinCommand.java
@@ -62,7 +62,10 @@ public class SkinCommand {
 
     public static MojangAPI getMojangAPI() {
         if (mojangAPIInstance == null) {
-            mojangAPIInstance = new MojangApiHttpImpl(MojangEndpoints.DEFAULT, new JavaHttpClient());
+            MojangProfileCache sharedCache = new MojangProfileCache(
+                    Config.MOJANG_CACHE_TTL_MS.get(), Config.MOJANG_CACHE_MAX_SIZE.get());
+            mojangAPIInstance = new MojangApiHttpImpl(MojangEndpoints.DEFAULT, new JavaHttpClient(), true, sharedCache);
+            CompletionSources.setMojangProfileCache(sharedCache);
         }
         return mojangAPIInstance;
     }

--- a/forge-1.21.1/src/main/java/levosilimo/everlastingskins/forge21/skinchanger/SkinCommand.java
+++ b/forge-1.21.1/src/main/java/levosilimo/everlastingskins/forge21/skinchanger/SkinCommand.java
@@ -17,6 +17,7 @@ import levosilimo.everlastingskins.skinchanger.MineSkinApiHttpImpl;
 import levosilimo.everlastingskins.skinchanger.MojangAPI;
 import levosilimo.everlastingskins.skinchanger.MojangApiHttpImpl;
 import levosilimo.everlastingskins.skinchanger.MojangEndpoints;
+import levosilimo.everlastingskins.skinchanger.MojangProfileCache;
 import levosilimo.everlastingskins.Config;
 import levosilimo.everlastingskins.enums.SkinActionType;
 import levosilimo.everlastingskins.enums.SkinVariant;
@@ -62,7 +63,10 @@ public class SkinCommand {
 
     public static MojangAPI getMojangAPI() {
         if (mojangAPIInstance == null) {
-            mojangAPIInstance = new MojangApiHttpImpl(MojangEndpoints.DEFAULT, new JavaHttpClient());
+            MojangProfileCache sharedCache = new MojangProfileCache(
+                    Config.MOJANG_CACHE_TTL_MS.get(), Config.MOJANG_CACHE_MAX_SIZE.get());
+            mojangAPIInstance = new MojangApiHttpImpl(MojangEndpoints.DEFAULT, new JavaHttpClient(), true, sharedCache);
+            CompletionSources.setMojangProfileCache(sharedCache);
         }
         return mojangAPIInstance;
     }

--- a/forge-1.21.4/src/main/java/levosilimo/everlastingskins/forge21/skinchanger/SkinCommand.java
+++ b/forge-1.21.4/src/main/java/levosilimo/everlastingskins/forge21/skinchanger/SkinCommand.java
@@ -17,6 +17,7 @@ import levosilimo.everlastingskins.skinchanger.MineSkinApiHttpImpl;
 import levosilimo.everlastingskins.skinchanger.MojangAPI;
 import levosilimo.everlastingskins.skinchanger.MojangApiHttpImpl;
 import levosilimo.everlastingskins.skinchanger.MojangEndpoints;
+import levosilimo.everlastingskins.skinchanger.MojangProfileCache;
 import levosilimo.everlastingskins.Config;
 import levosilimo.everlastingskins.enums.SkinActionType;
 import levosilimo.everlastingskins.enums.SkinVariant;
@@ -62,7 +63,10 @@ public class SkinCommand {
 
     public static MojangAPI getMojangAPI() {
         if (mojangAPIInstance == null) {
-            mojangAPIInstance = new MojangApiHttpImpl(MojangEndpoints.DEFAULT, new JavaHttpClient());
+            MojangProfileCache sharedCache = new MojangProfileCache(
+                    Config.MOJANG_CACHE_TTL_MS.get(), Config.MOJANG_CACHE_MAX_SIZE.get());
+            mojangAPIInstance = new MojangApiHttpImpl(MojangEndpoints.DEFAULT, new JavaHttpClient(), true, sharedCache);
+            CompletionSources.setMojangProfileCache(sharedCache);
         }
         return mojangAPIInstance;
     }

--- a/forge-1.21.8/src/main/java/levosilimo/everlastingskins/forge21/skinchanger/SkinCommand.java
+++ b/forge-1.21.8/src/main/java/levosilimo/everlastingskins/forge21/skinchanger/SkinCommand.java
@@ -17,6 +17,7 @@ import levosilimo.everlastingskins.skinchanger.MineSkinApiHttpImpl;
 import levosilimo.everlastingskins.skinchanger.MojangAPI;
 import levosilimo.everlastingskins.skinchanger.MojangApiHttpImpl;
 import levosilimo.everlastingskins.skinchanger.MojangEndpoints;
+import levosilimo.everlastingskins.skinchanger.MojangProfileCache;
 import levosilimo.everlastingskins.Config;
 import levosilimo.everlastingskins.enums.SkinActionType;
 import levosilimo.everlastingskins.enums.SkinVariant;
@@ -62,7 +63,10 @@ public class SkinCommand {
 
     public static MojangAPI getMojangAPI() {
         if (mojangAPIInstance == null) {
-            mojangAPIInstance = new MojangApiHttpImpl(MojangEndpoints.DEFAULT, new JavaHttpClient());
+            MojangProfileCache sharedCache = new MojangProfileCache(
+                    Config.MOJANG_CACHE_TTL_MS.get(), Config.MOJANG_CACHE_MAX_SIZE.get());
+            mojangAPIInstance = new MojangApiHttpImpl(MojangEndpoints.DEFAULT, new JavaHttpClient(), true, sharedCache);
+            CompletionSources.setMojangProfileCache(sharedCache);
         }
         return mojangAPIInstance;
     }

--- a/forge-1.21/src/main/java/levosilimo/everlastingskins/forge21/skinchanger/SkinCommand.java
+++ b/forge-1.21/src/main/java/levosilimo/everlastingskins/forge21/skinchanger/SkinCommand.java
@@ -17,6 +17,7 @@ import levosilimo.everlastingskins.skinchanger.MineSkinApiHttpImpl;
 import levosilimo.everlastingskins.skinchanger.MojangAPI;
 import levosilimo.everlastingskins.skinchanger.MojangApiHttpImpl;
 import levosilimo.everlastingskins.skinchanger.MojangEndpoints;
+import levosilimo.everlastingskins.skinchanger.MojangProfileCache;
 import levosilimo.everlastingskins.Config;
 import levosilimo.everlastingskins.enums.SkinActionType;
 import levosilimo.everlastingskins.enums.SkinVariant;
@@ -62,7 +63,10 @@ public class SkinCommand {
 
     public static MojangAPI getMojangAPI() {
         if (mojangAPIInstance == null) {
-            mojangAPIInstance = new MojangApiHttpImpl(MojangEndpoints.DEFAULT, new JavaHttpClient());
+            MojangProfileCache sharedCache = new MojangProfileCache(
+                    Config.MOJANG_CACHE_TTL_MS.get(), Config.MOJANG_CACHE_MAX_SIZE.get());
+            mojangAPIInstance = new MojangApiHttpImpl(MojangEndpoints.DEFAULT, new JavaHttpClient(), true, sharedCache);
+            CompletionSources.setMojangProfileCache(sharedCache);
         }
         return mojangAPIInstance;
     }

--- a/forge-26.1/src/main/java/levosilimo/everlastingskins/forge26_1/skinchanger/SkinCommand.java
+++ b/forge-26.1/src/main/java/levosilimo/everlastingskins/forge26_1/skinchanger/SkinCommand.java
@@ -17,6 +17,7 @@ import levosilimo.everlastingskins.skinchanger.MineSkinApiHttpImpl;
 import levosilimo.everlastingskins.skinchanger.MojangAPI;
 import levosilimo.everlastingskins.skinchanger.MojangApiHttpImpl;
 import levosilimo.everlastingskins.skinchanger.MojangEndpoints;
+import levosilimo.everlastingskins.skinchanger.MojangProfileCache;
 import levosilimo.everlastingskins.Config;
 import levosilimo.everlastingskins.enums.SkinActionType;
 import levosilimo.everlastingskins.enums.SkinVariant;
@@ -62,7 +63,10 @@ public class SkinCommand {
 
     public static MojangAPI getMojangAPI() {
         if (mojangAPIInstance == null) {
-            mojangAPIInstance = new MojangApiHttpImpl(MojangEndpoints.DEFAULT, new JavaHttpClient());
+            MojangProfileCache sharedCache = new MojangProfileCache(
+                    Config.MOJANG_CACHE_TTL_MS.get(), Config.MOJANG_CACHE_MAX_SIZE.get());
+            mojangAPIInstance = new MojangApiHttpImpl(MojangEndpoints.DEFAULT, new JavaHttpClient(), true, sharedCache);
+            CompletionSources.setMojangProfileCache(sharedCache);
         }
         return mojangAPIInstance;
     }

--- a/forge-26.2/src/main/java/levosilimo/everlastingskins/forge26/skinchanger/SkinCommand.java
+++ b/forge-26.2/src/main/java/levosilimo/everlastingskins/forge26/skinchanger/SkinCommand.java
@@ -17,6 +17,7 @@ import levosilimo.everlastingskins.skinchanger.MineSkinApiHttpImpl;
 import levosilimo.everlastingskins.skinchanger.MojangAPI;
 import levosilimo.everlastingskins.skinchanger.MojangApiHttpImpl;
 import levosilimo.everlastingskins.skinchanger.MojangEndpoints;
+import levosilimo.everlastingskins.skinchanger.MojangProfileCache;
 import levosilimo.everlastingskins.Config;
 import levosilimo.everlastingskins.enums.SkinActionType;
 import levosilimo.everlastingskins.enums.SkinVariant;
@@ -62,7 +63,10 @@ public class SkinCommand {
 
     public static MojangAPI getMojangAPI() {
         if (mojangAPIInstance == null) {
-            mojangAPIInstance = new MojangApiHttpImpl(MojangEndpoints.DEFAULT, new JavaHttpClient());
+            MojangProfileCache sharedCache = new MojangProfileCache(
+                    Config.MOJANG_CACHE_TTL_MS.get(), Config.MOJANG_CACHE_MAX_SIZE.get());
+            mojangAPIInstance = new MojangApiHttpImpl(MojangEndpoints.DEFAULT, new JavaHttpClient(), true, sharedCache);
+            CompletionSources.setMojangProfileCache(sharedCache);
         }
         return mojangAPIInstance;
     }

--- a/mc1.12.2/src/main/java/levosilimo/everlastingskins/skinchanger/SkinCommand.java
+++ b/mc1.12.2/src/main/java/levosilimo/everlastingskins/skinchanger/SkinCommand.java
@@ -18,6 +18,7 @@ import levosilimo.everlastingskins.permission.PermissionServiceManager;
 import levosilimo.everlastingskins.skinchanger.responses.mojang.MojangSkinDataResult;
 import levosilimo.everlastingskins.util.CompletionSources;
 import levosilimo.everlastingskins.util.CustomSkinProperty;
+import levosilimo.everlastingskins.util.HttpsUrlConnectionHttpClient;
 import levosilimo.everlastingskins.util.I18nUtils;
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.CommandException;
@@ -40,7 +41,18 @@ public class SkinCommand extends CommandBase {
     static final String PREFIX = "§6[" + EverlastingSkins.MOD_NAME + "]§f ";
 
     private static MineSkinAPI mineSkinAPI = new MineSkinApiHttpImpl();
-    private static MojangAPI mojangAPI = new MojangApiHttpImpl();
+    private static MojangAPI mojangAPI = createMojangAPI();
+
+    /**
+     * Builds the Mojang API with a caller-owned profile cache shared with
+     * {@link CompletionSources}, so recently fetched profiles show up in
+     * tab completion.
+     */
+    private static MojangAPI createMojangAPI() {
+        MojangProfileCache sharedCache = new MojangProfileCache();
+        CompletionSources.setMojangProfileCache(sharedCache);
+        return new MojangApiHttpImpl(MojangEndpoints.DEFAULT, new HttpsUrlConnectionHttpClient(), true, sharedCache);
+    }
 
     public static MineSkinAPI getMineSkinAPI() {
         return mineSkinAPI;
@@ -60,7 +72,7 @@ public class SkinCommand extends CommandBase {
     }
 
     static void resetAPIs() {
-        mojangAPI = new MojangApiHttpImpl();
+        mojangAPI = createMojangAPI();
         mineSkinAPI = new MineSkinApiHttpImpl();
     }
 


### PR DESCRIPTION
Per tab-completion research (lib-4): recent Mojang-fetched profiles now appear in /skin completion.

**What changed (per lane):**
- **Changed (all 10 lanes):** every lane previously gave CompletionSources its own private MojangProfileCache while the Mojang API path (MojangApiHttpImpl) held a second, hardwired instance — nothing was shared. Each lane now builds ONE cache and passes it to both the Mojang API and CompletionSources.setMojangProfileCache(), so any profile fetched by `set mojang <name>` shows up in tab completion immediately.
  - forge-1.21 / 1.21.1 / 1.21.4 / 1.21.8 (byte-identical, forge21.\*)
  - forge-26.1 / forge-26.2
  - forge-1.16.5, forge-1.18.2, forge-1.20.1 (out-of-band lanes)
  - mc1.12.2 (eager init + test resetAPIs() both route through the shared-cache factory)
- **Already shared:** none — verified per lane that `setMojangProfileCache` had zero production callers before this PR.

**No :common behavior change** — the one :common edit is additive: a 4-arg `MojangApiHttpImpl` constructor accepting a caller-owned cache (the injectable seam was genuinely missing; the old field was hardwired `new MojangProfileCache()`). All existing constructors delegate unchanged.

All touched lanes build green locally (root: :common + 1.21.x + 26.x; out-of-band: 1.16.5 / 1.18.2 / 1.20.1 / mc1.12.2 with their own wrappers).