### PR TITLE
feat(forge-1.10.2): add /skin with full parity surface + login-apply (per parity investigation)

### DIFF
--- a/forge-1.10.2/src/main/java/levosilimo/everlastingskins/broadcast/SkinProfileBroadcaster.java
+++ b/forge-1.10.2/src/main/java/levosilimo/everlastingskins/broadcast/SkinProfileBroadcaster.java
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.broadcast;
+
+import net.minecraft.entity.player.EntityPlayerMP;
+
+/**
+ * Profile-change fan-out seam for the 1.10.2 refresh cascade. The lane's
+ * {@link SkinBroadcaster} is the SimpleNetworkWrapper channel (client
+ * payloads); this is the server-side tab-list re-broadcast, kept separate
+ * so {@link SkinRefreshTask} can be tested with a recording fake without
+ * constructing real packets.
+ */
+public interface SkinProfileBroadcaster {
+
+    /**
+     * Forces every client to re-learn the target's GameProfile via the
+     * tab-list REMOVE+ADD pair. Must run after the GameProfile mutation.
+     */
+    void broadcastProfileChange(EntityPlayerMP target);
+}

--- a/forge-1.10.2/src/main/java/levosilimo/everlastingskins/broadcast/VanillaProfileBroadcaster.java
+++ b/forge-1.10.2/src/main/java/levosilimo/everlastingskins/broadcast/VanillaProfileBroadcaster.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.broadcast;
+
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.network.play.server.SPacketPlayerListItem;
+import net.minecraft.server.management.PlayerList;
+
+/**
+ * Production {@link SkinProfileBroadcaster} for Minecraft 1.10.2. Builds
+ * the REMOVE+ADD tab-list pair and delivers it via the live
+ * {@link PlayerList#sendPacketToAllPlayers} — the same shape the mc1.12.2
+ * {@code VanillaSkinBroadcaster} uses (1.10.2's PlayerList has the
+ * sendPacketToAllPlayers(Packet) surface; the rename to
+ * sendToAllTracking was 1.16+).
+ *
+ * <p>The ADD packet serializes the GameProfile at construction time, so
+ * this must run after the GameProfile mutation in {@code SkinRefreshTask}.
+ */
+public final class VanillaProfileBroadcaster implements SkinProfileBroadcaster {
+
+    @Override
+    public void broadcastProfileChange(EntityPlayerMP target) {
+        PlayerList playerList = target.mcServer.getPlayerList();
+        SPacketPlayerListItem removePacket =
+            new SPacketPlayerListItem(SPacketPlayerListItem.Action.REMOVE_PLAYER, target);
+        SPacketPlayerListItem addPacket =
+            new SPacketPlayerListItem(SPacketPlayerListItem.Action.ADD_PLAYER, target);
+        playerList.sendPacketToAllPlayers(removePacket);
+        playerList.sendPacketToAllPlayers(addPacket);
+    }
+}

--- a/forge-1.10.2/src/main/java/levosilimo/everlastingskins/forge102/EverlastingSkins.java
+++ b/forge-1.10.2/src/main/java/levosilimo/everlastingskins/forge102/EverlastingSkins.java
@@ -9,10 +9,14 @@ package levosilimo.everlastingskins.forge102;
 import levosilimo.everlastingskins.broadcast.SkinBroadcaster;
 import levosilimo.everlastingskins.command.SkinRestorerCommand;
 import levosilimo.everlastingskins.permission.forge.ForgePermissionService;
+import levosilimo.everlastingskins.skinchanger.SkinCommand;
+import levosilimo.everlastingskins.skinchanger.SkinLoginHandler;
 import levosilimo.everlastingskins.skinchanger.SkinRestorer;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLServerStartingEvent;
+import net.minecraftforge.fml.common.event.FMLServerStoppingEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -58,6 +62,16 @@ public class EverlastingSkins {
     public void serverStarting(FMLServerStartingEvent event) {
         SkinRestorer.init(event);
         event.registerServerCommand(new SkinRestorerCommand());
+        // /skin full-parity surface (set mojang|web|random, source, clear,
+        // metrics) + login-apply of stored skins.
+        event.registerServerCommand(new SkinCommand());
+        MinecraftForge.EVENT_BUS.register(new SkinLoginHandler());
         LOGGER.info("{} server starting", MOD_NAME);
+    }
+
+    @Mod.EventHandler
+    public void serverStopping(FMLServerStoppingEvent event) {
+        // Persist all queued storage writes before shutdown.
+        SkinRestorer.onServerStopping();
     }
 }

--- a/forge-1.10.2/src/main/java/levosilimo/everlastingskins/skinchanger/SkinAction.java
+++ b/forge-1.10.2/src/main/java/levosilimo/everlastingskins/skinchanger/SkinAction.java
@@ -1,0 +1,177 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import levosilimo.everlastingskins.enums.SkinActionType;
+import levosilimo.everlastingskins.enums.SkinVariant;
+import levosilimo.everlastingskins.forge102.EverlastingSkins;
+import levosilimo.everlastingskins.metrics.SkinMetrics;
+import levosilimo.everlastingskins.skinchanger.responses.mojang.MojangSkinDataResult;
+import levosilimo.everlastingskins.util.CustomSkinProperty;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.text.TextComponentString;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Provider-fetch pipeline for /skin actions (1.10.2 era-adapted mirror of
+ * the mc1.12.2 class of the same name). Runs off the server thread with a
+ * hard timeout so a slow Mojang/MineSkin HTTP call can never block the tick.
+ *
+ * <p>This lane has no Config file, so the 1.12.2 rate-limit, debounce and
+ * message-toggle layers are intentionally absent; the persistence +
+ * GameProfile-mutation core is kept 1:1.
+ */
+final class SkinAction {
+
+    static final ScheduledExecutorService EXECUTOR = Executors.newScheduledThreadPool(
+        Math.max(2, Runtime.getRuntime().availableProcessors() * 2));
+
+    /** Source-class discriminator persisted on Mojang-sourced skin properties. */
+    static final String SOURCE_MOJANG = "MojangAPI";
+    /** Source-class discriminator persisted on MineSkin-sourced skin properties. */
+    static final String SOURCE_MINESKIN = "MineSkin";
+
+    private SkinAction() {
+    }
+
+    static void apply(Collection<EntityPlayerMP> targets, ICommandSender sender,
+            SkinActionType type, SkinVariant variant, boolean withCape, @Nullable String customSource) {
+        long[] fetchNanos = {0L};
+        CompletableFuture<Map<UUID, CustomSkinProperty>> future = CompletableFuture.supplyAsync(() -> {
+            Map<UUID, CustomSkinProperty> fetched = new HashMap<>();
+            long fetchStartNanos = System.nanoTime();
+            try {
+                switch (type) {
+                    case clear:
+                        // Each target restores from its OWN stored source — the
+                        // first target's Mojang skin must not leak to the others.
+                        for (EntityPlayerMP t : targets) {
+                            String storedSource = SkinRestorer.getSkinStorage().getSource(t.getUniqueID());
+                            SkinCommand.MojangRestoreResult restore = SkinCommand.tryRestoreFromMojang(
+                                SkinCommand.getMojangAPI(), storedSource, t.getGameProfile().getName());
+                            fetched.put(t.getUniqueID(), restore != null ? restore.skin : null);
+                        }
+                        break;
+                    case url: {
+                        CustomSkinProperty sp = SkinCommand.getMineSkinAPI()
+                            .genSkin(customSource, variant).property();
+                        for (EntityPlayerMP t : targets) {
+                            fetched.put(t.getUniqueID(), sp);
+                        }
+                        break;
+                    }
+                    case username:
+                    case random: {
+                        String fetchName = customSource;
+                        if (type == SkinActionType.random) {
+                            // Cape mode swaps the candidate source: RandomMojangSkin's
+                            // decoded-CAPE check only finds legacy cape holders (Mojang
+                            // stopped embedding CAPE in the textures payload), so
+                            // RandomCapeSource (mskins with_capes + Cosmetica) is used
+                            // instead. The variant filter is intentionally not applied
+                            // in cape mode: the listing is not variant-tagged.
+                            fetchName = withCape
+                                ? new RandomCapeSource().pickRandomCapeUsername()
+                                : RandomMojangSkin.randomUsername(false, variant);
+                        }
+                        CustomSkinProperty sp = SkinCommand.getMojangAPI().getSkin(fetchName)
+                            .map(MojangSkinDataResult::skinProperty).orElse(null);
+                        for (EntityPlayerMP t : targets) {
+                            fetched.put(t.getUniqueID(), sp);
+                        }
+                        break;
+                    }
+                    default:
+                        throw new IllegalStateException("Unsupported action type: " + type);
+                }
+            } catch (Exception e) {
+                throw new CompletionException(e);
+            } finally {
+                fetchNanos[0] = System.nanoTime() - fetchStartNanos;
+            }
+            return fetched;
+        }, EXECUTOR);
+
+        final ScheduledFuture<?> timeoutFuture = EXECUTOR.schedule(() -> {
+            if (future.completeExceptionally(new TimeoutException("Skin fetch timeout"))) {
+                EverlastingSkins.LOGGER.error("Skin fetch timeout");
+                for (EntityPlayerMP p : targets) {
+                    SkinMetrics.INSTANCE.recordTimedOut(p.getUniqueID());
+                    p.sendMessage(new TextComponentString(SkinCommand.PREFIX + "Skin fetch timed out."));
+                }
+            }
+        }, 10, TimeUnit.SECONDS);
+
+        future.whenComplete((fetched, err) -> {
+            if (timeoutFuture != null) {
+                timeoutFuture.cancel(false);
+            }
+            if (err != null) {
+                EverlastingSkins.LOGGER.error("Skin process error", err);
+                for (EntityPlayerMP p : targets) {
+                    p.sendMessage(new TextComponentString(SkinCommand.PREFIX + "Failed to fetch skin."));
+                }
+                return;
+            }
+            MinecraftServer server = SkinRestorer.getServer();
+            for (EntityPlayerMP p : targets) {
+                CustomSkinProperty sp = fetched != null ? fetched.get(p.getUniqueID()) : null;
+                if (sp == null) {
+                    if (type != SkinActionType.clear) {
+                        EverlastingSkins.LOGGER.warn("Skin provider returned no result for {}", p.getName());
+                        p.sendMessage(new TextComponentString(SkinCommand.PREFIX + "No skin found."));
+                        continue;
+                    }
+                    EverlastingSkins.LOGGER.info("Skin cleared for player {} — no Mojang profile found", p.getName());
+                    SkinRestorer.getSkinStorage().setSkin(p.getUniqueID(), null);
+                    if (server != null) {
+                        server.addScheduledTask(() -> SkinRefreshTask.task(p, null, fetchNanos[0]));
+                    }
+                    continue;
+                }
+                boolean isRestore = (type == SkinActionType.clear);
+                if (isSkinUnchanged(p.getUniqueID(), sp)) {
+                    EverlastingSkins.LOGGER.debug("SKIN_REFRESH skipped: identical skin for {}", p.getUniqueID());
+                    SkinMetrics.INSTANCE.recordRefreshSkipped(p.getUniqueID());
+                    continue;
+                }
+                SkinRestorer.getSkinStorage().setSkin(p.getUniqueID(), sp);
+                p.sendMessage(new TextComponentString(SkinCommand.PREFIX
+                    + (isRestore ? "Restored original skin." : "Skin applied!")));
+                if (server != null) {
+                    server.addScheduledTask(() -> SkinRefreshTask.task(p, sp, fetchNanos[0]));
+                }
+            }
+        });
+    }
+
+    /** True when the fetched skin is byte-identical to what the player already has. */
+    private static boolean isSkinUnchanged(UUID uuid, @Nullable CustomSkinProperty newSkin) {
+        if (newSkin == null) return false;
+        CustomSkinProperty stored = SkinRestorer.getSkinStorage().getSkin(uuid);
+        if (stored == null) return false;
+        if (!newSkin.getOriginalProperty().getValue().equals(stored.getOriginalProperty().getValue())) {
+            return false;
+        }
+        return Objects.equals(newSkin.getSource(), stored.getSource());
+    }
+}

