### PR TITLE
feat(commands): pre-1.8 partial parity — random, metrics, multi-target (1.4.7/1.5.2/1.6.4)

### DIFF
--- a/forge-1.4.7/src/main/java/levosilimo/everlastingskins/command/SkinRestorerCommand.java
+++ b/forge-1.4.7/src/main/java/levosilimo/everlastingskins/command/SkinRestorerCommand.java
@@ -6,10 +6,17 @@
 
 package levosilimo.everlastingskins.command;
 
+import levosilimo.everlastingskins.enums.SkinVariant;
+import levosilimo.everlastingskins.metrics.MetricsFormat;
+import levosilimo.everlastingskins.metrics.PlayerSnapshot;
+import levosilimo.everlastingskins.metrics.SkinMetrics;
+import levosilimo.everlastingskins.metrics.Snapshot;
 import levosilimo.everlastingskins.permission.PermissionServiceManager;
 import levosilimo.everlastingskins.skinchanger.MojangAPI;
 import levosilimo.everlastingskins.skinchanger.MojangApiHttpImpl;
 import levosilimo.everlastingskins.skinchanger.MojangProfileCache;
+import levosilimo.everlastingskins.skinchanger.RandomCapeSource;
+import levosilimo.everlastingskins.skinchanger.RandomMojangSkin;
 import levosilimo.everlastingskins.skinchanger.SkinRestorer;
 import levosilimo.everlastingskins.skinchanger.responses.mojang.MojangSkinDataResult;
 import levosilimo.everlastingskins.util.CustomSkinProperty;
@@ -18,9 +25,12 @@ import net.minecraft.src.EntityPlayerMP;
 import net.minecraft.src.ICommand;
 import net.minecraft.src.ICommandSender;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -31,19 +41,28 @@ import java.util.UUID;
  * {@code getCommandAliases} / {@code getCommandUsage} / {@code processCommand}
  * / {@code canCommandSenderUseCommand} / {@code addTabCompletionOptions} /
  * {@code isUsernameIndex} — no {@code LiteralArgumentBuilder} (1.13+) and no
