### PR TITLE
feat(forge-1.8.9): add /skin with full parity surface + login-apply (per parity investigation)

### DIFF
--- a/forge-1.8.9/src/main/java/levosilimo/everlastingskins/EverlastingSkins.java
+++ b/forge-1.8.9/src/main/java/levosilimo/everlastingskins/EverlastingSkins.java
@@ -9,7 +9,9 @@ package levosilimo.everlastingskins;
 import levosilimo.everlastingskins.broadcast.SkinBroadcaster;
 import levosilimo.everlastingskins.command.SkinRestorerCommand;
 import levosilimo.everlastingskins.permission.forge.ForgePermissionService;
+import levosilimo.everlastingskins.skinchanger.SkinCommand;
 import levosilimo.everlastingskins.skinchanger.SkinRestorer;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLServerStartingEvent;
@@ -57,7 +59,10 @@ public class EverlastingSkins {
     @Mod.EventHandler
     public void serverStarting(FMLServerStartingEvent event) {
         SkinRestorer.init(event);
+        // Skin lifecycle: login-apply, logout-persist, mid-session apply.
+        MinecraftForge.EVENT_BUS.register(new SkinRestorer());
         event.registerServerCommand(new SkinRestorerCommand());
+        event.registerServerCommand(new SkinCommand());
         LOGGER.info("{} server starting", MOD_NAME);
     }
 }

