### PR TITLE
feat(commands): tab completion for /skin on 1.4.7/1.5.2/1.6.4/1.7.10

### DIFF
--- a/forge-1.4.7/src/main/java/levosilimo/everlastingskins/command/SkinRestorerCommand.java
+++ b/forge-1.4.7/src/main/java/levosilimo/everlastingskins/command/SkinRestorerCommand.java
@@ -9,6 +9,7 @@ package levosilimo.everlastingskins.command;
 import levosilimo.everlastingskins.permission.PermissionServiceManager;
 import levosilimo.everlastingskins.skinchanger.MojangAPI;
 import levosilimo.everlastingskins.skinchanger.MojangApiHttpImpl;
+import levosilimo.everlastingskins.skinchanger.MojangProfileCache;
 import levosilimo.everlastingskins.skinchanger.SkinRestorer;
 import levosilimo.everlastingskins.skinchanger.responses.mojang.MojangSkinDataResult;
 import levosilimo.everlastingskins.util.CustomSkinProperty;
@@ -17,6 +18,7 @@ import net.minecraft.src.EntityPlayerMP;
 import net.minecraft.src.ICommand;
 import net.minecraft.src.ICommandSender;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -52,6 +54,9 @@ public class SkinRestorerCommand implements ICommand {
 
     private static volatile MojangAPI mojangApi = new MojangApiHttpImpl();
     private static volatile MinecraftServer serverOverride;
+
+    /** Seen usernames for {@code /skin set} completion, populated on successful resolves. */
+    private static final MojangProfileCache seenProfiles = new MojangProfileCache();
 
     @Override
     public String getCommandName() {
@@ -130,6 +135,7 @@ public class SkinRestorerCommand implements ICommand {
             return;
         }
         CustomSkinProperty skin = result.get().skinProperty();
+        seenProfiles.put(username, skin);
         SkinRestorer.applySkin(uuid, skin);
         sender.sendChatToPlayer("Skin applied.");
     }
@@ -161,7 +167,53 @@ public class SkinRestorerCommand implements ICommand {
 
     @Override
     public List addTabCompletionOptions(ICommandSender sender, String[] args) {
+        if (args.length == 1) {
+            List<String> subcommands = new ArrayList<String>();
+            if (canUse(sender, NODE_SKIN)) subcommands.add("set");
+            if (canUse(sender, NODE_SKIN_CLEAR)) subcommands.add("clear");
+            if (canUse(sender, NODE_SKIN_SOURCE)) subcommands.add("source");
+            return filterCompletions(args[0], subcommands);
+        }
+        if (args.length == 2) {
+            List<String> candidates = new ArrayList<String>();
+            addOnlinePlayerNames(candidates);
+            for (String seen : seenProfiles.snapshot()) {
+                if (!candidates.contains(seen)) candidates.add(seen);
+            }
+            return filterCompletions(args[1], candidates);
+        }
         return null;
+    }
+
+    /** Silent permission check for completion (no denial message, unlike {@link #checkPermission}). */
+    private static boolean canUse(ICommandSender sender, String node) {
+        if (!(sender instanceof EntityPlayerMP)) return true;
+        EntityPlayerMP player = (EntityPlayerMP) sender;
+        return PermissionServiceManager.hasPermission(
+            SkinRestorer.uuidOf(player.getCommandSenderName()), 4, node);
+    }
+
+    /** Online player names via the era {@code playerEntityList} walk (no getAllUsernames pre-1.7). */
+    private void addOnlinePlayerNames(List<String> candidates) {
+        MinecraftServer server = serverOverride != null ? serverOverride : MinecraftServer.getServer();
+        if (server != null && server.getConfigurationManager() != null) {
+            for (Object o : server.getConfigurationManager().playerEntityList) {
+                if (o instanceof EntityPlayerMP) {
+                    candidates.add(((EntityPlayerMP) o).getCommandSenderName());
+                }
+            }
+        }
+    }
+
+    /** Case-insensitive prefix filter (pre-1.7 lanes have no CommandBase helper). */
+    private static List filterCompletions(String prefix, List<String> candidates) {
+        List<String> matches = new ArrayList<String>();
+        for (String candidate : candidates) {
+            if (candidate.regionMatches(true, 0, prefix, 0, prefix.length())) {
+                matches.add(candidate);
+            }
+        }
+        return matches;
     }
 
     @Override
@@ -182,5 +234,10 @@ public class SkinRestorerCommand implements ICommand {
     /** Test seam — mirrors the mc1.12.2 SkinRestorer.setServer pattern. */
     static void setServerOverrideForTest(MinecraftServer server) {
         serverOverride = server;
+    }
+
+    /** Test seam — deterministic completion tests (memory #1115). */
+    static void clearSeenProfilesForTest() {
+        seenProfiles.clear();
     }
 }

--- a/forge-1.4.7/src/test/java/levosilimo/everlastingskins/command/SkinRestorerCommandTest.java
+++ b/forge-1.4.7/src/test/java/levosilimo/everlastingskins/command/SkinRestorerCommandTest.java
@@ -27,6 +27,7 @@ import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -69,6 +70,7 @@ public class SkinRestorerCommandTest {
     public void tearDown() {
         SkinRestorerCommand.setMojangApiForTest(null);
         SkinRestorerCommand.setServerOverrideForTest(null);
+        SkinRestorerCommand.clearSeenProfilesForTest();
         SkinRestorer.setStorageForTest(null);
         SkinRestorer.setServerForTest(null);
     }
@@ -159,6 +161,71 @@ public class SkinRestorerCommandTest {
 
         command.processCommand(player, new String[]{"set", "ghost"});
         assertEquals(null, SkinRestorer.getSource(SkinRestorer.uuidOf("Notch")));
+    }
+
+    @Test
+    public void tabCompleteOffersSubcommands() {
+        ICommandSender sender = mock(ICommandSender.class);
+        List completions = command.addTabCompletionOptions(sender, new String[]{""});
+        assertTrue(completions.contains("set"));
+        assertTrue(completions.contains("clear"));
+        assertTrue(completions.contains("source"));
+    }
+
+    @Test
+    public void tabCompletePrefixFiltersSubcommands() {
+        ICommandSender sender = mock(ICommandSender.class);
+        List completions = command.addTabCompletionOptions(sender, new String[]{"c"});
+        assertEquals(1, completions.size());
+        assertEquals("clear", completions.get(0));
+    }
+
+    @Test
+    public void tabCompleteSecondArgOffersOnlineAndSeenNames() throws Exception {
+        // Seed the seen cache through the real set path (deterministic fake).
+        MojangSkinDataResult result = new MojangSkinDataResult(
+            UUID.randomUUID(),
+            new CustomSkinProperty("textures", "dGFi", null, "MojangAPI"));
+        SkinRestorerCommand.setMojangApiForTest(new FakeMojangApi(Optional.of(result)));
+
+        EntityPlayerMP xephos = mockPlayer("xephos");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(xephos));
+        command.processCommand(xephos, new String[]{"set", "xephos"});
+
+        // xephos left the server; only Notch + jeb_ are online now.
+        EntityPlayerMP self = mockPlayer("Notch");
+        EntityPlayerMP other = mockPlayer("jeb_");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(self, other));
+
+        ICommandSender sender = mock(ICommandSender.class);
+        List completions = command.addTabCompletionOptions(sender, new String[]{"set", ""});
+        assertTrue(completions.contains("Notch"));
+        assertTrue(completions.contains("jeb_"));
+        assertTrue(completions.contains("xephos")); // from the seen cache, not online
+    }
+
+    @Test
+    public void tabCompleteSecondArgPrefixFilters() throws Exception {
+        MojangSkinDataResult result = new MojangSkinDataResult(
+            UUID.randomUUID(),
+            new CustomSkinProperty("textures", "dGFi", null, "MojangAPI"));
+        SkinRestorerCommand.setMojangApiForTest(new FakeMojangApi(Optional.of(result)));
+        EntityPlayerMP xephos = mockPlayer("xephos");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(xephos));
+        command.processCommand(xephos, new String[]{"set", "xephos"});
+
+        SkinRestorerCommand.setServerOverrideForTest(
+            mockServer(mockPlayer("Notch"), mockPlayer("jeb_")));
+        ICommandSender sender = mock(ICommandSender.class);
+        List completions = command.addTabCompletionOptions(sender, new String[]{"set", "j"});
+        assertEquals(1, completions.size());
+        assertEquals("jeb_", completions.get(0));
+    }
+
+    @Test
+    public void tabCompleteBeyondSecondArgReturnsNull() {
+        ICommandSender sender = mock(ICommandSender.class);
+        assertEquals(null, command.addTabCompletionOptions(sender, new String[]{"set", "Notch", "extra"}));
     }
 
     private static EntityPlayerMP mockPlayer(String name) {

--- a/forge-1.5.2/src/main/java/levosilimo/everlastingskins/command/SkinRestorerCommand.java
+++ b/forge-1.5.2/src/main/java/levosilimo/everlastingskins/command/SkinRestorerCommand.java
@@ -9,6 +9,7 @@ package levosilimo.everlastingskins.command;
 import levosilimo.everlastingskins.permission.PermissionServiceManager;
 import levosilimo.everlastingskins.skinchanger.MojangAPI;
 import levosilimo.everlastingskins.skinchanger.MojangApiHttpImpl;
+import levosilimo.everlastingskins.skinchanger.MojangProfileCache;
 import levosilimo.everlastingskins.skinchanger.SkinRestorer;
 import levosilimo.everlastingskins.skinchanger.responses.mojang.MojangSkinDataResult;
 import levosilimo.everlastingskins.util.CustomSkinProperty;
@@ -17,6 +18,7 @@ import net.minecraft.src.EntityPlayerMP;
 import net.minecraft.src.ICommand;
 import net.minecraft.src.ICommandSender;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -51,6 +53,9 @@ public class SkinRestorerCommand implements ICommand {
 
     private static volatile MojangAPI mojangApi = new MojangApiHttpImpl();
     private static volatile MinecraftServer serverOverride;
+
+    /** Seen usernames for {@code /skin set} completion, populated on successful resolves. */
+    private static final MojangProfileCache seenProfiles = new MojangProfileCache();
 
     @Override
     public String getCommandName() {
@@ -129,6 +134,7 @@ public class SkinRestorerCommand implements ICommand {
             return;
         }
         CustomSkinProperty skin = result.get().skinProperty();
+        seenProfiles.put(username, skin);
         SkinRestorer.applySkin(uuid, skin);
         sender.sendChatToPlayer("Skin applied.");
     }
@@ -160,7 +166,53 @@ public class SkinRestorerCommand implements ICommand {
 
     @Override
     public List addTabCompletionOptions(ICommandSender sender, String[] args) {
+        if (args.length == 1) {
+            List<String> subcommands = new ArrayList<String>();
+            if (canUse(sender, NODE_SKIN)) subcommands.add("set");
+            if (canUse(sender, NODE_SKIN_CLEAR)) subcommands.add("clear");
+            if (canUse(sender, NODE_SKIN_SOURCE)) subcommands.add("source");
+            return filterCompletions(args[0], subcommands);
+        }
+        if (args.length == 2) {
+            List<String> candidates = new ArrayList<String>();
+            addOnlinePlayerNames(candidates);
+            for (String seen : seenProfiles.snapshot()) {
+                if (!candidates.contains(seen)) candidates.add(seen);
+            }
+            return filterCompletions(args[1], candidates);
+        }
         return null;
+    }
+
+    /** Silent permission check for completion (no denial message, unlike {@link #checkPermission}). */
+    private static boolean canUse(ICommandSender sender, String node) {
+        if (!(sender instanceof EntityPlayerMP)) return true;
+        EntityPlayerMP player = (EntityPlayerMP) sender;
+        return PermissionServiceManager.hasPermission(
+            SkinRestorer.uuidOf(player.getCommandSenderName()), 4, node);
+    }
+
+    /** Online player names via the era {@code playerEntityList} walk (no getAllUsernames pre-1.7). */
+    private void addOnlinePlayerNames(List<String> candidates) {
+        MinecraftServer server = serverOverride != null ? serverOverride : MinecraftServer.getServer();
+        if (server != null && server.getConfigurationManager() != null) {
+            for (Object o : server.getConfigurationManager().playerEntityList) {
+                if (o instanceof EntityPlayerMP) {
+                    candidates.add(((EntityPlayerMP) o).getCommandSenderName());
+                }
+            }
+        }
+    }
+
+    /** Case-insensitive prefix filter (pre-1.7 lanes have no CommandBase helper). */
+    private static List filterCompletions(String prefix, List<String> candidates) {
+        List<String> matches = new ArrayList<String>();
+        for (String candidate : candidates) {
+            if (candidate.regionMatches(true, 0, prefix, 0, prefix.length())) {
+                matches.add(candidate);
+            }
+        }
+        return matches;
     }
 
     @Override
@@ -181,5 +233,10 @@ public class SkinRestorerCommand implements ICommand {
     /** Test seam — mirrors the mc1.12.2 SkinRestorer.setServer pattern. */
     static void setServerOverrideForTest(MinecraftServer server) {
         serverOverride = server;
+    }
+
+    /** Test seam — deterministic completion tests (memory #1115). */
+    static void clearSeenProfilesForTest() {
+        seenProfiles.clear();
     }
 }

--- a/forge-1.5.2/src/test/java/levosilimo/everlastingskins/command/SkinRestorerCommandTest.java
+++ b/forge-1.5.2/src/test/java/levosilimo/everlastingskins/command/SkinRestorerCommandTest.java
@@ -27,6 +27,7 @@ import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -69,6 +70,7 @@ public class SkinRestorerCommandTest {
     public void tearDown() {
         SkinRestorerCommand.setMojangApiForTest(null);
         SkinRestorerCommand.setServerOverrideForTest(null);
+        SkinRestorerCommand.clearSeenProfilesForTest();
         SkinRestorer.setStorageForTest(null);
         SkinRestorer.setServerForTest(null);
     }
@@ -159,6 +161,71 @@ public class SkinRestorerCommandTest {
 
         command.processCommand(player, new String[]{"set", "ghost"});
         assertEquals(null, SkinRestorer.getSource(SkinRestorer.uuidOf("Notch")));
+    }
+
+    @Test
+    public void tabCompleteOffersSubcommands() {
+        ICommandSender sender = mock(ICommandSender.class);
+        List completions = command.addTabCompletionOptions(sender, new String[]{""});
+        assertTrue(completions.contains("set"));
+        assertTrue(completions.contains("clear"));
+        assertTrue(completions.contains("source"));
+    }
+
+    @Test
+    public void tabCompletePrefixFiltersSubcommands() {
+        ICommandSender sender = mock(ICommandSender.class);
+        List completions = command.addTabCompletionOptions(sender, new String[]{"c"});
+        assertEquals(1, completions.size());
+        assertEquals("clear", completions.get(0));
+    }
+
+    @Test
+    public void tabCompleteSecondArgOffersOnlineAndSeenNames() throws Exception {
+        // Seed the seen cache through the real set path (deterministic fake).
+        MojangSkinDataResult result = new MojangSkinDataResult(
+            UUID.randomUUID(),
+            new CustomSkinProperty("textures", "dGFi", null, "MojangAPI"));
+        SkinRestorerCommand.setMojangApiForTest(new FakeMojangApi(Optional.of(result)));
+
+        EntityPlayerMP xephos = mockPlayer("xephos");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(xephos));
+        command.processCommand(xephos, new String[]{"set", "xephos"});
+
+        // xephos left the server; only Notch + jeb_ are online now.
+        EntityPlayerMP self = mockPlayer("Notch");
+        EntityPlayerMP other = mockPlayer("jeb_");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(self, other));
+
+        ICommandSender sender = mock(ICommandSender.class);
+        List completions = command.addTabCompletionOptions(sender, new String[]{"set", ""});
+        assertTrue(completions.contains("Notch"));
+        assertTrue(completions.contains("jeb_"));
+        assertTrue(completions.contains("xephos")); // from the seen cache, not online
+    }
+
+    @Test
+    public void tabCompleteSecondArgPrefixFilters() throws Exception {
+        MojangSkinDataResult result = new MojangSkinDataResult(
+            UUID.randomUUID(),
+            new CustomSkinProperty("textures", "dGFi", null, "MojangAPI"));
+        SkinRestorerCommand.setMojangApiForTest(new FakeMojangApi(Optional.of(result)));
+        EntityPlayerMP xephos = mockPlayer("xephos");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(xephos));
+        command.processCommand(xephos, new String[]{"set", "xephos"});
+
+        SkinRestorerCommand.setServerOverrideForTest(
+            mockServer(mockPlayer("Notch"), mockPlayer("jeb_")));
+        ICommandSender sender = mock(ICommandSender.class);
+        List completions = command.addTabCompletionOptions(sender, new String[]{"set", "j"});
+        assertEquals(1, completions.size());
+        assertEquals("jeb_", completions.get(0));
+    }
+
+    @Test
+    public void tabCompleteBeyondSecondArgReturnsNull() {
+        ICommandSender sender = mock(ICommandSender.class);
+        assertEquals(null, command.addTabCompletionOptions(sender, new String[]{"set", "Notch", "extra"}));
     }
 
     private static EntityPlayerMP mockPlayer(String name) {

--- a/forge-1.6.4/src/main/java/levosilimo/everlastingskins/command/SkinRestorerCommand.java
+++ b/forge-1.6.4/src/main/java/levosilimo/everlastingskins/command/SkinRestorerCommand.java
@@ -9,6 +9,7 @@ package levosilimo.everlastingskins.command;
 import levosilimo.everlastingskins.permission.PermissionServiceManager;
 import levosilimo.everlastingskins.skinchanger.MojangAPI;
 import levosilimo.everlastingskins.skinchanger.MojangApiHttpImpl;
+import levosilimo.everlastingskins.skinchanger.MojangProfileCache;
 import levosilimo.everlastingskins.skinchanger.SkinRestorer;
 import levosilimo.everlastingskins.skinchanger.responses.mojang.MojangSkinDataResult;
 import levosilimo.everlastingskins.util.CustomSkinProperty;
@@ -18,6 +19,7 @@ import net.minecraft.src.EntityPlayerMP;
 import net.minecraft.src.ICommand;
 import net.minecraft.src.ICommandSender;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -52,6 +54,9 @@ public class SkinRestorerCommand implements ICommand {
 
     private static volatile MojangAPI mojangApi = new MojangApiHttpImpl();
     private static volatile MinecraftServer serverOverride;
+
+    /** Seen usernames for {@code /skin set} completion, populated on successful resolves. */
+    private static final MojangProfileCache seenProfiles = new MojangProfileCache();
 
     @Override
     public String getCommandName() {
@@ -130,6 +135,7 @@ public class SkinRestorerCommand implements ICommand {
             return;
         }
         CustomSkinProperty skin = result.get().skinProperty();
+        seenProfiles.put(username, skin);
         SkinRestorer.applySkin(uuid, skin);
         sender.sendChatToPlayer(ChatMessageComponent.createFromText("Skin applied."));
     }
@@ -161,7 +167,53 @@ public class SkinRestorerCommand implements ICommand {
 
     @Override
     public List addTabCompletionOptions(ICommandSender sender, String[] args) {
+        if (args.length == 1) {
+            List<String> subcommands = new ArrayList<String>();
+            if (canUse(sender, NODE_SKIN)) subcommands.add("set");
+            if (canUse(sender, NODE_SKIN_CLEAR)) subcommands.add("clear");
+            if (canUse(sender, NODE_SKIN_SOURCE)) subcommands.add("source");
+            return filterCompletions(args[0], subcommands);
+        }
+        if (args.length == 2) {
+            List<String> candidates = new ArrayList<String>();
+            addOnlinePlayerNames(candidates);
+            for (String seen : seenProfiles.snapshot()) {
+                if (!candidates.contains(seen)) candidates.add(seen);
+            }
+            return filterCompletions(args[1], candidates);
+        }
         return null;
+    }
+
+    /** Silent permission check for completion (no denial message, unlike {@link #checkPermission}). */
+    private static boolean canUse(ICommandSender sender, String node) {
+        if (!(sender instanceof EntityPlayerMP)) return true;
+        EntityPlayerMP player = (EntityPlayerMP) sender;
+        return PermissionServiceManager.hasPermission(
+            SkinRestorer.uuidOf(player.getCommandSenderName()), 4, node);
+    }
+
+    /** Online player names via the era {@code playerEntityList} walk (no getAllUsernames pre-1.7). */
+    private void addOnlinePlayerNames(List<String> candidates) {
+        MinecraftServer server = serverOverride != null ? serverOverride : MinecraftServer.getServer();
+        if (server != null && server.getConfigurationManager() != null) {
+            for (Object o : server.getConfigurationManager().playerEntityList) {
+                if (o instanceof EntityPlayerMP) {
+                    candidates.add(((EntityPlayerMP) o).getCommandSenderName());
+                }
+            }
+        }
+    }
+
+    /** Case-insensitive prefix filter (pre-1.7 lanes have no CommandBase helper). */
+    private static List filterCompletions(String prefix, List<String> candidates) {
+        List<String> matches = new ArrayList<String>();
+        for (String candidate : candidates) {
+            if (candidate.regionMatches(true, 0, prefix, 0, prefix.length())) {
+                matches.add(candidate);
+            }
+        }
+        return matches;
     }
 
     @Override
@@ -182,5 +234,10 @@ public class SkinRestorerCommand implements ICommand {
     /** Test seam — mirrors the mc1.12.2 SkinRestorer.setServer pattern. */
     static void setServerOverrideForTest(MinecraftServer server) {
         serverOverride = server;
+    }
+
+    /** Test seam — deterministic completion tests (memory #1115). */
+    static void clearSeenProfilesForTest() {
+        seenProfiles.clear();
     }
 }

--- a/forge-1.6.4/src/test/java/levosilimo/everlastingskins/command/SkinRestorerCommandTest.java
+++ b/forge-1.6.4/src/test/java/levosilimo/everlastingskins/command/SkinRestorerCommandTest.java
@@ -27,6 +27,7 @@ import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -69,6 +70,7 @@ public class SkinRestorerCommandTest {
     public void tearDown() {
         SkinRestorerCommand.setMojangApiForTest(null);
         SkinRestorerCommand.setServerOverrideForTest(null);
+        SkinRestorerCommand.clearSeenProfilesForTest();
         SkinRestorer.setStorageForTest(null);
         SkinRestorer.setServerForTest(null);
     }
@@ -159,6 +161,71 @@ public class SkinRestorerCommandTest {
 
         command.processCommand(player, new String[]{"set", "ghost"});
         assertEquals(null, SkinRestorer.getSource(SkinRestorer.uuidOf("Notch")));
+    }
+
+    @Test
+    public void tabCompleteOffersSubcommands() {
+        ICommandSender sender = mock(ICommandSender.class);
+        List completions = command.addTabCompletionOptions(sender, new String[]{""});
+        assertTrue(completions.contains("set"));
+        assertTrue(completions.contains("clear"));
+        assertTrue(completions.contains("source"));
+    }
+
+    @Test
+    public void tabCompletePrefixFiltersSubcommands() {
+        ICommandSender sender = mock(ICommandSender.class);
+        List completions = command.addTabCompletionOptions(sender, new String[]{"c"});
+        assertEquals(1, completions.size());
+        assertEquals("clear", completions.get(0));
+    }
+
+    @Test
+    public void tabCompleteSecondArgOffersOnlineAndSeenNames() throws Exception {
+        // Seed the seen cache through the real set path (deterministic fake).
+        MojangSkinDataResult result = new MojangSkinDataResult(
+            UUID.randomUUID(),
+            new CustomSkinProperty("textures", "dGFi", null, "MojangAPI"));
+        SkinRestorerCommand.setMojangApiForTest(new FakeMojangApi(Optional.of(result)));
+
+        EntityPlayerMP xephos = mockPlayer("xephos");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(xephos));
+        command.processCommand(xephos, new String[]{"set", "xephos"});
+
+        // xephos left the server; only Notch + jeb_ are online now.
+        EntityPlayerMP self = mockPlayer("Notch");
+        EntityPlayerMP other = mockPlayer("jeb_");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(self, other));
+
+        ICommandSender sender = mock(ICommandSender.class);
+        List completions = command.addTabCompletionOptions(sender, new String[]{"set", ""});
+        assertTrue(completions.contains("Notch"));
+        assertTrue(completions.contains("jeb_"));
+        assertTrue(completions.contains("xephos")); // from the seen cache, not online
+    }
+
+    @Test
+    public void tabCompleteSecondArgPrefixFilters() throws Exception {
+        MojangSkinDataResult result = new MojangSkinDataResult(
+            UUID.randomUUID(),
+            new CustomSkinProperty("textures", "dGFi", null, "MojangAPI"));
+        SkinRestorerCommand.setMojangApiForTest(new FakeMojangApi(Optional.of(result)));
+        EntityPlayerMP xephos = mockPlayer("xephos");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(xephos));
+        command.processCommand(xephos, new String[]{"set", "xephos"});
+
+        SkinRestorerCommand.setServerOverrideForTest(
+            mockServer(mockPlayer("Notch"), mockPlayer("jeb_")));
+        ICommandSender sender = mock(ICommandSender.class);
+        List completions = command.addTabCompletionOptions(sender, new String[]{"set", "j"});
+        assertEquals(1, completions.size());
+        assertEquals("jeb_", completions.get(0));
+    }
+
+    @Test
+    public void tabCompleteBeyondSecondArgReturnsNull() {
+        ICommandSender sender = mock(ICommandSender.class);
+        assertEquals(null, command.addTabCompletionOptions(sender, new String[]{"set", "Notch", "extra"}));
     }
 
     private static EntityPlayerMP mockPlayer(String name) {

--- a/forge-1.7.10/src/main/java/levosilimo/everlastingskins/skinchanger/SkinCommand.java
+++ b/forge-1.7.10/src/main/java/levosilimo/everlastingskins/skinchanger/SkinCommand.java
@@ -8,14 +8,17 @@ package levosilimo.everlastingskins.skinchanger;
 
 import com.mojang.authlib.GameProfile;
 import levosilimo.everlastingskins.permission.PermissionServiceManager;
+import levosilimo.everlastingskins.skinchanger.MojangProfileCache;
 import levosilimo.everlastingskins.skinchanger.responses.mojang.MojangSkinDataResult;
 import levosilimo.everlastingskins.util.CustomSkinProperty;
+import net.minecraft.command.CommandBase;
 import net.minecraft.command.ICommand;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.ChatComponentText;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -46,6 +49,9 @@ public class SkinCommand implements ICommand {
 
     private static volatile MojangAPI mojangApi = new MojangApiHttpImpl();
     private static volatile MinecraftServer serverOverride;
+
+    /** Seen usernames for {@code /skin set} completion, populated on successful resolves. */
+    private static final MojangProfileCache seenProfiles = new MojangProfileCache();
 
     private final SkinStorageProvider provider;
 
@@ -131,6 +137,7 @@ public class SkinCommand implements ICommand {
             return;
         }
         CustomSkinProperty skin = result.get().skinProperty();
+        seenProfiles.put(username, skin);
         provider.applySkin(profile, uuid, skin);
         sender.addChatMessage(new ChatComponentText("Skin applied."));
     }
@@ -162,7 +169,43 @@ public class SkinCommand implements ICommand {
 
     @Override
     public List addTabCompletionOptions(ICommandSender sender, String[] args) {
+        if (args.length == 1) {
+            List<String> subcommands = new ArrayList<String>();
+            if (canUse(sender, NODE_SKIN)) subcommands.add("set");
+            if (canUse(sender, NODE_SKIN_CLEAR)) subcommands.add("clear");
+            if (canUse(sender, NODE_SKIN_SOURCE)) subcommands.add("source");
+            return CommandBase.getListOfStringsMatchingLastWord(args, subcommands.toArray(new String[subcommands.size()]));
+        }
+        if (args.length == 2) {
+            List<String> candidates = new ArrayList<String>();
+            addOnlinePlayerNames(candidates);
+            for (String seen : seenProfiles.snapshot()) {
+                if (!candidates.contains(seen)) candidates.add(seen);
+            }
+            return CommandBase.getListOfStringsMatchingLastWord(args, candidates.toArray(new String[candidates.size()]));
+        }
         return null;
+    }
+
+    /** Silent permission check for completion (no denial message, unlike {@link #checkPermission}). */
+    private static boolean canUse(ICommandSender sender, String node) {
+        if (!(sender instanceof EntityPlayerMP)) return true;
+        EntityPlayerMP player = (EntityPlayerMP) sender;
+        return PermissionServiceManager.hasPermission(
+            player.getGameProfile().getId(), 4, node);
+    }
+
+    /** Online player names via the 1.7.10-era {@code getAllUsernames} (the later getOnlinePlayerNames). */
+    private void addOnlinePlayerNames(List<String> candidates) {
+        MinecraftServer server = serverOverride != null ? serverOverride : MinecraftServer.getServer();
+        if (server != null && server.getConfigurationManager() != null) {
+            String[] names = server.getConfigurationManager().getAllUsernames();
+            if (names != null) {
+                for (String name : names) {
+                    if (!candidates.contains(name)) candidates.add(name);
+                }
+            }
+        }
     }
 
     @Override
@@ -183,5 +226,10 @@ public class SkinCommand implements ICommand {
     /** Test seam — mirrors the mc1.12.2 SkinRestorer.setServer pattern. */
     static void setServerOverrideForTest(MinecraftServer server) {
         serverOverride = server;
+    }
+
+    /** Test seam — deterministic completion tests (memory #1115). */
+    static void clearSeenProfilesForTest() {
+        seenProfiles.clear();
     }
 }

--- a/forge-1.7.10/src/test/java/levosilimo/everlastingskins/skinchanger/SkinRestorerCommandTest.java
+++ b/forge-1.7.10/src/test/java/levosilimo/everlastingskins/skinchanger/SkinRestorerCommandTest.java
@@ -24,6 +24,7 @@ import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -68,6 +69,7 @@ public class SkinRestorerCommandTest {
     public void tearDown() {
         SkinCommand.setMojangApiForTest(null);
         SkinCommand.setServerOverrideForTest(null);
+        SkinCommand.clearSeenProfilesForTest();
         SkinRestorer.setProviderForTest(null);
         SkinRestorer.setServerForTest(null);
     }
@@ -178,6 +180,70 @@ public class SkinRestorerCommandTest {
         assertEquals(null, provider.getSkin(TEST_UUID));
     }
 
+    @Test
+    public void tabCompleteOffersSubcommands() {
+        ICommandSender sender = mock(ICommandSender.class);
+        List completions = command.addTabCompletionOptions(sender, new String[]{""});
+        assertTrue(completions.contains("set"));
+        assertTrue(completions.contains("clear"));
+        assertTrue(completions.contains("source"));
+    }
+
+    @Test
+    public void tabCompletePrefixFiltersSubcommands() {
+        ICommandSender sender = mock(ICommandSender.class);
+        List completions = command.addTabCompletionOptions(sender, new String[]{"c"});
+        assertEquals(1, completions.size());
+        assertEquals("clear", completions.get(0));
+    }
+
+    @Test
+    public void tabCompleteSecondArgOffersOnlineAndSeenNames() throws Exception {
+        // Seed the seen cache through the real set path (deterministic fake).
+        MojangSkinDataResult result = new MojangSkinDataResult(
+            TEST_UUID,
+            new CustomSkinProperty("textures", "dGFi", null, "MojangAPI"));
+        SkinCommand.setMojangApiForTest(new FakeMojangApi(Optional.of(result)));
+
+        EntityPlayerMP xephos = mockPlayer(UUID.randomUUID(), "xephos");
+        SkinCommand.setServerOverrideForTest(mockServer(xephos));
+        command.processCommand(xephos, new String[]{"set", "xephos"});
+
+        // xephos left the server; only Notch + jeb_ are online now.
+        SkinCommand.setServerOverrideForTest(
+            mockServer(mockPlayer(TEST_UUID, "Notch"), mockPlayer(UUID.randomUUID(), "jeb_")));
+
+        ICommandSender sender = mock(ICommandSender.class);
+        List completions = command.addTabCompletionOptions(sender, new String[]{"set", ""});
+        assertTrue(completions.contains("Notch"));
+        assertTrue(completions.contains("jeb_"));
+        assertTrue(completions.contains("xephos")); // from the seen cache, not online
+    }
+
+    @Test
+    public void tabCompleteSecondArgPrefixFilters() throws Exception {
+        MojangSkinDataResult result = new MojangSkinDataResult(
+            TEST_UUID,
+            new CustomSkinProperty("textures", "dGFi", null, "MojangAPI"));
+        SkinCommand.setMojangApiForTest(new FakeMojangApi(Optional.of(result)));
+        EntityPlayerMP xephos = mockPlayer(UUID.randomUUID(), "xephos");
+        SkinCommand.setServerOverrideForTest(mockServer(xephos));
+        command.processCommand(xephos, new String[]{"set", "xephos"});
+
+        SkinCommand.setServerOverrideForTest(
+            mockServer(mockPlayer(TEST_UUID, "Notch"), mockPlayer(UUID.randomUUID(), "jeb_")));
+        ICommandSender sender = mock(ICommandSender.class);
+        List completions = command.addTabCompletionOptions(sender, new String[]{"set", "j"});
+        assertEquals(1, completions.size());
+        assertEquals("jeb_", completions.get(0));
+    }
+
+    @Test
+    public void tabCompleteBeyondSecondArgReturnsNull() {
+        ICommandSender sender = mock(ICommandSender.class);
+        assertEquals(null, command.addTabCompletionOptions(sender, new String[]{"set", "Notch", "extra"}));
+    }
+
     private static EntityPlayerMP mockPlayer(UUID uuid, String name) {
         EntityPlayerMP player = mock(EntityPlayerMP.class);
         when(player.getUniqueID()).thenReturn(uuid);
@@ -195,6 +261,11 @@ public class SkinRestorerCommandTest {
         field.setAccessible(true);
         field.set(manager, players.length == 0 ? Collections.emptyList()
             : java.util.Arrays.asList(players));
+        String[] names = new String[players.length];
+        for (int i = 0; i < players.length; i++) {
+            names[i] = players[i].getCommandSenderName();
+        }
+        when(manager.getAllUsernames()).thenReturn(names);
         return server;
     }
 


### PR DESCRIPTION
Per tab-completion research (lib-4): all four pre-1.8 lanes had addTabCompletionOptions returning null. Now: subcommand completion at arg 1, MojangProfileCache.snapshot() seen usernames + online player names at arg 2 (set username slot). No :common changes; per-lane only.