- * {@code getName} (1.8+). Sender chat goes through
- * {@link ICommandSender#sendChatToPlayer(String)} — the PLAIN-STRING form;
- * {@code ChatMessageComponent} does not exist until 1.5, so there is no
- * component wrapping on this line.
+ * {@code getName} (1.8+). Sender chat goes through {@link ICommandSender#sendChatToPlayer(String)} (the plain-string form — {@code ChatMessageComponent} does not exist until 1.5).
  *
  * <p>Permission gating is delegated to {@link PermissionServiceManager} (the
  * Forge ops backend resolves the player by username-derived UUID — memory
  * #1123: UUID-only keying, never the player object). The manager fails closed
- * until a backend is registered.
+ * until a backend is registered. The gate is sender-based (mirroring
+ * mc1.12.2): the console is the trusted operator, players are checked by
+ * their own UUID, and targeting anyone other than the sender requires
+ * {@code everlastingskins.command.skin.other} (degraded to the lane's op
+ * model — op level 2 — by {@code ForgePermissionService.requiredOpLevel}).
  *
  * <p>No GameProfile on this line: targets resolve by username
  * ({@code getCommandSenderName()}) and storage keys are derived via
  * {@link SkinRestorer#uuidOf(String)}.
+ *
+ * <p>Command/storage parity with the modern surface (per the pre-1.8 parity
+ * investigation): {@code set random [cape] [variant]} (pick + resolve +
+ * store), {@code metrics [json|players|cleanup|reset]}, multi-target loops
+ * with per-target permission gating, and extended tab completion. Rendering
+ * parity stays era-limited — no GameProfile textures to inject and the
+ * legacy skins.minecraft.net username-keyed path is dead, so {@code set web}
+ * is honestly rejected with an era-limitation message.
  */
 public class SkinRestorerCommand implements ICommand {
 
@@ -51,12 +70,43 @@ public class SkinRestorerCommand implements ICommand {
     private static final String NODE_SKIN = NODE_PREFIX + ".skin";
     private static final String NODE_SKIN_CLEAR = NODE_PREFIX + ".skin.clear";
     private static final String NODE_SKIN_SOURCE = NODE_PREFIX + ".skin.source";
+    private static final String NODE_SKIN_RANDOM = NODE_PREFIX + ".skin.random";
+    private static final String NODE_SKIN_OTHER = NODE_PREFIX + ".skin.other";
+    private static final String NODE_METRICS = NODE_PREFIX + ".metrics";
+    private static final String NODE_METRICS_RESET = NODE_PREFIX + ".metrics.reset";
+
+    /** Honest rejection for {@code set web}: no MineSkin/URL pipeline exists pre-GameProfile. */
+    private static final String WEB_UNSUPPORTED = "web skins are not supported on this version";
+
+    /** Stale-window for {@code metrics cleanup}, mirroring the modern lanes (30 days). */
+    private static final long CLEANUP_OLDER_THAN_MS = 30L * 24 * 60 * 60 * 1000;
 
     private static volatile MojangAPI mojangApi = new MojangApiHttpImpl();
     private static volatile MinecraftServer serverOverride;
 
     /** Seen usernames for {@code /skin set} completion, populated on successful resolves. */
     private static final MojangProfileCache seenProfiles = new MojangProfileCache();
+
+    /**
+     * Random-pick indirection: cape mode swaps the candidate source for
+     * {@link RandomCapeSource} (mskins with_capes) — mirroring the modern
+     * lanes' random branch. Test seam: deterministic fakes only (memory
+     * #1115; no live HTTP).
+     */
+    interface RandomPickSource {
+        String pick(boolean cape, SkinVariant variant) throws IOException;
+    }
+
+    private static final RandomPickSource DEFAULT_RANDOM_PICK_SOURCE = new RandomPickSource() {
+        @Override
+        public String pick(boolean cape, SkinVariant variant) throws IOException {
+            return cape
+                ? new RandomCapeSource().pickRandomCapeUsername()
+                : RandomMojangSkin.randomUsername(false, variant);
+        }
+    };
+
+    private static volatile RandomPickSource randomPickSource = DEFAULT_RANDOM_PICK_SOURCE;
 
     @Override
     public String getCommandName() {
@@ -70,7 +120,7 @@ public class SkinRestorerCommand implements ICommand {
 
     @Override
     public String getCommandUsage(ICommandSender sender) {
-        return "/skin <set <username>|clear|source> [player]";
+        return "/skin <set <username|random [cape] [variant]>|clear|source|metrics [json|players|cleanup|reset]> [players...]";
     }
 
     @Override
@@ -88,36 +138,175 @@ public class SkinRestorerCommand implements ICommand {
             return;
         }
         String action = args[0];
-        EntityPlayerMP target = resolveTarget(sender, args);
-        if (target == null) {
+        if ("metrics".equals(action)) {
+            doMetrics(sender, args);
+            return;
+        }
+        if ("clear".equals(action)) {
+            doClear(sender, args);
+            return;
+        }
+        if ("source".equals(action)) {
+            doSource(sender, args);
+            return;
+        }
+        if ("set".equals(action)) {
+            doSet(sender, args);
+            return;
+        }
+        sender.sendChatToPlayer(getCommandUsage(sender));
+    }
+
+    private void doSet(ICommandSender sender, String[] args) {
+        if (args.length < 2) {
+            sender.sendChatToPlayer(getCommandUsage(sender));
+            return;
+        }
+        if ("web".equalsIgnoreCase(args[1])) {
+            // No MineSkin/URL pipeline exists on this line: pre-GameProfile
+            // has no client-side mechanism to render custom textures.
+            sender.sendChatToPlayer(WEB_UNSUPPORTED);
+            return;
+        }
+        if ("random".equalsIgnoreCase(args[1])) {
+            setRandom(sender, args);
+            return;
+        }
+        // /skin set <username> [players...]: apply the named skin to each target.
+        List<EntityPlayerMP> targets = resolveTargets(sender, args, 2);
+        if (targets == null) {
             sender.sendChatToPlayer("Player not found.");
             return;
         }
-        UUID uuid = SkinRestorer.uuidOf(target.getCommandSenderName());
-
-        switch (action) {
-            case "clear":
-                if (!checkPermission(sender, uuid, NODE_SKIN_CLEAR)) return;
-                SkinRestorer.clearSkin(uuid);
-                sender.sendChatToPlayer("Skin cleared.");
-                break;
-            case "source":
-                if (!checkPermission(sender, uuid, NODE_SKIN_SOURCE)) return;
-                String source = SkinRestorer.getSource(uuid);
-                sender.sendChatToPlayer(
-                    source != null ? "Skin source: " + source : "No custom skin stored.");
-                break;
-            case "set":
-                if (!checkPermission(sender, uuid, NODE_SKIN)) return;
-                if (args.length < 2) {
-                    sender.sendChatToPlayer(getCommandUsage(sender));
-                    return;
-                }
-                setSkin(sender, uuid, args[1]);
-                break;
-            default:
-                sender.sendChatToPlayer(getCommandUsage(sender));
+        if (!checkPermission(sender, targetsAreSelfOnly(sender, targets) ? NODE_SKIN : NODE_SKIN_OTHER)) {
+            return;
         }
+        for (EntityPlayerMP target : targets) {
+            setSkin(sender, SkinRestorer.uuidOf(target.getCommandSenderName()), args[1]);
+        }
+    }
+
+    /**
+     * /skin set random [<cape> [<variant>]] [players...]: the cape flag and
+     * variant are optional and parsed positionally to match the tab-completion
+     * cascade (bool, then variant, then targets) — the mc1.12.2 semantics.
+     */
+    private void setRandom(ICommandSender sender, String[] args) {
+        boolean cape = args.length >= 3 && "true".equalsIgnoreCase(args[2]);
+        SkinVariant variant = parseRandomVariant(args);
+        List<EntityPlayerMP> targets = resolveTargets(sender, args, 4);
+        if (targets == null) {
+            sender.sendChatToPlayer("Player not found.");
+            return;
+        }
+        if (!checkPermission(sender, targetsAreSelfOnly(sender, targets) ? NODE_SKIN_RANDOM : NODE_SKIN_OTHER)) {
+            return;
+        }
+        String username;
+        try {
+            username = randomPickSource.pick(cape, variant);
+        } catch (IOException e) {
+            sender.sendChatToPlayer("Could not pick a random skin (network error).");
+            return;
+        }
+        if (username == null) {
+            sender.sendChatToPlayer("Could not pick a random skin.");
+            return;
+        }
+        for (EntityPlayerMP target : targets) {
+            setSkin(sender, SkinRestorer.uuidOf(target.getCommandSenderName()), username);
+        }
+    }
+
+    private void doClear(ICommandSender sender, String[] args) {
+        List<EntityPlayerMP> targets = resolveTargets(sender, args, 1);
+        if (targets == null) {
+            sender.sendChatToPlayer("Player not found.");
+            return;
+        }
+        if (!checkPermission(sender, targetsAreSelfOnly(sender, targets) ? NODE_SKIN_CLEAR : NODE_SKIN_OTHER)) {
+            return;
+        }
+        for (EntityPlayerMP target : targets) {
+            UUID uuid = SkinRestorer.uuidOf(target.getCommandSenderName());
+            long startNanos = System.nanoTime();
+            SkinMetrics.INSTANCE.recordRefreshStarted(uuid);
+            SkinRestorer.clearSkin(uuid);
+            SkinMetrics.INSTANCE.recordRefreshCompleted(uuid, startNanos, 0, 0, 0);
+        }
+        sender.sendChatToPlayer("Skin cleared.");
+    }
+
+    private void doSource(ICommandSender sender, String[] args) {
+        List<EntityPlayerMP> targets = resolveTargets(sender, args, 1);
+        if (targets == null) {
+            sender.sendChatToPlayer("Player not found.");
+            return;
+        }
+        if (!checkPermission(sender, targetsAreSelfOnly(sender, targets) ? NODE_SKIN_SOURCE : NODE_SKIN_OTHER)) {
+            return;
+        }
+        if (targets.size() == 1) {
+            String source = SkinRestorer.getSource(SkinRestorer.uuidOf(targets.get(0).getCommandSenderName()));
+            sender.sendChatToPlayer(
+                source != null ? "Skin source: " + source : "No custom skin stored.");
+            return;
+        }
+        StringBuilder sb = new StringBuilder();
+        for (EntityPlayerMP target : targets) {
+            String name = target.getCommandSenderName();
+            String source = SkinRestorer.getSource(SkinRestorer.uuidOf(name));
+            if (sb.length() > 0) sb.append('\n');
+            sb.append(name).append(": ").append(source != null ? source : "No custom skin stored.");
+        }
+        sender.sendChatToPlayer(sb.toString());
+    }
+
+    /**
+     * /skin metrics [json|players|cleanup|reset]. View subcommands need
+     * {@code everlastingskins.command.metrics}; cleanup/reset additionally
+     * need {@code everlastingskins.command.metrics.reset}. Console senders
+     * are allowed (trusted operator) — mirrors the mc1.12.2 metrics surface.
+     */
+    private void doMetrics(ICommandSender sender, String[] args) {
+        String sub = args.length < 2 ? "human" : args[1];
+        if ("json".equals(sub)) {
+            if (!checkMetricsPermission(sender)) return;
+            sender.sendChatToPlayer(
+                MetricsFormat.json(SkinMetrics.INSTANCE.snapshot()));
+            return;
+        }
+        if ("players".equals(sub)) {
+            if (!checkMetricsPermission(sender)) return;
+            StringBuilder sb = new StringBuilder("EverlastingSkins top players:");
+            int rank = 0;
+            for (Map.Entry<UUID, PlayerSnapshot> e : SkinMetrics.INSTANCE.topPlayers(10)) {
+                sb.append('\n').append("  ").append(++rank).append(". ")
+                    .append(e.getKey()).append(" — ")
+                    .append(e.getValue().refreshCount()).append(" refreshes");
+            }
+            if (rank == 0) {
+                sb.append('\n').append("  No refreshes recorded.");
+            }
+            sender.sendChatToPlayer(sb.toString());
+            return;
+        }
+        if ("cleanup".equals(sub)) {
+            if (!checkMetricsResetPermission(sender)) return;
+            int removed = SkinMetrics.INSTANCE.cleanupStalePlayers(CLEANUP_OLDER_THAN_MS);
+            sender.sendChatToPlayer(
+                "Removed " + removed + " stale player(s) from metrics.");
+            return;
+        }
+        if ("reset".equals(sub)) {
+            if (!checkMetricsResetPermission(sender)) return;
+            SkinMetrics.INSTANCE.reset();
+            sender.sendChatToPlayer("Metrics reset.");
+            return;
+        }
+        if (!checkMetricsPermission(sender)) return;
+        sender.sendChatToPlayer(
+            MetricsFormat.human(SkinMetrics.INSTANCE.snapshot()));
     }
 
     private void setSkin(ICommandSender sender, UUID uuid, String username) {
@@ -129,40 +318,98 @@ public class SkinRestorerCommand implements ICommand {
             sender.sendChatToPlayer("Skin resolver unavailable.");
             return;
         }
+        long startNanos = System.nanoTime();
+        SkinMetrics.INSTANCE.recordRefreshStarted(uuid);
         Optional<MojangSkinDataResult> result = api.getSkin(username);
         if (!result.isPresent()) {
+            SkinMetrics.INSTANCE.recordRefreshFailed(uuid);
             sender.sendChatToPlayer("Could not resolve a skin for '" + username + "'.");
             return;
         }
         CustomSkinProperty skin = result.get().skinProperty();
         seenProfiles.put(username, skin);
         SkinRestorer.applySkin(uuid, skin);
+        SkinMetrics.INSTANCE.recordRefreshCompleted(uuid, startNanos, System.nanoTime() - startNanos, 0, 0);
         sender.sendChatToPlayer("Skin applied.");
     }
 
-    private boolean checkPermission(ICommandSender sender, UUID uuid, String node) {
-        int opLevel = sender instanceof EntityPlayerMP ? 4 : 0;
-        if (!PermissionServiceManager.hasPermission(uuid, opLevel, node)) {
+    /**
+     * Sender-based gate (mirrors mc1.12.2): the console is the trusted
+     * operator; players are checked by their own username-derived UUID
+     * (memory #1123 — never the target object).
+     */
+    private boolean checkPermission(ICommandSender sender, String node) {
+        if (!(sender instanceof EntityPlayerMP)) return true; // console
+        EntityPlayerMP player = (EntityPlayerMP) sender;
+        if (!PermissionServiceManager.hasPermission(
+                SkinRestorer.uuidOf(player.getCommandSenderName()), 4, node)) {
             sender.sendChatToPlayer("You do not have permission to use this command.");
             return false;
         }
         return true;
     }
 
-    private EntityPlayerMP resolveTarget(ICommandSender sender, String[] args) {
-        if (args.length >= 2 && !args[1].isEmpty()) {
-            MinecraftServer server = serverOverride != null ? serverOverride : MinecraftServer.getServer();
-            if (server != null && server.getConfigurationManager() != null) {
-                for (Object o : server.getConfigurationManager().playerEntityList) {
-                    if (o instanceof EntityPlayerMP) {
-                        EntityPlayerMP p = (EntityPlayerMP) o;
-                        if (p.getCommandSenderName().equalsIgnoreCase(args[1])) return p;
+    private boolean checkMetricsPermission(ICommandSender sender) {
+        if (!(sender instanceof EntityPlayerMP)) return true; // console
+        return checkPermission(sender, NODE_METRICS);
+    }
+
+    private boolean checkMetricsResetPermission(ICommandSender sender) {
+        if (!(sender instanceof EntityPlayerMP)) return true; // console
+        return checkPermission(sender, NODE_METRICS_RESET);
+    }
+
+    /**
+     * Resolves the target set: explicit names (args from {@code targetIndex})
+     * are matched against the online list, skipping unresolvable names
+     * (mirrors mc1.12.2's parseTargets); no explicit names resolve to the
+     * sender. Returns null when nothing resolved.
+     */
+    private List<EntityPlayerMP> resolveTargets(ICommandSender sender, String[] args, int targetIndex) {
+        MinecraftServer server = serverOverride != null ? serverOverride : MinecraftServer.getServer();
+        if (server != null && server.getConfigurationManager() != null) {
+            if (args.length > targetIndex) {
+                List<EntityPlayerMP> out = new ArrayList<EntityPlayerMP>();
+                for (int i = targetIndex; i < args.length; i++) {
+                    for (Object o : server.getConfigurationManager().playerEntityList) {
+                        if (o instanceof EntityPlayerMP) {
+                            EntityPlayerMP p = (EntityPlayerMP) o;
+                            if (p.getCommandSenderName().equalsIgnoreCase(args[i])) {
+                                out.add(p);
+                                break;
+                            }
+                        }
                     }
                 }
+                return out.isEmpty() ? null : out;
             }
-            return null;
+            for (Object o : server.getConfigurationManager().playerEntityList) {
+                if (o instanceof EntityPlayerMP && o == sender) {
+                    return Collections.singletonList((EntityPlayerMP) o);
+                }
+            }
         }
-        return sender instanceof EntityPlayerMP ? (EntityPlayerMP) sender : null;
+        if (sender instanceof EntityPlayerMP) {
+            return Collections.singletonList((EntityPlayerMP) sender);
+        }
+        return null;
+    }
+
+    private boolean targetsAreSelfOnly(ICommandSender sender, List<EntityPlayerMP> targets) {
+        return targets.size() == 1
+            && sender instanceof EntityPlayerMP
+            && targets.get(0) == sender;
+    }
+
+    /** Variant argument of {@code /skin set random}: optional, defaults to ALL. */
+    private static SkinVariant parseRandomVariant(String[] args) {
+        if (args.length >= 4 && "slim".equalsIgnoreCase(args[3])) {
+            return SkinVariant.SLIM;
+        }
+        if (args.length >= 4 && "classic".equalsIgnoreCase(args[3])) {
+            return SkinVariant.CLASSIC;
+        }
+        return SkinVariant.ALL;
     }
 
     @Override
@@ -172,17 +419,53 @@ public class SkinRestorerCommand implements ICommand {
             if (canUse(sender, NODE_SKIN)) subcommands.add("set");
             if (canUse(sender, NODE_SKIN_CLEAR)) subcommands.add("clear");
             if (canUse(sender, NODE_SKIN_SOURCE)) subcommands.add("source");
+            if (canUse(sender, NODE_METRICS)) subcommands.add("metrics");
             return filterCompletions(args[0], subcommands);
         }
         if (args.length == 2) {
+            if ("metrics".equals(args[0])) {
+                List<String> metricsSubs = new ArrayList<String>();
+                metricsSubs.add("json");
+                metricsSubs.add("players");
+                if (canUse(sender, NODE_METRICS_RESET)) {
+                    metricsSubs.add("cleanup");
+                    metricsSubs.add("reset");
+                }
+                return filterCompletions(args[1], metricsSubs);
+            }
             List<String> candidates = new ArrayList<String>();
+            if ("set".equals(args[0])) candidates.add("random");
             addOnlinePlayerNames(candidates);
             for (String seen : seenProfiles.snapshot()) {
                 if (!candidates.contains(seen)) candidates.add(seen);
             }
             return filterCompletions(args[1], candidates);
         }
+        if ("set".equals(args[0]) && "random".equals(args[1])) {
+            // Positional cascade mirroring mc1.12.2: cape bool, then variant,
+            // then target names.
+            if (args.length == 3) {
+                return filterCompletions(args[2], Arrays.asList("true", "false"));
+            }
+            if (args.length == 4) {
+                return filterCompletions(args[3], Arrays.asList("classic", "slim"));
+            }
+            return targetCompletions(args[args.length - 1]);
+        }
+        if ("set".equals(args[0]) || "clear".equals(args[0]) || "source".equals(args[0])) {
+            return targetCompletions(args[args.length - 1]);
+        }
         return null;
+    }
+
+    /** Online + seen-profile names for the target positions. */
+    private List targetCompletions(String prefix) {
+        List<String> candidates = new ArrayList<String>();
+        addOnlinePlayerNames(candidates);
+        for (String seen : seenProfiles.snapshot()) {
+            if (!candidates.contains(seen)) candidates.add(seen);
+        }
+        return filterCompletions(prefix, candidates);
     }
 
     /** Silent permission check for completion (no denial message, unlike {@link #checkPermission}). */
@@ -239,5 +522,10 @@ public class SkinRestorerCommand implements ICommand {
     /** Test seam — deterministic completion tests (memory #1115). */
     static void clearSeenProfilesForTest() {
         seenProfiles.clear();
+    }
+
+    /** Test seam — deterministic random-pick injection (null restores the live source). */
+    static void setRandomPickSourceForTest(RandomPickSource source) {
+        randomPickSource = source != null ? source : DEFAULT_RANDOM_PICK_SOURCE;
     }
 }

--- a/forge-1.4.7/src/test/java/levosilimo/everlastingskins/command/SkinRestorerCommandTest.java
+++ b/forge-1.4.7/src/test/java/levosilimo/everlastingskins/command/SkinRestorerCommandTest.java
@@ -6,6 +6,8 @@
 
 package levosilimo.everlastingskins.command;
 
+import levosilimo.everlastingskins.enums.SkinVariant;
+import levosilimo.everlastingskins.metrics.SkinMetrics;
 import levosilimo.everlastingskins.permission.IPermissionService;
 import levosilimo.everlastingskins.permission.PermissionServiceManager;
 import levosilimo.everlastingskins.skinchanger.MojangAPI;
@@ -23,6 +25,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -32,6 +35,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -42,12 +46,16 @@ import static org.mockito.Mockito.when;
  * 1.4.7 ICommand lifecycle + dispatch tests.
  *
  * <p>Deterministic fakes only (memory #1115): the Mojang lookup is a fake
- * resolver (no live HTTP); the sender/player/server are Mockito mocks over
- * the MCP 7.26a surface. The 1.4.7 command surface under test is
+ * resolver (no live HTTP); the random pick is an injected fake picker; the
+ * sender/player/server are Mockito mocks over the MCP 7.26a surface. The
+ * 1.6.4 command surface under test is
  * {@code getCommandName}/{@code getCommandAliases}/{@code processCommand} —
  * no {@code getName} (1.8+) and no LiteralArgumentBuilder (1.13+). Sender
- * chat goes through {@code sendChatToPlayer(String)} — the plain-string form
- * ({@code ChatMessageComponent} does not exist until 1.5).
+ * chat goes through {@code sendChatToPlayer(String)} (the plain-string form — {@code ChatMessageComponent} does not exist until 1.5).
+ *
+ * <p>Covers the command/storage parity surface (set random, metrics,
+ * multi-target + permission gating, web rejection) and the extended tab
+ * completion.
  */
 public class SkinRestorerCommandTest {
 
@@ -57,8 +65,12 @@ public class SkinRestorerCommandTest {
     public void setUp() throws Exception {
         // Highest-priority deterministic grant-all backend (memory #1115) so
         // permission checks in these dispatch tests are deterministic
-        // regardless of any backend left by earlier tests.
+        // regardless of any backend left by earlier tests. A sticky
+        // DenyNodeService (priority 1000) grants everything once its deny
+        // set is cleared, so behaviour stays grant-all across tests.
+        DenyNodeService.deny(null);
         PermissionServiceManager.registerService(new GrantAllService());
+        SkinMetrics.INSTANCE.reset();
 
         Path dir = Files.createTempDirectory("es-147-skin-restorer-test");
         SkinStorage.resetForTest();
@@ -71,6 +83,7 @@ public class SkinRestorerCommandTest {
         SkinRestorerCommand.setMojangApiForTest(null);
         SkinRestorerCommand.setServerOverrideForTest(null);
         SkinRestorerCommand.clearSeenProfilesForTest();
+        SkinRestorerCommand.setRandomPickSourceForTest(null);
         SkinRestorer.setStorageForTest(null);
         SkinRestorer.setServerForTest(null);
     }
@@ -164,12 +177,269 @@ public class SkinRestorerCommandTest {
     }
 
     @Test
+    public void setDispatchWebRejectsWithEraMessage() throws Exception {
+        // Pre-GameProfile era limitation: no MineSkin/URL pipeline exists,
+        // so set web is honestly rejected and nothing is stored.
+        MojangSkinDataResult result = new MojangSkinDataResult(
+            UUID.randomUUID(),
+            new CustomSkinProperty("textures", "d2Vi", null, "MojangAPI"));
+        SkinRestorerCommand.setMojangApiForTest(new FakeMojangApi(Optional.of(result)));
+
+        EntityPlayerMP player = mockPlayer("Notch");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(player));
+
+        command.processCommand(player, new String[]{"set", "web"});
+
+        assertEquals(null, SkinRestorer.getSource(SkinRestorer.uuidOf("Notch")));
+        verify(player).sendChatToPlayer(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    public void setDispatchMultiTargetAppliesToAllNamed() throws Exception {
+        MojangSkinDataResult result = new MojangSkinDataResult(
+            UUID.randomUUID(),
+            new CustomSkinProperty("textures", "bXVsdGk=", null, "MojangAPI"));
+        SkinRestorerCommand.setMojangApiForTest(new FakeMojangApi(Optional.of(result)));
+
+        EntityPlayerMP self = mockPlayer("Notch");
+        EntityPlayerMP other = mockPlayer("jeb_");
+        EntityPlayerMP third = mockPlayer("xephos");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(self, other, third));
+
+        command.processCommand(self, new String[]{"set", "Notch", "jeb_", "xephos"});
+
+        assertEquals("MojangAPI", SkinRestorer.getSource(SkinRestorer.uuidOf("jeb_")));
+        assertEquals("MojangAPI", SkinRestorer.getSource(SkinRestorer.uuidOf("xephos")));
+        assertEquals(null, SkinRestorer.getSource(SkinRestorer.uuidOf("Notch")));
+    }
+
+    @Test
+    public void setDispatchTargetingOthersRequiresOtherPermission() throws Exception {
+        MojangSkinDataResult result = new MojangSkinDataResult(
+            UUID.randomUUID(),
+            new CustomSkinProperty("textures", "b3RoZXI=", null, "MojangAPI"));
+        SkinRestorerCommand.setMojangApiForTest(new FakeMojangApi(Optional.of(result)));
+        DenyNodeService.deny("everlastingskins.command.skin.other");
+        PermissionServiceManager.registerService(new DenyNodeService());
+
+        EntityPlayerMP self = mockPlayer("Notch");
+        EntityPlayerMP other = mockPlayer("jeb_");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(self, other));
+
+        command.processCommand(self, new String[]{"set", "Notch", "jeb_"});
+
+        assertEquals(null, SkinRestorer.getSource(SkinRestorer.uuidOf("jeb_")));
+    }
+
+    @Test
+    public void clearDispatchMultiTargetClearsOnlyNamed() throws Exception {
+        UUID selfUuid = SkinRestorer.uuidOf("Notch");
+        UUID otherUuid = SkinRestorer.uuidOf("jeb_");
+        SkinRestorer.applySkin(selfUuid,
+            new CustomSkinProperty("textures", "YQ==", null, "fake"));
+        SkinRestorer.applySkin(otherUuid,
+            new CustomSkinProperty("textures", "Yg==", null, "fake"));
+
+        EntityPlayerMP self = mockPlayer("Notch");
+        EntityPlayerMP other = mockPlayer("jeb_");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(self, other));
+
+        command.processCommand(self, new String[]{"clear", "jeb_"});
+
+        assertEquals(null, SkinRestorer.getSource(otherUuid));
+        assertNotNull(SkinRestorer.getSource(selfUuid));
+    }
+
+    @Test
+    public void setRandomDispatchAppliesPickedSkin() throws Exception {
+        MojangSkinDataResult result = new MojangSkinDataResult(
+            UUID.randomUUID(),
+            new CustomSkinProperty("textures", "cmFuZG9t", null, "MojangAPI"));
+        SkinRestorerCommand.setMojangApiForTest(new FakeMojangApi(Optional.of(result)));
+        SkinRestorerCommand.setRandomPickSourceForTest(new FixedRandomPickSource("pickedUser"));
+
+        EntityPlayerMP player = mockPlayer("Notch");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(player));
+
+        command.processCommand(player, new String[]{"set", "random"});
+
+        assertEquals("MojangAPI", SkinRestorer.getSource(SkinRestorer.uuidOf("Notch")));
+    }
+
+    @Test
+    public void setRandomCapeFlagReachesPicker() throws Exception {
+        MojangSkinDataResult result = new MojangSkinDataResult(
+            UUID.randomUUID(),
+            new CustomSkinProperty("textures", "Y2FwZQ==", null, "MojangAPI"));
+        SkinRestorerCommand.setMojangApiForTest(new FakeMojangApi(Optional.of(result)));
+        RecordingRandomPickSource picker = new RecordingRandomPickSource("pickedUser");
+        SkinRestorerCommand.setRandomPickSourceForTest(picker);
+
+        EntityPlayerMP player = mockPlayer("Notch");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(player));
+
+        command.processCommand(player, new String[]{"set", "random", "true"});
+
+        assertTrue(picker.lastCape);
+        assertEquals(SkinVariant.ALL, picker.lastVariant);
+    }
+
+    @Test
+    public void setRandomVariantParsingReachesPicker() throws Exception {
+        MojangSkinDataResult result = new MojangSkinDataResult(
+            UUID.randomUUID(),
+            new CustomSkinProperty("textures", "dmFyaWFudA==", null, "MojangAPI"));
+        SkinRestorerCommand.setMojangApiForTest(new FakeMojangApi(Optional.of(result)));
+        RecordingRandomPickSource picker = new RecordingRandomPickSource("pickedUser");
+        SkinRestorerCommand.setRandomPickSourceForTest(picker);
+
+        EntityPlayerMP player = mockPlayer("Notch");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(player));
+
+        command.processCommand(player, new String[]{"set", "random", "false", "slim"});
+
+        assertFalse(picker.lastCape);
+        assertEquals(SkinVariant.SLIM, picker.lastVariant);
+    }
+
+    @Test
+    public void setRandomPickerNetworkFailureReportsError() throws Exception {
+        SkinRestorerCommand.setRandomPickSourceForTest(new FailingRandomPickSource());
+
+        EntityPlayerMP player = mockPlayer("Notch");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(player));
+
+        command.processCommand(player, new String[]{"set", "random"});
+
+        assertEquals(null, SkinRestorer.getSource(SkinRestorer.uuidOf("Notch")));
+    }
+
+    @Test
+    public void setRandomPickerEmptyPickReportsFailure() throws Exception {
+        SkinRestorerCommand.setRandomPickSourceForTest(new FixedRandomPickSource(null));
+
+        EntityPlayerMP player = mockPlayer("Notch");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(player));
+
+        command.processCommand(player, new String[]{"set", "random"});
+
+        assertEquals(null, SkinRestorer.getSource(SkinRestorer.uuidOf("Notch")));
+    }
+
+    @Test
+    public void setRandomDispatchTargetsOthers() throws Exception {
+        MojangSkinDataResult result = new MojangSkinDataResult(
+            UUID.randomUUID(),
+            new CustomSkinProperty("textures", "dGFyZ2V0", null, "MojangAPI"));
+        SkinRestorerCommand.setMojangApiForTest(new FakeMojangApi(Optional.of(result)));
+        SkinRestorerCommand.setRandomPickSourceForTest(new FixedRandomPickSource("pickedUser"));
+
+        EntityPlayerMP self = mockPlayer("Notch");
+        EntityPlayerMP other = mockPlayer("jeb_");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(self, other));
+
+        command.processCommand(self, new String[]{"set", "random", "false", "all", "jeb_"});
+
+        assertEquals("MojangAPI", SkinRestorer.getSource(SkinRestorer.uuidOf("jeb_")));
+        assertEquals(null, SkinRestorer.getSource(SkinRestorer.uuidOf("Notch")));
+    }
+
+    @Test
+    public void setRandomTargetingOthersRequiresOtherPermission() throws Exception {
+        MojangSkinDataResult result = new MojangSkinDataResult(
+            UUID.randomUUID(),
+            new CustomSkinProperty("textures", "ZGVueQ==", null, "MojangAPI"));
+        SkinRestorerCommand.setMojangApiForTest(new FakeMojangApi(Optional.of(result)));
+        SkinRestorerCommand.setRandomPickSourceForTest(new FixedRandomPickSource("pickedUser"));
+        DenyNodeService.deny("everlastingskins.command.skin.other");
+        PermissionServiceManager.registerService(new DenyNodeService());
+
+        EntityPlayerMP self = mockPlayer("Notch");
+        EntityPlayerMP other = mockPlayer("jeb_");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(self, other));
+
+        command.processCommand(self, new String[]{"set", "random", "false", "all", "jeb_"});
+
+        assertEquals(null, SkinRestorer.getSource(SkinRestorer.uuidOf("jeb_")));
+    }
+
+    @Test
+    public void metricsDispatchReportsSnapshot() throws Exception {
+        EntityPlayerMP player = mockPlayer("Notch");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(player));
+
+        command.processCommand(player, new String[]{"metrics"});
+
+        verify(player).sendChatToPlayer(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    public void metricsJsonDispatchReportsJson() throws Exception {
+        EntityPlayerMP player = mockPlayer("Notch");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(player));
+
+        command.processCommand(player, new String[]{"metrics", "json"});
+
+        verify(player).sendChatToPlayer(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    public void metricsPlayersDispatchReportsTopPlayers() throws Exception {
+        SkinMetrics.INSTANCE.recordRefreshCompleted(SkinRestorer.uuidOf("Notch"), 0, 1, 0, 0);
+        EntityPlayerMP player = mockPlayer("Notch");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(player));
+
+        command.processCommand(player, new String[]{"metrics", "players"});
+
+        verify(player).sendChatToPlayer(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    public void metricsResetDispatchClearsCounters() throws Exception {
+        SkinMetrics.INSTANCE.recordRefreshCompleted(SkinRestorer.uuidOf("Notch"), 0, 1, 0, 0);
+        assertEquals(1, SkinMetrics.INSTANCE.snapshot().refreshesCompleted());
+
+        EntityPlayerMP player = mockPlayer("Notch");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(player));
+
+        command.processCommand(player, new String[]{"metrics", "reset"});
+
+        assertEquals(0, SkinMetrics.INSTANCE.snapshot().refreshesCompleted());
+    }
+
+    @Test
+    public void metricsCleanupDispatchReportsRemoved() throws Exception {
+        EntityPlayerMP player = mockPlayer("Notch");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(player));
+
+        command.processCommand(player, new String[]{"metrics", "cleanup"});
+
+        verify(player).sendChatToPlayer(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    public void metricsResetRequiresResetPermission() throws Exception {
+        SkinMetrics.INSTANCE.recordRefreshCompleted(SkinRestorer.uuidOf("Notch"), 0, 1, 0, 0);
+        DenyNodeService.deny("everlastingskins.command.metrics.reset");
+        PermissionServiceManager.registerService(new DenyNodeService());
+
+        EntityPlayerMP player = mockPlayer("Notch");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(player));
+
+        command.processCommand(player, new String[]{"metrics", "reset"});
+
+        // Denied: counters survive the attempted reset.
+        assertEquals(1, SkinMetrics.INSTANCE.snapshot().refreshesCompleted());
+    }
+
+    @Test
     public void tabCompleteOffersSubcommands() {
         ICommandSender sender = mock(ICommandSender.class);
         List completions = command.addTabCompletionOptions(sender, new String[]{""});
         assertTrue(completions.contains("set"));
         assertTrue(completions.contains("clear"));
         assertTrue(completions.contains("source"));
+        assertTrue(completions.contains("metrics"));
     }
 
     @Test
@@ -202,6 +472,7 @@ public class SkinRestorerCommandTest {
         assertTrue(completions.contains("Notch"));
         assertTrue(completions.contains("jeb_"));
         assertTrue(completions.contains("xephos")); // from the seen cache, not online
+        assertTrue(completions.contains("random")); // the set sub-mode
     }
 
     @Test
@@ -223,9 +494,83 @@ public class SkinRestorerCommandTest {
     }
 
     @Test
-    public void tabCompleteBeyondSecondArgReturnsNull() {
+    public void tabCompleteMetricsSubcommands() {
         ICommandSender sender = mock(ICommandSender.class);
-        assertEquals(null, command.addTabCompletionOptions(sender, new String[]{"set", "Notch", "extra"}));
+        List completions = command.addTabCompletionOptions(sender, new String[]{"metrics", ""});
+        assertTrue(completions.contains("json"));
+        assertTrue(completions.contains("players"));
+        assertTrue(completions.contains("cleanup"));
+        assertTrue(completions.contains("reset"));
+    }
+
+    @Test
+    public void tabCompleteMetricsHideResetWithoutPermission() {
+        DenyNodeService.deny("everlastingskins.command.metrics.reset");
+        PermissionServiceManager.registerService(new DenyNodeService());
+        EntityPlayerMP player = mockPlayer("Notch");
+
+        List completions = command.addTabCompletionOptions(player, new String[]{"metrics", ""});
+
+        assertTrue(completions.contains("json"));
+        assertFalse(completions.contains("cleanup"));
+        assertFalse(completions.contains("reset"));
+    }
+
+    @Test
+    public void tabCompleteFirstArgHidesMetricsWithoutPermission() {
+        DenyNodeService.deny("everlastingskins.command.metrics");
+        PermissionServiceManager.registerService(new DenyNodeService());
+        EntityPlayerMP player = mockPlayer("Notch");
+
+        List completions = command.addTabCompletionOptions(player, new String[]{""});
+
+        assertTrue(completions.contains("set"));
+        assertFalse(completions.contains("metrics"));
+    }
+
+    @Test
+    public void tabCompleteSetRandomOffersCapeFlags() {
+        ICommandSender sender = mock(ICommandSender.class);
+        List completions = command.addTabCompletionOptions(sender, new String[]{"set", "random", ""});
+        assertTrue(completions.contains("true"));
+        assertTrue(completions.contains("false"));
+    }
+
+    @Test
+    public void tabCompleteSetRandomOffersVariants() {
+        ICommandSender sender = mock(ICommandSender.class);
+        List completions = command.addTabCompletionOptions(sender, new String[]{"set", "random", "false", ""});
+        assertTrue(completions.contains("classic"));
+        assertTrue(completions.contains("slim"));
+    }
+
+    @Test
+    public void tabCompleteSetRandomOffersTargetsAfterFlags() throws Exception {
+        EntityPlayerMP self = mockPlayer("Notch");
+        EntityPlayerMP other = mockPlayer("jeb_");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(self, other));
+
+        ICommandSender sender = mock(ICommandSender.class);
+        List completions = command.addTabCompletionOptions(sender, new String[]{"set", "random", "false", "all", ""});
+        assertTrue(completions.contains("jeb_"));
+    }
+
+    @Test
+    public void tabCompleteThirdArgOffersTargets() throws Exception {
+        EntityPlayerMP self = mockPlayer("Notch");
+        EntityPlayerMP other = mockPlayer("jeb_");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(self, other));
+
+        ICommandSender sender = mock(ICommandSender.class);
+        List completions = command.addTabCompletionOptions(sender, new String[]{"set", "Notch", ""});
+        assertTrue(completions.contains("jeb_"));
+        assertTrue(completions.contains("Notch"));
+    }
+
+    @Test
+    public void tabCompleteUnknownActionReturnsNull() {
+        ICommandSender sender = mock(ICommandSender.class);
+        assertEquals(null, command.addTabCompletionOptions(sender, new String[]{"bogus", "x", "y"}));
     }
 
     private static EntityPlayerMP mockPlayer(String name) {
@@ -284,6 +629,74 @@ public class SkinRestorerCommandTest {
         @Override
         public int getPriority() {
             return 100;
+        }
+    }
+
+    /**
+     * Deterministic deny-one-node backend (memory #1115). The denied node is
+     * a static so the sticky registration (priority 1000) can be re-targeted
+     * across tests; {@link #deny(String)} with null restores grant-all.
+     */
+    private static final class DenyNodeService implements IPermissionService {
+        private static volatile String deniedNode;
+
+        static void deny(String node) {
+            deniedNode = node;
+        }
+
+        @Override
+        public boolean hasPermission(UUID uuid, int opLevel, String permissionNode) {
+            return deniedNode == null || !permissionNode.equals(deniedNode);
+        }
+
+        @Override
+        public String getActiveBackendName() {
+            return "DenyNode";
+        }
+
+        @Override
+        public int getPriority() {
+            return 1000;
+        }
+    }
+
+    /** Deterministic random-pick fake (memory #1115). */
+    private static final class FixedRandomPickSource implements SkinRestorerCommand.RandomPickSource {
+        private final String username;
+
+        FixedRandomPickSource(String username) {
+            this.username = username;
+        }
+
+        @Override
+        public String pick(boolean cape, SkinVariant variant) throws IOException {
+            return username;
+        }
+    }
+
+    /** Records picker arguments for the parse tests. */
+    private static final class RecordingRandomPickSource implements SkinRestorerCommand.RandomPickSource {
+        private final String username;
+        private boolean lastCape;
+        private SkinVariant lastVariant;
+
+        RecordingRandomPickSource(String username) {
+            this.username = username;
+        }
+
+        @Override
+        public String pick(boolean cape, SkinVariant variant) throws IOException {
+            lastCape = cape;
+            lastVariant = variant;
+            return username;
+        }
+    }
+
+    /** Picker that fails like a network error. */
+    private static final class FailingRandomPickSource implements SkinRestorerCommand.RandomPickSource {
+        @Override
+        public String pick(boolean cape, SkinVariant variant) throws IOException {
+            throw new IOException("offline");
         }
     }
 }

--- a/forge-1.5.2/src/main/java/levosilimo/everlastingskins/command/SkinRestorerCommand.java
+++ b/forge-1.5.2/src/main/java/levosilimo/everlastingskins/command/SkinRestorerCommand.java
@@ -6,10 +6,17 @@
 
 package levosilimo.everlastingskins.command;
 
+import levosilimo.everlastingskins.enums.SkinVariant;
+import levosilimo.everlastingskins.metrics.MetricsFormat;
+import levosilimo.everlastingskins.metrics.PlayerSnapshot;
+import levosilimo.everlastingskins.metrics.SkinMetrics;
+import levosilimo.everlastingskins.metrics.Snapshot;
 import levosilimo.everlastingskins.permission.PermissionServiceManager;
 import levosilimo.everlastingskins.skinchanger.MojangAPI;
 import levosilimo.everlastingskins.skinchanger.MojangApiHttpImpl;
 import levosilimo.everlastingskins.skinchanger.MojangProfileCache;
+import levosilimo.everlastingskins.skinchanger.RandomCapeSource;
+import levosilimo.everlastingskins.skinchanger.RandomMojangSkin;
 import levosilimo.everlastingskins.skinchanger.SkinRestorer;
 import levosilimo.everlastingskins.skinchanger.responses.mojang.MojangSkinDataResult;
 import levosilimo.everlastingskins.util.CustomSkinProperty;
@@ -18,9 +25,12 @@ import net.minecraft.src.EntityPlayerMP;
 import net.minecraft.src.ICommand;
 import net.minecraft.src.ICommandSender;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -31,18 +41,28 @@ import java.util.UUID;
  * {@code getCommandAliases} / {@code getCommandUsage} / {@code processCommand}
  * / {@code canCommandSenderUseCommand} / {@code addTabCompletionOptions} /
  * {@code isUsernameIndex} — no {@code LiteralArgumentBuilder} (1.13+) and no
- * {@code getName} (1.8+). Sender chat goes through
- * {@link ICommandSender#sendChatToPlayer(String)} — the plain-String surface
- * (1.5.2 predates {@code ChatMessageComponent}, which arrived in 1.6).
+ * {@code getName} (1.8+). Sender chat goes through {@link ICommandSender#sendChatToPlayer(String)} (1.5.2 predates {@code ChatMessageComponent}, which arrived in 1.6).
  *
  * <p>Permission gating is delegated to {@link PermissionServiceManager} (the
  * Forge ops backend resolves the player by username-derived UUID — memory
  * #1123: UUID-only keying, never the player object). The manager fails closed
- * until a backend is registered.
+ * until a backend is registered. The gate is sender-based (mirroring
+ * mc1.12.2): the console is the trusted operator, players are checked by
+ * their own UUID, and targeting anyone other than the sender requires
+ * {@code everlastingskins.command.skin.other} (degraded to the lane's op
+ * model — op level 2 — by {@code ForgePermissionService.requiredOpLevel}).
  *
  * <p>No GameProfile on this line: targets resolve by username
  * ({@code getCommandSenderName()}) and storage keys are derived via
  * {@link SkinRestorer#uuidOf(String)}.
+ *
+ * <p>Command/storage parity with the modern surface (per the pre-1.8 parity
+ * investigation): {@code set random [cape] [variant]} (pick + resolve +
+ * store), {@code metrics [json|players|cleanup|reset]}, multi-target loops
+ * with per-target permission gating, and extended tab completion. Rendering
+ * parity stays era-limited — no GameProfile textures to inject and the
+ * legacy skins.minecraft.net username-keyed path is dead, so {@code set web}
+ * is honestly rejected with an era-limitation message.
  */
 public class SkinRestorerCommand implements ICommand {
 
@@ -50,12 +70,43 @@ public class SkinRestorerCommand implements ICommand {
     private static final String NODE_SKIN = NODE_PREFIX + ".skin";
     private static final String NODE_SKIN_CLEAR = NODE_PREFIX + ".skin.clear";
     private static final String NODE_SKIN_SOURCE = NODE_PREFIX + ".skin.source";
+    private static final String NODE_SKIN_RANDOM = NODE_PREFIX + ".skin.random";
+    private static final String NODE_SKIN_OTHER = NODE_PREFIX + ".skin.other";
+    private static final String NODE_METRICS = NODE_PREFIX + ".metrics";
+    private static final String NODE_METRICS_RESET = NODE_PREFIX + ".metrics.reset";
+
+    /** Honest rejection for {@code set web}: no MineSkin/URL pipeline exists pre-GameProfile. */
+    private static final String WEB_UNSUPPORTED = "web skins are not supported on this version";
+
+    /** Stale-window for {@code metrics cleanup}, mirroring the modern lanes (30 days). */
+    private static final long CLEANUP_OLDER_THAN_MS = 30L * 24 * 60 * 60 * 1000;
 
     private static volatile MojangAPI mojangApi = new MojangApiHttpImpl();
     private static volatile MinecraftServer serverOverride;
 
     /** Seen usernames for {@code /skin set} completion, populated on successful resolves. */
     private static final MojangProfileCache seenProfiles = new MojangProfileCache();
+
+    /**
+     * Random-pick indirection: cape mode swaps the candidate source for
+     * {@link RandomCapeSource} (mskins with_capes) — mirroring the modern
+     * lanes' random branch. Test seam: deterministic fakes only (memory
+     * #1115; no live HTTP).
+     */
+    interface RandomPickSource {
+        String pick(boolean cape, SkinVariant variant) throws IOException;
+    }
+
+    private static final RandomPickSource DEFAULT_RANDOM_PICK_SOURCE = new RandomPickSource() {
+        @Override
+        public String pick(boolean cape, SkinVariant variant) throws IOException {
+            return cape
+                ? new RandomCapeSource().pickRandomCapeUsername()
+                : RandomMojangSkin.randomUsername(false, variant);
+        }
+    };
+
+    private static volatile RandomPickSource randomPickSource = DEFAULT_RANDOM_PICK_SOURCE;
 
     @Override
     public String getCommandName() {
@@ -69,7 +120,7 @@ public class SkinRestorerCommand implements ICommand {
 
     @Override
     public String getCommandUsage(ICommandSender sender) {
-        return "/skin <set <username>|clear|source> [player]";
+        return "/skin <set <username|random [cape] [variant]>|clear|source|metrics [json|players|cleanup|reset]> [players...]";
     }
 
     @Override
@@ -87,36 +138,175 @@ public class SkinRestorerCommand implements ICommand {
             return;
         }
         String action = args[0];
-        EntityPlayerMP target = resolveTarget(sender, args);
-        if (target == null) {
+        if ("metrics".equals(action)) {
+            doMetrics(sender, args);
+            return;
+        }
+        if ("clear".equals(action)) {
+            doClear(sender, args);
+            return;
+        }
+        if ("source".equals(action)) {
+            doSource(sender, args);
+            return;
+        }
+        if ("set".equals(action)) {
+            doSet(sender, args);
+            return;
+        }
+        sender.sendChatToPlayer(getCommandUsage(sender));
+    }
+
+    private void doSet(ICommandSender sender, String[] args) {
+        if (args.length < 2) {
+            sender.sendChatToPlayer(getCommandUsage(sender));
+            return;
+        }
+        if ("web".equalsIgnoreCase(args[1])) {
+            // No MineSkin/URL pipeline exists on this line: pre-GameProfile
+            // has no client-side mechanism to render custom textures.
+            sender.sendChatToPlayer(WEB_UNSUPPORTED);
+            return;
+        }
+        if ("random".equalsIgnoreCase(args[1])) {
+            setRandom(sender, args);
+            return;
+        }
+        // /skin set <username> [players...]: apply the named skin to each target.
+        List<EntityPlayerMP> targets = resolveTargets(sender, args, 2);
+        if (targets == null) {
             sender.sendChatToPlayer("Player not found.");
             return;
         }
-        UUID uuid = SkinRestorer.uuidOf(target.getCommandSenderName());
-
-        switch (action) {
-            case "clear":
-                if (!checkPermission(sender, uuid, NODE_SKIN_CLEAR)) return;
-                SkinRestorer.clearSkin(uuid);
-                sender.sendChatToPlayer("Skin cleared.");
-                break;
-            case "source":
-                if (!checkPermission(sender, uuid, NODE_SKIN_SOURCE)) return;
-                String source = SkinRestorer.getSource(uuid);
-                sender.sendChatToPlayer(
-                    source != null ? "Skin source: " + source : "No custom skin stored.");
-                break;
-            case "set":
-                if (!checkPermission(sender, uuid, NODE_SKIN)) return;
-                if (args.length < 2) {
-                    sender.sendChatToPlayer(getCommandUsage(sender));
-                    return;
-                }
-                setSkin(sender, uuid, args[1]);
-                break;
-            default:
-                sender.sendChatToPlayer(getCommandUsage(sender));
+        if (!checkPermission(sender, targetsAreSelfOnly(sender, targets) ? NODE_SKIN : NODE_SKIN_OTHER)) {
+            return;
         }
+        for (EntityPlayerMP target : targets) {
+            setSkin(sender, SkinRestorer.uuidOf(target.getCommandSenderName()), args[1]);
+        }
+    }
+
+    /**
+     * /skin set random [<cape> [<variant>]] [players...]: the cape flag and
+     * variant are optional and parsed positionally to match the tab-completion
+     * cascade (bool, then variant, then targets) — the mc1.12.2 semantics.
+     */
+    private void setRandom(ICommandSender sender, String[] args) {
+        boolean cape = args.length >= 3 && "true".equalsIgnoreCase(args[2]);
+        SkinVariant variant = parseRandomVariant(args);
+        List<EntityPlayerMP> targets = resolveTargets(sender, args, 4);
+        if (targets == null) {
+            sender.sendChatToPlayer("Player not found.");
+            return;
+        }
+        if (!checkPermission(sender, targetsAreSelfOnly(sender, targets) ? NODE_SKIN_RANDOM : NODE_SKIN_OTHER)) {
+            return;
+        }
+        String username;
+        try {
+            username = randomPickSource.pick(cape, variant);
+        } catch (IOException e) {
+            sender.sendChatToPlayer("Could not pick a random skin (network error).");
+            return;
+        }
+        if (username == null) {
+            sender.sendChatToPlayer("Could not pick a random skin.");
+            return;
+        }
+        for (EntityPlayerMP target : targets) {
+            setSkin(sender, SkinRestorer.uuidOf(target.getCommandSenderName()), username);
+        }
+    }
+
+    private void doClear(ICommandSender sender, String[] args) {
+        List<EntityPlayerMP> targets = resolveTargets(sender, args, 1);
+        if (targets == null) {
+            sender.sendChatToPlayer("Player not found.");
+            return;
+        }
+        if (!checkPermission(sender, targetsAreSelfOnly(sender, targets) ? NODE_SKIN_CLEAR : NODE_SKIN_OTHER)) {
+            return;
+        }
+        for (EntityPlayerMP target : targets) {
+            UUID uuid = SkinRestorer.uuidOf(target.getCommandSenderName());
+            long startNanos = System.nanoTime();
+            SkinMetrics.INSTANCE.recordRefreshStarted(uuid);
+            SkinRestorer.clearSkin(uuid);
+            SkinMetrics.INSTANCE.recordRefreshCompleted(uuid, startNanos, 0, 0, 0);
+        }
+        sender.sendChatToPlayer("Skin cleared.");
+    }
+
+    private void doSource(ICommandSender sender, String[] args) {
+        List<EntityPlayerMP> targets = resolveTargets(sender, args, 1);
+        if (targets == null) {
+            sender.sendChatToPlayer("Player not found.");
+            return;
+        }
+        if (!checkPermission(sender, targetsAreSelfOnly(sender, targets) ? NODE_SKIN_SOURCE : NODE_SKIN_OTHER)) {
+            return;
+        }
+        if (targets.size() == 1) {
+            String source = SkinRestorer.getSource(SkinRestorer.uuidOf(targets.get(0).getCommandSenderName()));
+            sender.sendChatToPlayer(
+                source != null ? "Skin source: " + source : "No custom skin stored.");
+            return;
+        }
+        StringBuilder sb = new StringBuilder();
+        for (EntityPlayerMP target : targets) {
+            String name = target.getCommandSenderName();
+            String source = SkinRestorer.getSource(SkinRestorer.uuidOf(name));
+            if (sb.length() > 0) sb.append('\n');
+            sb.append(name).append(": ").append(source != null ? source : "No custom skin stored.");
+        }
+        sender.sendChatToPlayer(sb.toString());
+    }
+
+    /**
+     * /skin metrics [json|players|cleanup|reset]. View subcommands need
+     * {@code everlastingskins.command.metrics}; cleanup/reset additionally
+     * need {@code everlastingskins.command.metrics.reset}. Console senders
+     * are allowed (trusted operator) — mirrors the mc1.12.2 metrics surface.
+     */
+    private void doMetrics(ICommandSender sender, String[] args) {
+        String sub = args.length < 2 ? "human" : args[1];
+        if ("json".equals(sub)) {
+            if (!checkMetricsPermission(sender)) return;
+            sender.sendChatToPlayer(
+                MetricsFormat.json(SkinMetrics.INSTANCE.snapshot()));
+            return;
+        }
+        if ("players".equals(sub)) {
+            if (!checkMetricsPermission(sender)) return;
+            StringBuilder sb = new StringBuilder("EverlastingSkins top players:");
+            int rank = 0;
+            for (Map.Entry<UUID, PlayerSnapshot> e : SkinMetrics.INSTANCE.topPlayers(10)) {
+                sb.append('\n').append("  ").append(++rank).append(". ")
+                    .append(e.getKey()).append(" — ")
+                    .append(e.getValue().refreshCount()).append(" refreshes");
+            }
+            if (rank == 0) {
+                sb.append('\n').append("  No refreshes recorded.");
+            }
+            sender.sendChatToPlayer(sb.toString());
+            return;
+        }
+        if ("cleanup".equals(sub)) {
+            if (!checkMetricsResetPermission(sender)) return;
+            int removed = SkinMetrics.INSTANCE.cleanupStalePlayers(CLEANUP_OLDER_THAN_MS);
+            sender.sendChatToPlayer(
+                "Removed " + removed + " stale player(s) from metrics.");
+            return;
+        }
+        if ("reset".equals(sub)) {
+            if (!checkMetricsResetPermission(sender)) return;
+            SkinMetrics.INSTANCE.reset();
+            sender.sendChatToPlayer("Metrics reset.");
+            return;
+        }
+        if (!checkMetricsPermission(sender)) return;
+        sender.sendChatToPlayer(
+            MetricsFormat.human(SkinMetrics.INSTANCE.snapshot()));
     }
 
     private void setSkin(ICommandSender sender, UUID uuid, String username) {
@@ -128,40 +318,98 @@ public class SkinRestorerCommand implements ICommand {
             sender.sendChatToPlayer("Skin resolver unavailable.");
             return;
         }
+        long startNanos = System.nanoTime();
+        SkinMetrics.INSTANCE.recordRefreshStarted(uuid);
         Optional<MojangSkinDataResult> result = api.getSkin(username);
         if (!result.isPresent()) {
+            SkinMetrics.INSTANCE.recordRefreshFailed(uuid);
             sender.sendChatToPlayer("Could not resolve a skin for '" + username + "'.");
             return;
         }
         CustomSkinProperty skin = result.get().skinProperty();
         seenProfiles.put(username, skin);
         SkinRestorer.applySkin(uuid, skin);
+        SkinMetrics.INSTANCE.recordRefreshCompleted(uuid, startNanos, System.nanoTime() - startNanos, 0, 0);
         sender.sendChatToPlayer("Skin applied.");
     }
 
-    private boolean checkPermission(ICommandSender sender, UUID uuid, String node) {
-        int opLevel = sender instanceof EntityPlayerMP ? 4 : 0;
-        if (!PermissionServiceManager.hasPermission(uuid, opLevel, node)) {
+    /**
+     * Sender-based gate (mirrors mc1.12.2): the console is the trusted
+     * operator; players are checked by their own username-derived UUID
+     * (memory #1123 — never the target object).
+     */
+    private boolean checkPermission(ICommandSender sender, String node) {
+        if (!(sender instanceof EntityPlayerMP)) return true; // console
+        EntityPlayerMP player = (EntityPlayerMP) sender;
+        if (!PermissionServiceManager.hasPermission(
+                SkinRestorer.uuidOf(player.getCommandSenderName()), 4, node)) {
             sender.sendChatToPlayer("You do not have permission to use this command.");
             return false;
         }
         return true;
     }
 
-    private EntityPlayerMP resolveTarget(ICommandSender sender, String[] args) {
-        if (args.length >= 2 && !args[1].isEmpty()) {
-            MinecraftServer server = serverOverride != null ? serverOverride : MinecraftServer.getServer();
-            if (server != null && server.getConfigurationManager() != null) {
-                for (Object o : server.getConfigurationManager().playerEntityList) {
-                    if (o instanceof EntityPlayerMP) {
-                        EntityPlayerMP p = (EntityPlayerMP) o;
-                        if (p.getCommandSenderName().equalsIgnoreCase(args[1])) return p;
+    private boolean checkMetricsPermission(ICommandSender sender) {
+        if (!(sender instanceof EntityPlayerMP)) return true; // console
+        return checkPermission(sender, NODE_METRICS);
+    }
+
+    private boolean checkMetricsResetPermission(ICommandSender sender) {
+        if (!(sender instanceof EntityPlayerMP)) return true; // console
+        return checkPermission(sender, NODE_METRICS_RESET);
+    }
+
+    /**
+     * Resolves the target set: explicit names (args from {@code targetIndex})
+     * are matched against the online list, skipping unresolvable names
+     * (mirrors mc1.12.2's parseTargets); no explicit names resolve to the
+     * sender. Returns null when nothing resolved.
+     */
+    private List<EntityPlayerMP> resolveTargets(ICommandSender sender, String[] args, int targetIndex) {
+        MinecraftServer server = serverOverride != null ? serverOverride : MinecraftServer.getServer();
+        if (server != null && server.getConfigurationManager() != null) {
+            if (args.length > targetIndex) {
+                List<EntityPlayerMP> out = new ArrayList<EntityPlayerMP>();
+                for (int i = targetIndex; i < args.length; i++) {
+                    for (Object o : server.getConfigurationManager().playerEntityList) {
+                        if (o instanceof EntityPlayerMP) {
+                            EntityPlayerMP p = (EntityPlayerMP) o;
+                            if (p.getCommandSenderName().equalsIgnoreCase(args[i])) {
+                                out.add(p);
+                                break;
+                            }
+                        }
                     }
                 }
+                return out.isEmpty() ? null : out;
             }
-            return null;
+            for (Object o : server.getConfigurationManager().playerEntityList) {
+                if (o instanceof EntityPlayerMP && o == sender) {
+                    return Collections.singletonList((EntityPlayerMP) o);
+                }
+            }
         }
-        return sender instanceof EntityPlayerMP ? (EntityPlayerMP) sender : null;
+        if (sender instanceof EntityPlayerMP) {
+            return Collections.singletonList((EntityPlayerMP) sender);
+        }
+        return null;
+    }
+
+    private boolean targetsAreSelfOnly(ICommandSender sender, List<EntityPlayerMP> targets) {
+        return targets.size() == 1
+            && sender instanceof EntityPlayerMP
+            && targets.get(0) == sender;
+    }
+
+    /** Variant argument of {@code /skin set random}: optional, defaults to ALL. */
+    private static SkinVariant parseRandomVariant(String[] args) {
+        if (args.length >= 4 && "slim".equalsIgnoreCase(args[3])) {
+            return SkinVariant.SLIM;
+        }
+        if (args.length >= 4 && "classic".equalsIgnoreCase(args[3])) {
+            return SkinVariant.CLASSIC;
+        }
+        return SkinVariant.ALL;
     }
 
     @Override
@@ -171,17 +419,53 @@ public class SkinRestorerCommand implements ICommand {
             if (canUse(sender, NODE_SKIN)) subcommands.add("set");
             if (canUse(sender, NODE_SKIN_CLEAR)) subcommands.add("clear");
             if (canUse(sender, NODE_SKIN_SOURCE)) subcommands.add("source");
+            if (canUse(sender, NODE_METRICS)) subcommands.add("metrics");
             return filterCompletions(args[0], subcommands);
         }
         if (args.length == 2) {
+            if ("metrics".equals(args[0])) {
+                List<String> metricsSubs = new ArrayList<String>();
+                metricsSubs.add("json");
+                metricsSubs.add("players");
+                if (canUse(sender, NODE_METRICS_RESET)) {
+                    metricsSubs.add("cleanup");
+                    metricsSubs.add("reset");
+                }
+                return filterCompletions(args[1], metricsSubs);
+            }
             List<String> candidates = new ArrayList<String>();
+            if ("set".equals(args[0])) candidates.add("random");
             addOnlinePlayerNames(candidates);
             for (String seen : seenProfiles.snapshot()) {
                 if (!candidates.contains(seen)) candidates.add(seen);
             }
             return filterCompletions(args[1], candidates);
         }
+        if ("set".equals(args[0]) && "random".equals(args[1])) {
+            // Positional cascade mirroring mc1.12.2: cape bool, then variant,
+            // then target names.
+            if (args.length == 3) {
+                return filterCompletions(args[2], Arrays.asList("true", "false"));
+            }
+            if (args.length == 4) {
+                return filterCompletions(args[3], Arrays.asList("classic", "slim"));
+            }
+            return targetCompletions(args[args.length - 1]);
+        }
+        if ("set".equals(args[0]) || "clear".equals(args[0]) || "source".equals(args[0])) {
+            return targetCompletions(args[args.length - 1]);
+        }
         return null;
+    }
+
+    /** Online + seen-profile names for the target positions. */
+    private List targetCompletions(String prefix) {
+        List<String> candidates = new ArrayList<String>();
+        addOnlinePlayerNames(candidates);
+        for (String seen : seenProfiles.snapshot()) {
+            if (!candidates.contains(seen)) candidates.add(seen);
+        }
+        return filterCompletions(prefix, candidates);
     }
 
     /** Silent permission check for completion (no denial message, unlike {@link #checkPermission}). */
@@ -238,5 +522,10 @@ public class SkinRestorerCommand implements ICommand {
     /** Test seam — deterministic completion tests (memory #1115). */
     static void clearSeenProfilesForTest() {
         seenProfiles.clear();
+    }
+
+    /** Test seam — deterministic random-pick injection (null restores the live source). */
+    static void setRandomPickSourceForTest(RandomPickSource source) {
+        randomPickSource = source != null ? source : DEFAULT_RANDOM_PICK_SOURCE;
     }
 }

--- a/forge-1.5.2/src/test/java/levosilimo/everlastingskins/command/SkinRestorerCommandTest.java
+++ b/forge-1.5.2/src/test/java/levosilimo/everlastingskins/command/SkinRestorerCommandTest.java
@@ -6,6 +6,8 @@
 
 package levosilimo.everlastingskins.command;
 
+import levosilimo.everlastingskins.enums.SkinVariant;
+import levosilimo.everlastingskins.metrics.SkinMetrics;
 import levosilimo.everlastingskins.permission.IPermissionService;
 import levosilimo.everlastingskins.permission.PermissionServiceManager;
 import levosilimo.everlastingskins.skinchanger.MojangAPI;
@@ -23,6 +25,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -32,6 +35,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -42,12 +46,16 @@ import static org.mockito.Mockito.when;
  * 1.5.2 ICommand lifecycle + dispatch tests.
  *
  * <p>Deterministic fakes only (memory #1115): the Mojang lookup is a fake
- * resolver (no live HTTP); the sender/player/server are Mockito mocks over
- * the MCP 7.51 surface. The 1.5.2 command surface under test is
+ * resolver (no live HTTP); the random pick is an injected fake picker; the
+ * sender/player/server are Mockito mocks over the MCP 7.51 surface. The
+ * 1.6.4 command surface under test is
  * {@code getCommandName}/{@code getCommandAliases}/{@code processCommand} —
  * no {@code getName} (1.8+) and no LiteralArgumentBuilder (1.13+). Sender
- * chat goes through {@code sendChatToPlayer(String)} (1.5.2 predates
- * {@code ChatMessageComponent}, which arrived in 1.6).
+ * chat goes through {@code sendChatToPlayer(String)} (1.5.2 predates {@code ChatMessageComponent}, which arrived in 1.6).
+ *
+ * <p>Covers the command/storage parity surface (set random, metrics,
+ * multi-target + permission gating, web rejection) and the extended tab
+ * completion.
  */
 public class SkinRestorerCommandTest {
 
@@ -57,8 +65,12 @@ public class SkinRestorerCommandTest {
     public void setUp() throws Exception {
         // Highest-priority deterministic grant-all backend (memory #1115) so
         // permission checks in these dispatch tests are deterministic
-        // regardless of any backend left by earlier tests.
+        // regardless of any backend left by earlier tests. A sticky
+        // DenyNodeService (priority 1000) grants everything once its deny
+        // set is cleared, so behaviour stays grant-all across tests.
+        DenyNodeService.deny(null);
         PermissionServiceManager.registerService(new GrantAllService());
+        SkinMetrics.INSTANCE.reset();
 
         Path dir = Files.createTempDirectory("es-152-skin-restorer-test");
         SkinStorage.resetForTest();
@@ -71,6 +83,7 @@ public class SkinRestorerCommandTest {
         SkinRestorerCommand.setMojangApiForTest(null);
         SkinRestorerCommand.setServerOverrideForTest(null);
         SkinRestorerCommand.clearSeenProfilesForTest();
+        SkinRestorerCommand.setRandomPickSourceForTest(null);
         SkinRestorer.setStorageForTest(null);
         SkinRestorer.setServerForTest(null);
     }
@@ -164,12 +177,269 @@ public class SkinRestorerCommandTest {
     }
 
     @Test
+    public void setDispatchWebRejectsWithEraMessage() throws Exception {
+        // Pre-GameProfile era limitation: no MineSkin/URL pipeline exists,
+        // so set web is honestly rejected and nothing is stored.
+        MojangSkinDataResult result = new MojangSkinDataResult(
+            UUID.randomUUID(),
+            new CustomSkinProperty("textures", "d2Vi", null, "MojangAPI"));
+        SkinRestorerCommand.setMojangApiForTest(new FakeMojangApi(Optional.of(result)));
+
+        EntityPlayerMP player = mockPlayer("Notch");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(player));
+
+        command.processCommand(player, new String[]{"set", "web"});
+
+        assertEquals(null, SkinRestorer.getSource(SkinRestorer.uuidOf("Notch")));
+        verify(player).sendChatToPlayer(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    public void setDispatchMultiTargetAppliesToAllNamed() throws Exception {
+        MojangSkinDataResult result = new MojangSkinDataResult(
+            UUID.randomUUID(),
+            new CustomSkinProperty("textures", "bXVsdGk=", null, "MojangAPI"));
+        SkinRestorerCommand.setMojangApiForTest(new FakeMojangApi(Optional.of(result)));
+
+        EntityPlayerMP self = mockPlayer("Notch");
+        EntityPlayerMP other = mockPlayer("jeb_");
+        EntityPlayerMP third = mockPlayer("xephos");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(self, other, third));
+
+        command.processCommand(self, new String[]{"set", "Notch", "jeb_", "xephos"});
+
+        assertEquals("MojangAPI", SkinRestorer.getSource(SkinRestorer.uuidOf("jeb_")));
+        assertEquals("MojangAPI", SkinRestorer.getSource(SkinRestorer.uuidOf("xephos")));
+        assertEquals(null, SkinRestorer.getSource(SkinRestorer.uuidOf("Notch")));
+    }
+
+    @Test
+    public void setDispatchTargetingOthersRequiresOtherPermission() throws Exception {
+        MojangSkinDataResult result = new MojangSkinDataResult(
+            UUID.randomUUID(),
+            new CustomSkinProperty("textures", "b3RoZXI=", null, "MojangAPI"));
+        SkinRestorerCommand.setMojangApiForTest(new FakeMojangApi(Optional.of(result)));
+        DenyNodeService.deny("everlastingskins.command.skin.other");
+        PermissionServiceManager.registerService(new DenyNodeService());
+
+        EntityPlayerMP self = mockPlayer("Notch");
+        EntityPlayerMP other = mockPlayer("jeb_");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(self, other));
+
+        command.processCommand(self, new String[]{"set", "Notch", "jeb_"});
+
+        assertEquals(null, SkinRestorer.getSource(SkinRestorer.uuidOf("jeb_")));
+    }
+
+    @Test
+    public void clearDispatchMultiTargetClearsOnlyNamed() throws Exception {
+        UUID selfUuid = SkinRestorer.uuidOf("Notch");
+        UUID otherUuid = SkinRestorer.uuidOf("jeb_");
+        SkinRestorer.applySkin(selfUuid,
+            new CustomSkinProperty("textures", "YQ==", null, "fake"));
+        SkinRestorer.applySkin(otherUuid,
+            new CustomSkinProperty("textures", "Yg==", null, "fake"));
+
+        EntityPlayerMP self = mockPlayer("Notch");
+        EntityPlayerMP other = mockPlayer("jeb_");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(self, other));
+
+        command.processCommand(self, new String[]{"clear", "jeb_"});
+
+        assertEquals(null, SkinRestorer.getSource(otherUuid));
+        assertNotNull(SkinRestorer.getSource(selfUuid));
+    }
+
+    @Test
+    public void setRandomDispatchAppliesPickedSkin() throws Exception {
+        MojangSkinDataResult result = new MojangSkinDataResult(
+            UUID.randomUUID(),
+            new CustomSkinProperty("textures", "cmFuZG9t", null, "MojangAPI"));
+        SkinRestorerCommand.setMojangApiForTest(new FakeMojangApi(Optional.of(result)));
+        SkinRestorerCommand.setRandomPickSourceForTest(new FixedRandomPickSource("pickedUser"));
+
+        EntityPlayerMP player = mockPlayer("Notch");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(player));
+
+        command.processCommand(player, new String[]{"set", "random"});
+
+        assertEquals("MojangAPI", SkinRestorer.getSource(SkinRestorer.uuidOf("Notch")));
+    }
+
+    @Test
+    public void setRandomCapeFlagReachesPicker() throws Exception {
+        MojangSkinDataResult result = new MojangSkinDataResult(
+            UUID.randomUUID(),
+            new CustomSkinProperty("textures", "Y2FwZQ==", null, "MojangAPI"));
+        SkinRestorerCommand.setMojangApiForTest(new FakeMojangApi(Optional.of(result)));
+        RecordingRandomPickSource picker = new RecordingRandomPickSource("pickedUser");
+        SkinRestorerCommand.setRandomPickSourceForTest(picker);
+
+        EntityPlayerMP player = mockPlayer("Notch");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(player));
+
+        command.processCommand(player, new String[]{"set", "random", "true"});
+
+        assertTrue(picker.lastCape);
+        assertEquals(SkinVariant.ALL, picker.lastVariant);
+    }
+
+    @Test
+    public void setRandomVariantParsingReachesPicker() throws Exception {
+        MojangSkinDataResult result = new MojangSkinDataResult(
+            UUID.randomUUID(),
+            new CustomSkinProperty("textures", "dmFyaWFudA==", null, "MojangAPI"));
+        SkinRestorerCommand.setMojangApiForTest(new FakeMojangApi(Optional.of(result)));
+        RecordingRandomPickSource picker = new RecordingRandomPickSource("pickedUser");
+        SkinRestorerCommand.setRandomPickSourceForTest(picker);
+
+        EntityPlayerMP player = mockPlayer("Notch");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(player));
+
+        command.processCommand(player, new String[]{"set", "random", "false", "slim"});
+
+        assertFalse(picker.lastCape);
+        assertEquals(SkinVariant.SLIM, picker.lastVariant);
+    }
+
+    @Test
+    public void setRandomPickerNetworkFailureReportsError() throws Exception {
+        SkinRestorerCommand.setRandomPickSourceForTest(new FailingRandomPickSource());
+
+        EntityPlayerMP player = mockPlayer("Notch");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(player));
+
+        command.processCommand(player, new String[]{"set", "random"});
+
+        assertEquals(null, SkinRestorer.getSource(SkinRestorer.uuidOf("Notch")));
+    }
+
+    @Test
+    public void setRandomPickerEmptyPickReportsFailure() throws Exception {
+        SkinRestorerCommand.setRandomPickSourceForTest(new FixedRandomPickSource(null));
+
+        EntityPlayerMP player = mockPlayer("Notch");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(player));
+
+        command.processCommand(player, new String[]{"set", "random"});
+
+        assertEquals(null, SkinRestorer.getSource(SkinRestorer.uuidOf("Notch")));
+    }
+
+    @Test
+    public void setRandomDispatchTargetsOthers() throws Exception {
+        MojangSkinDataResult result = new MojangSkinDataResult(
+            UUID.randomUUID(),
+            new CustomSkinProperty("textures", "dGFyZ2V0", null, "MojangAPI"));
+        SkinRestorerCommand.setMojangApiForTest(new FakeMojangApi(Optional.of(result)));
+        SkinRestorerCommand.setRandomPickSourceForTest(new FixedRandomPickSource("pickedUser"));
+
+        EntityPlayerMP self = mockPlayer("Notch");
+        EntityPlayerMP other = mockPlayer("jeb_");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(self, other));
+
+        command.processCommand(self, new String[]{"set", "random", "false", "all", "jeb_"});
+
+        assertEquals("MojangAPI", SkinRestorer.getSource(SkinRestorer.uuidOf("jeb_")));
+        assertEquals(null, SkinRestorer.getSource(SkinRestorer.uuidOf("Notch")));
+    }
+
+    @Test
+    public void setRandomTargetingOthersRequiresOtherPermission() throws Exception {
+        MojangSkinDataResult result = new MojangSkinDataResult(
+            UUID.randomUUID(),
+            new CustomSkinProperty("textures", "ZGVueQ==", null, "MojangAPI"));
+        SkinRestorerCommand.setMojangApiForTest(new FakeMojangApi(Optional.of(result)));
+        SkinRestorerCommand.setRandomPickSourceForTest(new FixedRandomPickSource("pickedUser"));
+        DenyNodeService.deny("everlastingskins.command.skin.other");
+        PermissionServiceManager.registerService(new DenyNodeService());
+
+        EntityPlayerMP self = mockPlayer("Notch");
+        EntityPlayerMP other = mockPlayer("jeb_");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(self, other));
+
+        command.processCommand(self, new String[]{"set", "random", "false", "all", "jeb_"});
+
+        assertEquals(null, SkinRestorer.getSource(SkinRestorer.uuidOf("jeb_")));
+    }
+
+    @Test
+    public void metricsDispatchReportsSnapshot() throws Exception {
+        EntityPlayerMP player = mockPlayer("Notch");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(player));
+
+        command.processCommand(player, new String[]{"metrics"});
+
+        verify(player).sendChatToPlayer(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    public void metricsJsonDispatchReportsJson() throws Exception {
+        EntityPlayerMP player = mockPlayer("Notch");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(player));
+
+        command.processCommand(player, new String[]{"metrics", "json"});
+
+        verify(player).sendChatToPlayer(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    public void metricsPlayersDispatchReportsTopPlayers() throws Exception {
+        SkinMetrics.INSTANCE.recordRefreshCompleted(SkinRestorer.uuidOf("Notch"), 0, 1, 0, 0);
+        EntityPlayerMP player = mockPlayer("Notch");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(player));
+
+        command.processCommand(player, new String[]{"metrics", "players"});
+
+        verify(player).sendChatToPlayer(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    public void metricsResetDispatchClearsCounters() throws Exception {
+        SkinMetrics.INSTANCE.recordRefreshCompleted(SkinRestorer.uuidOf("Notch"), 0, 1, 0, 0);
+        assertEquals(1, SkinMetrics.INSTANCE.snapshot().refreshesCompleted());
+
+        EntityPlayerMP player = mockPlayer("Notch");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(player));
+
+        command.processCommand(player, new String[]{"metrics", "reset"});
+
+        assertEquals(0, SkinMetrics.INSTANCE.snapshot().refreshesCompleted());
+    }
+
+    @Test
+    public void metricsCleanupDispatchReportsRemoved() throws Exception {
+        EntityPlayerMP player = mockPlayer("Notch");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(player));
+
+        command.processCommand(player, new String[]{"metrics", "cleanup"});
+
+        verify(player).sendChatToPlayer(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    public void metricsResetRequiresResetPermission() throws Exception {
+        SkinMetrics.INSTANCE.recordRefreshCompleted(SkinRestorer.uuidOf("Notch"), 0, 1, 0, 0);
+        DenyNodeService.deny("everlastingskins.command.metrics.reset");
+        PermissionServiceManager.registerService(new DenyNodeService());
+
+        EntityPlayerMP player = mockPlayer("Notch");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(player));
+
+        command.processCommand(player, new String[]{"metrics", "reset"});
+
+        // Denied: counters survive the attempted reset.
+        assertEquals(1, SkinMetrics.INSTANCE.snapshot().refreshesCompleted());
+    }
+
+    @Test
     public void tabCompleteOffersSubcommands() {
         ICommandSender sender = mock(ICommandSender.class);
         List completions = command.addTabCompletionOptions(sender, new String[]{""});
         assertTrue(completions.contains("set"));
         assertTrue(completions.contains("clear"));
         assertTrue(completions.contains("source"));
+        assertTrue(completions.contains("metrics"));
     }
 
     @Test
@@ -202,6 +472,7 @@ public class SkinRestorerCommandTest {
         assertTrue(completions.contains("Notch"));
         assertTrue(completions.contains("jeb_"));
         assertTrue(completions.contains("xephos")); // from the seen cache, not online
+        assertTrue(completions.contains("random")); // the set sub-mode
     }
 
     @Test
@@ -223,9 +494,83 @@ public class SkinRestorerCommandTest {
     }
 
     @Test
-    public void tabCompleteBeyondSecondArgReturnsNull() {
+    public void tabCompleteMetricsSubcommands() {
         ICommandSender sender = mock(ICommandSender.class);
-        assertEquals(null, command.addTabCompletionOptions(sender, new String[]{"set", "Notch", "extra"}));
+        List completions = command.addTabCompletionOptions(sender, new String[]{"metrics", ""});
+        assertTrue(completions.contains("json"));
+        assertTrue(completions.contains("players"));
+        assertTrue(completions.contains("cleanup"));
+        assertTrue(completions.contains("reset"));
+    }
+
+    @Test
+    public void tabCompleteMetricsHideResetWithoutPermission() {
+        DenyNodeService.deny("everlastingskins.command.metrics.reset");
+        PermissionServiceManager.registerService(new DenyNodeService());
+        EntityPlayerMP player = mockPlayer("Notch");
+
+        List completions = command.addTabCompletionOptions(player, new String[]{"metrics", ""});
+
+        assertTrue(completions.contains("json"));
+        assertFalse(completions.contains("cleanup"));
+        assertFalse(completions.contains("reset"));
+    }
+
+    @Test
+    public void tabCompleteFirstArgHidesMetricsWithoutPermission() {
+        DenyNodeService.deny("everlastingskins.command.metrics");
+        PermissionServiceManager.registerService(new DenyNodeService());
+        EntityPlayerMP player = mockPlayer("Notch");
+
+        List completions = command.addTabCompletionOptions(player, new String[]{""});
+
+        assertTrue(completions.contains("set"));
+        assertFalse(completions.contains("metrics"));
+    }
+
+    @Test
+    public void tabCompleteSetRandomOffersCapeFlags() {
+        ICommandSender sender = mock(ICommandSender.class);
+        List completions = command.addTabCompletionOptions(sender, new String[]{"set", "random", ""});
+        assertTrue(completions.contains("true"));
+        assertTrue(completions.contains("false"));
+    }
+
+    @Test
+    public void tabCompleteSetRandomOffersVariants() {
+        ICommandSender sender = mock(ICommandSender.class);
+        List completions = command.addTabCompletionOptions(sender, new String[]{"set", "random", "false", ""});
+        assertTrue(completions.contains("classic"));
+        assertTrue(completions.contains("slim"));
+    }
+
+    @Test
+    public void tabCompleteSetRandomOffersTargetsAfterFlags() throws Exception {
+        EntityPlayerMP self = mockPlayer("Notch");
+        EntityPlayerMP other = mockPlayer("jeb_");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(self, other));
+
+        ICommandSender sender = mock(ICommandSender.class);
+        List completions = command.addTabCompletionOptions(sender, new String[]{"set", "random", "false", "all", ""});
+        assertTrue(completions.contains("jeb_"));
+    }
+
+    @Test
+    public void tabCompleteThirdArgOffersTargets() throws Exception {
+        EntityPlayerMP self = mockPlayer("Notch");
+        EntityPlayerMP other = mockPlayer("jeb_");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(self, other));
+
+        ICommandSender sender = mock(ICommandSender.class);
+        List completions = command.addTabCompletionOptions(sender, new String[]{"set", "Notch", ""});
+        assertTrue(completions.contains("jeb_"));
+        assertTrue(completions.contains("Notch"));
+    }
+
+    @Test
+    public void tabCompleteUnknownActionReturnsNull() {
+        ICommandSender sender = mock(ICommandSender.class);
+        assertEquals(null, command.addTabCompletionOptions(sender, new String[]{"bogus", "x", "y"}));
     }
 
     private static EntityPlayerMP mockPlayer(String name) {
@@ -284,6 +629,74 @@ public class SkinRestorerCommandTest {
         @Override
         public int getPriority() {
             return 100;
+        }
+    }
+
+    /**
+     * Deterministic deny-one-node backend (memory #1115). The denied node is
+     * a static so the sticky registration (priority 1000) can be re-targeted
+     * across tests; {@link #deny(String)} with null restores grant-all.
+     */
+    private static final class DenyNodeService implements IPermissionService {
+        private static volatile String deniedNode;
+
+        static void deny(String node) {
+            deniedNode = node;
+        }
+
+        @Override
+        public boolean hasPermission(UUID uuid, int opLevel, String permissionNode) {
+            return deniedNode == null || !permissionNode.equals(deniedNode);
+        }
+
+        @Override
+        public String getActiveBackendName() {
+            return "DenyNode";
+        }
+
+        @Override
+        public int getPriority() {
+            return 1000;
+        }
+    }
+
+    /** Deterministic random-pick fake (memory #1115). */
+    private static final class FixedRandomPickSource implements SkinRestorerCommand.RandomPickSource {
+        private final String username;
+
+        FixedRandomPickSource(String username) {
+            this.username = username;
+        }
+
+        @Override
+        public String pick(boolean cape, SkinVariant variant) throws IOException {
+            return username;
+        }
+    }
+
+    /** Records picker arguments for the parse tests. */
+    private static final class RecordingRandomPickSource implements SkinRestorerCommand.RandomPickSource {
+        private final String username;
+        private boolean lastCape;
+        private SkinVariant lastVariant;
+
+        RecordingRandomPickSource(String username) {
+            this.username = username;
+        }
+
+        @Override
+        public String pick(boolean cape, SkinVariant variant) throws IOException {
+            lastCape = cape;
+            lastVariant = variant;
+            return username;
+        }
+    }
+
+    /** Picker that fails like a network error. */
+    private static final class FailingRandomPickSource implements SkinRestorerCommand.RandomPickSource {
+        @Override
+        public String pick(boolean cape, SkinVariant variant) throws IOException {
+            throw new IOException("offline");
         }
     }
 }

--- a/forge-1.6.4/src/main/java/levosilimo/everlastingskins/command/SkinRestorerCommand.java
+++ b/forge-1.6.4/src/main/java/levosilimo/everlastingskins/command/SkinRestorerCommand.java
@@ -6,10 +6,17 @@
 
 package levosilimo.everlastingskins.command;
 
+import levosilimo.everlastingskins.enums.SkinVariant;
+import levosilimo.everlastingskins.metrics.MetricsFormat;
+import levosilimo.everlastingskins.metrics.PlayerSnapshot;
+import levosilimo.everlastingskins.metrics.SkinMetrics;
+import levosilimo.everlastingskins.metrics.Snapshot;
 import levosilimo.everlastingskins.permission.PermissionServiceManager;
 import levosilimo.everlastingskins.skinchanger.MojangAPI;
 import levosilimo.everlastingskins.skinchanger.MojangApiHttpImpl;
 import levosilimo.everlastingskins.skinchanger.MojangProfileCache;
+import levosilimo.everlastingskins.skinchanger.RandomCapeSource;
+import levosilimo.everlastingskins.skinchanger.RandomMojangSkin;
 import levosilimo.everlastingskins.skinchanger.SkinRestorer;
 import levosilimo.everlastingskins.skinchanger.responses.mojang.MojangSkinDataResult;
 import levosilimo.everlastingskins.util.CustomSkinProperty;
@@ -19,9 +26,12 @@ import net.minecraft.src.EntityPlayerMP;
 import net.minecraft.src.ICommand;
 import net.minecraft.src.ICommandSender;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -39,11 +49,23 @@ import java.util.UUID;
  * <p>Permission gating is delegated to {@link PermissionServiceManager} (the
  * Forge ops backend resolves the player by username-derived UUID — memory
  * #1123: UUID-only keying, never the player object). The manager fails closed
- * until a backend is registered.
+ * until a backend is registered. The gate is sender-based (mirroring
+ * mc1.12.2): the console is the trusted operator, players are checked by
+ * their own UUID, and targeting anyone other than the sender requires
+ * {@code everlastingskins.command.skin.other} (degraded to the lane's op
+ * model — op level 2 — by {@code ForgePermissionService.requiredOpLevel}).
  *
  * <p>No GameProfile on this line: targets resolve by username
  * ({@code getCommandSenderName()}) and storage keys are derived via
  * {@link SkinRestorer#uuidOf(String)}.
+ *
+ * <p>Command/storage parity with the modern surface (per the pre-1.8 parity
+ * investigation): {@code set random [cape] [variant]} (pick + resolve +
+ * store), {@code metrics [json|players|cleanup|reset]}, multi-target loops
+ * with per-target permission gating, and extended tab completion. Rendering
+ * parity stays era-limited — no GameProfile textures to inject and the
+ * legacy skins.minecraft.net username-keyed path is dead, so {@code set web}
+ * is honestly rejected with an era-limitation message.
  */
 public class SkinRestorerCommand implements ICommand {
 
@@ -51,12 +73,43 @@ public class SkinRestorerCommand implements ICommand {
     private static final String NODE_SKIN = NODE_PREFIX + ".skin";
     private static final String NODE_SKIN_CLEAR = NODE_PREFIX + ".skin.clear";
     private static final String NODE_SKIN_SOURCE = NODE_PREFIX + ".skin.source";
+    private static final String NODE_SKIN_RANDOM = NODE_PREFIX + ".skin.random";
+    private static final String NODE_SKIN_OTHER = NODE_PREFIX + ".skin.other";
+    private static final String NODE_METRICS = NODE_PREFIX + ".metrics";
+    private static final String NODE_METRICS_RESET = NODE_PREFIX + ".metrics.reset";
+
+    /** Honest rejection for {@code set web}: no MineSkin/URL pipeline exists pre-GameProfile. */
+    private static final String WEB_UNSUPPORTED = "web skins are not supported on this version";
+
+    /** Stale-window for {@code metrics cleanup}, mirroring the modern lanes (30 days). */
+    private static final long CLEANUP_OLDER_THAN_MS = 30L * 24 * 60 * 60 * 1000;
 
     private static volatile MojangAPI mojangApi = new MojangApiHttpImpl();
     private static volatile MinecraftServer serverOverride;
 
     /** Seen usernames for {@code /skin set} completion, populated on successful resolves. */
     private static final MojangProfileCache seenProfiles = new MojangProfileCache();
+
+    /**
+     * Random-pick indirection: cape mode swaps the candidate source for
+     * {@link RandomCapeSource} (mskins with_capes) — mirroring the modern
+     * lanes' random branch. Test seam: deterministic fakes only (memory
+     * #1115; no live HTTP).
+     */
+    interface RandomPickSource {
+        String pick(boolean cape, SkinVariant variant) throws IOException;
+    }
+
+    private static final RandomPickSource DEFAULT_RANDOM_PICK_SOURCE = new RandomPickSource() {
+        @Override
+        public String pick(boolean cape, SkinVariant variant) throws IOException {
+            return cape
+                ? new RandomCapeSource().pickRandomCapeUsername()
+                : RandomMojangSkin.randomUsername(false, variant);
+        }
+    };
+
+    private static volatile RandomPickSource randomPickSource = DEFAULT_RANDOM_PICK_SOURCE;
 
     @Override
     public String getCommandName() {
@@ -70,7 +123,7 @@ public class SkinRestorerCommand implements ICommand {
 
     @Override
     public String getCommandUsage(ICommandSender sender) {
-        return "/skin <set <username>|clear|source> [player]";
+        return "/skin <set <username|random [cape] [variant]>|clear|source|metrics [json|players|cleanup|reset]> [players...]";
     }
 
     @Override
@@ -88,36 +141,175 @@ public class SkinRestorerCommand implements ICommand {
             return;
         }
         String action = args[0];
-        EntityPlayerMP target = resolveTarget(sender, args);
-        if (target == null) {
+        if ("metrics".equals(action)) {
+            doMetrics(sender, args);
+            return;
+        }
+        if ("clear".equals(action)) {
+            doClear(sender, args);
+            return;
+        }
+        if ("source".equals(action)) {
+            doSource(sender, args);
+            return;
+        }
+        if ("set".equals(action)) {
+            doSet(sender, args);
+            return;
+        }
+        sender.sendChatToPlayer(ChatMessageComponent.createFromText(getCommandUsage(sender)));
+    }
+
+    private void doSet(ICommandSender sender, String[] args) {
+        if (args.length < 2) {
+            sender.sendChatToPlayer(ChatMessageComponent.createFromText(getCommandUsage(sender)));
+            return;
+        }
+        if ("web".equalsIgnoreCase(args[1])) {
+            // No MineSkin/URL pipeline exists on this line: pre-GameProfile
+            // has no client-side mechanism to render custom textures.
+            sender.sendChatToPlayer(ChatMessageComponent.createFromText(WEB_UNSUPPORTED));
+            return;
+        }
+        if ("random".equalsIgnoreCase(args[1])) {
+            setRandom(sender, args);
+            return;
+        }
+        // /skin set <username> [players...]: apply the named skin to each target.
+        List<EntityPlayerMP> targets = resolveTargets(sender, args, 2);
+        if (targets == null) {
             sender.sendChatToPlayer(ChatMessageComponent.createFromText("Player not found."));
             return;
         }
-        UUID uuid = SkinRestorer.uuidOf(target.getCommandSenderName());
-
-        switch (action) {
-            case "clear":
-                if (!checkPermission(sender, uuid, NODE_SKIN_CLEAR)) return;
-                SkinRestorer.clearSkin(uuid);
-                sender.sendChatToPlayer(ChatMessageComponent.createFromText("Skin cleared."));
-                break;
-            case "source":
-                if (!checkPermission(sender, uuid, NODE_SKIN_SOURCE)) return;
-                String source = SkinRestorer.getSource(uuid);
-                sender.sendChatToPlayer(ChatMessageComponent.createFromText(
-                    source != null ? "Skin source: " + source : "No custom skin stored."));
-                break;
-            case "set":
-                if (!checkPermission(sender, uuid, NODE_SKIN)) return;
-                if (args.length < 2) {
-                    sender.sendChatToPlayer(ChatMessageComponent.createFromText(getCommandUsage(sender)));
-                    return;
-                }
-                setSkin(sender, uuid, args[1]);
-                break;
-            default:
-                sender.sendChatToPlayer(ChatMessageComponent.createFromText(getCommandUsage(sender)));
+        if (!checkPermission(sender, targetsAreSelfOnly(sender, targets) ? NODE_SKIN : NODE_SKIN_OTHER)) {
+            return;
         }
+        for (EntityPlayerMP target : targets) {
+            setSkin(sender, SkinRestorer.uuidOf(target.getCommandSenderName()), args[1]);
+        }
+    }
+
+    /**
+     * /skin set random [<cape> [<variant>]] [players...]: the cape flag and
+     * variant are optional and parsed positionally to match the tab-completion
+     * cascade (bool, then variant, then targets) — the mc1.12.2 semantics.
+     */
+    private void setRandom(ICommandSender sender, String[] args) {
+        boolean cape = args.length >= 3 && "true".equalsIgnoreCase(args[2]);
+        SkinVariant variant = parseRandomVariant(args);
+        List<EntityPlayerMP> targets = resolveTargets(sender, args, 4);
+        if (targets == null) {
+            sender.sendChatToPlayer(ChatMessageComponent.createFromText("Player not found."));
+            return;
+        }
+        if (!checkPermission(sender, targetsAreSelfOnly(sender, targets) ? NODE_SKIN_RANDOM : NODE_SKIN_OTHER)) {
+            return;
+        }
+        String username;
+        try {
+            username = randomPickSource.pick(cape, variant);
+        } catch (IOException e) {
+            sender.sendChatToPlayer(ChatMessageComponent.createFromText("Could not pick a random skin (network error)."));
+            return;
+        }
+        if (username == null) {
+            sender.sendChatToPlayer(ChatMessageComponent.createFromText("Could not pick a random skin."));
+            return;
+        }
+        for (EntityPlayerMP target : targets) {
+            setSkin(sender, SkinRestorer.uuidOf(target.getCommandSenderName()), username);
+        }
+    }
+
+    private void doClear(ICommandSender sender, String[] args) {
+        List<EntityPlayerMP> targets = resolveTargets(sender, args, 1);
+        if (targets == null) {
+            sender.sendChatToPlayer(ChatMessageComponent.createFromText("Player not found."));
+            return;
+        }
+        if (!checkPermission(sender, targetsAreSelfOnly(sender, targets) ? NODE_SKIN_CLEAR : NODE_SKIN_OTHER)) {
+            return;
+        }
+        for (EntityPlayerMP target : targets) {
+            UUID uuid = SkinRestorer.uuidOf(target.getCommandSenderName());
+            long startNanos = System.nanoTime();
+            SkinMetrics.INSTANCE.recordRefreshStarted(uuid);
+            SkinRestorer.clearSkin(uuid);
+            SkinMetrics.INSTANCE.recordRefreshCompleted(uuid, startNanos, 0, 0, 0);
+        }
+        sender.sendChatToPlayer(ChatMessageComponent.createFromText("Skin cleared."));
+    }
+
+    private void doSource(ICommandSender sender, String[] args) {
+        List<EntityPlayerMP> targets = resolveTargets(sender, args, 1);
+        if (targets == null) {
+            sender.sendChatToPlayer(ChatMessageComponent.createFromText("Player not found."));
+            return;
+        }
+        if (!checkPermission(sender, targetsAreSelfOnly(sender, targets) ? NODE_SKIN_SOURCE : NODE_SKIN_OTHER)) {
+            return;
+        }
+        if (targets.size() == 1) {
+            String source = SkinRestorer.getSource(SkinRestorer.uuidOf(targets.get(0).getCommandSenderName()));
+            sender.sendChatToPlayer(ChatMessageComponent.createFromText(
+                source != null ? "Skin source: " + source : "No custom skin stored."));
+            return;
+        }
+        StringBuilder sb = new StringBuilder();
+        for (EntityPlayerMP target : targets) {
+            String name = target.getCommandSenderName();
+            String source = SkinRestorer.getSource(SkinRestorer.uuidOf(name));
+            if (sb.length() > 0) sb.append('\n');
+            sb.append(name).append(": ").append(source != null ? source : "No custom skin stored.");
+        }
+        sender.sendChatToPlayer(ChatMessageComponent.createFromText(sb.toString()));
+    }
+
+    /**
+     * /skin metrics [json|players|cleanup|reset]. View subcommands need
+     * {@code everlastingskins.command.metrics}; cleanup/reset additionally
+     * need {@code everlastingskins.command.metrics.reset}. Console senders
+     * are allowed (trusted operator) — mirrors the mc1.12.2 metrics surface.
+     */
+    private void doMetrics(ICommandSender sender, String[] args) {
+        String sub = args.length < 2 ? "human" : args[1];
+        if ("json".equals(sub)) {
+            if (!checkMetricsPermission(sender)) return;
+            sender.sendChatToPlayer(ChatMessageComponent.createFromText(
+                MetricsFormat.json(SkinMetrics.INSTANCE.snapshot())));
+            return;
+        }
+        if ("players".equals(sub)) {
+            if (!checkMetricsPermission(sender)) return;
+            StringBuilder sb = new StringBuilder("EverlastingSkins top players:");
+            int rank = 0;
+            for (Map.Entry<UUID, PlayerSnapshot> e : SkinMetrics.INSTANCE.topPlayers(10)) {
+                sb.append('\n').append("  ").append(++rank).append(". ")
+                    .append(e.getKey()).append(" — ")
+                    .append(e.getValue().refreshCount()).append(" refreshes");
+            }
+            if (rank == 0) {
+                sb.append('\n').append("  No refreshes recorded.");
+            }
+            sender.sendChatToPlayer(ChatMessageComponent.createFromText(sb.toString()));
+            return;
+        }
+        if ("cleanup".equals(sub)) {
+            if (!checkMetricsResetPermission(sender)) return;
+            int removed = SkinMetrics.INSTANCE.cleanupStalePlayers(CLEANUP_OLDER_THAN_MS);
+            sender.sendChatToPlayer(ChatMessageComponent.createFromText(
+                "Removed " + removed + " stale player(s) from metrics."));
+            return;
+        }
+        if ("reset".equals(sub)) {
+            if (!checkMetricsResetPermission(sender)) return;
+            SkinMetrics.INSTANCE.reset();
+            sender.sendChatToPlayer(ChatMessageComponent.createFromText("Metrics reset."));
+            return;
+        }
+        if (!checkMetricsPermission(sender)) return;
+        sender.sendChatToPlayer(ChatMessageComponent.createFromText(
+            MetricsFormat.human(SkinMetrics.INSTANCE.snapshot())));
     }
 
     private void setSkin(ICommandSender sender, UUID uuid, String username) {
@@ -129,40 +321,98 @@ public class SkinRestorerCommand implements ICommand {
             sender.sendChatToPlayer(ChatMessageComponent.createFromText("Skin resolver unavailable."));
             return;
         }
+        long startNanos = System.nanoTime();
+        SkinMetrics.INSTANCE.recordRefreshStarted(uuid);
         Optional<MojangSkinDataResult> result = api.getSkin(username);
         if (!result.isPresent()) {
+            SkinMetrics.INSTANCE.recordRefreshFailed(uuid);
             sender.sendChatToPlayer(ChatMessageComponent.createFromText("Could not resolve a skin for '" + username + "'."));
             return;
         }
         CustomSkinProperty skin = result.get().skinProperty();
         seenProfiles.put(username, skin);
         SkinRestorer.applySkin(uuid, skin);
+        SkinMetrics.INSTANCE.recordRefreshCompleted(uuid, startNanos, System.nanoTime() - startNanos, 0, 0);
         sender.sendChatToPlayer(ChatMessageComponent.createFromText("Skin applied."));
     }
 
-    private boolean checkPermission(ICommandSender sender, UUID uuid, String node) {
-        int opLevel = sender instanceof EntityPlayerMP ? 4 : 0;
-        if (!PermissionServiceManager.hasPermission(uuid, opLevel, node)) {
+    /**
+     * Sender-based gate (mirrors mc1.12.2): the console is the trusted
+     * operator; players are checked by their own username-derived UUID
+     * (memory #1123 — never the target object).
+     */
+    private boolean checkPermission(ICommandSender sender, String node) {
+        if (!(sender instanceof EntityPlayerMP)) return true; // console
+        EntityPlayerMP player = (EntityPlayerMP) sender;
+        if (!PermissionServiceManager.hasPermission(
+                SkinRestorer.uuidOf(player.getCommandSenderName()), 4, node)) {
             sender.sendChatToPlayer(ChatMessageComponent.createFromText("You do not have permission to use this command."));
             return false;
         }
         return true;
     }
 
-    private EntityPlayerMP resolveTarget(ICommandSender sender, String[] args) {
-        if (args.length >= 2 && !args[1].isEmpty()) {
-            MinecraftServer server = serverOverride != null ? serverOverride : MinecraftServer.getServer();
-            if (server != null && server.getConfigurationManager() != null) {
-                for (Object o : server.getConfigurationManager().playerEntityList) {
-                    if (o instanceof EntityPlayerMP) {
-                        EntityPlayerMP p = (EntityPlayerMP) o;
-                        if (p.getCommandSenderName().equalsIgnoreCase(args[1])) return p;
+    private boolean checkMetricsPermission(ICommandSender sender) {
+        if (!(sender instanceof EntityPlayerMP)) return true; // console
+        return checkPermission(sender, NODE_METRICS);
+    }
+
+    private boolean checkMetricsResetPermission(ICommandSender sender) {
+        if (!(sender instanceof EntityPlayerMP)) return true; // console
+        return checkPermission(sender, NODE_METRICS_RESET);
+    }
+
+    /**
+     * Resolves the target set: explicit names (args from {@code targetIndex})
+     * are matched against the online list, skipping unresolvable names
+     * (mirrors mc1.12.2's parseTargets); no explicit names resolve to the
+     * sender. Returns null when nothing resolved.
+     */
+    private List<EntityPlayerMP> resolveTargets(ICommandSender sender, String[] args, int targetIndex) {
+        MinecraftServer server = serverOverride != null ? serverOverride : MinecraftServer.getServer();
+        if (server != null && server.getConfigurationManager() != null) {
+            if (args.length > targetIndex) {
+                List<EntityPlayerMP> out = new ArrayList<EntityPlayerMP>();
+                for (int i = targetIndex; i < args.length; i++) {
+                    for (Object o : server.getConfigurationManager().playerEntityList) {
+                        if (o instanceof EntityPlayerMP) {
+                            EntityPlayerMP p = (EntityPlayerMP) o;
+                            if (p.getCommandSenderName().equalsIgnoreCase(args[i])) {
+                                out.add(p);
+                                break;
+                            }
+                        }
                     }
                 }
+                return out.isEmpty() ? null : out;
             }
-            return null;
+            for (Object o : server.getConfigurationManager().playerEntityList) {
+                if (o instanceof EntityPlayerMP && o == sender) {
+                    return Collections.singletonList((EntityPlayerMP) o);
+                }
+            }
         }
-        return sender instanceof EntityPlayerMP ? (EntityPlayerMP) sender : null;
+        if (sender instanceof EntityPlayerMP) {
+            return Collections.singletonList((EntityPlayerMP) sender);
+        }
+        return null;
+    }
+
+    private boolean targetsAreSelfOnly(ICommandSender sender, List<EntityPlayerMP> targets) {
+        return targets.size() == 1
+            && sender instanceof EntityPlayerMP
+            && targets.get(0) == sender;
+    }
+
+    /** Variant argument of {@code /skin set random}: optional, defaults to ALL. */
+    private static SkinVariant parseRandomVariant(String[] args) {
+        if (args.length >= 4 && "slim".equalsIgnoreCase(args[3])) {
+            return SkinVariant.SLIM;
+        }
+        if (args.length >= 4 && "classic".equalsIgnoreCase(args[3])) {
+            return SkinVariant.CLASSIC;
+        }
+        return SkinVariant.ALL;
     }
 
     @Override
@@ -172,17 +422,53 @@ public class SkinRestorerCommand implements ICommand {
             if (canUse(sender, NODE_SKIN)) subcommands.add("set");
             if (canUse(sender, NODE_SKIN_CLEAR)) subcommands.add("clear");
             if (canUse(sender, NODE_SKIN_SOURCE)) subcommands.add("source");
+            if (canUse(sender, NODE_METRICS)) subcommands.add("metrics");
             return filterCompletions(args[0], subcommands);
         }
         if (args.length == 2) {
+            if ("metrics".equals(args[0])) {
+                List<String> metricsSubs = new ArrayList<String>();
+                metricsSubs.add("json");
+                metricsSubs.add("players");
+                if (canUse(sender, NODE_METRICS_RESET)) {
+                    metricsSubs.add("cleanup");
+                    metricsSubs.add("reset");
+                }
+                return filterCompletions(args[1], metricsSubs);
+            }
             List<String> candidates = new ArrayList<String>();
+            if ("set".equals(args[0])) candidates.add("random");
             addOnlinePlayerNames(candidates);
             for (String seen : seenProfiles.snapshot()) {
                 if (!candidates.contains(seen)) candidates.add(seen);
             }
             return filterCompletions(args[1], candidates);
         }
+        if ("set".equals(args[0]) && "random".equals(args[1])) {
+            // Positional cascade mirroring mc1.12.2: cape bool, then variant,
+            // then target names.
+            if (args.length == 3) {
+                return filterCompletions(args[2], Arrays.asList("true", "false"));
+            }
+            if (args.length == 4) {
+                return filterCompletions(args[3], Arrays.asList("classic", "slim"));
+            }
+            return targetCompletions(args[args.length - 1]);
+        }
+        if ("set".equals(args[0]) || "clear".equals(args[0]) || "source".equals(args[0])) {
+            return targetCompletions(args[args.length - 1]);
+        }
         return null;
+    }
+
+    /** Online + seen-profile names for the target positions. */
+    private List targetCompletions(String prefix) {
+        List<String> candidates = new ArrayList<String>();
+        addOnlinePlayerNames(candidates);
+        for (String seen : seenProfiles.snapshot()) {
+            if (!candidates.contains(seen)) candidates.add(seen);
+        }
+        return filterCompletions(prefix, candidates);
     }
 
     /** Silent permission check for completion (no denial message, unlike {@link #checkPermission}). */
@@ -239,5 +525,10 @@ public class SkinRestorerCommand implements ICommand {
     /** Test seam — deterministic completion tests (memory #1115). */
     static void clearSeenProfilesForTest() {
         seenProfiles.clear();
+    }
+
+    /** Test seam — deterministic random-pick injection (null restores the live source). */
+    static void setRandomPickSourceForTest(RandomPickSource source) {
+        randomPickSource = source != null ? source : DEFAULT_RANDOM_PICK_SOURCE;
     }
 }

--- a/forge-1.6.4/src/test/java/levosilimo/everlastingskins/command/SkinRestorerCommandTest.java
+++ b/forge-1.6.4/src/test/java/levosilimo/everlastingskins/command/SkinRestorerCommandTest.java
@@ -6,6 +6,8 @@
 
 package levosilimo.everlastingskins.command;
 
+import levosilimo.everlastingskins.enums.SkinVariant;
+import levosilimo.everlastingskins.metrics.SkinMetrics;
 import levosilimo.everlastingskins.permission.IPermissionService;
 import levosilimo.everlastingskins.permission.PermissionServiceManager;
 import levosilimo.everlastingskins.skinchanger.MojangAPI;
@@ -23,6 +25,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -32,6 +35,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -42,12 +46,17 @@ import static org.mockito.Mockito.when;
  * 1.6.4 ICommand lifecycle + dispatch tests.
  *
  * <p>Deterministic fakes only (memory #1115): the Mojang lookup is a fake
- * resolver (no live HTTP); the sender/player/server are Mockito mocks over
- * the MCP 8.11 surface. The 1.6.4 command surface under test is
+ * resolver (no live HTTP); the random pick is an injected fake picker; the
+ * sender/player/server are Mockito mocks over the MCP 8.11 surface. The
+ * 1.6.4 command surface under test is
  * {@code getCommandName}/{@code getCommandAliases}/{@code processCommand} —
  * no {@code getName} (1.8+) and no LiteralArgumentBuilder (1.13+). Sender
  * chat goes through {@code sendChatToPlayer(ChatMessageComponent)} (1.6.4
  * has no addChatMessage — that is 1.7+).
+ *
+ * <p>Covers the command/storage parity surface (set random, metrics,
+ * multi-target + permission gating, web rejection) and the extended tab
+ * completion.
  */
 public class SkinRestorerCommandTest {
 
@@ -57,8 +66,12 @@ public class SkinRestorerCommandTest {
     public void setUp() throws Exception {
         // Highest-priority deterministic grant-all backend (memory #1115) so
         // permission checks in these dispatch tests are deterministic
-        // regardless of any backend left by earlier tests.
+        // regardless of any backend left by earlier tests. A sticky
+        // DenyNodeService (priority 1000) grants everything once its deny
+        // set is cleared, so behaviour stays grant-all across tests.
+        DenyNodeService.deny(null);
         PermissionServiceManager.registerService(new GrantAllService());
+        SkinMetrics.INSTANCE.reset();
 
         Path dir = Files.createTempDirectory("es-164-skin-restorer-test");
         SkinStorage.resetForTest();
@@ -71,6 +84,7 @@ public class SkinRestorerCommandTest {
         SkinRestorerCommand.setMojangApiForTest(null);
         SkinRestorerCommand.setServerOverrideForTest(null);
         SkinRestorerCommand.clearSeenProfilesForTest();
+        SkinRestorerCommand.setRandomPickSourceForTest(null);
         SkinRestorer.setStorageForTest(null);
         SkinRestorer.setServerForTest(null);
     }
@@ -164,12 +178,269 @@ public class SkinRestorerCommandTest {
     }
 
     @Test
+    public void setDispatchWebRejectsWithEraMessage() throws Exception {
+        // Pre-GameProfile era limitation: no MineSkin/URL pipeline exists,
+        // so set web is honestly rejected and nothing is stored.
+        MojangSkinDataResult result = new MojangSkinDataResult(
+            UUID.randomUUID(),
+            new CustomSkinProperty("textures", "d2Vi", null, "MojangAPI"));
+        SkinRestorerCommand.setMojangApiForTest(new FakeMojangApi(Optional.of(result)));
+
+        EntityPlayerMP player = mockPlayer("Notch");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(player));
+
+        command.processCommand(player, new String[]{"set", "web"});
+
+        assertEquals(null, SkinRestorer.getSource(SkinRestorer.uuidOf("Notch")));
+        verify(player).sendChatToPlayer(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    public void setDispatchMultiTargetAppliesToAllNamed() throws Exception {
+        MojangSkinDataResult result = new MojangSkinDataResult(
+            UUID.randomUUID(),
+            new CustomSkinProperty("textures", "bXVsdGk=", null, "MojangAPI"));
+        SkinRestorerCommand.setMojangApiForTest(new FakeMojangApi(Optional.of(result)));
+
+        EntityPlayerMP self = mockPlayer("Notch");
+        EntityPlayerMP other = mockPlayer("jeb_");
+        EntityPlayerMP third = mockPlayer("xephos");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(self, other, third));
+
+        command.processCommand(self, new String[]{"set", "Notch", "jeb_", "xephos"});
+
+        assertEquals("MojangAPI", SkinRestorer.getSource(SkinRestorer.uuidOf("jeb_")));
+        assertEquals("MojangAPI", SkinRestorer.getSource(SkinRestorer.uuidOf("xephos")));
+        assertEquals(null, SkinRestorer.getSource(SkinRestorer.uuidOf("Notch")));
+    }
+
+    @Test
+    public void setDispatchTargetingOthersRequiresOtherPermission() throws Exception {
+        MojangSkinDataResult result = new MojangSkinDataResult(
+            UUID.randomUUID(),
+            new CustomSkinProperty("textures", "b3RoZXI=", null, "MojangAPI"));
+        SkinRestorerCommand.setMojangApiForTest(new FakeMojangApi(Optional.of(result)));
+        DenyNodeService.deny("everlastingskins.command.skin.other");
+        PermissionServiceManager.registerService(new DenyNodeService());
+
+        EntityPlayerMP self = mockPlayer("Notch");
+        EntityPlayerMP other = mockPlayer("jeb_");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(self, other));
+
+        command.processCommand(self, new String[]{"set", "Notch", "jeb_"});
+
+        assertEquals(null, SkinRestorer.getSource(SkinRestorer.uuidOf("jeb_")));
+    }
+
+    @Test
+    public void clearDispatchMultiTargetClearsOnlyNamed() throws Exception {
+        UUID selfUuid = SkinRestorer.uuidOf("Notch");
+        UUID otherUuid = SkinRestorer.uuidOf("jeb_");
+        SkinRestorer.applySkin(selfUuid,
+            new CustomSkinProperty("textures", "YQ==", null, "fake"));
+        SkinRestorer.applySkin(otherUuid,
+            new CustomSkinProperty("textures", "Yg==", null, "fake"));
+
+        EntityPlayerMP self = mockPlayer("Notch");
+        EntityPlayerMP other = mockPlayer("jeb_");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(self, other));
+
+        command.processCommand(self, new String[]{"clear", "jeb_"});
+
+        assertEquals(null, SkinRestorer.getSource(otherUuid));
+        assertNotNull(SkinRestorer.getSource(selfUuid));
+    }
+
+    @Test
+    public void setRandomDispatchAppliesPickedSkin() throws Exception {
+        MojangSkinDataResult result = new MojangSkinDataResult(
+            UUID.randomUUID(),
+            new CustomSkinProperty("textures", "cmFuZG9t", null, "MojangAPI"));
+        SkinRestorerCommand.setMojangApiForTest(new FakeMojangApi(Optional.of(result)));
+        SkinRestorerCommand.setRandomPickSourceForTest(new FixedRandomPickSource("pickedUser"));
+
+        EntityPlayerMP player = mockPlayer("Notch");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(player));
+
+        command.processCommand(player, new String[]{"set", "random"});
+
+        assertEquals("MojangAPI", SkinRestorer.getSource(SkinRestorer.uuidOf("Notch")));
+    }
+
+    @Test
+    public void setRandomCapeFlagReachesPicker() throws Exception {
+        MojangSkinDataResult result = new MojangSkinDataResult(
+            UUID.randomUUID(),
+            new CustomSkinProperty("textures", "Y2FwZQ==", null, "MojangAPI"));
+        SkinRestorerCommand.setMojangApiForTest(new FakeMojangApi(Optional.of(result)));
+        RecordingRandomPickSource picker = new RecordingRandomPickSource("pickedUser");
+        SkinRestorerCommand.setRandomPickSourceForTest(picker);
+
+        EntityPlayerMP player = mockPlayer("Notch");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(player));
+
+        command.processCommand(player, new String[]{"set", "random", "true"});
+
+        assertTrue(picker.lastCape);
+        assertEquals(SkinVariant.ALL, picker.lastVariant);
+    }
+
+    @Test
+    public void setRandomVariantParsingReachesPicker() throws Exception {
+        MojangSkinDataResult result = new MojangSkinDataResult(
+            UUID.randomUUID(),
+            new CustomSkinProperty("textures", "dmFyaWFudA==", null, "MojangAPI"));
+        SkinRestorerCommand.setMojangApiForTest(new FakeMojangApi(Optional.of(result)));
+        RecordingRandomPickSource picker = new RecordingRandomPickSource("pickedUser");
+        SkinRestorerCommand.setRandomPickSourceForTest(picker);
+
+        EntityPlayerMP player = mockPlayer("Notch");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(player));
+
+        command.processCommand(player, new String[]{"set", "random", "false", "slim"});
+
+        assertFalse(picker.lastCape);
+        assertEquals(SkinVariant.SLIM, picker.lastVariant);
+    }
+
+    @Test
+    public void setRandomPickerNetworkFailureReportsError() throws Exception {
+        SkinRestorerCommand.setRandomPickSourceForTest(new FailingRandomPickSource());
+
+        EntityPlayerMP player = mockPlayer("Notch");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(player));
+
+        command.processCommand(player, new String[]{"set", "random"});
+
+        assertEquals(null, SkinRestorer.getSource(SkinRestorer.uuidOf("Notch")));
+    }
+
+    @Test
+    public void setRandomPickerEmptyPickReportsFailure() throws Exception {
+        SkinRestorerCommand.setRandomPickSourceForTest(new FixedRandomPickSource(null));
+
+        EntityPlayerMP player = mockPlayer("Notch");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(player));
+
+        command.processCommand(player, new String[]{"set", "random"});
+
+        assertEquals(null, SkinRestorer.getSource(SkinRestorer.uuidOf("Notch")));
+    }
+
+    @Test
+    public void setRandomDispatchTargetsOthers() throws Exception {
+        MojangSkinDataResult result = new MojangSkinDataResult(
+            UUID.randomUUID(),
+            new CustomSkinProperty("textures", "dGFyZ2V0", null, "MojangAPI"));
+        SkinRestorerCommand.setMojangApiForTest(new FakeMojangApi(Optional.of(result)));
+        SkinRestorerCommand.setRandomPickSourceForTest(new FixedRandomPickSource("pickedUser"));
+
+        EntityPlayerMP self = mockPlayer("Notch");
+        EntityPlayerMP other = mockPlayer("jeb_");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(self, other));
+
+        command.processCommand(self, new String[]{"set", "random", "false", "all", "jeb_"});
+
+        assertEquals("MojangAPI", SkinRestorer.getSource(SkinRestorer.uuidOf("jeb_")));
+        assertEquals(null, SkinRestorer.getSource(SkinRestorer.uuidOf("Notch")));
+    }
+
+    @Test
+    public void setRandomTargetingOthersRequiresOtherPermission() throws Exception {
+        MojangSkinDataResult result = new MojangSkinDataResult(
+            UUID.randomUUID(),
+            new CustomSkinProperty("textures", "ZGVueQ==", null, "MojangAPI"));
+        SkinRestorerCommand.setMojangApiForTest(new FakeMojangApi(Optional.of(result)));
+        SkinRestorerCommand.setRandomPickSourceForTest(new FixedRandomPickSource("pickedUser"));
+        DenyNodeService.deny("everlastingskins.command.skin.other");
+        PermissionServiceManager.registerService(new DenyNodeService());
+
+        EntityPlayerMP self = mockPlayer("Notch");
+        EntityPlayerMP other = mockPlayer("jeb_");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(self, other));
+
+        command.processCommand(self, new String[]{"set", "random", "false", "all", "jeb_"});
+
+        assertEquals(null, SkinRestorer.getSource(SkinRestorer.uuidOf("jeb_")));
+    }
+
+    @Test
+    public void metricsDispatchReportsSnapshot() throws Exception {
+        EntityPlayerMP player = mockPlayer("Notch");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(player));
+
+        command.processCommand(player, new String[]{"metrics"});
+
+        verify(player).sendChatToPlayer(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    public void metricsJsonDispatchReportsJson() throws Exception {
+        EntityPlayerMP player = mockPlayer("Notch");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(player));
+
+        command.processCommand(player, new String[]{"metrics", "json"});
+
+        verify(player).sendChatToPlayer(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    public void metricsPlayersDispatchReportsTopPlayers() throws Exception {
+        SkinMetrics.INSTANCE.recordRefreshCompleted(SkinRestorer.uuidOf("Notch"), 0, 1, 0, 0);
+        EntityPlayerMP player = mockPlayer("Notch");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(player));
+
+        command.processCommand(player, new String[]{"metrics", "players"});
+
+        verify(player).sendChatToPlayer(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    public void metricsResetDispatchClearsCounters() throws Exception {
+        SkinMetrics.INSTANCE.recordRefreshCompleted(SkinRestorer.uuidOf("Notch"), 0, 1, 0, 0);
+        assertEquals(1, SkinMetrics.INSTANCE.snapshot().refreshesCompleted());
+
+        EntityPlayerMP player = mockPlayer("Notch");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(player));
+
+        command.processCommand(player, new String[]{"metrics", "reset"});
+
+        assertEquals(0, SkinMetrics.INSTANCE.snapshot().refreshesCompleted());
+    }
+
+    @Test
+    public void metricsCleanupDispatchReportsRemoved() throws Exception {
+        EntityPlayerMP player = mockPlayer("Notch");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(player));
+
+        command.processCommand(player, new String[]{"metrics", "cleanup"});
+
+        verify(player).sendChatToPlayer(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    public void metricsResetRequiresResetPermission() throws Exception {
+        SkinMetrics.INSTANCE.recordRefreshCompleted(SkinRestorer.uuidOf("Notch"), 0, 1, 0, 0);
+        DenyNodeService.deny("everlastingskins.command.metrics.reset");
+        PermissionServiceManager.registerService(new DenyNodeService());
+
+        EntityPlayerMP player = mockPlayer("Notch");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(player));
+
+        command.processCommand(player, new String[]{"metrics", "reset"});
+
+        // Denied: counters survive the attempted reset.
+        assertEquals(1, SkinMetrics.INSTANCE.snapshot().refreshesCompleted());
+    }
+
+    @Test
     public void tabCompleteOffersSubcommands() {
         ICommandSender sender = mock(ICommandSender.class);
         List completions = command.addTabCompletionOptions(sender, new String[]{""});
         assertTrue(completions.contains("set"));
         assertTrue(completions.contains("clear"));
         assertTrue(completions.contains("source"));
+        assertTrue(completions.contains("metrics"));
     }
 
     @Test
@@ -202,6 +473,7 @@ public class SkinRestorerCommandTest {
         assertTrue(completions.contains("Notch"));
         assertTrue(completions.contains("jeb_"));
         assertTrue(completions.contains("xephos")); // from the seen cache, not online
+        assertTrue(completions.contains("random")); // the set sub-mode
     }
 
     @Test
@@ -223,9 +495,83 @@ public class SkinRestorerCommandTest {
     }
 
     @Test
-    public void tabCompleteBeyondSecondArgReturnsNull() {
+    public void tabCompleteMetricsSubcommands() {
         ICommandSender sender = mock(ICommandSender.class);
-        assertEquals(null, command.addTabCompletionOptions(sender, new String[]{"set", "Notch", "extra"}));
+        List completions = command.addTabCompletionOptions(sender, new String[]{"metrics", ""});
+        assertTrue(completions.contains("json"));
+        assertTrue(completions.contains("players"));
+        assertTrue(completions.contains("cleanup"));
+        assertTrue(completions.contains("reset"));
+    }
+
+    @Test
+    public void tabCompleteMetricsHideResetWithoutPermission() {
+        DenyNodeService.deny("everlastingskins.command.metrics.reset");
+        PermissionServiceManager.registerService(new DenyNodeService());
+        EntityPlayerMP player = mockPlayer("Notch");
+
+        List completions = command.addTabCompletionOptions(player, new String[]{"metrics", ""});
+
+        assertTrue(completions.contains("json"));
+        assertFalse(completions.contains("cleanup"));
+        assertFalse(completions.contains("reset"));
+    }
+
+    @Test
+    public void tabCompleteFirstArgHidesMetricsWithoutPermission() {
+        DenyNodeService.deny("everlastingskins.command.metrics");
+        PermissionServiceManager.registerService(new DenyNodeService());
+        EntityPlayerMP player = mockPlayer("Notch");
+
+        List completions = command.addTabCompletionOptions(player, new String[]{""});
+
+        assertTrue(completions.contains("set"));
+        assertFalse(completions.contains("metrics"));
+    }
+
+    @Test
+    public void tabCompleteSetRandomOffersCapeFlags() {
+        ICommandSender sender = mock(ICommandSender.class);
+        List completions = command.addTabCompletionOptions(sender, new String[]{"set", "random", ""});
+        assertTrue(completions.contains("true"));
+        assertTrue(completions.contains("false"));
+    }
+
+    @Test
+    public void tabCompleteSetRandomOffersVariants() {
+        ICommandSender sender = mock(ICommandSender.class);
+        List completions = command.addTabCompletionOptions(sender, new String[]{"set", "random", "false", ""});
+        assertTrue(completions.contains("classic"));
+        assertTrue(completions.contains("slim"));
+    }
+
+    @Test
+    public void tabCompleteSetRandomOffersTargetsAfterFlags() throws Exception {
+        EntityPlayerMP self = mockPlayer("Notch");
+        EntityPlayerMP other = mockPlayer("jeb_");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(self, other));
+
+        ICommandSender sender = mock(ICommandSender.class);
+        List completions = command.addTabCompletionOptions(sender, new String[]{"set", "random", "false", "all", ""});
+        assertTrue(completions.contains("jeb_"));
+    }
+
+    @Test
+    public void tabCompleteThirdArgOffersTargets() throws Exception {
+        EntityPlayerMP self = mockPlayer("Notch");
+        EntityPlayerMP other = mockPlayer("jeb_");
+        SkinRestorerCommand.setServerOverrideForTest(mockServer(self, other));
+
+        ICommandSender sender = mock(ICommandSender.class);
+        List completions = command.addTabCompletionOptions(sender, new String[]{"set", "Notch", ""});
+        assertTrue(completions.contains("jeb_"));
+        assertTrue(completions.contains("Notch"));
+    }
+
+    @Test
+    public void tabCompleteUnknownActionReturnsNull() {
+        ICommandSender sender = mock(ICommandSender.class);
+        assertEquals(null, command.addTabCompletionOptions(sender, new String[]{"bogus", "x", "y"}));
     }
 
     private static EntityPlayerMP mockPlayer(String name) {
@@ -284,6 +630,74 @@ public class SkinRestorerCommandTest {
         @Override
         public int getPriority() {
             return 100;
+        }
+    }
+
+    /**
+     * Deterministic deny-one-node backend (memory #1115). The denied node is
+     * a static so the sticky registration (priority 1000) can be re-targeted
+     * across tests; {@link #deny(String)} with null restores grant-all.
+     */
+    private static final class DenyNodeService implements IPermissionService {
+        private static volatile String deniedNode;
+
+        static void deny(String node) {
+            deniedNode = node;
+        }
+
+        @Override
+        public boolean hasPermission(UUID uuid, int opLevel, String permissionNode) {
+            return deniedNode == null || !permissionNode.equals(deniedNode);
+        }
+
+        @Override
+        public String getActiveBackendName() {
+            return "DenyNode";
+        }
+
+        @Override
+        public int getPriority() {
+            return 1000;
+        }
+    }
+
+    /** Deterministic random-pick fake (memory #1115). */
+    private static final class FixedRandomPickSource implements SkinRestorerCommand.RandomPickSource {
+        private final String username;
+
+        FixedRandomPickSource(String username) {
+            this.username = username;
+        }
+
+        @Override
+        public String pick(boolean cape, SkinVariant variant) throws IOException {
+            return username;
+        }
+    }
+
+    /** Records picker arguments for the parse tests. */
+    private static final class RecordingRandomPickSource implements SkinRestorerCommand.RandomPickSource {
+        private final String username;
+        private boolean lastCape;
+        private SkinVariant lastVariant;
+
+        RecordingRandomPickSource(String username) {
+            this.username = username;
+        }
+
+        @Override
+        public String pick(boolean cape, SkinVariant variant) throws IOException {
+            lastCape = cape;
+            lastVariant = variant;
+            return username;
+        }
+    }
+
+    /** Picker that fails like a network error. */
+    private static final class FailingRandomPickSource implements SkinRestorerCommand.RandomPickSource {
+        @Override
+        public String pick(boolean cape, SkinVariant variant) throws IOException {
+            throw new IOException("offline");
         }
     }
 }


### PR DESCRIPTION
Per command-parity investigation (exp-1 + lib-2): pre-1.8 lanes cannot render custom skins (no GameProfile textures; dead skins.minecraft.net) — set web is honestly rejected with an era-limitation message. Adds set random (pick+resolve+store), metrics [json|players|cleanup|reset], multi-target with permission gating, extended completion. Command + storage surface parity; rendering parity requires a client-side mechanism (documented).