--- a/forge-1.8.9/src/main/java/levosilimo/everlastingskins/skinchanger/SkinAction.java
+++ b/forge-1.8.9/src/main/java/levosilimo/everlastingskins/skinchanger/SkinAction.java
@@ -1,0 +1,173 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import levosilimo.everlastingskins.EverlastingSkins;
+import levosilimo.everlastingskins.enums.SkinActionType;
+import levosilimo.everlastingskins.enums.SkinVariant;
+import levosilimo.everlastingskins.metrics.SkinMetrics;
+import levosilimo.everlastingskins.skinchanger.responses.mojang.MojangSkinDataResult;
+import levosilimo.everlastingskins.util.CustomSkinProperty;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.ChatComponentText;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Provider-fetch pipeline for the 1.8.9 {@code /skin} command. Runs the
+ * Mojang/MineSkin/random HTTP fetch off the server thread and applies the
+ * result back on the server thread via {@link MinecraftServer#addScheduledTask}
+ * so packet sends stay thread-safe — the same shape as the mc1.12.2
+ * SkinAction, trimmed to this lane's scope (no Config, no rate limiting,
+ * no DiscordSRV hook).
+ */
+final class SkinAction {
+
+    /** Source-class discriminator persisted on Mojang-sourced skins. */
+    static final String SOURCE_MOJANG = "MojangAPI";
+
+    private static ExecutorService executor = Executors.newCachedThreadPool();
+
+    private SkinAction() {}
+
+    /** Test seam: inject a direct executor for deterministic tests. */
+    static void setExecutorForTest(ExecutorService testExecutor) {
+        executor = testExecutor;
+    }
+
+    static void apply(Collection<EntityPlayerMP> targets, ICommandSender sender,
+            SkinActionType type, SkinVariant variant, boolean withCape, @Nullable String customSource) {
+        if (targets.isEmpty()) {
+            return;
+        }
+        // A5 (mc1.12.2 parity): when the stored skin already came from the
+        // provider this request would use AND was fetched for the same
+        // username, skip the fetch and re-apply the stored skin.
+        if (type == SkinActionType.username && storedSourceMatches(targets, customSource)) {
+            for (EntityPlayerMP p : targets) {
+                UUID uuid = SkinRestorer.profileIdOf(p);
+                SkinMetrics.INSTANCE.recordRefreshSkippedStored(uuid);
+                CustomSkinProperty stored = SkinRestorer.getSkinStorage().getSkin(uuid);
+                MinecraftServer server = SkinRestorer.getServer();
+                if (server != null) {
+                    server.addScheduledTask(() -> SkinRestorer.applySkin(p, stored));
+                }
+            }
+            return;
+        }
+        executor.submit(() -> {
+            Map<UUID, CustomSkinProperty> fetched = new HashMap<>();
+            try {
+                switch (type) {
+                    case clear:
+                        // Each target restores from its OWN stored source —
+                        // the first target's Mojang skin must not leak to
+                        // the others.
+                        for (EntityPlayerMP t : targets) {
+                            UUID uuid = SkinRestorer.profileIdOf(t);
+                            String storedSource = SkinRestorer.getSkinStorage().getSource(uuid);
+                            SkinCommand.MojangRestoreResult restore = SkinCommand.tryRestoreFromMojang(
+                                SkinCommand.getMojangAPI(), storedSource, t.getGameProfile().getName());
+                            fetched.put(uuid, restore != null ? restore.skin : null);
+                        }
+                        break;
+                    case url: {
+                        levosilimo.everlastingskins.skinchanger.responses.mineskin.MineSkinResponse response =
+                            SkinCommand.getMineSkinAPI().genSkin(customSource, variant);
+                        CustomSkinProperty sp = response != null ? response.property() : null;
+                        for (EntityPlayerMP t : targets) {
+                            fetched.put(SkinRestorer.profileIdOf(t), sp);
+                        }
+                        break;
+                    }
+                    case username:
+                    case random: {
+                        String fetchName = customSource;
+                        if (type == SkinActionType.random) {
+                            // Cape mode swaps the candidate source: the
+                            // RandomCapeSource (mskins with_capes + Cosmetica)
+                            // listing instead of RandomMojangSkin, which only
+                            // finds legacy cape holders.
+                            fetchName = withCape
+                                ? new RandomCapeSource().pickRandomCapeUsername()
+                                : RandomMojangSkin.randomUsername(false, variant);
+                        }
+                        CustomSkinProperty sp = SkinCommand.getMojangAPI().getSkin(fetchName)
+                            .map(MojangSkinDataResult::skinProperty).orElse(null);
+                        for (EntityPlayerMP t : targets) {
+                            fetched.put(SkinRestorer.profileIdOf(t), sp);
+                        }
+                        break;
+                    }
+                    default:
+                        return;
+                }
+            } catch (Exception e) {
+                EverlastingSkins.LOGGER.error("Skin fetch failed for /skin {}", type, e);
+                for (EntityPlayerMP p : targets) {
+                    SkinMetrics.INSTANCE.recordTimedOut(SkinRestorer.profileIdOf(p));
+                    p.addChatMessage(new ChatComponentText(SkinCommand.PREFIX + "Skin fetch failed, please try again"));
+                }
+                return;
+            }
+            MinecraftServer server = SkinRestorer.getServer();
+            if (server == null) {
+                return;
+            }
+            server.addScheduledTask(() -> {
+                for (EntityPlayerMP p : targets) {
+                    UUID uuid = SkinRestorer.profileIdOf(p);
+                    CustomSkinProperty sp = fetched.get(uuid);
+                    if (sp == null || sp.isEmpty()) {
+                        if (type != SkinActionType.clear) {
+                            EverlastingSkins.LOGGER.warn("Skin provider returned no result for {}", p.getName());
+                            p.addChatMessage(new ChatComponentText(SkinCommand.PREFIX + "No skin found for that source"));
+                            continue;
+                        }
+                        // Clear with no Mojang profile to restore: storage is
+                        // already dropped and the applied textures stripped.
+                        SkinRestorer.clearSkin(p);
+                        continue;
+                    }
+                    SkinRestorer.applySkin(p, sp);
+                    p.addChatMessage(new ChatComponentText(SkinCommand.PREFIX + "Skin applied"));
+                }
+            });
+        });
+    }
+
+    /**
+     * True when every target's stored skin is Mojang-class AND was fetched
+     * for the requested username (mirror of the mc1.12.2 A5 skip).
+     */
+    private static boolean storedSourceMatches(Collection<EntityPlayerMP> targets, @Nullable String customSource) {
+        if (customSource == null) {
+            return false;
+        }
+        SkinStorage storage = SkinRestorer.getSkinStorage();
+        if (storage == null) {
+            return false;
+        }
+        for (EntityPlayerMP p : targets) {
+            CustomSkinProperty stored = storage.getSkin(SkinRestorer.profileIdOf(p));
+            if (stored == null
+                    || !SOURCE_MOJANG.equals(stored.getSource())
+                    || !customSource.equals(stored.getUsername())) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/forge-1.8.9/src/main/java/levosilimo/everlastingskins/skinchanger/SkinCommand.java
+++ b/forge-1.8.9/src/main/java/levosilimo/everlastingskins/skinchanger/SkinCommand.java
@@ -1,0 +1,481 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import levosilimo.everlastingskins.enums.SkinActionType;
+import levosilimo.everlastingskins.enums.SkinVariant;
+import levosilimo.everlastingskins.metrics.MetricsFormat;
+import levosilimo.everlastingskins.metrics.PlayerSnapshot;
+import levosilimo.everlastingskins.metrics.SkinMetrics;
+import levosilimo.everlastingskins.permission.PermissionServiceManager;
+import levosilimo.everlastingskins.permission.forge.ForgePermissionService;
+import levosilimo.everlastingskins.skinchanger.responses.mojang.MojangSkinDataResult;
+import levosilimo.everlastingskins.util.CustomSkinProperty;
+import levosilimo.everlastingskins.util.HttpsUrlConnectionHttpClient;
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.CommandException;
+import net.minecraft.command.ICommand;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.BlockPos;
+import net.minecraft.util.ChatComponentText;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * 1.8.9 {@code /skin} command over the legacy {@link ICommand} surface
+ * (getCommandName/processCommand — the 1.8-era MCP names; the getName/
+ * execute rename landed in 1.11). Full parity surface with the mc1.12.2
+ * SkinCommand: {@code set mojang|web|random}, {@code source}, {@code clear},
+ * {@code metrics} with multi-target support.
+ *
+ * <p>Permission model: the vanilla {@link ICommand} op gate is left open
+ * (parity with the 1.12.2 {@code checkPermission}) and every subcommand
+ * gates through {@link PermissionServiceManager} with the lane's node
+ * naming (see {@link ForgePermissionService}). Console senders pass all
+ * node checks. Target-other, URL and metrics-cleanup operations require
+ * op level 2.
+ */
+public class SkinCommand implements ICommand {
+
+    static final String PREFIX = "§6[Everlasting Skins]§f ";
+
+    private static final String NAME = "skin";
+    private static final List<String> ALIASES = Collections.singletonList("eskin");
+
+    private static MineSkinAPI mineSkinAPI = new MineSkinApiHttpImpl();
+    private static MojangAPI mojangAPI = new MojangApiHttpImpl(MojangEndpoints.DEFAULT,
+        new HttpsUrlConnectionHttpClient(), true, new MojangProfileCache());
+
+    /* Package-private for tests: inject fakes without reflection. */
+    static MojangAPI getMojangAPI() {
+        return mojangAPI;
+    }
+
+    static MineSkinAPI getMineSkinAPI() {
+        return mineSkinAPI;
+    }
+
+    static void setMojangAPI(MojangAPI api) {
+        mojangAPI = api;
+    }
+
+    static void setMineSkinAPI(MineSkinAPI api) {
+        mineSkinAPI = api;
+    }
+
+    static void resetAPIs() {
+        mojangAPI = new MojangApiHttpImpl(MojangEndpoints.DEFAULT,
+            new HttpsUrlConnectionHttpClient(), true, new MojangProfileCache());
+        mineSkinAPI = new MineSkinApiHttpImpl();
+    }
+
+    @Override
+    public String getCommandName() {
+        return NAME;
+    }
+
+    @Override
+    public String getCommandUsage(ICommandSender sender) {
+        return "/skin <set|clear|source|metrics> ...";
+    }
+
+    @Override
+    public List<String> getCommandAliases() {
+        return ALIASES;
+    }
+
+    @Override
+    public void processCommand(ICommandSender sender, String[] args) throws CommandException {
+        if (args.length < 1) {
+            sender.addChatMessage(new ChatComponentText(PREFIX + getCommandUsage(sender)));
+            return;
+        }
+        String sub = args[0];
+        if ("clear".equals(sub)) {
+            doClear(sender, args);
+        } else if ("source".equals(sub)) {
+            doSource(sender, args);
+        } else if ("set".equals(sub)) {
+            doSet(sender, args);
+        } else if ("metrics".equals(sub)) {
+            doMetrics(sender, args);
+        } else {
+            sender.addChatMessage(new ChatComponentText(PREFIX + getCommandUsage(sender)));
+        }
+    }
+
+    /**
+     * Node checks live inside the subcommands (parity with the 1.12.2
+     * {@code checkPermission} returning true): the vanilla dispatcher never
+     * pre-gates, so denial messages are under the command's control.
+     */
+    @Override
+    public boolean canCommandSenderUseCommand(ICommandSender sender) {
+        return true;
+    }
+
+    @Override
+    public List<String> addTabCompletionOptions(ICommandSender sender, String[] args, BlockPos pos) {
+        if (args.length == 1) {
+            return subcommandCompletions(sender, args);
+        }
+        if ("set".equals(args[0])) {
+            return setTabCompletions(sender, args);
+        }
+        if (("clear".equals(args[0]) || "source".equals(args[0])) && args.length == 2) {
+            return canTargetOthers(sender)
+                ? CommandBase.getListOfStringsMatchingLastWord(args, onlinePlayerNames())
+                : Collections.emptyList();
+        }
+        if ("metrics".equals(args[0]) && args.length == 2) {
+            return CommandBase.getListOfStringsMatchingLastWord(args, "json", "players", "cleanup", "reset");
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public boolean isUsernameIndex(String[] args, int index) {
+        return false;
+    }
+
+    @Override
+    public int compareTo(ICommand other) {
+        return getCommandName().compareTo(other.getCommandName());
+    }
+
+    /** Subcommand names the sender may actually use, in /skin usage order. */
+    private List<String> subcommandCompletions(ICommandSender sender, String[] args) {
+        List<String> subcommands = new ArrayList<>();
+        if (hasPermission(sender, ForgePermissionService.SKIN_NODE, 2)) {
+            subcommands.add("set");
+        }
+        if (hasPermission(sender, ForgePermissionService.SKIN_CLEAR_NODE, 2)) {
+            subcommands.add("clear");
+        }
+        if (hasPermission(sender, ForgePermissionService.SKIN_SOURCE_NODE, 2)) {
+            subcommands.add("source");
+        }
+        if (hasPermission(sender, ForgePermissionService.METRICS_NODE, 2)) {
+            subcommands.add("metrics");
+        }
+        return CommandBase.getListOfStringsMatchingLastWord(args, subcommands);
+    }
+
+    /** Per-position candidates under {@code /skin set ...}. */
+    private List<String> setTabCompletions(ICommandSender sender, String[] args) {
+        if (args.length == 2) {
+            return CommandBase.getListOfStringsMatchingLastWord(args, "mojang", "web", "random");
+        }
+        if ("mojang".equals(args[1]) && args.length == 3) {
+            return CommandBase.getListOfStringsMatchingLastWord(args, onlinePlayerNames());
+        }
+        if ("web".equals(args[1])) {
+            if (args.length == 3) {
+                return CommandBase.getListOfStringsMatchingLastWord(args, "classic", "slim");
+            }
+            if (args.length == 4) {
+                return canTargetOthers(sender)
+                    ? CommandBase.getListOfStringsMatchingLastWord(args, onlinePlayerNames())
+                    : Collections.emptyList();
+            }
+        }
+        if ("random".equals(args[1])) {
+            if (args.length == 3) {
+                return CommandBase.getListOfStringsMatchingLastWord(args, "true", "false");
+            }
+            if (args.length == 4) {
+                return CommandBase.getListOfStringsMatchingLastWord(args, "classic", "slim");
+            }
+            if (args.length == 5) {
+                return canTargetOthers(sender)
+                    ? CommandBase.getListOfStringsMatchingLastWord(args, onlinePlayerNames())
+                    : Collections.emptyList();
+            }
+        }
+        return Collections.emptyList();
+    }
+
+    private void doClear(ICommandSender sender, String[] args) throws CommandException {
+        Collection<EntityPlayerMP> targets = parseTargets(sender, args, 2);
+        String node = singleSelf(targets, sender)
+            ? ForgePermissionService.SKIN_CLEAR_NODE
+            : ForgePermissionService.SKIN_OTHER_NODE;
+        if (!checkPermission(sender, node, 2)) {
+            return;
+        }
+        SkinAction.apply(targets, sender, SkinActionType.clear, SkinVariant.ALL, false, null);
+    }
+
+    private void doSource(ICommandSender sender, String[] args) throws CommandException {
+        EntityPlayerMP target;
+        try {
+            target = args.length >= 2
+                ? CommandBase.getPlayer(sender, args[1])
+                : CommandBase.getCommandSenderAsPlayer(sender);
+        } catch (CommandException e) {
+            sender.addChatMessage(new ChatComponentText(PREFIX + e.getMessage()));
+            return;
+        }
+        if (args.length >= 2 && !checkPermission(sender, ForgePermissionService.SKIN_OTHER_NODE, 2)) {
+            return;
+        }
+        // SKIN_SOURCE_NODE grants unconditionally on the Forge backend, but
+        // stays fail-closed when no backend is registered.
+        if (!checkPermission(sender, ForgePermissionService.SKIN_SOURCE_NODE, 2)) {
+            return;
+        }
+        UUID uuid = SkinRestorer.profileIdOf(target);
+        SkinStorage storage = SkinRestorer.getSkinStorage();
+        if (storage == null) {
+            sender.addChatMessage(new ChatComponentText(PREFIX + "Skin storage not ready"));
+            return;
+        }
+        if (storage.hasDefaultSkin(uuid)) {
+            sender.addChatMessage(new ChatComponentText(PREFIX + target.getGameProfile().getName()));
+            return;
+        }
+        String source = storage.getSource(uuid);
+        sender.addChatMessage(new ChatComponentText(PREFIX
+            + (source != null ? source : "No stored source for " + target.getGameProfile().getName())));
+    }
+
+    private void doSet(ICommandSender sender, String[] args) throws CommandException {
+        if (args.length < 2) {
+            sender.addChatMessage(new ChatComponentText(PREFIX + getCommandUsage(sender)));
+            return;
+        }
+        String provider = args[1];
+        if ("mojang".equals(provider)) {
+            if (args.length < 3) {
+                sender.addChatMessage(new ChatComponentText(PREFIX + "Usage: /skin set mojang <name>"));
+                return;
+            }
+            Collection<EntityPlayerMP> targets = parseTargets(sender, args, 4);
+            String node = singleSelf(targets, sender)
+                ? ForgePermissionService.SKIN_NODE
+                : ForgePermissionService.SKIN_OTHER_NODE;
+            if (!checkPermission(sender, node, 2)) {
+                return;
+            }
+            SkinAction.apply(targets, sender, SkinActionType.username, SkinVariant.ALL, false, args[2]);
+        } else if ("web".equals(provider)) {
+            if (args.length < 4) {
+                sender.addChatMessage(new ChatComponentText(PREFIX + "Usage: /skin set web <classic|slim> <url>"));
+                return;
+            }
+            SkinVariant variant = "slim".equalsIgnoreCase(args[2]) ? SkinVariant.SLIM : SkinVariant.CLASSIC;
+            Collection<EntityPlayerMP> targets = parseTargets(sender, args, 5);
+            String node = singleSelf(targets, sender)
+                ? ForgePermissionService.SKIN_URL_NODE
+                : ForgePermissionService.SKIN_OTHER_NODE;
+            if (!checkPermission(sender, node, 2)) {
+                return;
+            }
+            SkinAction.apply(targets, sender, SkinActionType.url, variant, false, args[3]);
+        } else if ("random".equals(provider)) {
+            // /skin set random [<cape> [<variant>]] [<targets...>]: the cape
+            // flag and variant are optional and parsed to match the tab
+            // completion cascade (bool, then variant, then targets).
+            boolean cape = args.length >= 3 && "true".equalsIgnoreCase(args[2]);
+            SkinVariant variant = parseRandomVariant(args);
+            Collection<EntityPlayerMP> targets = parseTargets(sender, args, 4);
+            String node = singleSelf(targets, sender)
+                ? ForgePermissionService.SKIN_NODE
+                : ForgePermissionService.SKIN_OTHER_NODE;
+            if (!checkPermission(sender, node, 2)) {
+                return;
+            }
+            SkinAction.apply(targets, sender, SkinActionType.random, variant, cape, null);
+        } else {
+            sender.addChatMessage(new ChatComponentText(PREFIX + "Usage: /skin set <mojang|web|random>"));
+        }
+    }
+
+    /**
+     * Variant argument of {@code /skin set random}: optional, defaults to ALL.
+     */
+    private static SkinVariant parseRandomVariant(String[] args) {
+        if (args.length >= 4 && "slim".equalsIgnoreCase(args[3])) {
+            return SkinVariant.SLIM;
+        }
+        if (args.length >= 4 && "classic".equalsIgnoreCase(args[3])) {
+            return SkinVariant.CLASSIC;
+        }
+        return SkinVariant.ALL;
+    }
+
+    /**
+     * /skin metrics [json|players|cleanup|reset]. View commands need
+     * everlastingskins.command.metrics; cleanup/reset additionally need
+     * everlastingskins.command.metrics.reset. Console senders are allowed.
+     */
+    private void doMetrics(ICommandSender sender, String[] args) {
+        String sub = args.length < 2 ? "human" : args[1];
+        if ("json".equals(sub)) {
+            if (!checkMetricsPermission(sender)) {
+                return;
+            }
+            sender.addChatMessage(new ChatComponentText(PREFIX + MetricsFormat.json(SkinMetrics.INSTANCE.snapshot())));
+        } else if ("players".equals(sub)) {
+            if (!checkMetricsPermission(sender)) {
+                return;
+            }
+            StringBuilder sb = new StringBuilder(PREFIX + "Top players by skin refresh:");
+            int rank = 0;
+            for (Map.Entry<UUID, PlayerSnapshot> e : SkinMetrics.INSTANCE.topPlayers(10)) {
+                sb.append("\n  ").append(++rank).append(". ")
+                    .append(e.getKey()).append(" — ")
+                    .append(e.getValue().refreshCount()).append(" refreshes");
+            }
+            if (rank == 0) {
+                sb.append("\n  No refreshes recorded yet");
+            }
+            sender.addChatMessage(new ChatComponentText(sb.toString()));
+        } else if ("cleanup".equals(sub)) {
+            if (!checkMetricsResetPermission(sender)) {
+                return;
+            }
+            int removed = SkinMetrics.INSTANCE.cleanupStalePlayers(30L * 24 * 60 * 60 * 1000);
+            sender.addChatMessage(new ChatComponentText(PREFIX + "Removed " + removed + " stale player metric records"));
+        } else if ("reset".equals(sub)) {
+            if (!checkMetricsResetPermission(sender)) {
+                return;
+            }
+            SkinMetrics.INSTANCE.reset();
+            sender.addChatMessage(new ChatComponentText(PREFIX + "Metrics reset"));
+        } else {
+            if (!checkMetricsPermission(sender)) {
+                return;
+            }
+            sender.addChatMessage(new ChatComponentText(PREFIX + MetricsFormat.human(SkinMetrics.INSTANCE.snapshot())));
+        }
+    }
+
+    private boolean checkMetricsPermission(ICommandSender sender) {
+        return checkPermission(sender, ForgePermissionService.METRICS_NODE, 2);
+    }
+
+    private boolean checkMetricsResetPermission(ICommandSender sender) {
+        return checkPermission(sender, ForgePermissionService.METRICS_RESET_NODE, 2);
+    }
+
+    /**
+     * Node-gated permission check: console senders pass, players are checked
+     * through {@link PermissionServiceManager} against the lane's backend
+     * with the given required op level.
+     */
+    private boolean checkPermission(ICommandSender sender, String node, int requiredLevel) {
+        if (sender instanceof EntityPlayerMP) {
+            EntityPlayerMP player = (EntityPlayerMP) sender;
+            if (!PermissionServiceManager.hasPermission(SkinRestorer.profileIdOf(player), requiredLevel, node)) {
+                sender.addChatMessage(new ChatComponentText(PREFIX + "You do not have permission to use this command"));
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /** Permission probe for tab completion (console always completes). */
+    private boolean hasPermission(ICommandSender sender, String node, int requiredLevel) {
+        if (!(sender instanceof EntityPlayerMP)) {
+            return true;
+        }
+        return PermissionServiceManager.hasPermission(SkinRestorer.profileIdOf((EntityPlayerMP) sender),
+            requiredLevel, node);
+    }
+
+    private boolean canTargetOthers(ICommandSender sender) {
+        return hasPermission(sender, ForgePermissionService.SKIN_OTHER_NODE, 2);
+    }
+
+    /**
+     * Online player names from the 1.8.9 {@link ServerConfigurationManager}
+     * surface (getAllUsernames — the getOnlinePlayerNames rename is 1.12).
+     * Empty when no server context is available (unit tests, pre-boot).
+     */
+    private static List<String> onlinePlayerNames() {
+        MinecraftServer server = MinecraftServer.getServer();
+        if (server == null || server.getConfigurationManager() == null) {
+            return Collections.emptyList();
+        }
+        String[] names = server.getConfigurationManager().getAllUsernames();
+        return names != null ? Arrays.asList(names) : Collections.emptyList();
+    }
+
+    /**
+     * Targets after the provider arguments, or the sender itself when no
+     * targets are given. Multi-target use requires the .other node — the
+     * permission check runs before any target is resolved, so a denied
+     * sender never even looks players up.
+     */
+    private Collection<EntityPlayerMP> parseTargets(ICommandSender sender, String[] args, int targetIndex)
+            throws CommandException {
+        if (args.length > targetIndex) {
+            if (!checkPermission(sender, ForgePermissionService.SKIN_OTHER_NODE, 2)) {
+                return Collections.emptyList();
+            }
+            List<EntityPlayerMP> out = new ArrayList<>();
+            for (int i = targetIndex; i < args.length; i++) {
+                try {
+                    out.add(CommandBase.getPlayer(sender, args[i]));
+                } catch (CommandException ignored) {
+                    // Unknown names are skipped, mirroring the 1.12.2 parser.
+                }
+            }
+            return out;
+        }
+        try {
+            return Collections.singletonList(CommandBase.getCommandSenderAsPlayer(sender));
+        } catch (CommandException e) {
+            sender.addChatMessage(new ChatComponentText(PREFIX + e.getMessage()));
+            return Collections.emptyList();
+        }
+    }
+
+    private static boolean singleSelf(Collection<EntityPlayerMP> targets, ICommandSender sender) {
+        return targets.size() == 1 && targets.iterator().next() == sender;
+    }
+
+    /**
+     * Restores a skin from Mojang for the stored source username (or the
+     * player's own name when no source is stored) — the /skin clear
+     * fallback, mirroring the 1.12.2 SkinCommand.
+     */
+    @Nullable
+    static MojangRestoreResult tryRestoreFromMojang(MojangAPI mojangAPI, @Nullable String storedSource,
+            String playerName) {
+        String licensedUsername = (storedSource != null && !storedSource.trim().isEmpty())
+            ? storedSource : playerName;
+        CustomSkinProperty skin = mojangAPI.getSkin(licensedUsername)
+            .map(MojangSkinDataResult::skinProperty)
+            .filter(s -> !s.isEmpty())
+            .orElse(null);
+        if (skin == null) {
+            return null;
+        }
+        return new MojangRestoreResult(skin, licensedUsername);
+    }
+
+    static class MojangRestoreResult {
+        final CustomSkinProperty skin;
+        final String licensedUsername;
+
+        MojangRestoreResult(CustomSkinProperty skin, String licensedUsername) {
+            this.skin = skin;
+            this.licensedUsername = licensedUsername;
+        }
+    }
+}

--- a/forge-1.8.9/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRestorer.java
+++ b/forge-1.8.9/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRestorer.java
@@ -6,11 +6,24 @@
 
 package levosilimo.everlastingskins.skinchanger;
 
+import com.mojang.authlib.GameProfile;
 import levosilimo.everlastingskins.EverlastingSkins;
+import levosilimo.everlastingskins.metrics.SkinMetrics;
+import levosilimo.everlastingskins.util.CustomSkinProperty;
 import levosilimo.everlastingskins.util.UUIDUtils;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.network.play.server.S07PacketRespawn;
+import net.minecraft.network.play.server.S0CPacketSpawnPlayer;
+import net.minecraft.network.play.server.S1DPacketEntityEffect;
+import net.minecraft.network.play.server.S38PacketPlayerListItem;
+import net.minecraft.potion.PotionEffect;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.World;
+import net.minecraft.world.WorldServer;
 import net.minecraftforge.fml.common.event.FMLServerStartingEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.PlayerEvent;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -22,28 +35,50 @@ import java.util.UUID;
 /**
  * 1.8.9 binding for the {@code :common} {@link SkinStorage}.
  *
- * Storage constraint (memory #1123): SkinStorage is keyed by UUID only —
+ * <p>Storage constraint (memory #1123): SkinStorage is keyed by UUID only —
  * no EntityPlayer/GameProfile object ever crosses the lane boundary into
  * :common. This class extracts the player UUID at the lane edge:
  * {@link EntityPlayer#getPersistentID()} (inherited from Entity, dashed
  * form) and {@link EntityPlayer#getGameProfile()} (authlib surface) are
  * the 1.8.9 legacy APIs; 32-char no-dash UUID strings are normalized via
  * {@link UUIDUtils#convertToDashed(String)}.
+ *
+ * <p>Skin lifecycle (parity investigation): the instance is registered on
+ * the FML event bus at server start — {@link #onPlayerLoggedIn} applies the
+ * saved skin on login, {@link #onPlayerLoggedOut} persists it on disconnect,
+ * and {@link #applySkin}/{@link #clearSkin} drive the mid-session apply with
+ * the standard 1.8-1.12 skin-changer re-send (tab-list REMOVE+ADD to all
+ * players, in-world respawn to tracking observers, in-place target respawn).
  */
-public final class SkinRestorer {
+public class SkinRestorer {
 
     private static volatile SkinStorage skinStorage;
+    private static volatile MinecraftServer server;
 
-    private SkinRestorer() {}
+    public SkinRestorer() {}
 
     @Nullable
     public static SkinStorage getSkinStorage() {
         return skinStorage;
     }
 
+    public static MinecraftServer getServer() {
+        return server;
+    }
+
+    /** Test-only: replaces the static server reference without a full FML lifecycle. */
+    public static void setServerForTest(MinecraftServer testServer) {
+        server = testServer;
+    }
+
+    /** Test-only: injects a storage without a full FML lifecycle. */
+    public static void setStorageForTest(SkinStorage testStorage) {
+        skinStorage = testStorage;
+    }
+
     /** Server-start bootstrap: creates the data dir and the storage. */
     public static void init(FMLServerStartingEvent event) {
-        MinecraftServer server = event.getServer();
+        server = event.getServer();
         Path dataDir = server.getFile("EverlastingSkins").toPath();
         try {
             Files.createDirectories(dataDir);
@@ -85,5 +120,134 @@ public final class SkinRestorer {
     public static UUID normalizeUuid(String rawUuid) {
         return UUIDUtils.tryParseUniqueId(rawUuid)
             .orElseThrow(() -> new IllegalArgumentException("Invalid UUID: " + rawUuid));
+    }
+
+    /**
+     * Applies the saved skin on login. The profile mutation happens before
+     * the player is visible to observers, so there is no vanilla-skin flash.
+     */
+    @SubscribeEvent
+    public void onPlayerLoggedIn(PlayerEvent.PlayerLoggedInEvent event) {
+        SkinStorage storage = skinStorage;
+        if (storage == null || !(event.player instanceof EntityPlayerMP)) {
+            return;
+        }
+        EntityPlayerMP player = (EntityPlayerMP) event.player;
+        SkinMetrics.INSTANCE.recordPlayerJoined();
+        CustomSkinProperty skin = storage.getSkin(profileIdOf(player));
+        if (skin != null && !skin.isEmpty()) {
+            mutateProfile(player, skin);
+        }
+        // No skin on disk: leave the profile unmutated — the client renders
+        // the default Steve/Alex from the UUID hash.
+    }
+
+    /** Saves the player's skin on disconnect so it persists across sessions. */
+    @SubscribeEvent
+    public void onPlayerLoggedOut(PlayerEvent.PlayerLoggedOutEvent event) {
+        SkinStorage storage = skinStorage;
+        if (storage == null || !(event.player instanceof EntityPlayerMP)) {
+            return;
+        }
+        EntityPlayerMP player = (EntityPlayerMP) event.player;
+        SkinMetrics.INSTANCE.recordPlayerLeft();
+        UUID uuid = profileIdOf(player);
+        if (storage.getSkin(uuid) != null) {
+            storage.saveSkin(uuid);
+        }
+    }
+
+    /**
+     * Mid-session apply: stores the skin, mutates the GameProfile's
+     * {@code textures} property and re-sends the profile to every observer.
+     * Must run on the server thread (callers marshal via addScheduledTask).
+     */
+    public static void applySkin(EntityPlayerMP player, CustomSkinProperty skin) {
+        SkinStorage storage = skinStorage;
+        if (storage == null || player == null) {
+            return;
+        }
+        if (skin == null || skin.isEmpty()) {
+            clearSkin(player);
+            return;
+        }
+        UUID uuid = profileIdOf(player);
+        // Persist BEFORE mutating the profile (mc1.12.2 invariant): a failed
+        // enqueue leaves the applied profile untouched, so in-memory and
+        // on-disk state stay consistent.
+        storage.setSkin(uuid, skin);
+        storage.saveSkinAsync(uuid, skin);
+        mutateProfile(player, skin);
+        cascade(player);
+    }
+
+    /**
+     * Removes the stored skin and strips the applied {@code textures}
+     * property, re-sending the profile only when stale textures existed.
+     */
+    public static void clearSkin(EntityPlayerMP player) {
+        SkinStorage storage = skinStorage;
+        if (storage == null || player == null) {
+            return;
+        }
+        storage.removeSkin(profileIdOf(player));
+        boolean hadAppliedTextures = !player.getGameProfile().getProperties().get("textures").isEmpty();
+        player.getGameProfile().getProperties().removeAll("textures");
+        if (hadAppliedTextures) {
+            cascade(player);
+        }
+    }
+
+    /** GameProfile mutation is what every client ultimately reads textures from. */
+    private static void mutateProfile(EntityPlayerMP player, CustomSkinProperty skin) {
+        GameProfile profile = player.getGameProfile();
+        profile.getProperties().removeAll("textures");
+        profile.getProperties().put("textures", skin.getOriginalProperty());
+    }
+
+    /**
+     * The standard 1.8-1.12 skin-changer re-send: tab-list REMOVE+ADD to
+     * ALL online players (the ADD packet serializes the GameProfile at
+     * construction time, so this must run after the profile mutation), an
+     * in-world respawn packet to every tracking observer, and an in-place
+     * respawn of the target for its own view.
+     */
+    private static void cascade(EntityPlayerMP player) {
+        MinecraftServer srv = server != null ? server : player.mcServer;
+        if (srv == null || srv.getConfigurationManager() == null) {
+            return;
+        }
+        S38PacketPlayerListItem removePacket =
+            new S38PacketPlayerListItem(S38PacketPlayerListItem.Action.REMOVE_PLAYER, player);
+        S38PacketPlayerListItem addPacket =
+            new S38PacketPlayerListItem(S38PacketPlayerListItem.Action.ADD_PLAYER, player);
+        srv.getConfigurationManager().sendPacketToAllPlayers(removePacket);
+        srv.getConfigurationManager().sendPacketToAllPlayers(addPacket);
+        if (player.worldObj instanceof WorldServer) {
+            ((WorldServer) player.worldObj).getEntityTracker()
+                .sendToAllTrackingEntity(player, new S0CPacketSpawnPlayer(player));
+        }
+        respawnSelf(player);
+    }
+
+    /** In-place respawn so the target's own view re-renders with the new skin. */
+    private static void respawnSelf(EntityPlayerMP player) {
+        try {
+            World world = player.worldObj;
+            player.playerNetServerHandler.sendPacket(new S07PacketRespawn(
+                player.dimension, world.getDifficulty(), world.getWorldInfo().getTerrainType(),
+                player.theItemInWorldManager.getGameType()));
+            player.playerNetServerHandler.setPlayerLocation(
+                player.posX, player.posY, player.posZ, player.rotationYaw, player.rotationPitch);
+            player.sendPlayerAbilities();
+            // Potion effects must be replayed after respawn (vanilla
+            // transferPlayerToDimension parity, mirror of the 1.12.2 lane).
+            for (PotionEffect effect : player.getActivePotionEffects()) {
+                player.playerNetServerHandler.sendPacket(new S1DPacketEntityEffect(player.getEntityId(), effect));
+            }
+        } catch (Throwable t) {
+            // Fail soft: a partial cascade must not abort the apply.
+            EverlastingSkins.LOGGER.warn("Skin respawn cascade failed for {}", player.getName(), t);
+        }
     }
 }

--- a/forge-1.8.9/src/main/resources/endpoints.properties
+++ b/forge-1.8.9/src/main/resources/endpoints.properties
@@ -1,0 +1,34 @@
+# EverlastingSkins external endpoint configuration
+# All service URLs and patterns are defined here instead of as
+# hardcoded Java string literals in production source files.
+#
+# To update an endpoint, change the value here and rebuild.
+
+# --- Mojang / MineTools ---
+# Eclipse endpoints (skinsrestorer.net) were aliased to Mojang and removed;
+# UUID lookup uses Mojang API directly; profile lookup uses Mojang session server.
+endpoint.uuid.mojang=https://api.mojang.com/users/profiles/minecraft/%playerName%
+endpoint.uuid.minetools=https://api.minetools.eu/uuid/%playerName%
+endpoint.profile.mojang=https://sessionserver.mojang.com/session/minecraft/profile/%uuid%?unsigned=false
+endpoint.profile.minetools=https://api.minetools.eu/profile/%uuid%
+
+# --- MineSkin ---
+endpoint.mineskin.generate=https://api.mineskin.org/generate/url
+
+# --- Texture URL strip pattern (regex) ---
+# Strips the textures.minecraft.net base from a texture URL to leave the ID.
+pattern.texture.strip=^https?://textures\\.minecraft\\.net/texture/
+
+# --- NameMC ---
+url.namemc.img=https://s.namemc.com/i/%s.png
+
+# --- mskins.net (random skin fallback) ---
+url.mskins.latest=https://mskins.net/ru/skins/latest
+url.mskins.random=https://mskins.net/en/skins/random
+url.mskins.cape=https://mskins.net/en/cape/minecon_
+# Cape-bearing skin listing (48 players/page); the %d is the page number.
+url.mskins.with_capes=https://mskins.net/en/skins/with_capes?page=%d
+
+# --- Cosmetica (cape directory; OpenAPI at https://api.cosmetica.cc/docs-json) ---
+# GET /players/{name-or-uuid} returns the player's known capes (externalCape).
+endpoint.cosmetica.player=https://api.cosmetica.cc/players/%player%

--- a/forge-1.8.9/src/test/java/levosilimo/everlastingskins/skinchanger/SkinCommandTest.java
+++ b/forge-1.8.9/src/test/java/levosilimo/everlastingskins/skinchanger/SkinCommandTest.java
@@ -1,0 +1,354 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import com.mojang.authlib.GameProfile;
+import com.mojang.authlib.properties.Property;
+import levosilimo.everlastingskins.enums.SkinVariant;
+import levosilimo.everlastingskins.metrics.SkinMetrics;
+import levosilimo.everlastingskins.permission.PermissionServiceManager;
+import levosilimo.everlastingskins.permission.forge.ForgePermissionService;
+import levosilimo.everlastingskins.skinchanger.responses.mineskin.MineSkinResponse;
+import levosilimo.everlastingskins.skinchanger.responses.mojang.MojangSkinDataResult;
+import levosilimo.everlastingskins.util.CustomSkinProperty;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.IChatComponent;
+import net.minecraft.world.World;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.annotation.Nullable;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pure-JUnit tests for the 1.8.9 {@link SkinCommand} (memory #1115:
+ * deterministic fakes only — fake Mojang/MineSkin APIs, a direct executor
+ * for the async pipeline, mocked server surface; no live HTTP, no threads).
+ */
+class SkinCommandTest {
+
+    private static final UUID PLAYER = UUID.fromString("01234567-89ab-cdef-0123-456789abcdef");
+
+    /** Backend stub with a mutable op level; highest priority always wins. */
+    private static final class FixedOpService extends ForgePermissionService {
+        private static int level = 2;
+
+        static void level(int opLevel) {
+            level = opLevel;
+        }
+
+        @Override
+        protected int resolveOpLevel(UUID uuid) {
+            return level;
+        }
+
+        @Override
+        public int getPriority() {
+            return 100;
+        }
+    }
+
+    /** Fake Mojang API recording requested usernames. */
+    private static final class FakeMojangAPI implements MojangAPI {
+        private final Optional<MojangSkinDataResult> result;
+
+        FakeMojangAPI(@Nullable CustomSkinProperty skin) {
+            this.result = skin != null
+                ? Optional.of(new MojangSkinDataResult(PLAYER, skin))
+                : Optional.empty();
+        }
+
+        @Override
+        public Optional<MojangSkinDataResult> getSkin(String nameOrUniqueId) {
+            return result;
+        }
+
+        @Override
+        public Optional<UUID> getUUID(String playerName) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<CustomSkinProperty> getProfile(ProfileLookup lookup) {
+            return Optional.empty();
+        }
+    }
+
+    /** Fake MineSkin API recording the requested variant. */
+    private static final class FakeMineSkinAPI implements MineSkinAPI {
+        private final MineSkinResponse response;
+        private SkinVariant capturedVariant;
+
+        FakeMineSkinAPI(@Nullable MineSkinResponse response) {
+            this.response = response;
+        }
+
+        @Override
+        public MineSkinResponse genSkin(String url, @Nullable SkinVariant variant) {
+            capturedVariant = variant;
+            return response;
+        }
+    }
+
+    /** Direct executor: fetch + apply run inline, fully deterministic. */
+    private static final ExecutorService DIRECT = new AbstractExecutorService() {
+        @Override
+        public void execute(Runnable command) {
+            command.run();
+        }
+
+        @Override
+        public void shutdown() {
+        }
+
+        @Override
+        public List<Runnable> shutdownNow() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public boolean isShutdown() {
+            return true;
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return true;
+        }
+
+        @Override
+        public boolean awaitTermination(long timeout, TimeUnit unit) {
+            return true;
+        }
+    };
+
+    @TempDir
+    Path tempDir;
+
+    private SkinCommand command;
+    private EntityPlayerMP player;
+    private ICommandSender console;
+    private MinecraftServer server;
+    private SkinStorage storage;
+    private GameProfile profile;
+
+    @BeforeEach
+    void setUp() {
+        command = new SkinCommand();
+        profile = new GameProfile(PLAYER, "TestPlayer");
+        player = mock(EntityPlayerMP.class);
+        when(player.getPersistentID()).thenReturn(PLAYER);
+        when(player.getGameProfile()).thenReturn(profile);
+        World world = mock(World.class);
+        when(world.getPlayerEntityByName(anyString())).thenReturn(null);
+        when(player.getEntityWorld()).thenReturn(world);
+        console = mock(ICommandSender.class);
+        server = mock(MinecraftServer.class);
+        when(server.addScheduledTask(any(Runnable.class))).thenAnswer(invocation -> {
+            ((Runnable) invocation.getArgument(0)).run();
+            return null;
+        });
+        SkinRestorer.setServerForTest(server);
+        storage = new SkinStorage(new SkinIO(tempDir));
+        SkinRestorer.setStorageForTest(storage);
+        SkinAction.setExecutorForTest(DIRECT);
+        FixedOpService.level(2);
+        PermissionServiceManager.registerService(new FixedOpService());
+        SkinMetrics.INSTANCE.reset();
+    }
+
+    @AfterEach
+    void tearDown() {
+        SkinCommand.resetAPIs();
+        SkinStorage.resetForTest();
+    }
+
+    private static CustomSkinProperty skin(String name, String source) {
+        return new CustomSkinProperty(name, "value", "signature", source);
+    }
+
+    @Test
+    void exposesLegacySkinCommandSurface() {
+        assertEquals("skin", command.getCommandName());
+        assertTrue(command.getCommandAliases().contains("eskin"));
+        assertEquals("/skin <set|clear|source|metrics> ...", command.getCommandUsage(console));
+    }
+
+    @Test
+    void dispatchesNoArgsAsUsage() throws Exception {
+        command.processCommand(console, new String[]{});
+        verify(console).addChatMessage(any(IChatComponent.class));
+    }
+
+    @Test
+    void setMojangAppliesSkinToSelf() throws Exception {
+        CustomSkinProperty fetched = skin("Notch", "MojangAPI");
+        SkinCommand.setMojangAPI(new FakeMojangAPI(fetched));
+        command.processCommand(player, new String[]{"set", "mojang", "Notch"});
+        // Stored + applied to the GameProfile textures property.
+        assertEquals(fetched, storage.getSkin(PLAYER));
+        assertTrue(profile.getProperties().get("textures").contains(fetched.getOriginalProperty()));
+        verify(player).addChatMessage(any(IChatComponent.class)); // "Skin applied"
+    }
+
+    @Test
+    void setMojangDeniedWithoutPermissionNeverFetches() throws Exception {
+        FixedOpService.level(0);
+        SkinCommand.setMojangAPI(new FakeMojangAPI(skin("Notch", "MojangAPI")));
+        command.processCommand(player, new String[]{"set", "mojang", "Notch"});
+        assertNull(storage.getSkin(PLAYER));
+        verify(server, never()).addScheduledTask(any(Runnable.class));
+        verify(player).addChatMessage(any(IChatComponent.class)); // denial message
+    }
+
+    @Test
+    void setWebAppliesWithRequestedVariant() throws Exception {
+        CustomSkinProperty fetched = skin("web", "MineSkin");
+        FakeMineSkinAPI mineSkin = new FakeMineSkinAPI(new MineSkinResponse(fetched, "id", null, null));
+        SkinCommand.setMineSkinAPI(mineSkin);
+        command.processCommand(player, new String[]{"set", "web", "slim", "https://example.com/skin.png"});
+        assertEquals(SkinVariant.SLIM, mineSkin.capturedVariant);
+        assertEquals(fetched, storage.getSkin(PLAYER));
+        assertTrue(profile.getProperties().get("textures").contains(fetched.getOriginalProperty()));
+    }
+
+    @Test
+    void setWebRequiresUrlNode() throws Exception {
+        FixedOpService.level(0);
+        SkinCommand.setMineSkinAPI(new FakeMineSkinAPI(null));
+        command.processCommand(player, new String[]{"set", "web", "classic", "https://example.com/skin.png"});
+        assertNull(storage.getSkin(PLAYER));
+        verify(server, never()).addScheduledTask(any(Runnable.class));
+    }
+
+    @Test
+    void setRandomDeniedNeverFetches() throws Exception {
+        // The granted random path hits the live RandomMojangSkin source, so
+        // only the permission gate is exercised here (never touches HTTP).
+        FixedOpService.level(0);
+        SkinCommand.setMojangAPI(new FakeMojangAPI(skin("random", "MojangAPI")));
+        command.processCommand(player, new String[]{"set", "random", "true", "slim"});
+        assertNull(storage.getSkin(PLAYER));
+        verify(server, never()).addScheduledTask(any(Runnable.class));
+    }
+
+    @Test
+    void clearStripsStoredSkinAndTextures() throws Exception {
+        storage.setSkin(PLAYER, skin("Notch", "MojangAPI"));
+        profile.getProperties().put("textures", new Property("textures", "value", "signature"));
+        SkinCommand.setMojangAPI(new FakeMojangAPI(null));
+        command.processCommand(player, new String[]{"clear"});
+        assertNull(storage.getSkin(PLAYER));
+        assertTrue(profile.getProperties().get("textures").isEmpty());
+    }
+
+    @Test
+    void clearDeniedWithoutClearNode() throws Exception {
+        FixedOpService.level(0);
+        storage.setSkin(PLAYER, skin("Notch", "MojangAPI"));
+        SkinCommand.setMojangAPI(new FakeMojangAPI(null));
+        command.processCommand(player, new String[]{"clear"});
+        assertNotNull(storage.getSkin(PLAYER));
+        verify(server, never()).addScheduledTask(any(Runnable.class));
+    }
+
+    @Test
+    void targetingOthersRequiresOtherNode() throws Exception {
+        FixedOpService.level(0);
+        SkinCommand.setMojangAPI(new FakeMojangAPI(skin("Notch", "MojangAPI")));
+        command.processCommand(player, new String[]{"set", "mojang", "Notch", "A", "B"});
+        assertNull(storage.getSkin(PLAYER));
+        verify(server, never()).addScheduledTask(any(Runnable.class));
+    }
+
+    @Test
+    void sourceReportsStoredSource() throws Exception {
+        storage.setSkin(PLAYER, skin("Notch", "CustomSource"));
+        command.processCommand(player, new String[]{"source"});
+        // The message must carry the stored source label.
+        org.mockito.ArgumentCaptor<IChatComponent> captor =
+            org.mockito.ArgumentCaptor.forClass(IChatComponent.class);
+        verify(player).addChatMessage(captor.capture());
+        assertTrue(captor.getValue().getUnformattedText().contains("CustomSource"));
+    }
+
+    @Test
+    void sourceReportsOwnNameWhenUnset() throws Exception {
+        // mc1.12.2 parity: a player with no stored source is reported by
+        // name (the default-skin case).
+        command.processCommand(player, new String[]{"source"});
+        org.mockito.ArgumentCaptor<IChatComponent> captor =
+            org.mockito.ArgumentCaptor.forClass(IChatComponent.class);
+        verify(player).addChatMessage(captor.capture());
+        assertTrue(captor.getValue().getUnformattedText().contains("TestPlayer"));
+    }
+
+    @Test
+    void metricsJsonAllowedForConsole() throws Exception {
+        command.processCommand(console, new String[]{"metrics", "json"});
+        verify(console).addChatMessage(any(IChatComponent.class));
+    }
+
+    @Test
+    void metricsResetRequiresResetNode() throws Exception {
+        FixedOpService.level(0);
+        command.processCommand(player, new String[]{"metrics", "reset"});
+        verify(player).addChatMessage(any(IChatComponent.class)); // denial message
+    }
+
+    @Test
+    void tabCompletesSubcommandsByPermission() {
+        List<String> completions = command.addTabCompletionOptions(player, new String[]{"se"}, null);
+        assertEquals(Collections.singletonList("set"), completions);
+        FixedOpService.level(0);
+        // With no op level only the unconditional source node completes.
+        List<String> denied = command.addTabCompletionOptions(player, new String[]{""}, null);
+        assertEquals(Collections.singletonList("source"), denied);
+    }
+
+    @Test
+    void tabCompletesSetProvidersAndCascade() {
+        assertEquals(Collections.singletonList("mojang"),
+            command.addTabCompletionOptions(player, new String[]{"set", "m"}, null));
+        assertEquals(Collections.singletonList("slim"),
+            command.addTabCompletionOptions(player, new String[]{"set", "web", "s"}, null));
+        assertEquals(Collections.singletonList("true"),
+            command.addTabCompletionOptions(player, new String[]{"set", "random", "t"}, null));
+        assertEquals(Collections.singletonList("classic"),
+            command.addTabCompletionOptions(player, new String[]{"set", "random", "true", "c"}, null));
+        assertEquals(Collections.singletonList("cleanup"),
+            command.addTabCompletionOptions(player, new String[]{"metrics", "c"}, null));
+    }
+
+    @Test
+    void tabCompletesMetricsSubcommands() {
+        List<String> completions = command.addTabCompletionOptions(player, new String[]{"metrics", "c"}, null);
+        assertEquals(Collections.singletonList("cleanup"), completions);
+    }
+}

--- a/forge-1.8.9/src/test/java/levosilimo/everlastingskins/skinchanger/SkinRestorerApplyTest.java
+++ b/forge-1.8.9/src/test/java/levosilimo/everlastingskins/skinchanger/SkinRestorerApplyTest.java
@@ -1,0 +1,203 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import com.mojang.authlib.GameProfile;
+import com.mojang.authlib.properties.Property;
+import levosilimo.everlastingskins.util.CustomSkinProperty;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.entity.player.InventoryPlayer;
+import net.minecraft.network.NetHandlerPlayServer;
+import net.minecraft.network.play.server.S07PacketRespawn;
+import net.minecraft.network.play.server.S38PacketPlayerListItem;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.management.ServerConfigurationManager;
+import net.minecraft.world.EnumDifficulty;
+import net.minecraft.world.World;
+import net.minecraft.world.WorldSettings;
+import net.minecraft.world.WorldType;
+import net.minecraft.world.storage.WorldInfo;
+import net.minecraftforge.fml.common.gameevent.PlayerEvent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.internal.util.reflection.FieldSetter;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pure-JUnit tests for the 1.8.9 apply path: login-apply, logout-persist
+ * and the mid-session apply with the standard 1.8-1.12 skin-changer re-send
+ * (tab-list REMOVE+ADD to all players, in-world respawn to tracking
+ * observers, in-place target respawn). Memory #1115: deterministic fakes
+ * only — no live server, no HTTP, no threads.
+ */
+class SkinRestorerApplyTest {
+
+    private static final UUID PLAYER = UUID.fromString("01234567-89ab-cdef-0123-456789abcdef");
+
+    @TempDir
+    Path tempDir;
+
+    private SkinStorage storage;
+    private SkinRestorer restorer;
+    private EntityPlayerMP player;
+    private GameProfile profile;
+    private MinecraftServer server;
+    private ServerConfigurationManager config;
+    private World world;
+    private NetHandlerPlayServer netHandler;
+
+    @BeforeEach
+    void setUp() {
+        storage = new SkinStorage(new SkinIO(tempDir));
+        SkinRestorer.setStorageForTest(storage);
+        restorer = new SkinRestorer();
+        profile = new GameProfile(PLAYER, "TestPlayer");
+        player = mock(EntityPlayerMP.class);
+        when(player.getPersistentID()).thenReturn(PLAYER);
+        when(player.getGameProfile()).thenReturn(profile);
+        when(player.getEntityId()).thenReturn(42);
+        when(player.getName()).thenReturn("TestPlayer");
+        when(player.getActivePotionEffects()).thenReturn(Collections.emptyList());
+        // Entity public fields on the mock (the packet ctors read them).
+        InventoryPlayer inventory = mock(InventoryPlayer.class);
+        when(inventory.getCurrentItem()).thenReturn(null);
+        player.inventory = inventory;
+        // NOTE: the world is mocked as plain World, not WorldServer — the
+        // WorldServer static init (Items/Blocks registries) requires the
+        // LaunchWrapper Bootstrap chain, which cannot run in a bare JVM.
+        // The tracker fan-out branch of the cascade (instanceof WorldServer)
+        // is therefore not unit-covered; it mirrors the 1.12.2 lane.
+        world = mock(World.class);
+        when(world.getDifficulty()).thenReturn(EnumDifficulty.PEACEFUL);
+        WorldInfo worldInfo = mock(WorldInfo.class);
+        when(world.getWorldInfo()).thenReturn(worldInfo);
+        when(worldInfo.getTerrainType()).thenReturn(WorldType.DEFAULT);
+        player.worldObj = world;
+        netHandler = mock(NetHandlerPlayServer.class);
+        player.playerNetServerHandler = netHandler;
+        // theItemInWorldManager is final in 1.8.9 — set via reflection.
+        WorldSettings.GameType gameType = WorldSettings.GameType.SURVIVAL;
+        net.minecraft.server.management.ItemInWorldManager itemManager =
+            mock(net.minecraft.server.management.ItemInWorldManager.class);
+        when(itemManager.getGameType()).thenReturn(gameType);
+        try {
+            FieldSetter.setField(player, EntityPlayerMP.class.getDeclaredField("theItemInWorldManager"), itemManager);
+        } catch (NoSuchFieldException e) {
+            throw new IllegalStateException("1.8.9 EntityPlayerMP.theItemInWorldManager missing", e);
+        }
+        server = mock(MinecraftServer.class);
+        config = mock(ServerConfigurationManager.class);
+        when(server.getConfigurationManager()).thenReturn(config);
+        SkinRestorer.setServerForTest(server);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SkinStorage.resetForTest();
+    }
+
+    private static CustomSkinProperty skin(String name, String source) {
+        return new CustomSkinProperty(name, "value", "signature", source);
+    }
+
+    private static void assertTexturesContain(GameProfile p, CustomSkinProperty s) {
+        assertTrue(p.getProperties().get("textures").contains(s.getOriginalProperty()));
+    }
+
+    @Test
+    void loginAppliesStoredSkinToProfile() {
+        CustomSkinProperty stored = skin("Notch", "MojangAPI");
+        storage.setSkin(PLAYER, stored);
+        restorer.onPlayerLoggedIn(new PlayerEvent.PlayerLoggedInEvent(player));
+        assertTexturesContain(profile, stored);
+    }
+
+    @Test
+    void loginLeavesProfileUntouchedWithoutStoredSkin() {
+        restorer.onPlayerLoggedIn(new PlayerEvent.PlayerLoggedInEvent(player));
+        assertTrue(profile.getProperties().get("textures").isEmpty());
+    }
+
+    @Test
+    void loginIgnoresNonServerPlayerEvents() {
+        EntityPlayer nonServerPlayer = mock(EntityPlayer.class);
+        restorer.onPlayerLoggedIn(new PlayerEvent.PlayerLoggedInEvent(nonServerPlayer));
+        restorer.onPlayerLoggedOut(new PlayerEvent.PlayerLoggedOutEvent(nonServerPlayer));
+        // No exception, no interaction with the player surface.
+    }
+
+    @Test
+    void logoutPersistsStoredSkin() {
+        CustomSkinProperty stored = skin("Notch", "MojangAPI");
+        storage.setSkin(PLAYER, stored);
+        SkinStorage spyStorage = spy(storage);
+        SkinRestorer.setStorageForTest(spyStorage);
+        restorer.onPlayerLoggedOut(new PlayerEvent.PlayerLoggedOutEvent(player));
+        verify(spyStorage).saveSkin(PLAYER);
+    }
+
+    @Test
+    void logoutSkipsSaveWithoutStoredSkin() {
+        SkinStorage spyStorage = spy(storage);
+        SkinRestorer.setStorageForTest(spyStorage);
+        restorer.onPlayerLoggedOut(new PlayerEvent.PlayerLoggedOutEvent(player));
+        verify(spyStorage, never()).saveSkin(PLAYER);
+    }
+
+    @Test
+    void applySkinMutatesProfilePersistsAndResendsToObservers() {
+        CustomSkinProperty applied = skin("Notch", "MojangAPI");
+        SkinRestorer.applySkin(player, applied);
+        // Stored + applied to the GameProfile textures property.
+        assertEquals(applied, storage.getSkin(PLAYER));
+        assertTexturesContain(profile, applied);
+        // Tab-list REMOVE+ADD to ALL players.
+        verify(config, times(2)).sendPacketToAllPlayers(any(S38PacketPlayerListItem.class));
+        // In-place respawn for the target's own view.
+        verify(netHandler).sendPacket(any(S07PacketRespawn.class));
+    }
+
+    @Test
+    void clearSkinStripsTexturesAndResends() {
+        CustomSkinProperty applied = skin("Notch", "MojangAPI");
+        storage.setSkin(PLAYER, applied);
+        profile.getProperties().put("textures", new Property("textures", "value", "signature"));
+        SkinRestorer.clearSkin(player);
+        assertNull(storage.getSkin(PLAYER));
+        assertTrue(profile.getProperties().get("textures").isEmpty());
+        verify(config, times(2)).sendPacketToAllPlayers(any(S38PacketPlayerListItem.class));
+        verify(netHandler).sendPacket(any(S07PacketRespawn.class));
+    }
+
+    @Test
+    void applySkinSurvivesMissingServerContext() {
+        SkinRestorer.setServerForTest(null);
+        CustomSkinProperty applied = skin("Notch", "MojangAPI");
+        SkinRestorer.applySkin(player, applied);
+        // Storage + profile still applied; the re-send silently degrades.
+        assertEquals(applied, storage.getSkin(PLAYER));
+        assertTexturesContain(profile, applied);
+        verify(config, never()).sendPacketToAllPlayers(any());
+    }
+}


### PR DESCRIPTION
Per command-parity investigation: 1.8.9 had only the admin /everlastingskins command and no skin application. Adds /skin set mojang|web|random, source, clear, metrics, targets + GameProfile textures apply on login and re-send. Admin command untouched. :common classes only.