--- a/forge-1.10.2/src/main/java/levosilimo/everlastingskins/skinchanger/SkinCommand.java
+++ b/forge-1.10.2/src/main/java/levosilimo/everlastingskins/skinchanger/SkinCommand.java
@@ -1,0 +1,416 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import levosilimo.everlastingskins.enums.SkinActionType;
+import levosilimo.everlastingskins.enums.SkinVariant;
+import levosilimo.everlastingskins.metrics.MetricsFormat;
+import levosilimo.everlastingskins.metrics.PlayerSnapshot;
+import levosilimo.everlastingskins.metrics.SkinMetrics;
+import levosilimo.everlastingskins.permission.PermissionServiceManager;
+import levosilimo.everlastingskins.skinchanger.responses.mojang.MojangSkinDataResult;
+import levosilimo.everlastingskins.util.CompletionSources;
+import levosilimo.everlastingskins.util.CustomSkinProperty;
+import levosilimo.everlastingskins.util.HttpsUrlConnectionHttpClient;
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.CommandException;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.TextComponentString;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * 1.10.2 {@code /skin} command — full-parity surface with the mc1.12.2
+ * reference, era-adapted to the modern MCP command names this lane already
+ * uses (getName/execute/checkPermission/getTabCompletions — verified for
+ * stable_29 during the lane spike; the 1.8.9-era names are gone here).
+ *
+ * <p>Subcommands: {@code set mojang|web|random}, {@code source},
+ * {@code clear}, {@code metrics} — see {@link #getUsage(ICommandSender)}.
+ * The admin {@code /everlastingskins} command lives in its own class
+ * ({@link levosilimo.everlastingskins.command.SkinRestorerCommand}) and is
+ * untouched by this command.
+ *
+ * <p>Permission model: this lane's {@code ForgePermissionService} contract
+ * is {@code hasPermission(uuid, REQUIRED_OP_LEVEL, node)} (the service
+ * resolves the player's actual level itself). Required levels mirror the
+ * mc1.12.2 Config defaults: self-service mojang/random/clear = 0, web
+ * (url node) = 2, targeting others = 2, metrics = 2, metrics reset = 2.
+ */
+public class SkinCommand extends CommandBase {
+    static final String PREFIX = "§6[" + "Everlasting Skins" + "]§f ";
+
+    private static MineSkinAPI mineSkinAPI = new MineSkinApiHttpImpl();
+    private static MojangAPI mojangAPI = createMojangAPI();
+
+    /**
+     * Builds the Mojang API with a caller-owned profile cache shared with
+     * {@link CompletionSources}, so recently fetched profiles show up in
+     * tab completion.
+     */
+    private static MojangAPI createMojangAPI() {
+        MojangProfileCache sharedCache = new MojangProfileCache();
+        CompletionSources.setMojangProfileCache(sharedCache);
+        return new MojangApiHttpImpl(MojangEndpoints.DEFAULT, new HttpsUrlConnectionHttpClient(), true, sharedCache);
+    }
+
+    public static MineSkinAPI getMineSkinAPI() {
+        return mineSkinAPI;
+    }
+
+    public static MojangAPI getMojangAPI() {
+        return mojangAPI;
+    }
+
+    /* Package-private for tests: inject fakes without reflection. */
+    static void setMineSkinAPI(MineSkinAPI api) {
+        mineSkinAPI = api;
+    }
+
+    static void setMojangAPI(MojangAPI api) {
+        mojangAPI = api;
+    }
+
+    static void resetAPIs() {
+        mojangAPI = createMojangAPI();
+        mineSkinAPI = new MineSkinApiHttpImpl();
+    }
+
+    @Override
+    public String getName() {
+        return "skin";
+    }
+
+    @Override
+    public String getUsage(ICommandSender sender) {
+        return "/skin <set|clear|source|metrics> ...";
+    }
+
+    @Override
+    public List<String> getAliases() {
+        return Collections.singletonList("eskin");
+    }
+
+    @Override
+    public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException {
+        if (args.length < 1) {
+            sender.sendMessage(new TextComponentString(PREFIX + getUsage(sender)));
+            return;
+        }
+        switch (args[0]) {
+            case "clear":   doClear(server, sender, args); break;
+            case "source":  doSource(server, sender, args); break;
+            case "set":     doSet(server, sender, args); break;
+            case "metrics": doMetrics(sender, args); break;
+            default:
+                sender.sendMessage(new TextComponentString(PREFIX + getUsage(sender)));
+        }
+    }
+
+    @Override
+    public boolean checkPermission(MinecraftServer server, ICommandSender sender) {
+        return true;
+    }
+
+    @Override
+    public List<String> getTabCompletions(MinecraftServer server, ICommandSender sender,
+            String[] args, @Nullable BlockPos targetPos) {
+        if (args.length == 1) {
+            return subcommandCompletions(sender, args);
+        }
+        if ("set".equals(args[0])) {
+            return setTabCompletions(server, sender, args);
+        }
+        if (("clear".equals(args[0]) || "source".equals(args[0])) && args.length == 2) {
+            return canTargetOthers(sender)
+                ? getListOfStringsMatchingLastWord(args, CompletionSources.onlinePlayerNames(server))
+                : Collections.emptyList();
+        }
+        if ("metrics".equals(args[0]) && args.length == 2) {
+            return getListOfStringsMatchingLastWord(args, CompletionSources.metricsSubcommands(sender));
+        }
+        return Collections.emptyList();
+    }
+
+    /** Subcommand names the sender may actually use, in /skin usage order. */
+    private List<String> subcommandCompletions(ICommandSender sender, String[] args) {
+        List<String> subcommands = new ArrayList<>();
+        if (CompletionSources.hasPermission(sender, "everlastingskins.command.skin", 0)) {
+            subcommands.add("set");
+        }
+        if (CompletionSources.hasPermission(sender, "everlastingskins.command.skin.clear", 0)) {
+            subcommands.add("clear");
+        }
+        if (CompletionSources.hasPermission(sender, "everlastingskins.command.skin", 0)) {
+            subcommands.add("source");
+        }
+        if (CompletionSources.hasPermission(sender, "everlastingskins.command.metrics", 2)) {
+            subcommands.add("metrics");
+        }
+        return getListOfStringsMatchingLastWord(args, subcommands);
+    }
+
+    /** Per-position candidates under {@code /skin set ...}. */
+    private List<String> setTabCompletions(MinecraftServer server, ICommandSender sender, String[] args) {
+        if (args.length == 2) {
+            return getListOfStringsMatchingLastWord(args, CompletionSources.providerNames());
+        }
+        if ("mojang".equals(args[1]) && args.length == 3) {
+            return getListOfStringsMatchingLastWord(args, CompletionSources.recentUsernames());
+        }
+        if ("web".equals(args[1])) {
+            if (args.length == 3) return getListOfStringsMatchingLastWord(args, "classic", "slim");
+            if (args.length == 4) return getListOfStringsMatchingLastWord(args, CompletionSources.urlCandidates());
+        }
+        if ("random".equals(args[1]) && args.length >= 3 && args.length <= 5) {
+            if (args.length == 3) return getListOfStringsMatchingLastWord(args, "true", "false");
+            if (args.length == 4) return getListOfStringsMatchingLastWord(args, "classic", "slim");
+            return canTargetOthers(sender)
+                ? getListOfStringsMatchingLastWord(args, CompletionSources.onlinePlayerNames(server))
+                : Collections.emptyList();
+        }
+        return Collections.emptyList();
+    }
+
+    private boolean canTargetOthers(ICommandSender sender) {
+        return CompletionSources.hasPermission(sender, "everlastingskins.command.skin.other", 2);
+    }
+
+    private void doClear(MinecraftServer server, ICommandSender sender, String[] args) {
+        Collection<EntityPlayerMP> targets = parseTargets(server, sender, args, 2);
+        String node = targets.size() == 1 && targets.iterator().next() == sender
+            ? "everlastingskins.command.skin.clear"
+            : "everlastingskins.command.skin.other";
+        int required = targets.size() == 1 && targets.iterator().next() == sender ? 0 : 2;
+        if (!checkPermission(sender, node, required)) return;
+        SkinAction.apply(targets, sender, SkinActionType.clear, SkinVariant.ALL, false, null);
+    }
+
+    private void doSource(MinecraftServer server, ICommandSender sender, String[] args) {
+        EntityPlayerMP target;
+        try {
+            target = args.length >= 2
+                ? CommandBase.getPlayer(server, sender, args[1])
+                : CommandBase.getCommandSenderAsPlayer(sender);
+        } catch (CommandException e) {
+            sender.sendMessage(new TextComponentString(PREFIX + e.getMessage()));
+            return;
+        }
+        if (args.length >= 2) {
+            if (!checkPermission(sender, "everlastingskins.command.skin.other", 2)) return;
+        }
+        UUID uuid = target.getUniqueID();
+        if (SkinRestorer.getSkinStorage().hasDefaultSkin(uuid)) {
+            sender.sendMessage(new TextComponentString(PREFIX + target.getGameProfile().getName()));
+            return;
+        }
+        String source = SkinRestorer.getSkinStorage().getSource(uuid);
+        sender.sendMessage(new TextComponentString(PREFIX
+            + (source != null ? source : "No skin source stored.")));
+    }
+
+    private void doSet(MinecraftServer server, ICommandSender sender, String[] args) {
+        if (args.length < 2) {
+            sender.sendMessage(new TextComponentString(PREFIX + getUsage(sender)));
+            return;
+        }
+        switch (args[1]) {
+            case "mojang": {
+                if (args.length < 3) {
+                    sender.sendMessage(new TextComponentString(PREFIX + "Usage: /skin set mojang <name>"));
+                    return;
+                }
+                Collection<EntityPlayerMP> targets = parseTargets(server, sender, args, 3);
+                String node = targets.size() == 1 && targets.iterator().next() == sender
+                    ? "everlastingskins.command.skin"
+                    : "everlastingskins.command.skin.other";
+                int required = targets.size() == 1 && targets.iterator().next() == sender ? 0 : 2;
+                if (!checkPermission(sender, node, required)) return;
+                SkinAction.apply(targets, sender, SkinActionType.username, SkinVariant.ALL, false, args[2]);
+                break;
+            }
+            case "web": {
+                if (args.length < 4) {
+                    sender.sendMessage(new TextComponentString(PREFIX + "Usage: /skin set web <classic|slim> <url>"));
+                    return;
+                }
+                SkinVariant variant = "slim".equalsIgnoreCase(args[2]) ? SkinVariant.SLIM : SkinVariant.CLASSIC;
+                Collection<EntityPlayerMP> targets = parseTargets(server, sender, args, 4);
+                String node = targets.size() == 1 && targets.iterator().next() == sender
+                    ? "everlastingskins.command.skin.url"
+                    : "everlastingskins.command.skin.other";
+                // Web (MineSkin) self-service requires op level 2 on this
+                // lane (mirror of the mc1.12.2 Config default).
+                int required = targets.size() == 1 && targets.iterator().next() == sender ? 2 : 2;
+                if (!checkPermission(sender, node, required)) return;
+                SkinAction.apply(targets, sender, SkinActionType.url, variant, false, args[3]);
+                break;
+            }
+            case "random": {
+                // /skin set random [<cape> [<variant>]] [<targets...>]: the
+                // cape flag and variant are optional and parsed to match the
+                // tab-completion cascade (bool, then variant, then targets).
+                boolean cape = args.length >= 3 && "true".equalsIgnoreCase(args[2]);
+                SkinVariant variant = parseRandomVariant(args);
+                Collection<EntityPlayerMP> targets = parseTargets(server, sender, args, 4);
+                String node = targets.size() == 1 && targets.iterator().next() == sender
+                    ? "everlastingskins.command.skin"
+                    : "everlastingskins.command.skin.other";
+                int required = targets.size() == 1 && targets.iterator().next() == sender ? 0 : 2;
+                if (!checkPermission(sender, node, required)) return;
+                SkinAction.apply(targets, sender, SkinActionType.random, variant, cape, null);
+                break;
+            }
+            default:
+                sender.sendMessage(new TextComponentString(PREFIX + "Usage: /skin set <mojang|web|random>"));
+        }
+    }
+
+    /**
+     * Variant argument of {@code /skin set random}: optional, defaults to ALL.
+     */
+    private static SkinVariant parseRandomVariant(String[] args) {
+        if (args.length >= 4 && "slim".equalsIgnoreCase(args[3])) {
+            return SkinVariant.SLIM;
+        }
+        if (args.length >= 4 && "classic".equalsIgnoreCase(args[3])) {
+            return SkinVariant.CLASSIC;
+        }
+        return SkinVariant.ALL;
+    }
+
+    /**
+     * Node gate for player senders. The required op level is resolved by
+     * the registered {@code ForgePermissionService} (actual level from the
+     * server ops list, compared against the required level passed here).
+     * Console senders bypass the gate.
+     */
+    private boolean checkPermission(ICommandSender sender, String node, int requiredOpLevel) {
+        if (!hasPermission(sender, node, requiredOpLevel)) {
+            sender.sendMessage(new TextComponentString(PREFIX + "You don't have permission to use this command."));
+            return false;
+        }
+        return true;
+    }
+
+    /** Silent permission check (no denial message is sent). */
+    private boolean hasPermission(ICommandSender sender, String node, int requiredOpLevel) {
+        if (sender instanceof EntityPlayerMP) {
+            EntityPlayerMP player = (EntityPlayerMP) sender;
+            return PermissionServiceManager.hasPermission(player.getUniqueID(), requiredOpLevel, node);
+        }
+        return true;
+    }
+
+    /**
+     * /skin metrics [human|json|players|cleanup|reset]. View commands need
+     * everlastingskins.command.metrics; cleanup/reset additionally need
+     * everlastingskins.command.metrics.reset. Console senders are allowed.
+     */
+    private void doMetrics(ICommandSender sender, String[] args) {
+        String sub = args.length < 2 ? "human" : args[1];
+        switch (sub) {
+            case "json":
+                if (!checkMetricsPermission(sender)) return;
+                sender.sendMessage(new TextComponentString(PREFIX + MetricsFormat.json(SkinMetrics.INSTANCE.snapshot())));
+                break;
+            case "players":
+                if (!checkMetricsPermission(sender)) return;
+                StringBuilder sb = new StringBuilder(PREFIX + "Top players:");
+                int rank = 0;
+                for (Map.Entry<UUID, PlayerSnapshot> e : SkinMetrics.INSTANCE.topPlayers(10)) {
+                    sb.append("\n  ").append(++rank).append(". ")
+                        .append(e.getKey()).append(" — ")
+                        .append(e.getValue().refreshCount())
+                        .append(" refresh(es)");
+                }
+                if (rank == 0) {
+                    sb.append("\n  ").append("No refreshes recorded yet.");
+                }
+                sender.sendMessage(new TextComponentString(sb.toString()));
+                break;
+            case "cleanup":
+                if (!checkMetricsResetPermission(sender)) return;
+                int removed = SkinMetrics.INSTANCE.cleanupStalePlayers(30L * 24 * 60 * 60 * 1000);
+                sender.sendMessage(new TextComponentString(PREFIX
+                    + "Removed " + removed + " stale player(s) from metrics."));
+                break;
+            case "reset":
+                if (!checkMetricsResetPermission(sender)) return;
+                SkinMetrics.INSTANCE.reset();
+                sender.sendMessage(new TextComponentString(PREFIX + "Metrics reset."));
+                break;
+            default:
+                if (!checkMetricsPermission(sender)) return;
+                sender.sendMessage(new TextComponentString(PREFIX + MetricsFormat.human(SkinMetrics.INSTANCE.snapshot())));
+        }
+    }
+
+    private boolean checkMetricsPermission(ICommandSender sender) {
+        return checkPermission(sender, "everlastingskins.command.metrics", 2);
+    }
+
+    private boolean checkMetricsResetPermission(ICommandSender sender) {
+        return checkPermission(sender, "everlastingskins.command.metrics.reset", 2);
+    }
+
+    private Collection<EntityPlayerMP> parseTargets(MinecraftServer server, ICommandSender sender,
+            String[] args, int targetIndex) {
+        if (args.length > targetIndex) {
+            // Silent denial: the caller's node check sends exactly one
+            // permission message (a message here would double-send).
+            if (!hasPermission(sender, "everlastingskins.command.skin.other", 2)) {
+                return Collections.emptyList();
+            }
+            List<EntityPlayerMP> out = new ArrayList<>();
+            for (int i = targetIndex; i < args.length; i++) {
+                try {
+                    out.add(CommandBase.getPlayer(server, sender, args[i]));
+                } catch (CommandException ignored) {
+                }
+            }
+            return out;
+        }
+        try {
+            return Collections.singletonList(CommandBase.getCommandSenderAsPlayer(sender));
+        } catch (CommandException e) {
+            sender.sendMessage(new TextComponentString(PREFIX + e.getMessage()));
+            return Collections.emptyList();
+        }
+    }
+
+    @Nullable
+    static MojangRestoreResult tryRestoreFromMojang(MojangAPI mojangAPI, @Nullable String storedSource, String playerName) {
+        String licensedUsername = (storedSource != null && !storedSource.trim().isEmpty())
+            ? storedSource : playerName;
+        CustomSkinProperty skin = mojangAPI.getSkin(licensedUsername)
+            .map(MojangSkinDataResult::skinProperty)
+            .filter(s -> !s.isEmpty())
+            .orElse(null);
+        if (skin == null) return null;
+        return new MojangRestoreResult(skin, licensedUsername);
+    }
+
+    static class MojangRestoreResult {
+        final CustomSkinProperty skin;
+        final String licensedUsername;
+
+        MojangRestoreResult(CustomSkinProperty skin, String licensedUsername) {
+            this.skin = skin;
+            this.licensedUsername = licensedUsername;
+        }
+    }
+}

--- a/forge-1.10.2/src/main/java/levosilimo/everlastingskins/skinchanger/SkinLoginHandler.java
+++ b/forge-1.10.2/src/main/java/levosilimo/everlastingskins/skinchanger/SkinLoginHandler.java
@@ -1,0 +1,59 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import levosilimo.everlastingskins.metrics.SkinMetrics;
+import levosilimo.everlastingskins.util.CustomSkinProperty;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.PlayerEvent;
+
+/**
+ * 1.10.2 login/logout binding for the {@code :common} {@link SkinStorage}
+ * (era-adapted mirror of the mc1.12.2 SkinRestorer event handlers).
+ *
+ * <p>Login-apply: the stored skin is applied synchronously by mutating the
+ * GameProfile's textures property — the skin is already on disk, so no HTTP
+ * runs on the login thread (the async default-skin resolution of the
+ * mc1.12.2 lane is Config-driven and does not exist on this lane). NOTE:
+ * PlayerLoggedInEvent fires after the player is already visible to other
+ * players, so there is a brief flash of the default skin before the saved
+ * custom skin applies.
+ *
+ * <p>Logout: persist the player's skin so it survives the session.
+ */
+public class SkinLoginHandler {
+
+    @SubscribeEvent
+    public void onPlayerLoggedIn(PlayerEvent.PlayerLoggedInEvent event) {
+        if (!(event.player instanceof EntityPlayerMP)) return;
+        EntityPlayerMP player = (EntityPlayerMP) event.player;
+        SkinMetrics.INSTANCE.recordPlayerJoined();
+
+        SkinStorage storage = SkinRestorer.getSkinStorage();
+        if (storage == null) return;
+        CustomSkinProperty skin = storage.getSkin(player.getUniqueID());
+        if (skin != null && !skin.isEmpty()) {
+            player.getGameProfile().getProperties().removeAll("textures");
+            player.getGameProfile().getProperties().put("textures", skin.getOriginalProperty());
+        }
+        // When skin is null or empty (no custom skin on disk), leave the
+        // profile unmutated — the client renders Steve or Alex by UUID hash.
+    }
+
+    @SubscribeEvent
+    public void onPlayerLoggedOut(PlayerEvent.PlayerLoggedOutEvent event) {
+        if (!(event.player instanceof EntityPlayerMP)) return;
+        EntityPlayerMP player = (EntityPlayerMP) event.player;
+        SkinMetrics.INSTANCE.recordPlayerLeft();
+
+        SkinStorage storage = SkinRestorer.getSkinStorage();
+        if (storage != null && storage.getSkin(player.getUniqueID()) != null) {
+            storage.saveSkin(player.getUniqueID());
+        }
+    }
+}

--- a/forge-1.10.2/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRefreshTask.java
+++ b/forge-1.10.2/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRefreshTask.java
@@ -1,0 +1,169 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import levosilimo.everlastingskins.broadcast.SkinProfileBroadcaster;
+import levosilimo.everlastingskins.broadcast.VanillaProfileBroadcaster;
+import levosilimo.everlastingskins.forge102.EverlastingSkins;
+import levosilimo.everlastingskins.metrics.SkinMetrics;
+import levosilimo.everlastingskins.util.CustomSkinProperty;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.network.play.server.SPacketEntityEffect;
+import net.minecraft.network.play.server.SPacketRespawn;
+import net.minecraft.network.play.server.SPacketServerDifficulty;
+import net.minecraft.potion.PotionEffect;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.management.PlayerList;
+import net.minecraft.world.WorldServer;
+
+/**
+ * Server-tick half of a skin change (1.10.2 era-adapted mirror of the
+ * mc1.12.2 class of the same name): enqueues the async disk flush, mutates
+ * the GameProfile, and forces every viewer to re-read it. Runs on the main
+ * thread via {@code addScheduledTask} so packet sends are thread-safe.
+ *
+ * <p>The flush is enqueued before the mutation so a failed enqueue leaves
+ * the applied profile untouched (applied and on-disk state stay
+ * consistent). The 1.10.2 entity surface uses the pre-1.11 field names
+ * ({@code worldObj}, {@code mcServer}) — the refresh packets
+ * (SPacketRespawn / SPacketServerDifficulty / SPacketEntityEffect) are
+ * already the modern MCP names on this version.
+ */
+final class SkinRefreshTask {
+
+    /**
+     * Seam for the per-viewer packet fan-out. Production uses
+     * {@link VanillaProfileBroadcaster}; tests inject a recording fake to
+     * assert call shape without re-implementing the REMOVE+ADD+cascade
+     * pipeline.
+     */
+    private static volatile SkinProfileBroadcaster broadcaster = new VanillaProfileBroadcaster();
+
+    /** Test seam: replace the broadcaster. */
+    static void setBroadcaster(SkinProfileBroadcaster newBroadcaster) {
+        broadcaster = newBroadcaster;
+    }
+
+    private SkinRefreshTask() {
+    }
+
+    static void task(EntityPlayerMP target, CustomSkinProperty property, long fetchNanos) {
+        if (target == null) return;
+
+        long startNanos = System.nanoTime();
+        SkinMetrics.INSTANCE.recordRefreshStarted(target.getUniqueID());
+
+        if (property == null || property.isEmpty()) {
+            // /skin clear with no Mojang profile: storage is already null, so
+            // drop the applied textures property; stale applied textures are
+            // re-broadcast + cascaded, a textureless profile is a silent no-op.
+            try {
+                clearCascade(target);
+            } catch (Throwable t) {
+                EverlastingSkins.LOGGER.error("Skin clear failed for {}", target.getName(), t);
+                SkinMetrics.INSTANCE.recordRefreshFailed(target.getUniqueID());
+            }
+            return;
+        }
+
+        try {
+            cascade(target, property, startNanos, fetchNanos);
+            long durationNanos = System.nanoTime() - startNanos;
+            SkinMetrics.INSTANCE.recordTaskDuration(durationNanos);
+            if (durationNanos > 50_000_000L) {
+                EverlastingSkins.LOGGER.warn("SkinRefresh spike: {}ms for player {}",
+                    durationNanos / 1_000_000, target.getName());
+            }
+        } catch (Throwable t) {
+            // Fail soft: a partial cascade (profile mutated, observers stale) must
+            // not abort the server tick or crash scheduled-task execution.
+            EverlastingSkins.LOGGER.error("Skin refresh failed for {}", target.getName(), t);
+            SkinMetrics.INSTANCE.recordRefreshFailed(target.getUniqueID());
+        }
+    }
+
+    private static void cascade(EntityPlayerMP target, CustomSkinProperty property, long startNanos,
+            long fetchNanos) {
+        // Atomicity invariant: the disk flush is enqueued BEFORE the
+        // GameProfile is mutated. saveSkinAsync serializes the property
+        // synchronously, so when the enqueue throws, the applied profile is
+        // left untouched and in-memory and on-disk state still agree.
+        long saveStartNanos = System.nanoTime();
+        SkinRestorer.getSkinStorage().saveSkinAsync(target.getUniqueID(), property);
+        long saveNanos = System.nanoTime() - saveStartNanos;
+
+        // GameProfile mutation is what every client ultimately reads textures from.
+        mutateProfile(target, property);
+
+        // Tab-list re-add to ALL online players (global, no dimension scoping).
+        long broadcastNanos = broadcastProfileChange(target);
+
+        // Respawn in the same dimension so the target's own view refreshes
+        // without an inventory wipe.
+        respawnSelf(target);
+
+        SkinMetrics.INSTANCE.recordRefreshCompleted(
+            target.getUniqueID(), startNanos, fetchNanos, saveNanos, broadcastNanos);
+    }
+
+    private static void mutateProfile(EntityPlayerMP target, CustomSkinProperty property) {
+        target.getGameProfile().getProperties().removeAll("textures");
+        target.getGameProfile().getProperties().put("textures", property.getOriginalProperty());
+    }
+
+    /**
+     * Clear half of the cascade: drop the applied textures property and, only
+     * when stale textures actually existed, re-broadcast REMOVE+ADD so
+     * observers re-learn the profile and run the respawn cascade so the
+     * target's own view reverts to the default skin. A textureless profile has
+     * nothing to revert or re-learn: the clear is a silent no-op.
+     */
+    private static void clearCascade(EntityPlayerMP target) {
+        boolean hadAppliedTextures = !target.getGameProfile().getProperties().get("textures").isEmpty();
+        target.getGameProfile().getProperties().removeAll("textures");
+        if (!hadAppliedTextures) {
+            return;
+        }
+        broadcastProfileChange(target);
+        respawnSelf(target);
+    }
+
+    /** Tab-list REMOVE+ADD to ALL online players; returns the measured broadcast nanos. */
+    private static long broadcastProfileChange(EntityPlayerMP target) {
+        long broadcastStartNanos = System.nanoTime();
+        broadcaster.broadcastProfileChange(target);
+        return System.nanoTime() - broadcastStartNanos;
+    }
+
+    /** Respawn cascade for the target's own view (same-dimension, no inventory wipe). */
+    private static void respawnSelf(EntityPlayerMP target) {
+        MinecraftServer server = target.mcServer;
+        PlayerList playerList = server.getPlayerList();
+        WorldServer world = (WorldServer) target.world;
+
+        EntityPlayerMP self = target;
+        self.connection.sendPacket(new SPacketRespawn(
+            self.dimension, self.world.getDifficulty(),
+            self.world.getWorldInfo().getTerrainType(),
+            self.interactionManager.getGameType()));
+        self.connection.setPlayerLocation(
+            self.posX, self.posY, self.posZ, self.rotationYaw, self.rotationPitch);
+        self.connection.sendPacket(new SPacketServerDifficulty(
+            self.world.getDifficulty(),
+            self.world.getWorldInfo().isDifficultyLocked()));
+        playerList.updatePermissionLevel(self);
+        self.sendPlayerAbilities();
+
+        // Potion effects must be replayed after respawn (vanilla transferPlayerToDimension parity).
+        for (PotionEffect effect : self.getActivePotionEffects()) {
+            self.connection.sendPacket(new SPacketEntityEffect(self.getEntityId(), effect));
+        }
+
+        // Time/weather resend, matching join behavior.
+        playerList.updateTimeAndWeatherForPlayer(self, world);
+    }
+}

--- a/forge-1.10.2/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRestorer.java
+++ b/forge-1.10.2/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRestorer.java
@@ -34,6 +34,7 @@ import java.util.UUID;
 public final class SkinRestorer {
 
     private static volatile SkinStorage skinStorage;
+    private static volatile MinecraftServer server;
 
     private SkinRestorer() {}
 
@@ -42,9 +43,33 @@ public final class SkinRestorer {
         return skinStorage;
     }
 
+    @Nullable
+    public static MinecraftServer getServer() {
+        return server;
+    }
+
+    /**
+     * Test-only: replaces the static storage reference without a full FML
+     * lifecycle. Package-private because the lane's tests live in this
+     * package.
+     */
+    static void setSkinStorageForTest(SkinStorage storage) {
+        skinStorage = storage;
+    }
+
+    /**
+     * Test-only: replaces the static server reference (mirror of the
+     * mc1.12.2 test seam). Package-private because the lane's tests live
+     * in this package.
+     */
+    static void setServerForTest(@Nullable MinecraftServer server) {
+        SkinRestorer.server = server;
+    }
+
     /** Server-start bootstrap: creates the data dir and the storage. */
     public static void init(FMLServerStartingEvent event) {
         MinecraftServer server = event.getServer();
+        SkinRestorer.server = server;
         Path dataDir = server.getFile("EverlastingSkins").toPath();
         try {
             Files.createDirectories(dataDir);

--- a/forge-1.10.2/src/main/java/levosilimo/everlastingskins/util/CompletionSources.java
+++ b/forge-1.10.2/src/main/java/levosilimo/everlastingskins/util/CompletionSources.java
@@ -1,0 +1,116 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.util;
+
+import levosilimo.everlastingskins.permission.PermissionServiceManager;
+import levosilimo.everlastingskins.skinchanger.MojangProfileCache;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.server.MinecraftServer;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Shared candidate sources for /skin tab completion (1.10.2 era-adapted
+ * port of the mc1.12.2 class of the same name).
+ *
+ * <p>This lane has no Config file, so the 1.12.2 configuration inputs are
+ * replaced by compile-time constants mirroring the mc1.12.2 defaults: the
+ * URL allowlist domains ({@link #URL_ALLOWLIST_DOMAINS}) and the always-on
+ * MineSkin provider ({@link #providerNames()}).
+ *
+ * <p>Permission checks use the lane's {@code (UUID, requiredOpLevel, node)}
+ * contract — the {@link levosilimo.everlastingskins.permission.forge.ForgePermissionService}
+ * resolves the player's actual op level itself.
+ */
+public final class CompletionSources {
+
+    private static final String METRICS_RESET_PERMISSION = "everlastingskins.command.metrics.reset";
+
+    /** View subcommands every metrics-authorized sender may complete. */
+    private static final List<String> METRICS_VIEW_SUBCOMMANDS =
+            Collections.unmodifiableList(Arrays.asList("human", "json", "players"));
+
+    /**
+     * Allowlisted URL domains for {@code set web <classic|slim> <url>}
+     * completion — mirror of the mc1.12.2 Config default list (this lane
+     * has no config file; the security check itself still runs via
+     * {@link UrlAllowlist} in :common).
+     */
+    private static final List<String> URL_ALLOWLIST_DOMAINS = Collections.unmodifiableList(Arrays.asList(
+            "imgur.com", "storage.googleapis.com", "cdn.discordapp.com",
+            "textures.minecraft.net", "namemc.com", "crafatar.com",
+            "mc-heads.net", "githubusercontent.com", "minecraftskins.com"));
+
+    private static volatile MojangProfileCache profileCache = new MojangProfileCache();
+
+    private CompletionSources() {
+    }
+
+    /**
+     * Swaps the cache backing {@link #recentUsernames()}. Primarily a test
+     * seam; production deployments can point it at the same cache instance
+     * the Mojang API uses so recently fetched profiles are offered.
+     */
+    public static void setMojangProfileCache(MojangProfileCache cache) {
+        profileCache = cache != null ? cache : new MojangProfileCache();
+    }
+
+    /** Mojang usernames worth offering for {@code set mojang <name>}. */
+    public static List<String> recentUsernames() {
+        return Collections.unmodifiableList(new ArrayList<>(profileCache.snapshot()));
+    }
+
+    /** Every allowlisted domain as both an https:// and an http:// URL. */
+    public static List<String> urlCandidates() {
+        List<String> candidates = new ArrayList<>();
+        for (String domain : URL_ALLOWLIST_DOMAINS) {
+            candidates.add("https://" + domain);
+            candidates.add("http://" + domain);
+        }
+        return Collections.unmodifiableList(candidates);
+    }
+
+    /** Providers for {@code set <provider>}; web is always available on this lane. */
+    public static List<String> providerNames() {
+        return Collections.unmodifiableList(Arrays.asList("mojang", "random", "web"));
+    }
+
+    /** Names of every player currently online on the server. */
+    public static List<String> onlinePlayerNames(MinecraftServer server) {
+        if (server == null || server.getPlayerList() == null) return Collections.emptyList();
+        return Collections.unmodifiableList(new ArrayList<>(Arrays.asList(server.getPlayerList().getOnlinePlayerNames())));
+    }
+
+    /**
+     * Metrics subcommands the sender may complete. View subcommands are
+     * always offered (the execution gate re-checks); cleanup/reset are
+     * offered only with the reset permission, so unauthorized users never
+     * see them.
+     */
+    public static List<String> metricsSubcommands(ICommandSender sender) {
+        List<String> subcommands = new ArrayList<>(METRICS_VIEW_SUBCOMMANDS);
+        if (hasPermission(sender, METRICS_RESET_PERMISSION, 2)) {
+            subcommands.add("cleanup");
+            subcommands.add("reset");
+        }
+        return Collections.unmodifiableList(subcommands);
+    }
+
+    /**
+     * Silent permission check (no denial message is sent, unlike the command
+     * execution paths). Console senders pass, mirroring the execution gates.
+     */
+    public static boolean hasPermission(ICommandSender sender, String node, int requiredOpLevel) {
+        if (!(sender instanceof EntityPlayerMP)) return true;
+        EntityPlayerMP player = (EntityPlayerMP) sender;
+        return PermissionServiceManager.hasPermission(player.getUniqueID(), requiredOpLevel, node);
+    }
+}

--- a/forge-1.10.2/src/main/resources/endpoints.properties
+++ b/forge-1.10.2/src/main/resources/endpoints.properties
@@ -1,0 +1,34 @@
+# EverlastingSkins external endpoint configuration
+# All service URLs and patterns are defined here instead of as
+# hardcoded Java string literals in production source files.
+#
+# To update an endpoint, change the value here and rebuild.
+
+# --- Mojang / MineTools ---
+# Eclipse endpoints (skinsrestorer.net) were aliased to Mojang and removed;
+# UUID lookup uses Mojang API directly; profile lookup uses Mojang session server.
+endpoint.uuid.mojang=https://api.mojang.com/users/profiles/minecraft/%playerName%
+endpoint.uuid.minetools=https://api.minetools.eu/uuid/%playerName%
+endpoint.profile.mojang=https://sessionserver.mojang.com/session/minecraft/profile/%uuid%?unsigned=false
+endpoint.profile.minetools=https://api.minetools.eu/profile/%uuid%
+
+# --- MineSkin ---
+endpoint.mineskin.generate=https://api.mineskin.org/generate/url
+
+# --- Texture URL strip pattern (regex) ---
+# Strips the textures.minecraft.net base from a texture URL to leave the ID.
+pattern.texture.strip=^https?://textures\\.minecraft\\.net/texture/
+
+# --- NameMC ---
+url.namemc.img=https://s.namemc.com/i/%s.png
+
+# --- mskins.net (random skin fallback) ---
+url.mskins.latest=https://mskins.net/ru/skins/latest
+url.mskins.random=https://mskins.net/en/skins/random
+url.mskins.cape=https://mskins.net/en/cape/minecon_
+# Cape-bearing skin listing (48 players/page); the %d is the page number.
+url.mskins.with_capes=https://mskins.net/en/skins/with_capes?page=%d
+
+# --- Cosmetica (cape directory; OpenAPI at https://api.cosmetica.cc/docs-json) ---
+# GET /players/{name-or-uuid} returns the player's known capes (externalCape).
+endpoint.cosmetica.player=https://api.cosmetica.cc/players/%player%

--- a/forge-1.10.2/src/test/java/levosilimo/everlastingskins/permission/PermissionTestSupport.java
+++ b/forge-1.10.2/src/test/java/levosilimo/everlastingskins/permission/PermissionTestSupport.java
@@ -1,0 +1,48 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.permission;
+
+import levosilimo.everlastingskins.permission.forge.ForgePermissionService;
+
+import java.util.UUID;
+
+/**
+ * Deterministic permission-manager control for the lane's tests: the
+ * manager's {@code reset()} is package-private, so cross-package tests
+ * (e.g. the skinchanger command tests) drive the fail-closed manager and a
+ * fixed-op-level stub backend through this support class.
+ */
+public final class PermissionTestSupport {
+
+    private PermissionTestSupport() {
+    }
+
+    /** Stub backend with a fixed player op level (protected resolveOpLevel seam). */
+    public static final class StubForgePermissionService extends ForgePermissionService {
+        private final int opLevel;
+
+        public StubForgePermissionService(int opLevel) {
+            this.opLevel = opLevel;
+        }
+
+        @Override
+        protected int resolveOpLevel(UUID uuid) {
+            return opLevel;
+        }
+    }
+
+    /** Drops all registered backends (fail-closed until the next register). */
+    public static void resetManager() {
+        PermissionServiceManager.reset();
+    }
+
+    /** Resets the manager and registers a stub granting the given op level. */
+    public static void grantOpLevel(int level) {
+        resetManager();
+        PermissionServiceManager.registerService(new StubForgePermissionService(level));
+    }
+}

--- a/forge-1.10.2/src/test/java/levosilimo/everlastingskins/skinchanger/SkinCommandTest.java
+++ b/forge-1.10.2/src/test/java/levosilimo/everlastingskins/skinchanger/SkinCommandTest.java
@@ -1,0 +1,343 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import com.mojang.authlib.GameProfile;
+import levosilimo.everlastingskins.enums.SkinVariant;
+import levosilimo.everlastingskins.permission.PermissionTestSupport;
+import levosilimo.everlastingskins.skinchanger.responses.mojang.MojangSkinDataResult;
+import levosilimo.everlastingskins.skinchanger.responses.mineskin.MineSkinResponse;
+import levosilimo.everlastingskins.util.CustomSkinProperty;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.management.PlayerList;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TextComponentString;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pure-JUnit tests for the 1.10.2 {@link SkinCommand} full-parity surface
+ * (memory #1115: deterministic fakes only — fake Mojang/MineSkin APIs via
+ * the package-private static seams, mocked storage via the SkinRestorer
+ * test seam, permission stub via the ForgePermissionService protected
+ * resolveOpLevel seam; no live server, no HTTP).
+ *
+ * <p>The /skin set/clear apply path is async (SkinAction executor); storage
+ * mutations and player messages are asserted with Mockito timeout verifies.
+ */
+class SkinCommandTest {
+
+    private static final UUID PLAYER_UUID = UUID.fromString("01234567-89ab-cdef-0123-456789abcdef");
+    private static final String FAKE_VALUE = "validTextureValue";
+    private static final String FAKE_SIG = "validSignature";
+
+    private SkinCommand command;
+    private MinecraftServer server;
+    private PlayerList playerList;
+    private EntityPlayerMP player;
+    private SkinStorage storage;
+    private FakeMojangAPI fakeMojang;
+    private FakeMineSkinAPI fakeMineSkin;
+
+    static class FakeMojangAPI implements MojangAPI {
+        final Map<String, CustomSkinProperty> skins = new HashMap<>();
+
+        void addSkin(String name, CustomSkinProperty skin) {
+            skins.put(name.toLowerCase(), skin);
+        }
+
+        @Override
+        public Optional<MojangSkinDataResult> getSkin(String nameOrUniqueId) {
+            CustomSkinProperty skin = skins.get(nameOrUniqueId.toLowerCase());
+            if (skin == null) return Optional.empty();
+            return Optional.of(new MojangSkinDataResult(UUID.randomUUID(), skin));
+        }
+
+        @Override
+        public Optional<UUID> getUUID(String playerName) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<CustomSkinProperty> getProfile(ProfileLookup lookup) {
+            return Optional.empty();
+        }
+    }
+
+    static class FakeMineSkinAPI implements MineSkinAPI {
+        CustomSkinProperty property = new CustomSkinProperty(FAKE_VALUE, FAKE_SIG, "MineSkin");
+
+        @Override
+        public MineSkinResponse genSkin(String url, SkinVariant variant) {
+            return new MineSkinResponse(property, "fake-id", variant, variant);
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        command = new SkinCommand();
+        server = mock(MinecraftServer.class);
+        playerList = mock(PlayerList.class);
+        when(server.getPlayerList()).thenReturn(playerList);
+
+        player = mock(EntityPlayerMP.class);
+        when(player.getUniqueID()).thenReturn(PLAYER_UUID);
+        when(player.getGameProfile()).thenReturn(new GameProfile(PLAYER_UUID, "Steve"));
+
+        storage = mock(SkinStorage.class);
+        SkinRestorer.setSkinStorageForTest(storage);
+        SkinRestorer.setServerForTest(server);
+
+        fakeMojang = new FakeMojangAPI();
+        fakeMineSkin = new FakeMineSkinAPI();
+        SkinCommand.setMojangAPI(fakeMojang);
+        SkinCommand.setMineSkinAPI(fakeMineSkin);
+
+        grantOpLevel(4);
+    }
+
+    @AfterEach
+    void tearDown() {
+        PermissionTestSupport.resetManager();
+        SkinRestorer.setSkinStorageForTest(null);
+        SkinRestorer.setServerForTest(null);
+        SkinCommand.resetAPIs();
+    }
+
+    private void grantOpLevel(int level) {
+        PermissionTestSupport.grantOpLevel(level);
+    }
+
+    private static ITextComponent textContaining(String fragment) {
+        return argThat(c -> c != null && c.getUnformattedText().contains(fragment));
+    }
+
+    @Test
+    void exposesModernICommandSurface() {
+        assertEquals("skin", command.getName());
+        assertTrue(command.getAliases().contains("eskin"));
+        assertTrue(command.getUsage(player).contains("set"));
+        assertTrue(command.checkPermission(server, player));
+    }
+
+    @Test
+    void noArgsSendsUsage() throws Exception {
+        command.execute(server, player, new String[]{});
+        verify(player).sendMessage(textContaining("/skin"));
+    }
+
+    @Test
+    void setMojangSelfAppliesSkin() throws Exception {
+        fakeMojang.addSkin("Notch", new CustomSkinProperty(FAKE_VALUE, FAKE_SIG, "MojangAPI"));
+
+        command.execute(server, player, new String[]{"set", "mojang", "Notch"});
+
+        verify(storage, timeout(3000)).setSkin(eq(PLAYER_UUID), any(CustomSkinProperty.class));
+        verify(player, timeout(3000)).sendMessage(textContaining("Skin applied!"));
+    }
+
+    @Test
+    void setMojangUnknownNameReportsNoSkin() throws Exception {
+        command.execute(server, player, new String[]{"set", "mojang", "Nobody"});
+
+        // The timeout-verify on the message proves the async pipeline settled
+        // before the never-verify on the storage (mockito 2.x has no
+        // timeout().never() combinator).
+        verify(player, timeout(3000)).sendMessage(textContaining("No skin found."));
+        verify(storage, never()).setSkin(any(UUID.class), any(CustomSkinProperty.class));
+    }
+
+    @Test
+    void setWebSelfAppliesSkin() throws Exception {
+        command.execute(server, player,
+            new String[]{"set", "web", "classic", "http://imgur.com/x.png"});
+
+        verify(storage, timeout(3000)).setSkin(eq(PLAYER_UUID), any(CustomSkinProperty.class));
+        verify(player, timeout(3000)).sendMessage(textContaining("Skin applied!"));
+    }
+
+    @Test
+    void setWebRequiresOpLevelTwoForSelf() throws Exception {
+        grantOpLevel(1);
+
+        command.execute(server, player,
+            new String[]{"set", "web", "slim", "http://imgur.com/x.png"});
+
+        verify(player).sendMessage(textContaining("permission"));
+        verify(storage, never()).setSkin(any(UUID.class), any(CustomSkinProperty.class));
+    }
+
+    @Test
+    void setMojangTargetingOthersRequiresOtherPermission() throws Exception {
+        grantOpLevel(1);
+        EntityPlayerMP other = mock(EntityPlayerMP.class);
+        when(other.getUniqueID()).thenReturn(UUID.randomUUID());
+        when(playerList.getPlayerByUsername("Alice")).thenReturn(other);
+
+        command.execute(server, player, new String[]{"set", "mojang", "Notch", "Alice"});
+
+        verify(player).sendMessage(textContaining("permission"));
+        verify(storage, never()).setSkin(any(UUID.class), any(CustomSkinProperty.class));
+    }
+
+    @Test
+    void clearRestoresFromStoredSource() throws Exception {
+        fakeMojang.addSkin("Steve", new CustomSkinProperty(FAKE_VALUE, FAKE_SIG, "MojangAPI"));
+        when(storage.getSource(PLAYER_UUID)).thenReturn("Steve");
+
+        command.execute(server, player, new String[]{"clear"});
+
+        verify(storage, timeout(3000)).setSkin(eq(PLAYER_UUID), any(CustomSkinProperty.class));
+        verify(player, timeout(3000)).sendMessage(textContaining("Restored"));
+    }
+
+    @Test
+    void sourceReportsStoredSource() throws Exception {
+        when(storage.hasDefaultSkin(PLAYER_UUID)).thenReturn(false);
+        when(storage.getSource(PLAYER_UUID)).thenReturn("MojangAPI");
+
+        command.execute(server, player, new String[]{"source"});
+
+        verify(player).sendMessage(textContaining("MojangAPI"));
+    }
+
+    @Test
+    void sourceWithoutStoredSkinReportsDefault() throws Exception {
+        when(storage.hasDefaultSkin(PLAYER_UUID)).thenReturn(true);
+
+        command.execute(server, player, new String[]{"source"});
+
+        verify(player).sendMessage(textContaining("Steve"));
+    }
+
+    @Test
+    void metricsJsonSendsSnapshot() throws Exception {
+        command.execute(server, player, new String[]{"metrics", "json"});
+        verify(player).sendMessage(textContaining("{"));
+    }
+
+    @Test
+    void metricsCleanupRequiresResetPermission() throws Exception {
+        grantOpLevel(1);
+
+        command.execute(server, player, new String[]{"metrics", "cleanup"});
+
+        verify(player).sendMessage(textContaining("permission"));
+    }
+
+    @Test
+    void tabCompletesRandomCascade() {
+        List<String> capes = command.getTabCompletions(server, player, new String[]{"set", "random", ""}, new BlockPos(0, 0, 0));
+        assertTrue(capes.contains("true"));
+        assertTrue(capes.contains("false"));
+
+        List<String> variants = command.getTabCompletions(server, player, new String[]{"set", "random", "true", ""}, new BlockPos(0, 0, 0));
+        assertTrue(variants.contains("classic"));
+        assertTrue(variants.contains("slim"));
+    }
+
+    @Test
+    void tabCompletesProviders() {
+        List<String> matches = command.getTabCompletions(server, player, new String[]{"set", ""}, new BlockPos(0, 0, 0));
+        assertTrue(matches.contains("mojang"));
+        assertTrue(matches.contains("web"));
+        assertTrue(matches.contains("random"));
+    }
+
+    @Test
+    void tabCompletesWebVariantAndUrls() {
+        List<String> variants = command.getTabCompletions(server, player, new String[]{"set", "web", ""}, new BlockPos(0, 0, 0));
+        assertTrue(variants.contains("classic"));
+        assertTrue(variants.contains("slim"));
+
+        List<String> urls = command.getTabCompletions(server, player, new String[]{"set", "web", "classic", ""}, new BlockPos(0, 0, 0));
+        assertTrue(urls.contains("https://imgur.com"));
+        assertTrue(urls.contains("http://crafatar.com"));
+    }
+
+    @Test
+    void tabCompletesOnlinePlayersForClearWhenCanTargetOthers() {
+        when(playerList.getOnlinePlayerNames()).thenReturn(new String[]{"Alice", "Bob"});
+
+        List<String> matches = command.getTabCompletions(server, player, new String[]{"clear", ""}, new BlockPos(0, 0, 0));
+        assertTrue(matches.contains("Alice"));
+        assertTrue(matches.contains("Bob"));
+    }
+
+    @Test
+    void tabCompletesOnlinePlayersOnlyWithOtherPermission() {
+        grantOpLevel(1);
+        when(playerList.getOnlinePlayerNames()).thenReturn(new String[]{"Alice"});
+
+        List<String> matches = command.getTabCompletions(server, player, new String[]{"clear", ""}, new BlockPos(0, 0, 0));
+        assertFalse(matches.contains("Alice"));
+    }
+
+    @Test
+    void tabCompletesMetricsResetOnlyWithPermission() {
+        List<String> allowed = command.getTabCompletions(server, player, new String[]{"metrics", ""}, new BlockPos(0, 0, 0));
+        assertTrue(allowed.contains("reset"));
+        assertTrue(allowed.contains("json"));
+
+        grantOpLevel(1);
+        List<String> denied = command.getTabCompletions(server, player, new String[]{"metrics", ""}, new BlockPos(0, 0, 0));
+        assertFalse(denied.contains("reset"));
+        assertTrue(denied.contains("json"));
+    }
+
+    @Test
+    void tryRestoreFromMojangRestoresStoredSource() {
+        fakeMojang.addSkin("Notch", new CustomSkinProperty(FAKE_VALUE, FAKE_SIG, "MojangAPI"));
+
+        SkinCommand.MojangRestoreResult result =
+            SkinCommand.tryRestoreFromMojang(fakeMojang, "Notch", "Steve");
+
+        assertNotNull(result);
+        assertEquals(FAKE_VALUE, result.skin.getOriginalProperty().getValue());
+        assertEquals("Notch", result.licensedUsername);
+    }
+
+    @Test
+    void tryRestoreFromMojangFallsBackToPlayerName() {
+        fakeMojang.addSkin("Steve", new CustomSkinProperty(FAKE_VALUE, FAKE_SIG, "MojangAPI"));
+
+        SkinCommand.MojangRestoreResult result =
+            SkinCommand.tryRestoreFromMojang(fakeMojang, null, "Steve");
+
+        assertNotNull(result);
+        assertEquals("Steve", result.licensedUsername);
+    }
+
+    @Test
+    void tryRestoreFromMojangReturnsNullWhenNoProfile() {
+        assertNull(SkinCommand.tryRestoreFromMojang(fakeMojang, "Nobody", "Steve"));
+    }
+}

--- a/forge-1.10.2/src/test/java/levosilimo/everlastingskins/skinchanger/SkinLoginHandlerTest.java
+++ b/forge-1.10.2/src/test/java/levosilimo/everlastingskins/skinchanger/SkinLoginHandlerTest.java
@@ -1,0 +1,123 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import com.mojang.authlib.GameProfile;
+import com.mojang.authlib.properties.Property;
+import levosilimo.everlastingskins.metrics.SkinMetrics;
+import levosilimo.everlastingskins.util.CustomSkinProperty;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraftforge.fml.common.gameevent.PlayerEvent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pure-JUnit tests for the 1.10.2 {@link SkinLoginHandler} login-apply /
+ * logout-persist contract (memory #1115: deterministic fakes only — mocked
+ * player + storage via the SkinRestorer test seam; no live server, no HTTP).
+ */
+class SkinLoginHandlerTest {
+
+    private static final UUID PLAYER_UUID = UUID.fromString("01234567-89ab-cdef-0123-456789abcdef");
+    private static final CustomSkinProperty SKIN =
+            new CustomSkinProperty("textures", "value-1", "signature-1", "MojangAPI");
+
+    private SkinLoginHandler handler;
+    private EntityPlayerMP player;
+    private GameProfile profile;
+    private SkinStorage storage;
+
+    @BeforeEach
+    void setUp() {
+        SkinMetrics.INSTANCE.reset();
+        handler = new SkinLoginHandler();
+        profile = new GameProfile(PLAYER_UUID, "Steve");
+        player = mock(EntityPlayerMP.class);
+        when(player.getGameProfile()).thenReturn(profile);
+        when(player.getUniqueID()).thenReturn(PLAYER_UUID);
+        storage = mock(SkinStorage.class);
+        SkinRestorer.setSkinStorageForTest(storage);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SkinRestorer.setSkinStorageForTest(null);
+    }
+
+    private Collection<Property> appliedTextures() {
+        return profile.getProperties().get("textures");
+    }
+
+    @Test
+    void loginAppliesStoredSkinToProfile() {
+        when(storage.getSkin(PLAYER_UUID)).thenReturn(SKIN);
+
+        handler.onPlayerLoggedIn(new PlayerEvent.PlayerLoggedInEvent(player));
+
+        assertEquals(1, appliedTextures().size());
+        assertEquals("value-1", appliedTextures().iterator().next().getValue());
+    }
+
+    @Test
+    void loginWithoutStoredSkinLeavesProfileUntouched() {
+        when(storage.getSkin(PLAYER_UUID)).thenReturn(null);
+
+        handler.onPlayerLoggedIn(new PlayerEvent.PlayerLoggedInEvent(player));
+
+        assertTrue(appliedTextures().isEmpty());
+    }
+
+    @Test
+    void loginWithNullStorageIsSafe() {
+        SkinRestorer.setSkinStorageForTest(null);
+
+        handler.onPlayerLoggedIn(new PlayerEvent.PlayerLoggedInEvent(player));
+
+        assertTrue(appliedTextures().isEmpty());
+    }
+
+    @Test
+    void loginReplacesStaleAppliedTextures() {
+        profile.getProperties().put("textures", new Property("textures", "stale", "sig"));
+        when(storage.getSkin(PLAYER_UUID)).thenReturn(SKIN);
+
+        handler.onPlayerLoggedIn(new PlayerEvent.PlayerLoggedInEvent(player));
+
+        assertEquals(1, appliedTextures().size());
+        assertEquals("value-1", appliedTextures().iterator().next().getValue());
+    }
+
+    @Test
+    void logoutPersistsStoredSkin() {
+        when(storage.getSkin(PLAYER_UUID)).thenReturn(SKIN);
+
+        handler.onPlayerLoggedOut(new PlayerEvent.PlayerLoggedOutEvent(player));
+
+        verify(storage).saveSkin(PLAYER_UUID);
+    }
+
+    @Test
+    void logoutWithoutStoredSkinSkipsSave() {
+        when(storage.getSkin(PLAYER_UUID)).thenReturn(null);
+
+        handler.onPlayerLoggedOut(new PlayerEvent.PlayerLoggedOutEvent(player));
+
+        verify(storage, never()).saveSkin(any(UUID.class));
+    }
+}

--- a/forge-1.10.2/src/test/java/levosilimo/everlastingskins/skinchanger/SkinRefreshTaskTest.java
+++ b/forge-1.10.2/src/test/java/levosilimo/everlastingskins/skinchanger/SkinRefreshTaskTest.java
@@ -1,0 +1,203 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import com.mojang.authlib.GameProfile;
+import com.mojang.authlib.properties.Property;
+import levosilimo.everlastingskins.broadcast.SkinProfileBroadcaster;
+import levosilimo.everlastingskins.broadcast.VanillaProfileBroadcaster;
+import levosilimo.everlastingskins.metrics.SkinMetrics;
+import levosilimo.everlastingskins.util.CustomSkinProperty;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.network.NetHandlerPlayServer;
+import net.minecraft.network.Packet;
+import net.minecraft.network.play.server.SPacketEntityEffect;
+import net.minecraft.network.play.server.SPacketRespawn;
+import net.minecraft.network.play.server.SPacketServerDifficulty;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.management.PlayerInteractionManager;
+import net.minecraft.server.management.PlayerList;
+import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.EnumDifficulty;
+import net.minecraft.world.GameType;
+import net.minecraft.world.World;
+import net.minecraft.world.WorldProvider;
+import net.minecraft.world.WorldServer;
+import net.minecraft.world.WorldType;
+import net.minecraft.world.storage.WorldInfo;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Refresh-pipeline call-shape contract for the 1.10.2 {@link SkinRefreshTask}
+ * (memory #1115: deterministic fakes only — a real EntityPlayerMP built
+ * over mocked server/world/connection, storage via the SkinRestorer test
+ * seam, packet fan-out via the {@link SkinProfileBroadcaster} seam; no live
+ * server, no HTTP).
+ *
+ * <p>Contract pinned here: the task enqueues the disk flush BEFORE mutating
+ * the GameProfile (atomicity), then mutates the profile, re-broadcasts the
+ * tab-list entry once, and runs the same-dimension respawn cascade
+ * (respawn < position < difficulty < permission-level < abilities).
+ */
+class SkinRefreshTaskTest {
+
+    private static final UUID TARGET_UUID = UUID.fromString("11223344-5566-7788-99aa-bbccddeeff00");
+    private static final Property OLD_PROPERTY = new Property("textures", "oldValue", "oldSignature");
+    private static final CustomSkinProperty NEW_SKIN =
+            new CustomSkinProperty("textures", "newValue", "newSignature", "MojangAPI");
+
+    private MinecraftServer server;
+    private PlayerList playerList;
+    private WorldServer world;
+    private EntityPlayerMP target;
+    private NetHandlerPlayServer connection;
+    private SkinStorage storage;
+    private RecordingBroadcaster broadcaster;
+
+    /** Recording fake for the per-viewer fan-out seam. */
+    static final class RecordingBroadcaster implements SkinProfileBroadcaster {
+        int broadcastCalls;
+
+        @Override
+        public void broadcastProfileChange(EntityPlayerMP target) {
+            broadcastCalls++;
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        SkinMetrics.INSTANCE.reset();
+        // ForgeHooks/Items throw "Accessed Blocks before Bootstrap!" unless
+        // the vanilla registry bootstrap has run; the real server does this
+        // at boot (mirror of the mc1.12.2 test harness).
+        net.minecraft.init.Bootstrap.register();
+
+        server = mock(MinecraftServer.class);
+        playerList = mock(PlayerList.class);
+        when(server.getPlayerList()).thenReturn(playerList);
+
+        world = mock(WorldServer.class);
+        when(world.getDifficulty()).thenReturn(EnumDifficulty.PEACEFUL);
+        WorldInfo worldInfo = mock(WorldInfo.class);
+        when(world.getWorldInfo()).thenReturn(worldInfo);
+        when(worldInfo.getTerrainType()).thenReturn(WorldType.DEFAULT);
+        when(worldInfo.isDifficultyLocked()).thenReturn(false);
+        when(world.getSpawnPoint()).thenReturn(new BlockPos(0, 64, 0));
+        when(world.getCollisionBoxes(any(Entity.class), any(AxisAlignedBB.class)))
+            .thenReturn(Collections.emptyList());
+        // World.provider is a public final field on 1.10.2; Mockito cannot
+        // stub it, so the real player constructor reads it via reflection.
+        WorldProvider provider = mock(WorldProvider.class);
+        when(provider.getDimension()).thenReturn(0);
+        when(provider.getRandomizedSpawnPoint()).thenReturn(new BlockPos(0, 64, 0));
+        setProviderField(world, provider);
+
+        GameProfile profile = new GameProfile(TARGET_UUID, "Target");
+        PlayerInteractionManager interactionManager = mock(PlayerInteractionManager.class);
+        when(interactionManager.getGameType()).thenReturn(GameType.SURVIVAL);
+        target = new EntityPlayerMP(server, world, profile, interactionManager);
+        connection = mock(NetHandlerPlayServer.class);
+        target.connection = connection;
+
+        storage = mock(SkinStorage.class);
+        when(storage.saveSkinAsync(any(UUID.class), any(CustomSkinProperty.class)))
+            .thenReturn(CompletableFuture.completedFuture(null));
+        SkinRestorer.setSkinStorageForTest(storage);
+        SkinRestorer.setServerForTest(server);
+
+        broadcaster = new RecordingBroadcaster();
+        SkinRefreshTask.setBroadcaster(broadcaster);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SkinRefreshTask.setBroadcaster(new VanillaProfileBroadcaster());
+        SkinRestorer.setSkinStorageForTest(null);
+        SkinRestorer.setServerForTest(null);
+    }
+
+    private void applyTexture(Property property) {
+        target.getGameProfile().getProperties().put("textures", property);
+    }
+
+    /** World.provider is a public final field on 1.10.2; Mockito cannot stub it. */
+    private static void setProviderField(WorldServer world, WorldProvider provider) {
+        try {
+            Field field = World.class.getField("provider");
+            field.setAccessible(true);
+            field.set(world, provider);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Cannot stub World.provider", e);
+        }
+    }
+
+    @Test
+    void cascadeFlushesBeforeMutatingAndRebroadcasts() {
+        applyTexture(OLD_PROPERTY);
+
+        SkinRefreshTask.task(target, NEW_SKIN, 0L);
+
+        verify(storage).saveSkinAsync(TARGET_UUID, NEW_SKIN);
+        Collection<Property> applied = target.getGameProfile().getProperties().get("textures");
+        assertEquals(1, applied.size());
+        assertEquals("newValue", applied.iterator().next().getValue());
+        assertEquals(1, broadcaster.broadcastCalls);
+        verify(connection).sendPacket(any(SPacketRespawn.class));
+        verify(connection).sendPacket(any(SPacketServerDifficulty.class));
+        // No potions on a fresh player: the effect replay must be a no-op.
+        verify(connection, never()).sendPacket(any(SPacketEntityEffect.class));
+    }
+
+    @Test
+    void clearWithoutAppliedTexturesIsSilentNoOp() {
+        SkinRefreshTask.task(target, null, 0L);
+
+        assertEquals(0, broadcaster.broadcastCalls);
+        verify(connection, never()).sendPacket(any(Packet.class));
+        assertTrue(target.getGameProfile().getProperties().get("textures").isEmpty());
+    }
+
+    @Test
+    void clearWithStaleTexturesDropsProfileAndRebroadcasts() {
+        applyTexture(OLD_PROPERTY);
+
+        SkinRefreshTask.task(target, null, 0L);
+
+        assertTrue(target.getGameProfile().getProperties().get("textures").isEmpty());
+        assertEquals(1, broadcaster.broadcastCalls);
+        verify(connection).sendPacket(any(SPacketRespawn.class));
+    }
+
+    @Test
+    void emptyPropertyIsTreatedAsClear() {
+        applyTexture(OLD_PROPERTY);
+        CustomSkinProperty empty = new CustomSkinProperty("", "", null);
+
+        SkinRefreshTask.task(target, empty, 0L);
+
+        assertTrue(target.getGameProfile().getProperties().get("textures").isEmpty());
+        assertEquals(1, broadcaster.broadcastCalls);
+    }
+}


### PR DESCRIPTION
Per command-parity investigation: 1.10.2 had only the admin /everlastingskins command and no skin application. Adds /skin set mojang|web|random, source, clear, metrics, targets + GameProfile textures apply on login and re-send (modern MCP names). Admin command untouched. :common classes only.