### PR TITLE
feat(client): pre-1.8 joint client-side skin rendering (1.4.7/1.5.2/1.6.4)

### DIFF
--- a/forge-1.4.7/build.gradle
+++ b/forge-1.4.7/build.gradle
@@ -76,6 +76,16 @@ ext {
             [name: 'minecraft_server.1.4.7.jar',
              url: 'https://piston-data.mojang.com/v1/objects/2f0ec8efddd2f2c674c77be9ddb370b727dec676/server.jar',
              algo: 'SHA-1', digest: '2f0ec8efddd2f2c674c77be9ddb370b727dec676'],
+            // Joint client-side jar (lib-5 design, PR #422): the mod is no
+            // longer serverSideOnly — the same jar carries a client packet
+            // handler that injects skin PNGs into the era renderer. The vanilla
+            // CLIENT jar is vendored + deobf'd (harness clientInput) and added
+            // to the compile classpath after the server-first merged jar.
+            // sha1 verified against launcher.mojang.com version_manifest 1.4.7
+            // (downloads.client.sha1).
+            [name: 'minecraft_client.1.4.7.jar',
+             url: 'https://launcher.mojang.com/v1/objects/53ed4b9d5c358ecfff2d8b846b4427b888287028/client.jar',
+             algo: 'SHA-1', digest: '53ed4b9d5c358ecfff2d8b846b4427b888287028'],
         ],
         mcpVersion: '7.26a',
         archiveBaseName: 'everlastingskins-1.4.7',

--- a/forge-1.4.7/src/main/java/levosilimo/everlastingskins/broadcast/ClientSkinHandler.java
+++ b/forge-1.4.7/src/main/java/levosilimo/everlastingskins/broadcast/ClientSkinHandler.java
@@ -1,0 +1,81 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.broadcast;
+
+import cpw.mods.fml.common.network.IPacketHandler;
+import cpw.mods.fml.common.network.Player;
+import levosilimo.everlastingskins.client.ClientSkinApplier;
+import net.minecraft.client.Minecraft;
+import net.minecraft.src.EntityPlayer;
+import net.minecraft.src.IImageBuffer;
+import net.minecraft.src.INetworkManager;
+import net.minecraft.src.ImageBufferDownload;
+import net.minecraft.src.Packet250CustomPayload;
+import net.minecraft.src.ThreadDownloadImageData;
+
+import java.awt.image.BufferedImage;
+
+/**
+ * 1.4.7 client-side skin receiver (lib-5 Option B: joint client side inside
+ * the same jar). Registered by the {@code @NetworkMod} joint pattern
+ * (clientPacketHandlerSpec on the @Mod class — FML registers the client spec
+ * only on a client process, so the same jar works on both sides).
+ *
+ * <p>Decodes the existing {@link SkinMessage} wire format and injects the PNG
+ * into the player's skin {@link ThreadDownloadImageData} via
+ * {@link ClientSkinApplier} — no ASM. The player is resolved by name from
+ * {@code World.playerEntities} (1.4.7 has no UUID on the wire); the cached
+ * TDI is looked up by the player's {@code skinUrl} through
+ * {@code RenderEngine.obtainImageData} (the cache keyed by skin URL, seeded
+ * by {@code RenderGlobal.updateEntitySkin} when the entity spawned).
+ *
+ * <p>Re-injection on join: the server re-broadcasts the stored skin on every
+ * login, so a packet that arrives before the player entity spawns is simply
+ * dropped here (the join broadcast re-delivers it). Caveat (documented, not
+ * hardened): if the vanilla skin-download thread completes AFTER the
+ * injection, it overwrites the pixels with the default skin — the ASM
+ * hardening that would prevent this (shielding the download) is a future
+ * upgrade, out of scope.
+ */
+public final class ClientSkinHandler implements IPacketHandler {
+
+    @Override
+    public void onPacketData(INetworkManager manager, Packet250CustomPayload packet, Player player) {
+        try {
+            SkinMessage message = SkinMessage.decode(packet.data);
+            byte[] png = message.getTexturePng();
+            if (png == null) {
+                // Notification-only broadcast from a pre-joint server.
+                return;
+            }
+            Minecraft mc = Minecraft.getMinecraft();
+            if (mc.theWorld == null) {
+                return;
+            }
+            EntityPlayer target = ClientSkinApplier.findPlayer(mc.theWorld, message.getPlayerName());
+            if (target == null) {
+                // Not spawned yet — the join broadcast re-delivers.
+                return;
+            }
+            String skinUrl = target.skinUrl;
+            if (skinUrl == null) {
+                return;
+            }
+            ThreadDownloadImageData imageData = mc.renderEngine.obtainImageData(skinUrl, new ImageBufferDownload());
+            if (imageData == null) {
+                return;
+            }
+            BufferedImage image = ClientSkinApplier.flattenToLegacy(ClientSkinApplier.decode(png));
+            ClientSkinApplier.apply(imageData, image);
+            // textureSetupComplete=false makes the next render pass re-upload
+            // the injected pixels into the existing GL texture.
+        } catch (Exception e) {
+            // Never crash the network thread on a malformed/undecodable payload.
+            System.err.println("EverlastingSkins: client skin apply failed: " + e);
+        }
+    }
+}

--- a/forge-1.4.7/src/main/java/levosilimo/everlastingskins/broadcast/ServerPacketHandler.java
+++ b/forge-1.4.7/src/main/java/levosilimo/everlastingskins/broadcast/ServerPacketHandler.java
@@ -1,0 +1,27 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.broadcast;
+
+import cpw.mods.fml.common.network.IPacketHandler;
+import cpw.mods.fml.common.network.Player;
+import net.minecraft.src.INetworkManager;
+import net.minecraft.src.Packet250CustomPayload;
+
+/**
+ * 1.4.7 server-side receiver for the {@code everlastingskins} channel,
+ * referenced by the {@code @NetworkMod} joint pattern
+ * (serverPacketHandlerSpec). FML dispatches server-side custom payloads to
+ * the server handler (registered with Side.SERVER) and client-side payloads
+ * to {@link ClientSkinHandler} — both handlers live in the same jar.
+ */
+public final class ServerPacketHandler implements IPacketHandler {
+
+    @Override
+    public void onPacketData(INetworkManager manager, Packet250CustomPayload packet, Player player) {
+        // No client→server traffic on this channel.
+    }
+}

--- a/forge-1.4.7/src/main/java/levosilimo/everlastingskins/broadcast/SkinBroadcaster.java
+++ b/forge-1.4.7/src/main/java/levosilimo/everlastingskins/broadcast/SkinBroadcaster.java
@@ -6,62 +6,49 @@
 
 package levosilimo.everlastingskins.broadcast;
 
-import cpw.mods.fml.common.network.IPacketHandler;
-import cpw.mods.fml.common.network.NetworkRegistry;
 import cpw.mods.fml.common.network.PacketDispatcher;
-import cpw.mods.fml.common.network.Player;
-import net.minecraft.src.EntityPlayer;
-import net.minecraft.src.INetworkManager;
 import net.minecraft.src.Packet;
-import net.minecraft.src.Packet250CustomPayload;
 
 /**
  * 1.4.7 skin-broadcast channel (FML 4.7 custom-payload surface).
  *
  * <p>FML 4.7 has no netty {@code SimpleNetworkWrapper} (that is 1.8+) and no
- * {@code newChannel} on {@link NetworkRegistry} — the 1.4.7 surface is
- * {@code NetworkRegistry.instance().registerChannel(IPacketHandler, String)}
- * with {@link Packet250CustomPayload} payloads, sent via
- * {@link PacketDispatcher}. The channel name must be ≤ 16 chars
- * (NetworkRegistry.java throws beyond that); {@code everlastingskins} is
- * exactly 16 — at the ceiling, never lengthen it.
+ * {@code newChannel} — the 1.5.2 surface is {@code Packet250CustomPayload}
+ * payloads, sent via {@link PacketDispatcher}. The channel name must be
+ * ≤ 16 chars (NetworkRegistry.java throws beyond that);
+ * {@code everlastingskins} is exactly 16 — at the ceiling, never lengthen it.
  *
- * <p>Payloads carry the target player's username
- * ({@link SkinMessage#encode(String, byte[])}); the client-side handler would
- * re-fetch the skin (server-side mod: the channel is the notification
- * surface, matching the sibling lanes' broadcast contract). The registered
- * {@link IPacketHandler} is a server-side no-op — 1.4.7 clients never send
- * on this channel.
+ * <p>CHANNEL OWNERSHIP: since the joint client side landed (lib-5, PR #422)
+ * the channel is registered by the {@code @NetworkMod} joint pattern on the
+ * @Mod class — {@link ClientSkinHandler} on client processes,
+ * {@link ServerPacketHandler} on server processes — NOT by a manual
+ * {@code registerChannel} here (a universal no-op registration would shadow
+ * the client-side dispatch). {@link #broadcastProfileChange} only sends.
+ *
+ * <p>Payloads carry the target player's username AND the flattened 64x32 PNG
+ * bytes ({@link SkinMessage#encode(String, byte[])}); the client handler
+ * decodes and injects the pixels. Payload cap: 32766 bytes
+ * (Packet250CustomPayload 2-byte length, MC-16910) — a flattened 64x32 PNG is
+ * ≈ 1-4 KB, far under the cap; oversized payloads are dropped defensively.
  */
 public final class SkinBroadcaster {
 
     public static final String CHANNEL = "everlastingskins";
 
-    private static volatile boolean registered;
+    /** Packet250CustomPayload 2-byte length cap (MC-16910). */
+    private static final int MAX_PAYLOAD_BYTES = 32766;
 
     private SkinBroadcaster() {}
 
-    /** Registers the channel; safe to call once per JVM (idempotent). */
-    public static void init() {
-        if (registered) {
+    /** Broadcasts a skin-change payload for {@code playerName} to all players. */
+    public static void broadcastProfileChange(String playerName, byte[] pngBytes) {
+        byte[] payload = SkinMessage.encode(playerName, pngBytes);
+        if (payload.length > MAX_PAYLOAD_BYTES) {
+            System.err.println("EverlastingSkins: skin payload for '" + playerName
+                + "' exceeds " + MAX_PAYLOAD_BYTES + " bytes — dropped");
             return;
         }
-        NetworkRegistry.instance().registerChannel(new ServerPacketHandler(), CHANNEL);
-        registered = true;
-    }
-
-    /** Broadcasts a skin-change notification for {@code target} to all players. */
-    public static void broadcastProfileChange(EntityPlayer target) {
-        byte[] payload = SkinMessage.encode(target.getCommandSenderName(), null);
         Packet packet = PacketDispatcher.getPacket(CHANNEL, payload);
         PacketDispatcher.sendPacketToAllPlayers(packet);
-    }
-
-    /** Server-side no-op: the mod is serverSideOnly (FML 4.7). */
-    private static final class ServerPacketHandler implements IPacketHandler {
-        @Override
-        public void onPacketData(INetworkManager manager, Packet250CustomPayload packet, Player player) {
-            // No client→server traffic on this channel.
-        }
     }
 }

--- a/forge-1.4.7/src/main/java/levosilimo/everlastingskins/broadcast/SkinMessage.java
+++ b/forge-1.4.7/src/main/java/levosilimo/everlastingskins/broadcast/SkinMessage.java
@@ -45,6 +45,12 @@ public final class SkinMessage {
     /**
      * Wire format: [utf8 username][int png length][png bytes]. A null PNG
      * encodes as length 0 (notification-only broadcast).
+     *
+     * <p>Every length prefix is bounds-checked against the remaining unread
+     * payload BEFORE allocation ({@link #checkLength}), so a corrupted or
+     * malicious prefix fails with {@link IllegalArgumentException} instead
+     * of an {@link OutOfMemoryError} on the packet thread (lib-18 audit
+     * remediation).
      */
     public static byte[] encode(String playerName, byte[] texturePng) {
         try {
@@ -70,9 +76,11 @@ public final class SkinMessage {
         try {
             DataInputStream in = new DataInputStream(new ByteArrayInputStream(payload));
             int nameLen = in.readInt();
+            checkLength(nameLen, payload.length - 4, "name");
             byte[] name = new byte[nameLen];
             in.readFully(name);
             int pngLen = in.readInt();
+            checkLength(pngLen, payload.length - 8 - nameLen, "png");
             byte[] png = null;
             if (pngLen > 0) {
                 png = new byte[pngLen];
@@ -81,6 +89,20 @@ public final class SkinMessage {
             return new SkinMessage(new String(name, StandardCharsets.UTF_8), png);
         } catch (IOException e) {
             throw new IllegalArgumentException("Malformed SkinMessage payload", e);
+        }
+    }
+
+    /**
+     * Bounds guard for a length-prefixed field: rejects any length prefix
+     * that is negative or exceeds the remaining unread payload BEFORE the
+     * array allocation. The client handler catches
+     * {@link IllegalArgumentException}; an {@link OutOfMemoryError} would
+     * escape {@code catch (Exception)} and kill the network thread.
+     */
+    private static void checkLength(int len, int remaining, String field) {
+        if (len < 0 || len > remaining) {
+            throw new IllegalArgumentException("Malformed SkinMessage payload: " + field
+                + " length " + len + " exceeds remaining " + remaining + " bytes");
         }
     }
 }

--- a/forge-1.4.7/src/main/java/levosilimo/everlastingskins/client/ClientSkinApplier.java
+++ b/forge-1.4.7/src/main/java/levosilimo/everlastingskins/client/ClientSkinApplier.java
@@ -1,0 +1,92 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.client;
+
+import levosilimo.everlastingskins.skinchanger.TextureDecoder;
+import net.minecraft.src.EntityPlayer;
+import net.minecraft.src.ThreadDownloadImageData;
+import net.minecraft.src.World;
+
+import java.awt.Graphics;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+
+/**
+ * Pure-Java client-side skin application for the 1.4.7 lane (lib-5 Option B:
+ * the joint jar carries a client handler that makes skins ACTUALLY RENDER on
+ * pre-1.8 clients). Decode / flatten / apply are separated from the network
+ * and renderer bindings so they are unit-testable without a client.
+ *
+ * <p>Flatten contract: the 1.4.7 renderer uses the legacy 64x32 model whose
+ * left limbs MIRROR the right-limb regions (ModelBiped samples both arms from
+ * textureOffset(40,16) and both legs from (0,16) — spike-verified against the
+ * vanilla client jar). The correct 64x64 → 64x32 conversion is therefore the
+ * vanilla crop (1.4.7 {@code ImageBufferDownload.parseUserSkin} draws the
+ * source unscaled at (0,0)): the modern top half IS the legacy layout, and the
+ * modern bottom-left regions (left arm / left leg) are dropped.
+ */
+public final class ClientSkinApplier {
+
+    private ClientSkinApplier() {}
+
+    /**
+     * Decodes PNG bytes into an ARGB {@link BufferedImage}.
+     *
+     * @throws IOException if the bytes are not a decodable image
+     */
+    public static BufferedImage decode(byte[] png) throws IOException {
+        return TextureDecoder.decode(png);
+    }
+
+    /**
+     * Converts any skin to the legacy 64x32 model. 64x32 (and smaller-height
+     * 64-wide) inputs pass through unchanged; a 64x64 modern skin is cropped
+     * to its top half (vanilla 1.4.7 parity); any other size is drawn
+     * unscaled at (0,0) exactly like the vanilla download pipeline.
+     */
+    public static BufferedImage flattenToLegacy(BufferedImage source) {
+        if (source.getWidth() == 64 && source.getHeight() <= 32) {
+            return source;
+        }
+        BufferedImage legacy = new BufferedImage(64, 32, BufferedImage.TYPE_INT_ARGB);
+        Graphics g = legacy.getGraphics();
+        g.drawImage(source, 0, 0, null);
+        g.dispose();
+        return legacy;
+    }
+
+    /**
+     * Finds a spawned player by {@code getCommandSenderName()} in the client
+     * world ({@code World.playerEntities}), or null when not spawned yet.
+     */
+    public static EntityPlayer findPlayer(World world, String playerName) {
+        if (world == null || world.playerEntities == null) {
+            return null;
+        }
+        for (Object o : world.playerEntities) {
+            if (o instanceof EntityPlayer) {
+                EntityPlayer candidate = (EntityPlayer) o;
+                if (candidate.getCommandSenderName().equals(playerName)) {
+                    return candidate;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Injects the flattened image into the player's skin
+     * {@link ThreadDownloadImageData}. 1.4.7 (MCP 7.26a) exposes the image as
+     * the PUBLIC field {@code image}; resetting {@code textureSetupComplete}
+     * makes {@code RenderEngine.getTextureForDownloadableImage} re-upload the
+     * new pixels into the existing GL texture on the next render pass.
+     */
+    public static void apply(ThreadDownloadImageData target, BufferedImage image) {
+        target.image = image;
+        target.textureSetupComplete = false;
+    }
+}

--- a/forge-1.4.7/src/main/java/levosilimo/everlastingskins/command/SkinRestorerCommand.java
+++ b/forge-1.4.7/src/main/java/levosilimo/everlastingskins/command/SkinRestorerCommand.java
@@ -181,8 +181,10 @@ public class SkinRestorerCommand implements ICommand {
         if (!checkPermission(sender, targetsAreSelfOnly(sender, targets) ? NODE_SKIN : NODE_SKIN_OTHER)) {
             return;
         }
+        // #426: the broadcast is keyed by the TARGET player's name (the entity
+        // clients render), not the skin source's — real-PNG live update.
         for (EntityPlayerMP target : targets) {
-            setSkin(sender, SkinRestorer.uuidOf(target.getCommandSenderName()), args[1]);
+            setSkin(sender, SkinRestorer.uuidOf(target.getCommandSenderName()), target.getCommandSenderName(), args[1]);
         }
     }
 
@@ -214,7 +216,7 @@ public class SkinRestorerCommand implements ICommand {
             return;
         }
         for (EntityPlayerMP target : targets) {
-            setSkin(sender, SkinRestorer.uuidOf(target.getCommandSenderName()), username);
+            setSkin(sender, SkinRestorer.uuidOf(target.getCommandSenderName()), target.getCommandSenderName(), username);
         }
     }
 
@@ -309,7 +311,7 @@ public class SkinRestorerCommand implements ICommand {
             MetricsFormat.human(SkinMetrics.INSTANCE.snapshot()));
     }
 
-    private void setSkin(ICommandSender sender, UUID uuid, String username) {
+    private void setSkin(ICommandSender sender, UUID uuid, String targetName, String username) {
         // 1.4.7 has no per-player permission nodes beyond the op model; the
         // vanilla Mojang lookup is the only authoritative source (no
         // MineSkin/URL generation on this legacy surface).
@@ -328,7 +330,11 @@ public class SkinRestorerCommand implements ICommand {
         }
         CustomSkinProperty skin = result.get().skinProperty();
         seenProfiles.put(username, skin);
-        SkinRestorer.applySkin(uuid, skin);
+        // Username-keyed variant: stores the skin AND broadcasts the real PNG
+        // bytes to all clients (lib-5 joint client side — live update). The
+        // broadcast is keyed by the TARGET player's name (the entity clients
+        // render), not the skin source's.
+        SkinRestorer.applySkin(targetName, skin);
         SkinMetrics.INSTANCE.recordRefreshCompleted(uuid, startNanos, System.nanoTime() - startNanos, 0, 0);
         sender.sendChatToPlayer("Skin applied.");
     }

--- a/forge-1.4.7/src/main/java/levosilimo/everlastingskins/forge147/EverlastingSkins.java
+++ b/forge-1.4.7/src/main/java/levosilimo/everlastingskins/forge147/EverlastingSkins.java
@@ -6,13 +6,17 @@
 
 package levosilimo.everlastingskins.forge147;
 
+import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLServerStartingEvent;
 import cpw.mods.fml.common.event.FMLServerStoppingEvent;
 import cpw.mods.fml.common.network.IConnectionHandler;
+import cpw.mods.fml.common.network.NetworkMod;
 import cpw.mods.fml.common.network.NetworkRegistry;
 import cpw.mods.fml.common.network.Player;
+import levosilimo.everlastingskins.broadcast.ClientSkinHandler;
+import levosilimo.everlastingskins.broadcast.ServerPacketHandler;
 import levosilimo.everlastingskins.broadcast.SkinBroadcaster;
 import levosilimo.everlastingskins.permission.forge.ForgePermissionService;
 import levosilimo.everlastingskins.skinchanger.SkinRestorer;
@@ -25,13 +29,15 @@ import net.minecraft.src.NetLoginHandler;
 import net.minecraft.src.Packet1Login;
 
 /**
- * 1.4.7 entry point. FML 4.7.35 surface (pre-1.6 lifecycle markers): there is
- * no {@code @Mod.EventHandler} on this line — the lifecycle annotations are
- * {@code @Mod.Init} / {@code @Mod.ServerStarting} / {@code @Mod.ServerStopping}
- * (the {@code EventHandler} umbrella arrived in FML 5.x). No GameProfile, no
- * {@code PlayerEvent} gameevent package and no {@code @SubscribeEvent} — the
- * pre-1.7 player join/leave surface is {@link IConnectionHandler}, registered
- * via {@link NetworkRegistry#registerConnectionHandler}.
+ * 1.4.7 entry point. FML 4.7 surface (pre-LaunchWrapper, pre-1.6 lifecycle):
+ * classes live under {@code cpw.mods.fml.*}, the lifecycle markers are
+ * {@code @Mod.Init} / {@code @Mod.PostInit} / {@code @Mod.ServerStarting} /
+ * {@code @Mod.ServerStopping} (the {@code @Mod.EventHandler} marker did not
+ * exist until FML 6/7 — spike-verified against the universal zip's
+ * {@code Mod$Init.class}), there is no GameProfile and no
+ * {@code @SubscribeEvent} — the pre-1.7 player join/leave surface is
+ * {@link IConnectionHandler}, registered via
+ * {@link NetworkRegistry#registerConnectionHandler}.
  *
  * <p>Skin storage stays UUID-keyed in :common via a lane-local username
  * bridge ({@link SkinRestorer#uuidOf(String)}): 1.4.7 has no player-resolvable
@@ -39,16 +45,33 @@ import net.minecraft.src.Packet1Login;
  * UUID from {@code getCommandSenderName()} and :common never sees a player
  * object (memory #1123 contract, unchanged).
  *
- * <p>Network surface: FML 4.7 {@code Packet250CustomPayload} custom-payload
- * channel, registered in {@link #init} via
- * {@code NetworkRegistry.instance().registerChannel(...)} — the channel name
- * {@code everlastingskins} is exactly 16 chars, at the 1.4.7 hard cap.
+ * <p>Network surface: JOINT jar (lib-5 Option B, PR #422) — the channel
+ * {@code everlastingskins} (exactly 16 chars, at the FML 4.7 hard cap) is
+ * registered by the {@link NetworkMod} joint pattern below, NOT by a manual
+ * {@code registerChannel}: FML's {@code NetworkModHandler.configureNetworkMod}
+ * registers the client spec ({@link ClientSkinHandler}) only when
+ * {@code FMLCommonHandler.instance().getSide().isClient()} and the server spec
+ * ({@link ServerPacketHandler}) on both sides (dispatch is side-separated via
+ * {@code NetworkRegistry.handlePacket}'s EntityPlayerMP check), so one jar
+ * declares both and each process runs only its own receiver.
+ *
+ * <p>Side guard: FML loads the jar on both processes, so {@link #init} keeps
+ * the server bootstrap behind {@code getSide().isServer()} — on a client the
+ * only client-side surface is the @NetworkMod-registered client handler.
  */
 @Mod(
     modid = EverlastingSkins.MOD_ID,
     name = EverlastingSkins.MOD_NAME,
     version = EverlastingSkins.VERSION,
     acceptedMinecraftVersions = "[1.4.7]"
+)
+@NetworkMod(
+    clientPacketHandlerSpec = @NetworkMod.SidedPacketHandler(
+        channels = {SkinBroadcaster.CHANNEL},
+        packetHandler = ClientSkinHandler.class),
+    serverPacketHandlerSpec = @NetworkMod.SidedPacketHandler(
+        channels = {SkinBroadcaster.CHANNEL},
+        packetHandler = ServerPacketHandler.class)
 )
 public class EverlastingSkins {
     public static final String MOD_ID = "everlastingskins";
@@ -59,12 +82,18 @@ public class EverlastingSkins {
 
     @Mod.Init
     public void init(FMLInitializationEvent event) {
+        if (!FMLCommonHandler.instance().getSide().isServer()) {
+            // Client process: the client handler is registered by @NetworkMod;
+            // no server bootstrap here (the physical side is authoritative —
+            // an integrated server's SERVER lifecycle still fires
+            // serverStarting/serverStopping below).
+            return;
+        }
         // :common removed init() — per-version bootstrap registers candidates
         // itself; highest priority wins (Forge ops 10 > vanilla fallback 0).
         ForgePermissionService.register();
-        // 1.4.7 skin-broadcast channel (FML 4.7 custom-payload surface).
-        SkinBroadcaster.init();
-        // Pre-1.7 player join/leave hook (no PlayerEvent on this line).
+        // Pre-1.7 player join/leave hook (no PlayerEvent on this line). The
+        // broadcast channel itself is owned by @NetworkMod.
         NetworkRegistry.instance().registerConnectionHandler(new ConnectionHandler());
     }
 

--- a/forge-1.4.7/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRestorer.java
+++ b/forge-1.4.7/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRestorer.java
@@ -38,8 +38,10 @@ import java.util.UUID;
  * <p>Restore mechanism: 1.4.7 has no GameProfile textures to inject — the
  * legacy skins.minecraft.net username-keyed path is dead (Mojang shutdown),
  * so the lane re-broadcasts the stored skin over the FML 4.7 channel on
- * login ({@link SkinBroadcaster}), the notification surface for companion
- * clients. This is the lane's net-new adapter logic (no sibling lane has it).
+ * login ({@link SkinBroadcaster}) with the REAL flattened PNG bytes (lib-5
+ * joint client side, PR #422): the companion client handler in the same jar
+ * decodes the payload and injects the pixels into the era renderer. This is
+ * the lane's net-new adapter logic (no sibling lane has it).
  *
  * <p>authlib is absent from the 1.4.7 server classpath (compile-only dep;
  * see build.gradle): the username-keyed restore path above never constructs
@@ -113,7 +115,8 @@ public final class SkinRestorer {
         UUID uuid = uuidOf(player.getCommandSenderName());
         CustomSkinProperty skin = s.getSkin(uuid);
         if (skin != null) {
-            SkinBroadcaster.broadcastProfileChange(player);
+            SkinBroadcaster.broadcastProfileChange(player.getCommandSenderName(),
+                SkinTextureFetcher.fetchLegacyPng(skin));
         }
     }
 
@@ -153,6 +156,23 @@ public final class SkinRestorer {
             return;
         }
         s.setSkin(uuid, skin);
+    }
+
+    /**
+     * Command-layer accessor: stores the skin AND broadcasts the real PNG
+     * bytes to all clients (live update — no re-login needed). Username-keyed
+     * variant of {@link #applySkin(UUID, CustomSkinProperty)}: 1.4.7 has no
+     * account UUID, the offline bridge derives the storage key.
+     */
+    public static void applySkin(String username, CustomSkinProperty skin) {
+        applySkin(uuidOf(username), skin);
+        if (skin == null || skin.isEmpty()) {
+            return; // cleared — nothing to render
+        }
+        byte[] png = SkinTextureFetcher.fetchLegacyPng(skin);
+        if (png != null) {
+            SkinBroadcaster.broadcastProfileChange(username, png);
+        }
     }
 
     /** Command-layer accessor: removes the stored skin. */

--- a/forge-1.4.7/src/main/java/levosilimo/everlastingskins/skinchanger/SkinTextureFetcher.java
+++ b/forge-1.4.7/src/main/java/levosilimo/everlastingskins/skinchanger/SkinTextureFetcher.java
@@ -1,0 +1,100 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import levosilimo.everlastingskins.client.ClientSkinApplier;
+import levosilimo.everlastingskins.util.CustomSkinProperty;
+import levosilimo.everlastingskins.util.PropertyUtils;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+/**
+ * Server-side skin texture fetch for the joint client broadcast (lib-5,
+ * PR #422): the server stores only the textures property (base64 JSON with a
+ * URL), so the PNG bytes must be fetched over HTTP before they can ride in
+ * the {@code SkinMessage} payload.
+ *
+ * <p>The :common {@code HttpClient} is JSON/String-body-only and frozen
+ * (shared by every lane), so this lane-local fetch is byte-returning and
+ * HTTPS-only, mirroring the :common client's policy including its
+ * {@code everlastingskins.allowHttp} test escape hatch. The 64x64 modern skin
+ * is flattened to the pre-1.7.8 64x32 model via
+ * {@link ClientSkinApplier#flattenToLegacy} so every client payload is
+ * already in the era renderer's native layout.
+ *
+ * <p>Fail-soft: any fetch/decode/encode failure returns null (the broadcast
+ * degrades to the legacy notification-only payload rather than crashing the
+ * command/login path).
+ */
+public final class SkinTextureFetcher {
+
+    private static final String USER_AGENT = "EverlastingSkins/1.4.7";
+    private static final int TIMEOUT_MS = 10000;
+
+    private SkinTextureFetcher() {}
+
+    /**
+     * Fetches the skin PNG from the property's texture URL and returns it
+     * flattened to the legacy 64x32 model, re-encoded as PNG. Null when the
+     * fetch/decode fails or the property has no skin URL.
+     */
+    public static byte[] fetchLegacyPng(CustomSkinProperty skin) {
+        try {
+            byte[] png = fetchBytes(PropertyUtils.getSkinTextureUrl(skin));
+            if (png == null) {
+                return null;
+            }
+            BufferedImage image = ClientSkinApplier.decode(png);
+            BufferedImage legacy = ClientSkinApplier.flattenToLegacy(image);
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            ImageIO.write(legacy, "png", bos);
+            return bos.toByteArray();
+        } catch (Exception e) {
+            System.err.println("EverlastingSkins: skin texture fetch failed: " + e);
+            return null;
+        }
+    }
+
+    private static byte[] fetchBytes(String urlString) throws IOException {
+        URL url = new URL(urlString);
+        // textures.minecraft.net is https; mirror the :common HttpClient's
+        // https-only policy with the same controlled-testing escape hatch.
+        if (!"https".equals(url.getProtocol()) && !Boolean.getBoolean("everlastingskins.allowHttp")) {
+            throw new IOException("Only HTTPS is supported: " + urlString);
+        }
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        try {
+            connection.setConnectTimeout(TIMEOUT_MS);
+            connection.setReadTimeout(TIMEOUT_MS);
+            connection.setRequestProperty("User-Agent", USER_AGENT);
+            int code = connection.getResponseCode();
+            if (code < 200 || code >= 300) {
+                throw new IOException("HTTP " + code + " for " + urlString);
+            }
+            InputStream in = connection.getInputStream();
+            try {
+                ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                byte[] buf = new byte[8192];
+                int n;
+                while ((n = in.read(buf)) > 0) {
+                    bos.write(buf, 0, n);
+                }
+                return bos.toByteArray();
+            } finally {
+                in.close();
+            }
+        } finally {
+            connection.disconnect();
+        }
+    }
+}

--- a/forge-1.4.7/src/test/java/levosilimo/everlastingskins/broadcast/SkinMessageTest.java
+++ b/forge-1.4.7/src/test/java/levosilimo/everlastingskins/broadcast/SkinMessageTest.java
@@ -8,6 +8,8 @@ package levosilimo.everlastingskins.broadcast;
 
 import org.junit.Test;
 
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
 import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -68,6 +70,38 @@ public class SkinMessageTest {
     @Test(expected = IllegalArgumentException.class)
     public void malformedPayloadThrows() {
         SkinMessage.decode(new byte[]{0, 1, 2, 3});
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void malformedNameLengthRejectedBeforeAllocation() throws Exception {
+        // nameLen = 2^31-1: the bounds guard must reject it (an
+        // IllegalArgumentException the client handler catches), not
+        // allocate ~2 GiB and OOM the packet thread (lib-18 audit).
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        new DataOutputStream(bos).writeInt(Integer.MAX_VALUE);
+        SkinMessage.decode(bos.toByteArray());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void negativeNameLengthRejectedBeforeAllocation() throws Exception {
+        // nameLen = -1 (unsigned 0xFFFFFFFF): the len >= 0 half of the guard.
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        new DataOutputStream(bos).writeInt(-1);
+        SkinMessage.decode(bos.toByteArray());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void malformedPngLengthRejectedBeforeAllocation() throws Exception {
+        // pngLen = 2^31-1: the bounds guard must reject it before the
+        // allocation (lib-18 audit).
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bos);
+        byte[] name = "Legacy".getBytes(StandardCharsets.UTF_8);
+        out.writeInt(name.length);
+        out.write(name);
+        out.writeInt(Integer.MAX_VALUE);
+        out.flush();
+        SkinMessage.decode(bos.toByteArray());
     }
 
     @Test

--- a/forge-1.4.7/src/test/java/levosilimo/everlastingskins/broadcast/SkinMessageTest.java
+++ b/forge-1.4.7/src/test/java/levosilimo/everlastingskins/broadcast/SkinMessageTest.java
@@ -13,6 +13,7 @@ import java.nio.charset.StandardCharsets;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * 1.4.7 broadcast payload tests (pure Java — no server, no netty).
@@ -35,6 +36,23 @@ public class SkinMessageTest {
     @Test
     public void encodeDecodeRoundTripsWithPng() {
         byte[] png = new byte[]{1, 2, 3, 4, 5};
+        SkinMessage message = SkinMessage.decode(SkinMessage.encode("Steve", png));
+        assertEquals("Steve", message.getPlayerName());
+        assertArrayEquals(png, message.getTexturePng());
+    }
+
+    @Test
+    public void encodeDecodeRoundTripsRealPngBytes() throws Exception {
+        // A real PNG payload (the joint client broadcast now carries actual
+        // texture bytes — lib-5, PR #422), well under the 32766-byte
+        // Packet250CustomPayload cap (MC-16910).
+        java.awt.image.BufferedImage image =
+            new java.awt.image.BufferedImage(64, 32, java.awt.image.BufferedImage.TYPE_INT_ARGB);
+        java.io.ByteArrayOutputStream bos = new java.io.ByteArrayOutputStream();
+        javax.imageio.ImageIO.write(image, "png", bos);
+        byte[] png = bos.toByteArray();
+        assertTrue(png.length < 32766);
+
         SkinMessage message = SkinMessage.decode(SkinMessage.encode("Steve", png));
         assertEquals("Steve", message.getPlayerName());
         assertArrayEquals(png, message.getTexturePng());

--- a/forge-1.4.7/src/test/java/levosilimo/everlastingskins/client/ClientSkinApplierTest.java
+++ b/forge-1.4.7/src/test/java/levosilimo/everlastingskins/client/ClientSkinApplierTest.java
@@ -1,0 +1,149 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.client;
+
+import net.minecraft.src.EntityPlayer;
+import net.minecraft.src.IImageBuffer;
+import net.minecraft.src.ImageBufferDownload;
+import net.minecraft.src.ThreadDownloadImageData;
+import net.minecraft.src.World;
+import org.junit.Test;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * 1.5.2 client-side skin applier tests (lib-5 joint client side): pure-Java
+ * decode/flatten/findPlayer plus the TDI injection surface, with mocked
+ * client classes (mockito + reflection setField, mirroring the lane's
+ * existing test pattern — memory #1115: no live client, no GL).
+ */
+public class ClientSkinApplierTest {
+
+    @Test
+    public void decodeReturnsPngPixels() throws Exception {
+        BufferedImage source = solid(4, 4, 0xFF112233);
+        BufferedImage decoded = ClientSkinApplier.decode(png(source));
+        assertNotNull(decoded);
+        assertEquals(4, decoded.getWidth());
+        assertEquals(0xFF112233, decoded.getRGB(2, 2));
+    }
+
+    @Test(expected = java.io.IOException.class)
+    public void decodeRejectsGarbage() throws Exception {
+        ClientSkinApplier.decode(new byte[]{1, 2, 3});
+    }
+
+    @Test
+    public void flattenPassesLegacy64x32Through() {
+        BufferedImage legacy = solid(64, 32, 0xFF445566);
+        assertSame(legacy, ClientSkinApplier.flattenToLegacy(legacy));
+    }
+
+    @Test
+    public void flattenCropsModern64x64ToTopHalf() {
+        // 64x64 modern skin: the top half IS the legacy 64x32 layout; the
+        // bottom-left regions (left arm / left leg) are dropped because the
+        // pre-1.8 model mirrors the left limbs from the right-limb regions.
+        BufferedImage modern = new BufferedImage(64, 64, BufferedImage.TYPE_INT_ARGB);
+        for (int x = 0; x < 64; x++) {
+            for (int y = 0; y < 64; y++) {
+                modern.setRGB(x, y, 0xFF000000);
+            }
+        }
+        modern.setRGB(10, 10, 0xFFAA0000); // head region — kept
+        modern.setRGB(5, 25, 0xFF00BB00);  // right leg region — kept
+        modern.setRGB(45, 55, 0xFF0000CC); // left arm region — dropped
+
+        BufferedImage legacy = ClientSkinApplier.flattenToLegacy(modern);
+
+        assertEquals(64, legacy.getWidth());
+        assertEquals(32, legacy.getHeight());
+        assertEquals(0xFFAA0000, legacy.getRGB(10, 10));
+        assertEquals(0xFF00BB00, legacy.getRGB(5, 25));
+        // The dropped region must not leak into the canvas.
+        assertEquals(0xFF000000, legacy.getRGB(45, 25));
+    }
+
+    @Test
+    public void flattenDraws32x32UnscaledLikeVanilla() {
+        BufferedImage small = solid(32, 32, 0xFF123456);
+        small.setRGB(8, 8, 0xFFAABBCC);
+        BufferedImage legacy = ClientSkinApplier.flattenToLegacy(small);
+        assertEquals(64, legacy.getWidth());
+        assertEquals(32, legacy.getHeight());
+        assertEquals(0xFFAABBCC, legacy.getRGB(8, 8));
+        assertEquals(0xFF123456, legacy.getRGB(20, 20));
+    }
+
+    @Test
+    public void findPlayerMatchesByCommandSenderName() throws Exception {
+        World world = mock(World.class);
+        EntityPlayer notch = mock(EntityPlayer.class);
+        when(notch.getCommandSenderName()).thenReturn("Notch");
+        EntityPlayer steve = mock(EntityPlayer.class);
+        when(steve.getCommandSenderName()).thenReturn("Steve");
+        setField(world, "playerEntities", Arrays.asList(notch, steve));
+
+        assertSame(notch, ClientSkinApplier.findPlayer(world, "Notch"));
+        assertSame(steve, ClientSkinApplier.findPlayer(world, "Steve"));
+    }
+
+    @Test
+    public void findPlayerReturnsNullForUnknownOrEmptyWorld() throws Exception {
+        World world = mock(World.class);
+        setField(world, "playerEntities", Collections.emptyList());
+        assertNull(ClientSkinApplier.findPlayer(world, "Notch"));
+        assertNull(ClientSkinApplier.findPlayer(null, "Notch"));
+    }
+
+    @Test
+    public void applyWritesPublicImageFieldAndResetsUploadFlag() {
+        // Real TDI from the deobf'd client jar (no GL involved in the write).
+        ThreadDownloadImageData tdi = new ThreadDownloadImageData(
+            "https://example.invalid/skin.png", new ImageBufferDownload());
+        BufferedImage image = solid(64, 32, 0xFF010203);
+
+        ClientSkinApplier.apply(tdi, image);
+
+        assertSame(image, tdi.image);
+        assertEquals(false, tdi.textureSetupComplete);
+    }
+
+    private static void setField(Object target, String name, Object value) throws Exception {
+        Field field = target.getClass().getField(name);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    private static BufferedImage solid(int width, int height, int argb) {
+        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+        for (int x = 0; x < width; x++) {
+            for (int y = 0; y < height; y++) {
+                image.setRGB(x, y, argb);
+            }
+        }
+        return image;
+    }
+
+    private static byte[] png(BufferedImage image) throws Exception {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ImageIO.write(image, "png", bos);
+        return bos.toByteArray();
+    }
+}

--- a/forge-1.4.7/src/test/java/levosilimo/everlastingskins/skinchanger/SkinTextureFetcherTest.java
+++ b/forge-1.4.7/src/test/java/levosilimo/everlastingskins/skinchanger/SkinTextureFetcherTest.java
@@ -1,0 +1,135 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import com.sun.net.httpserver.HttpServer;
+import levosilimo.everlastingskins.util.CustomSkinProperty;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * 1.6.4 server-side skin texture fetch tests (lib-5 joint broadcast): the
+ * textures property is fetched over HTTP, decoded and flattened to the legacy
+ * 64x32 model. Deterministic fixtures only (memory #1115) — an in-process
+ * HttpServer serves a generated PNG on localhost; the lane-local fetch's
+ * {@code everlastingskins.allowHttp} escape hatch mirrors the :common
+ * client's controlled-testing policy.
+ */
+public class SkinTextureFetcherTest {
+
+    private HttpServer server;
+    private String baseUrl;
+
+    @Before
+    public void setUp() throws Exception {
+        System.setProperty("everlastingskins.allowHttp", "true");
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.start();
+        baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        System.clearProperty("everlastingskins.allowHttp");
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    public void fetchesAndFlattensModern64x64Skin() throws Exception {
+        BufferedImage modern = new BufferedImage(64, 64, BufferedImage.TYPE_INT_ARGB);
+        for (int x = 0; x < 64; x++) {
+            for (int y = 0; y < 64; y++) {
+                modern.setRGB(x, y, 0xFF445566);
+            }
+        }
+        modern.setRGB(10, 10, 0xFFAA0000);
+        serve("/skin64.png", png(modern));
+
+        byte[] result = SkinTextureFetcher.fetchLegacyPng(property("textures", baseUrl + "/skin64.png"));
+
+        assertNotNull(result);
+        BufferedImage flattened = ImageIO.read(new java.io.ByteArrayInputStream(result));
+        assertEquals(64, flattened.getWidth());
+        assertEquals(32, flattened.getHeight());
+        assertEquals(0xFFAA0000, flattened.getRGB(10, 10));
+    }
+
+    @Test
+    public void passesLegacy64x32Through() throws Exception {
+        serve("/skin32.png", png(new BufferedImage(64, 32, BufferedImage.TYPE_INT_ARGB)));
+
+        byte[] result = SkinTextureFetcher.fetchLegacyPng(property("textures", baseUrl + "/skin32.png"));
+
+        assertNotNull(result);
+        BufferedImage flattened = ImageIO.read(new java.io.ByteArrayInputStream(result));
+        assertEquals(64, flattened.getWidth());
+        assertEquals(32, flattened.getHeight());
+    }
+
+    @Test
+    public void httpStatusErrorYieldsNull() throws Exception {
+        serve("/missing.png", new byte[]{1, 2, 3});
+        server.createContext("/missing404", exchange -> {
+            exchange.sendResponseHeaders(404, -1);
+            exchange.close();
+        });
+
+        byte[] result = SkinTextureFetcher.fetchLegacyPng(property("textures", baseUrl + "/missing404"));
+
+        assertNull(result);
+    }
+
+    @Test
+    public void httpsOnlyWithoutEscapeHatch() throws Exception {
+        System.clearProperty("everlastingskins.allowHttp");
+        byte[] result = SkinTextureFetcher.fetchLegacyPng(property("textures", baseUrl + "/skin64.png"));
+        assertNull(result);
+    }
+
+    @Test
+    public void undecodableBodyYieldsNull() throws Exception {
+        serve("/garbage.png", new byte[]{0, 1, 2, 3, 4, 5});
+        byte[] result = SkinTextureFetcher.fetchLegacyPng(property("textures", baseUrl + "/garbage.png"));
+        assertNull(result);
+    }
+
+    private void serve(String path, byte[] body) {
+        server.createContext(path, exchange -> {
+            byte[] payload = body;
+            exchange.sendResponseHeaders(200, payload.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(payload);
+            }
+        });
+    }
+
+    /** Textures property whose base64 value is the JSON {"textures":{"SKIN":{"url":...}}}. */
+    private static CustomSkinProperty property(String name, String url) {
+        String json = "{\"textures\":{\"SKIN\":{\"url\":\"" + url + "\"}}}";
+        String value = java.util.Base64.getEncoder().encodeToString(json.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        return new CustomSkinProperty(name, value, null, "test");
+    }
+
+    private static byte[] png(BufferedImage image) throws Exception {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ImageIO.write(image, "png", bos);
+        return bos.toByteArray();
+    }
+}

--- a/forge-1.5.2/build.gradle
+++ b/forge-1.5.2/build.gradle
@@ -80,6 +80,16 @@ ext {
             [name: 'minecraft_server.1.5.2.jar',
              url: 'https://launcher.mojang.com/v1/objects/f9ae3f651319151ce99a0bfad6b34fa16eb6775f/server.jar',
              algo: 'SHA-1', digest: 'f9ae3f651319151ce99a0bfad6b34fa16eb6775f'],
+            // Joint client-side jar (lib-5 design, PR #422): the mod is no
+            // longer serverSideOnly — the same jar carries a client packet
+            // handler that injects skin PNGs into the era renderer. The vanilla
+            // CLIENT jar is vendored + deobf'd (harness clientInput) and added
+            // to the compile classpath after the server-first merged jar.
+            // sha1 verified against launcher.mojang.com version_manifest 1.5.2
+            // (downloads.client.sha1).
+            [name: 'minecraft_client.1.5.2.jar',
+             url: 'https://launcher.mojang.com/v1/objects/465378c9dc2f779ae1d6e8046ebc46fb53a57968/client.jar',
+             algo: 'SHA-1', digest: '465378c9dc2f779ae1d6e8046ebc46fb53a57968'],
         ],
         mcpVersion: '7.51',
         archiveBaseName: 'everlastingskins-1.5.2',

--- a/forge-1.5.2/src/main/java/levosilimo/everlastingskins/broadcast/ClientSkinHandler.java
+++ b/forge-1.5.2/src/main/java/levosilimo/everlastingskins/broadcast/ClientSkinHandler.java
@@ -1,0 +1,81 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.broadcast;
+
+import cpw.mods.fml.common.network.IPacketHandler;
+import cpw.mods.fml.common.network.Player;
+import levosilimo.everlastingskins.client.ClientSkinApplier;
+import net.minecraft.client.Minecraft;
+import net.minecraft.src.EntityPlayer;
+import net.minecraft.src.IImageBuffer;
+import net.minecraft.src.INetworkManager;
+import net.minecraft.src.ImageBufferDownload;
+import net.minecraft.src.Packet250CustomPayload;
+import net.minecraft.src.ThreadDownloadImageData;
+
+import java.awt.image.BufferedImage;
+
+/**
+ * 1.5.2 client-side skin receiver (lib-5 Option B: joint client side inside
+ * the same jar). Registered by the {@code @NetworkMod} joint pattern
+ * (clientPacketHandlerSpec on the @Mod class — FML registers the client spec
+ * only on a client process, so the same jar works on both sides).
+ *
+ * <p>Decodes the existing {@link SkinMessage} wire format and injects the PNG
+ * into the player's skin {@link ThreadDownloadImageData} via
+ * {@link ClientSkinApplier} — no ASM. The player is resolved by name from
+ * {@code World.playerEntities} (1.5.2 has no UUID on the wire); the cached
+ * TDI is looked up by the player's {@code skinUrl} through
+ * {@code RenderEngine.obtainImageData} (the cache keyed by skin URL, seeded
+ * by {@code RenderGlobal.updateEntitySkin} when the entity spawned).
+ *
+ * <p>Re-injection on join: the server re-broadcasts the stored skin on every
+ * login, so a packet that arrives before the player entity spawns is simply
+ * dropped here (the join broadcast re-delivers it). Caveat (documented, not
+ * hardened): if the vanilla skin-download thread completes AFTER the
+ * injection, it overwrites the pixels with the default skin — the ASM
+ * hardening that would prevent this (shielding the download) is a future
+ * upgrade, out of scope.
+ */
+public final class ClientSkinHandler implements IPacketHandler {
+
+    @Override
+    public void onPacketData(INetworkManager manager, Packet250CustomPayload packet, Player player) {
+        try {
+            SkinMessage message = SkinMessage.decode(packet.data);
+            byte[] png = message.getTexturePng();
+            if (png == null) {
+                // Notification-only broadcast from a pre-joint server.
+                return;
+            }
+            Minecraft mc = Minecraft.getMinecraft();
+            if (mc.theWorld == null) {
+                return;
+            }
+            EntityPlayer target = ClientSkinApplier.findPlayer(mc.theWorld, message.getPlayerName());
+            if (target == null) {
+                // Not spawned yet — the join broadcast re-delivers.
+                return;
+            }
+            String skinUrl = target.skinUrl;
+            if (skinUrl == null) {
+                return;
+            }
+            ThreadDownloadImageData imageData = mc.renderEngine.obtainImageData(skinUrl, new ImageBufferDownload());
+            if (imageData == null) {
+                return;
+            }
+            BufferedImage image = ClientSkinApplier.flattenToLegacy(ClientSkinApplier.decode(png));
+            ClientSkinApplier.apply(imageData, image);
+            // textureSetupComplete=false makes the next render pass re-upload
+            // the injected pixels into the existing GL texture.
+        } catch (Exception e) {
+            // Never crash the network thread on a malformed/undecodable payload.
+            System.err.println("EverlastingSkins: client skin apply failed: " + e);
+        }
+    }
+}

--- a/forge-1.5.2/src/main/java/levosilimo/everlastingskins/broadcast/ServerPacketHandler.java
+++ b/forge-1.5.2/src/main/java/levosilimo/everlastingskins/broadcast/ServerPacketHandler.java
@@ -1,0 +1,27 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.broadcast;
+
+import cpw.mods.fml.common.network.IPacketHandler;
+import cpw.mods.fml.common.network.Player;
+import net.minecraft.src.INetworkManager;
+import net.minecraft.src.Packet250CustomPayload;
+
+/**
+ * 1.5.2 server-side receiver for the {@code everlastingskins} channel,
+ * referenced by the {@code @NetworkMod} joint pattern
+ * (serverPacketHandlerSpec). FML dispatches server-side custom payloads to
+ * the server handler (registered with Side.SERVER) and client-side payloads
+ * to {@link ClientSkinHandler} — both handlers live in the same jar.
+ */
+public final class ServerPacketHandler implements IPacketHandler {
+
+    @Override
+    public void onPacketData(INetworkManager manager, Packet250CustomPayload packet, Player player) {
+        // No client→server traffic on this channel.
+    }
+}

--- a/forge-1.5.2/src/main/java/levosilimo/everlastingskins/broadcast/SkinBroadcaster.java
+++ b/forge-1.5.2/src/main/java/levosilimo/everlastingskins/broadcast/SkinBroadcaster.java
@@ -6,62 +6,49 @@
 
 package levosilimo.everlastingskins.broadcast;
 
-import cpw.mods.fml.common.network.IPacketHandler;
-import cpw.mods.fml.common.network.NetworkRegistry;
 import cpw.mods.fml.common.network.PacketDispatcher;
-import cpw.mods.fml.common.network.Player;
-import net.minecraft.src.EntityPlayer;
-import net.minecraft.src.INetworkManager;
 import net.minecraft.src.Packet;
-import net.minecraft.src.Packet250CustomPayload;
 
 /**
  * 1.5.2 skin-broadcast channel (FML 5.2 custom-payload surface).
  *
  * <p>FML 5.2 has no netty {@code SimpleNetworkWrapper} (that is 1.8+) and no
- * {@code newChannel} on {@link NetworkRegistry} — the 1.5.2 surface is
- * {@code NetworkRegistry.instance().registerChannel(IPacketHandler, String)}
- * with {@link Packet250CustomPayload} payloads, sent via
- * {@link PacketDispatcher}. The channel name must be ≤ 16 chars
- * (NetworkRegistry.java:99-105 throws beyond that); {@code everlastingskins}
- * is exactly 16 — at the ceiling, never lengthen it.
+ * {@code newChannel} — the 1.5.2 surface is {@code Packet250CustomPayload}
+ * payloads, sent via {@link PacketDispatcher}. The channel name must be
+ * ≤ 16 chars (NetworkRegistry.java throws beyond that);
+ * {@code everlastingskins} is exactly 16 — at the ceiling, never lengthen it.
  *
- * <p>Payloads carry the target player's username
- * ({@link SkinMessage#encode(String, byte[])}); the client-side handler would
- * re-fetch the skin (server-side mod: the channel is the notification
- * surface, matching the sibling lanes' broadcast contract). The registered
- * {@link IPacketHandler} is a server-side no-op — 1.5.2 clients never send
- * on this channel.
+ * <p>CHANNEL OWNERSHIP: since the joint client side landed (lib-5, PR #422)
+ * the channel is registered by the {@code @NetworkMod} joint pattern on the
+ * @Mod class — {@link ClientSkinHandler} on client processes,
+ * {@link ServerPacketHandler} on server processes — NOT by a manual
+ * {@code registerChannel} here (a universal no-op registration would shadow
+ * the client-side dispatch). {@link #broadcastProfileChange} only sends.
+ *
+ * <p>Payloads carry the target player's username AND the flattened 64x32 PNG
+ * bytes ({@link SkinMessage#encode(String, byte[])}); the client handler
+ * decodes and injects the pixels. Payload cap: 32766 bytes
+ * (Packet250CustomPayload 2-byte length, MC-16910) — a flattened 64x32 PNG is
+ * ≈ 1-4 KB, far under the cap; oversized payloads are dropped defensively.
  */
 public final class SkinBroadcaster {
 
     public static final String CHANNEL = "everlastingskins";
 
-    private static volatile boolean registered;
+    /** Packet250CustomPayload 2-byte length cap (MC-16910). */
+    private static final int MAX_PAYLOAD_BYTES = 32766;
 
     private SkinBroadcaster() {}
 
-    /** Registers the channel; safe to call once per JVM (idempotent). */
-    public static void init() {
-        if (registered) {
+    /** Broadcasts a skin-change payload for {@code playerName} to all players. */
+    public static void broadcastProfileChange(String playerName, byte[] pngBytes) {
+        byte[] payload = SkinMessage.encode(playerName, pngBytes);
+        if (payload.length > MAX_PAYLOAD_BYTES) {
+            System.err.println("EverlastingSkins: skin payload for '" + playerName
+                + "' exceeds " + MAX_PAYLOAD_BYTES + " bytes — dropped");
             return;
         }
-        NetworkRegistry.instance().registerChannel(new ServerPacketHandler(), CHANNEL);
-        registered = true;
-    }
-
-    /** Broadcasts a skin-change notification for {@code target} to all players. */
-    public static void broadcastProfileChange(EntityPlayer target) {
-        byte[] payload = SkinMessage.encode(target.getCommandSenderName(), null);
         Packet packet = PacketDispatcher.getPacket(CHANNEL, payload);
         PacketDispatcher.sendPacketToAllPlayers(packet);
-    }
-
-    /** Server-side no-op: the mod is serverSideOnly (FML 5.2). */
-    private static final class ServerPacketHandler implements IPacketHandler {
-        @Override
-        public void onPacketData(INetworkManager manager, Packet250CustomPayload packet, Player player) {
-            // No client→server traffic on this channel.
-        }
     }
 }

--- a/forge-1.5.2/src/main/java/levosilimo/everlastingskins/broadcast/SkinMessage.java
+++ b/forge-1.5.2/src/main/java/levosilimo/everlastingskins/broadcast/SkinMessage.java
@@ -45,6 +45,12 @@ public final class SkinMessage {
     /**
      * Wire format: [utf8 username][int png length][png bytes]. A null PNG
      * encodes as length 0 (notification-only broadcast).
+     *
+     * <p>Every length prefix is bounds-checked against the remaining unread
+     * payload BEFORE allocation ({@link #checkLength}), so a corrupted or
+     * malicious prefix fails with {@link IllegalArgumentException} instead
+     * of an {@link OutOfMemoryError} on the packet thread (lib-18 audit
+     * remediation).
      */
     public static byte[] encode(String playerName, byte[] texturePng) {
         try {
@@ -70,9 +76,11 @@ public final class SkinMessage {
         try {
             DataInputStream in = new DataInputStream(new ByteArrayInputStream(payload));
             int nameLen = in.readInt();
+            checkLength(nameLen, payload.length - 4, "name");
             byte[] name = new byte[nameLen];
             in.readFully(name);
             int pngLen = in.readInt();
+            checkLength(pngLen, payload.length - 8 - nameLen, "png");
             byte[] png = null;
             if (pngLen > 0) {
                 png = new byte[pngLen];
@@ -81,6 +89,20 @@ public final class SkinMessage {
             return new SkinMessage(new String(name, StandardCharsets.UTF_8), png);
         } catch (IOException e) {
             throw new IllegalArgumentException("Malformed SkinMessage payload", e);
+        }
+    }
+
+    /**
+     * Bounds guard for a length-prefixed field: rejects any length prefix
+     * that is negative or exceeds the remaining unread payload BEFORE the
+     * array allocation. The client handler catches
+     * {@link IllegalArgumentException}; an {@link OutOfMemoryError} would
+     * escape {@code catch (Exception)} and kill the network thread.
+     */
+    private static void checkLength(int len, int remaining, String field) {
+        if (len < 0 || len > remaining) {
+            throw new IllegalArgumentException("Malformed SkinMessage payload: " + field
+                + " length " + len + " exceeds remaining " + remaining + " bytes");
         }
     }
 }

--- a/forge-1.5.2/src/main/java/levosilimo/everlastingskins/client/ClientSkinApplier.java
+++ b/forge-1.5.2/src/main/java/levosilimo/everlastingskins/client/ClientSkinApplier.java
@@ -1,0 +1,92 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.client;
+
+import levosilimo.everlastingskins.skinchanger.TextureDecoder;
+import net.minecraft.src.EntityPlayer;
+import net.minecraft.src.ThreadDownloadImageData;
+import net.minecraft.src.World;
+
+import java.awt.Graphics;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+
+/**
+ * Pure-Java client-side skin application for the 1.5.2 lane (lib-5 Option B:
+ * the joint jar carries a client handler that makes skins ACTUALLY RENDER on
+ * pre-1.8 clients). Decode / flatten / apply are separated from the network
+ * and renderer bindings so they are unit-testable without a client.
+ *
+ * <p>Flatten contract: the 1.5.2 renderer uses the legacy 64x32 model whose
+ * left limbs MIRROR the right-limb regions (ModelBiped samples both arms from
+ * textureOffset(40,16) and both legs from (0,16) — spike-verified against the
+ * vanilla client jar). The correct 64x64 → 64x32 conversion is therefore the
+ * vanilla crop (1.5.2 {@code ImageBufferDownload.parseUserSkin} draws the
+ * source unscaled at (0,0)): the modern top half IS the legacy layout, and the
+ * modern bottom-left regions (left arm / left leg) are dropped.
+ */
+public final class ClientSkinApplier {
+
+    private ClientSkinApplier() {}
+
+    /**
+     * Decodes PNG bytes into an ARGB {@link BufferedImage}.
+     *
+     * @throws IOException if the bytes are not a decodable image
+     */
+    public static BufferedImage decode(byte[] png) throws IOException {
+        return TextureDecoder.decode(png);
+    }
+
+    /**
+     * Converts any skin to the legacy 64x32 model. 64x32 (and smaller-height
+     * 64-wide) inputs pass through unchanged; a 64x64 modern skin is cropped
+     * to its top half (vanilla 1.5.2 parity); any other size is drawn
+     * unscaled at (0,0) exactly like the vanilla download pipeline.
+     */
+    public static BufferedImage flattenToLegacy(BufferedImage source) {
+        if (source.getWidth() == 64 && source.getHeight() <= 32) {
+            return source;
+        }
+        BufferedImage legacy = new BufferedImage(64, 32, BufferedImage.TYPE_INT_ARGB);
+        Graphics g = legacy.getGraphics();
+        g.drawImage(source, 0, 0, null);
+        g.dispose();
+        return legacy;
+    }
+
+    /**
+     * Finds a spawned player by {@code getCommandSenderName()} in the client
+     * world ({@code World.playerEntities}), or null when not spawned yet.
+     */
+    public static EntityPlayer findPlayer(World world, String playerName) {
+        if (world == null || world.playerEntities == null) {
+            return null;
+        }
+        for (Object o : world.playerEntities) {
+            if (o instanceof EntityPlayer) {
+                EntityPlayer candidate = (EntityPlayer) o;
+                if (candidate.getCommandSenderName().equals(playerName)) {
+                    return candidate;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Injects the flattened image into the player's skin
+     * {@link ThreadDownloadImageData}. 1.5.2 (MCP 7.51) exposes the image as
+     * the PUBLIC field {@code image}; resetting {@code textureSetupComplete}
+     * makes {@code RenderEngine.getTextureForDownloadableImage} re-upload the
+     * new pixels into the existing GL texture on the next render pass.
+     */
+    public static void apply(ThreadDownloadImageData target, BufferedImage image) {
+        target.image = image;
+        target.textureSetupComplete = false;
+    }
+}

--- a/forge-1.5.2/src/main/java/levosilimo/everlastingskins/command/SkinRestorerCommand.java
+++ b/forge-1.5.2/src/main/java/levosilimo/everlastingskins/command/SkinRestorerCommand.java
@@ -181,8 +181,10 @@ public class SkinRestorerCommand implements ICommand {
         if (!checkPermission(sender, targetsAreSelfOnly(sender, targets) ? NODE_SKIN : NODE_SKIN_OTHER)) {
             return;
         }
+        // #426: the broadcast is keyed by the TARGET player's name (the entity
+        // clients render), not the skin source's — real-PNG live update.
         for (EntityPlayerMP target : targets) {
-            setSkin(sender, SkinRestorer.uuidOf(target.getCommandSenderName()), args[1]);
+            setSkin(sender, SkinRestorer.uuidOf(target.getCommandSenderName()), target.getCommandSenderName(), args[1]);
         }
     }
 
@@ -214,7 +216,7 @@ public class SkinRestorerCommand implements ICommand {
             return;
         }
         for (EntityPlayerMP target : targets) {
-            setSkin(sender, SkinRestorer.uuidOf(target.getCommandSenderName()), username);
+            setSkin(sender, SkinRestorer.uuidOf(target.getCommandSenderName()), target.getCommandSenderName(), username);
         }
     }
 
@@ -309,7 +311,7 @@ public class SkinRestorerCommand implements ICommand {
             MetricsFormat.human(SkinMetrics.INSTANCE.snapshot()));
     }
 
-    private void setSkin(ICommandSender sender, UUID uuid, String username) {
+    private void setSkin(ICommandSender sender, UUID uuid, String targetName, String username) {
         // 1.5.2 has no per-player permission nodes beyond the op model; the
         // vanilla Mojang lookup is the only authoritative source (no
         // MineSkin/URL generation on this legacy surface).
@@ -328,7 +330,11 @@ public class SkinRestorerCommand implements ICommand {
         }
         CustomSkinProperty skin = result.get().skinProperty();
         seenProfiles.put(username, skin);
-        SkinRestorer.applySkin(uuid, skin);
+        // Username-keyed variant: stores the skin AND broadcasts the real PNG
+        // bytes to all clients (lib-5 joint client side — live update). The
+        // broadcast is keyed by the TARGET player's name (the entity clients
+        // render), not the skin source's.
+        SkinRestorer.applySkin(targetName, skin);
         SkinMetrics.INSTANCE.recordRefreshCompleted(uuid, startNanos, System.nanoTime() - startNanos, 0, 0);
         sender.sendChatToPlayer("Skin applied.");
     }

--- a/forge-1.5.2/src/main/java/levosilimo/everlastingskins/forge152/EverlastingSkins.java
+++ b/forge-1.5.2/src/main/java/levosilimo/everlastingskins/forge152/EverlastingSkins.java
@@ -6,13 +6,17 @@
 
 package levosilimo.everlastingskins.forge152;
 
+import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLServerStartingEvent;
 import cpw.mods.fml.common.event.FMLServerStoppingEvent;
 import cpw.mods.fml.common.network.IConnectionHandler;
+import cpw.mods.fml.common.network.NetworkMod;
 import cpw.mods.fml.common.network.NetworkRegistry;
 import cpw.mods.fml.common.network.Player;
+import levosilimo.everlastingskins.broadcast.ClientSkinHandler;
+import levosilimo.everlastingskins.broadcast.ServerPacketHandler;
 import levosilimo.everlastingskins.broadcast.SkinBroadcaster;
 import levosilimo.everlastingskins.permission.forge.ForgePermissionService;
 import levosilimo.everlastingskins.skinchanger.SkinRestorer;
@@ -41,16 +45,33 @@ import net.minecraft.src.Packet1Login;
  * UUID from {@code getCommandSenderName()} and :common never sees a player
  * object (memory #1123 contract, unchanged).
  *
- * <p>Network surface: FML 5.2 {@code Packet250CustomPayload} custom-payload
- * channel, registered in {@link #init} via
- * {@code NetworkRegistry.instance().registerChannel(...)} — the channel name
- * {@code everlastingskins} is exactly 16 chars, at the FML 5.2 hard cap.
+ * <p>Network surface: JOINT jar (lib-5 Option B, PR #422) — the channel
+ * {@code everlastingskins} (exactly 16 chars, at the FML 5.2 hard cap) is
+ * registered by the {@link NetworkMod} joint pattern below, NOT by a manual
+ * {@code registerChannel}: FML's {@code NetworkModHandler.configureNetworkMod}
+ * registers the client spec ({@link ClientSkinHandler}) only when
+ * {@code FMLCommonHandler.instance().getSide().isClient()} and the server spec
+ * ({@link ServerPacketHandler}) on both sides (dispatch is side-separated via
+ * {@code NetworkRegistry.handlePacket}'s EntityPlayerMP check), so one jar
+ * declares both and each process runs only its own receiver.
+ *
+ * <p>Side guard: FML loads the jar on both processes, so {@link #init} keeps
+ * the server bootstrap behind {@code getSide().isServer()} — on a client the
+ * only client-side surface is the @NetworkMod-registered client handler.
  */
 @Mod(
     modid = EverlastingSkins.MOD_ID,
     name = EverlastingSkins.MOD_NAME,
     version = EverlastingSkins.VERSION,
     acceptedMinecraftVersions = "[1.5.2]"
+)
+@NetworkMod(
+    clientPacketHandlerSpec = @NetworkMod.SidedPacketHandler(
+        channels = {SkinBroadcaster.CHANNEL},
+        packetHandler = ClientSkinHandler.class),
+    serverPacketHandlerSpec = @NetworkMod.SidedPacketHandler(
+        channels = {SkinBroadcaster.CHANNEL},
+        packetHandler = ServerPacketHandler.class)
 )
 public class EverlastingSkins {
     public static final String MOD_ID = "everlastingskins";
@@ -61,12 +82,18 @@ public class EverlastingSkins {
 
     @Mod.Init
     public void init(FMLInitializationEvent event) {
+        if (!FMLCommonHandler.instance().getSide().isServer()) {
+            // Client process: the client handler is registered by @NetworkMod;
+            // no server bootstrap here (the physical side is authoritative —
+            // an integrated server's SERVER lifecycle still fires
+            // serverStarting/serverStopping below).
+            return;
+        }
         // :common removed init() — per-version bootstrap registers candidates
         // itself; highest priority wins (Forge ops 10 > vanilla fallback 0).
         ForgePermissionService.register();
-        // 1.5.2 skin-broadcast channel (FML 5.2 custom-payload surface).
-        SkinBroadcaster.init();
-        // Pre-1.7 player join/leave hook (no PlayerEvent on this line).
+        // Pre-1.7 player join/leave hook (no PlayerEvent on this line). The
+        // broadcast channel itself is owned by @NetworkMod.
         NetworkRegistry.instance().registerConnectionHandler(new ConnectionHandler());
     }
 

--- a/forge-1.5.2/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRestorer.java
+++ b/forge-1.5.2/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRestorer.java
@@ -38,8 +38,10 @@ import java.util.UUID;
  * <p>Restore mechanism: 1.5.2 has no GameProfile textures to inject — the
  * legacy skins.minecraft.net username-keyed path is dead (Mojang shutdown),
  * so the lane re-broadcasts the stored skin over the FML 5.2 channel on
- * login ({@link SkinBroadcaster}), the notification surface for companion
- * clients. This is the lane's net-new adapter logic (no sibling lane has it).
+ * login ({@link SkinBroadcaster}) with the REAL flattened PNG bytes (lib-5
+ * joint client side, PR #422): the companion client handler in the same jar
+ * decodes the payload and injects the pixels into the era renderer. This is
+ * the lane's net-new adapter logic (no sibling lane has it).
  */
 public final class SkinRestorer {
 
@@ -106,7 +108,8 @@ public final class SkinRestorer {
         UUID uuid = uuidOf(player.getCommandSenderName());
         CustomSkinProperty skin = s.getSkin(uuid);
         if (skin != null) {
-            SkinBroadcaster.broadcastProfileChange(player);
+            SkinBroadcaster.broadcastProfileChange(player.getCommandSenderName(),
+                SkinTextureFetcher.fetchLegacyPng(skin));
         }
     }
 
@@ -146,6 +149,23 @@ public final class SkinRestorer {
             return;
         }
         s.setSkin(uuid, skin);
+    }
+
+    /**
+     * Command-layer accessor: stores the skin AND broadcasts the real PNG
+     * bytes to all clients (live update — no re-login needed). Username-keyed
+     * variant of {@link #applySkin(UUID, CustomSkinProperty)}: 1.5.2 has no
+     * account UUID, the offline bridge derives the storage key.
+     */
+    public static void applySkin(String username, CustomSkinProperty skin) {
+        applySkin(uuidOf(username), skin);
+        if (skin == null || skin.isEmpty()) {
+            return; // cleared — nothing to render
+        }
+        byte[] png = SkinTextureFetcher.fetchLegacyPng(skin);
+        if (png != null) {
+            SkinBroadcaster.broadcastProfileChange(username, png);
+        }
     }
 
     /** Command-layer accessor: removes the stored skin. */

--- a/forge-1.5.2/src/main/java/levosilimo/everlastingskins/skinchanger/SkinTextureFetcher.java
+++ b/forge-1.5.2/src/main/java/levosilimo/everlastingskins/skinchanger/SkinTextureFetcher.java
@@ -1,0 +1,100 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import levosilimo.everlastingskins.client.ClientSkinApplier;
+import levosilimo.everlastingskins.util.CustomSkinProperty;
+import levosilimo.everlastingskins.util.PropertyUtils;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+/**
+ * Server-side skin texture fetch for the joint client broadcast (lib-5,
+ * PR #422): the server stores only the textures property (base64 JSON with a
+ * URL), so the PNG bytes must be fetched over HTTP before they can ride in
+ * the {@code SkinMessage} payload.
+ *
+ * <p>The :common {@code HttpClient} is JSON/String-body-only and frozen
+ * (shared by every lane), so this lane-local fetch is byte-returning and
+ * HTTPS-only, mirroring the :common client's policy including its
+ * {@code everlastingskins.allowHttp} test escape hatch. The 64x64 modern skin
+ * is flattened to the pre-1.7.8 64x32 model via
+ * {@link ClientSkinApplier#flattenToLegacy} so every client payload is
+ * already in the era renderer's native layout.
+ *
+ * <p>Fail-soft: any fetch/decode/encode failure returns null (the broadcast
+ * degrades to the legacy notification-only payload rather than crashing the
+ * command/login path).
+ */
+public final class SkinTextureFetcher {
+
+    private static final String USER_AGENT = "EverlastingSkins/1.5.2";
+    private static final int TIMEOUT_MS = 10000;
+
+    private SkinTextureFetcher() {}
+
+    /**
+     * Fetches the skin PNG from the property's texture URL and returns it
+     * flattened to the legacy 64x32 model, re-encoded as PNG. Null when the
+     * fetch/decode fails or the property has no skin URL.
+     */
+    public static byte[] fetchLegacyPng(CustomSkinProperty skin) {
+        try {
+            byte[] png = fetchBytes(PropertyUtils.getSkinTextureUrl(skin));
+            if (png == null) {
+                return null;
+            }
+            BufferedImage image = ClientSkinApplier.decode(png);
+            BufferedImage legacy = ClientSkinApplier.flattenToLegacy(image);
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            ImageIO.write(legacy, "png", bos);
+            return bos.toByteArray();
+        } catch (Exception e) {
+            System.err.println("EverlastingSkins: skin texture fetch failed: " + e);
+            return null;
+        }
+    }
+
+    private static byte[] fetchBytes(String urlString) throws IOException {
+        URL url = new URL(urlString);
+        // textures.minecraft.net is https; mirror the :common HttpClient's
+        // https-only policy with the same controlled-testing escape hatch.
+        if (!"https".equals(url.getProtocol()) && !Boolean.getBoolean("everlastingskins.allowHttp")) {
+            throw new IOException("Only HTTPS is supported: " + urlString);
+        }
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        try {
+            connection.setConnectTimeout(TIMEOUT_MS);
+            connection.setReadTimeout(TIMEOUT_MS);
+            connection.setRequestProperty("User-Agent", USER_AGENT);
+            int code = connection.getResponseCode();
+            if (code < 200 || code >= 300) {
+                throw new IOException("HTTP " + code + " for " + urlString);
+            }
+            InputStream in = connection.getInputStream();
+            try {
+                ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                byte[] buf = new byte[8192];
+                int n;
+                while ((n = in.read(buf)) > 0) {
+                    bos.write(buf, 0, n);
+                }
+                return bos.toByteArray();
+            } finally {
+                in.close();
+            }
+        } finally {
+            connection.disconnect();
+        }
+    }
+}

--- a/forge-1.5.2/src/test/java/levosilimo/everlastingskins/broadcast/SkinMessageTest.java
+++ b/forge-1.5.2/src/test/java/levosilimo/everlastingskins/broadcast/SkinMessageTest.java
@@ -13,6 +13,7 @@ import java.nio.charset.StandardCharsets;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * 1.5.2 broadcast payload tests (pure Java — no server, no netty).
@@ -35,6 +36,23 @@ public class SkinMessageTest {
     @Test
     public void encodeDecodeRoundTripsWithPng() {
         byte[] png = new byte[]{1, 2, 3, 4, 5};
+        SkinMessage message = SkinMessage.decode(SkinMessage.encode("Steve", png));
+        assertEquals("Steve", message.getPlayerName());
+        assertArrayEquals(png, message.getTexturePng());
+    }
+
+    @Test
+    public void encodeDecodeRoundTripsRealPngBytes() throws Exception {
+        // A real PNG payload (the joint client broadcast now carries actual
+        // texture bytes — lib-5, PR #422), well under the 32766-byte
+        // Packet250CustomPayload cap (MC-16910).
+        java.awt.image.BufferedImage image =
+            new java.awt.image.BufferedImage(64, 32, java.awt.image.BufferedImage.TYPE_INT_ARGB);
+        java.io.ByteArrayOutputStream bos = new java.io.ByteArrayOutputStream();
+        javax.imageio.ImageIO.write(image, "png", bos);
+        byte[] png = bos.toByteArray();
+        assertTrue(png.length < 32766);
+
         SkinMessage message = SkinMessage.decode(SkinMessage.encode("Steve", png));
         assertEquals("Steve", message.getPlayerName());
         assertArrayEquals(png, message.getTexturePng());

--- a/forge-1.5.2/src/test/java/levosilimo/everlastingskins/broadcast/SkinMessageTest.java
+++ b/forge-1.5.2/src/test/java/levosilimo/everlastingskins/broadcast/SkinMessageTest.java
@@ -8,6 +8,8 @@ package levosilimo.everlastingskins.broadcast;
 
 import org.junit.Test;
 
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
 import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -68,6 +70,38 @@ public class SkinMessageTest {
     @Test(expected = IllegalArgumentException.class)
     public void malformedPayloadThrows() {
         SkinMessage.decode(new byte[]{0, 1, 2, 3});
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void malformedNameLengthRejectedBeforeAllocation() throws Exception {
+        // nameLen = 2^31-1: the bounds guard must reject it (an
+        // IllegalArgumentException the client handler catches), not
+        // allocate ~2 GiB and OOM the packet thread (lib-18 audit).
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        new DataOutputStream(bos).writeInt(Integer.MAX_VALUE);
+        SkinMessage.decode(bos.toByteArray());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void negativeNameLengthRejectedBeforeAllocation() throws Exception {
+        // nameLen = -1 (unsigned 0xFFFFFFFF): the len >= 0 half of the guard.
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        new DataOutputStream(bos).writeInt(-1);
+        SkinMessage.decode(bos.toByteArray());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void malformedPngLengthRejectedBeforeAllocation() throws Exception {
+        // pngLen = 2^31-1: the bounds guard must reject it before the
+        // allocation (lib-18 audit).
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bos);
+        byte[] name = "Legacy".getBytes(StandardCharsets.UTF_8);
+        out.writeInt(name.length);
+        out.write(name);
+        out.writeInt(Integer.MAX_VALUE);
+        out.flush();
+        SkinMessage.decode(bos.toByteArray());
     }
 
     @Test

--- a/forge-1.5.2/src/test/java/levosilimo/everlastingskins/client/ClientSkinApplierTest.java
+++ b/forge-1.5.2/src/test/java/levosilimo/everlastingskins/client/ClientSkinApplierTest.java
@@ -1,0 +1,149 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.client;
+
+import net.minecraft.src.EntityPlayer;
+import net.minecraft.src.IImageBuffer;
+import net.minecraft.src.ImageBufferDownload;
+import net.minecraft.src.ThreadDownloadImageData;
+import net.minecraft.src.World;
+import org.junit.Test;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * 1.5.2 client-side skin applier tests (lib-5 joint client side): pure-Java
+ * decode/flatten/findPlayer plus the TDI injection surface, with mocked
+ * client classes (mockito + reflection setField, mirroring the lane's
+ * existing test pattern — memory #1115: no live client, no GL).
+ */
+public class ClientSkinApplierTest {
+
+    @Test
+    public void decodeReturnsPngPixels() throws Exception {
+        BufferedImage source = solid(4, 4, 0xFF112233);
+        BufferedImage decoded = ClientSkinApplier.decode(png(source));
+        assertNotNull(decoded);
+        assertEquals(4, decoded.getWidth());
+        assertEquals(0xFF112233, decoded.getRGB(2, 2));
+    }
+
+    @Test(expected = java.io.IOException.class)
+    public void decodeRejectsGarbage() throws Exception {
+        ClientSkinApplier.decode(new byte[]{1, 2, 3});
+    }
+
+    @Test
+    public void flattenPassesLegacy64x32Through() {
+        BufferedImage legacy = solid(64, 32, 0xFF445566);
+        assertSame(legacy, ClientSkinApplier.flattenToLegacy(legacy));
+    }
+
+    @Test
+    public void flattenCropsModern64x64ToTopHalf() {
+        // 64x64 modern skin: the top half IS the legacy 64x32 layout; the
+        // bottom-left regions (left arm / left leg) are dropped because the
+        // pre-1.8 model mirrors the left limbs from the right-limb regions.
+        BufferedImage modern = new BufferedImage(64, 64, BufferedImage.TYPE_INT_ARGB);
+        for (int x = 0; x < 64; x++) {
+            for (int y = 0; y < 64; y++) {
+                modern.setRGB(x, y, 0xFF000000);
+            }
+        }
+        modern.setRGB(10, 10, 0xFFAA0000); // head region — kept
+        modern.setRGB(5, 25, 0xFF00BB00);  // right leg region — kept
+        modern.setRGB(45, 55, 0xFF0000CC); // left arm region — dropped
+
+        BufferedImage legacy = ClientSkinApplier.flattenToLegacy(modern);
+
+        assertEquals(64, legacy.getWidth());
+        assertEquals(32, legacy.getHeight());
+        assertEquals(0xFFAA0000, legacy.getRGB(10, 10));
+        assertEquals(0xFF00BB00, legacy.getRGB(5, 25));
+        // The dropped region must not leak into the canvas.
+        assertEquals(0xFF000000, legacy.getRGB(45, 25));
+    }
+
+    @Test
+    public void flattenDraws32x32UnscaledLikeVanilla() {
+        BufferedImage small = solid(32, 32, 0xFF123456);
+        small.setRGB(8, 8, 0xFFAABBCC);
+        BufferedImage legacy = ClientSkinApplier.flattenToLegacy(small);
+        assertEquals(64, legacy.getWidth());
+        assertEquals(32, legacy.getHeight());
+        assertEquals(0xFFAABBCC, legacy.getRGB(8, 8));
+        assertEquals(0xFF123456, legacy.getRGB(20, 20));
+    }
+
+    @Test
+    public void findPlayerMatchesByCommandSenderName() throws Exception {
+        World world = mock(World.class);
+        EntityPlayer notch = mock(EntityPlayer.class);
+        when(notch.getCommandSenderName()).thenReturn("Notch");
+        EntityPlayer steve = mock(EntityPlayer.class);
+        when(steve.getCommandSenderName()).thenReturn("Steve");
+        setField(world, "playerEntities", Arrays.asList(notch, steve));
+
+        assertSame(notch, ClientSkinApplier.findPlayer(world, "Notch"));
+        assertSame(steve, ClientSkinApplier.findPlayer(world, "Steve"));
+    }
+
+    @Test
+    public void findPlayerReturnsNullForUnknownOrEmptyWorld() throws Exception {
+        World world = mock(World.class);
+        setField(world, "playerEntities", Collections.emptyList());
+        assertNull(ClientSkinApplier.findPlayer(world, "Notch"));
+        assertNull(ClientSkinApplier.findPlayer(null, "Notch"));
+    }
+
+    @Test
+    public void applyWritesPublicImageFieldAndResetsUploadFlag() {
+        // Real TDI from the deobf'd client jar (no GL involved in the write).
+        ThreadDownloadImageData tdi = new ThreadDownloadImageData(
+            "https://example.invalid/skin.png", new ImageBufferDownload());
+        BufferedImage image = solid(64, 32, 0xFF010203);
+
+        ClientSkinApplier.apply(tdi, image);
+
+        assertSame(image, tdi.image);
+        assertEquals(false, tdi.textureSetupComplete);
+    }
+
+    private static void setField(Object target, String name, Object value) throws Exception {
+        Field field = target.getClass().getField(name);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    private static BufferedImage solid(int width, int height, int argb) {
+        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+        for (int x = 0; x < width; x++) {
+            for (int y = 0; y < height; y++) {
+                image.setRGB(x, y, argb);
+            }
+        }
+        return image;
+    }
+
+    private static byte[] png(BufferedImage image) throws Exception {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ImageIO.write(image, "png", bos);
+        return bos.toByteArray();
+    }
+}

--- a/forge-1.5.2/src/test/java/levosilimo/everlastingskins/skinchanger/SkinTextureFetcherTest.java
+++ b/forge-1.5.2/src/test/java/levosilimo/everlastingskins/skinchanger/SkinTextureFetcherTest.java
@@ -1,0 +1,135 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import com.sun.net.httpserver.HttpServer;
+import levosilimo.everlastingskins.util.CustomSkinProperty;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * 1.6.4 server-side skin texture fetch tests (lib-5 joint broadcast): the
+ * textures property is fetched over HTTP, decoded and flattened to the legacy
+ * 64x32 model. Deterministic fixtures only (memory #1115) — an in-process
+ * HttpServer serves a generated PNG on localhost; the lane-local fetch's
+ * {@code everlastingskins.allowHttp} escape hatch mirrors the :common
+ * client's controlled-testing policy.
+ */
+public class SkinTextureFetcherTest {
+
+    private HttpServer server;
+    private String baseUrl;
+
+    @Before
+    public void setUp() throws Exception {
+        System.setProperty("everlastingskins.allowHttp", "true");
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.start();
+        baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        System.clearProperty("everlastingskins.allowHttp");
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    public void fetchesAndFlattensModern64x64Skin() throws Exception {
+        BufferedImage modern = new BufferedImage(64, 64, BufferedImage.TYPE_INT_ARGB);
+        for (int x = 0; x < 64; x++) {
+            for (int y = 0; y < 64; y++) {
+                modern.setRGB(x, y, 0xFF445566);
+            }
+        }
+        modern.setRGB(10, 10, 0xFFAA0000);
+        serve("/skin64.png", png(modern));
+
+        byte[] result = SkinTextureFetcher.fetchLegacyPng(property("textures", baseUrl + "/skin64.png"));
+
+        assertNotNull(result);
+        BufferedImage flattened = ImageIO.read(new java.io.ByteArrayInputStream(result));
+        assertEquals(64, flattened.getWidth());
+        assertEquals(32, flattened.getHeight());
+        assertEquals(0xFFAA0000, flattened.getRGB(10, 10));
+    }
+
+    @Test
+    public void passesLegacy64x32Through() throws Exception {
+        serve("/skin32.png", png(new BufferedImage(64, 32, BufferedImage.TYPE_INT_ARGB)));
+
+        byte[] result = SkinTextureFetcher.fetchLegacyPng(property("textures", baseUrl + "/skin32.png"));
+
+        assertNotNull(result);
+        BufferedImage flattened = ImageIO.read(new java.io.ByteArrayInputStream(result));
+        assertEquals(64, flattened.getWidth());
+        assertEquals(32, flattened.getHeight());
+    }
+
+    @Test
+    public void httpStatusErrorYieldsNull() throws Exception {
+        serve("/missing.png", new byte[]{1, 2, 3});
+        server.createContext("/missing404", exchange -> {
+            exchange.sendResponseHeaders(404, -1);
+            exchange.close();
+        });
+
+        byte[] result = SkinTextureFetcher.fetchLegacyPng(property("textures", baseUrl + "/missing404"));
+
+        assertNull(result);
+    }
+
+    @Test
+    public void httpsOnlyWithoutEscapeHatch() throws Exception {
+        System.clearProperty("everlastingskins.allowHttp");
+        byte[] result = SkinTextureFetcher.fetchLegacyPng(property("textures", baseUrl + "/skin64.png"));
+        assertNull(result);
+    }
+
+    @Test
+    public void undecodableBodyYieldsNull() throws Exception {
+        serve("/garbage.png", new byte[]{0, 1, 2, 3, 4, 5});
+        byte[] result = SkinTextureFetcher.fetchLegacyPng(property("textures", baseUrl + "/garbage.png"));
+        assertNull(result);
+    }
+
+    private void serve(String path, byte[] body) {
+        server.createContext(path, exchange -> {
+            byte[] payload = body;
+            exchange.sendResponseHeaders(200, payload.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(payload);
+            }
+        });
+    }
+
+    /** Textures property whose base64 value is the JSON {"textures":{"SKIN":{"url":...}}}. */
+    private static CustomSkinProperty property(String name, String url) {
+        String json = "{\"textures\":{\"SKIN\":{\"url\":\"" + url + "\"}}}";
+        String value = java.util.Base64.getEncoder().encodeToString(json.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        return new CustomSkinProperty(name, value, null, "test");
+    }
+
+    private static byte[] png(BufferedImage image) throws Exception {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ImageIO.write(image, "png", bos);
+        return bos.toByteArray();
+    }
+}

--- a/forge-1.6.4/build.gradle
+++ b/forge-1.6.4/build.gradle
@@ -63,6 +63,16 @@ ext {
             [name: 'minecraft_server.1.6.4.jar',
              url: 'https://piston-data.mojang.com/v1/objects/050f93c1f3fe9e2052398f7bd6aca10c63d64a87/server.jar',
              algo: 'SHA-1', digest: '050f93c1f3fe9e2052398f7bd6aca10c63d64a87'],
+            // Joint client-side jar (lib-5 design, PR #422): the mod is no
+            // longer serverSideOnly — the same jar carries a client packet
+            // handler that injects skin PNGs into the era renderer. The vanilla
+            // CLIENT jar is vendored + deobf'd (harness clientInput) and added
+            // to the compile classpath after the server-first merged jar.
+            // sha1 verified against launcher.mojang.com version_manifest 1.6.4
+            // (downloads.client.sha1).
+            [name: 'minecraft_client.1.6.4.jar',
+             url: 'https://launcher.mojang.com/v1/objects/1703704407101cf72bd88e68579e3696ce733ecd/client.jar',
+             algo: 'SHA-1', digest: '1703704407101cf72bd88e68579e3696ce733ecd'],
         ],
         mcpVersion: '8.11',
         archiveBaseName: 'everlastingskins-1.6.4',

--- a/forge-1.6.4/src/main/java/levosilimo/everlastingskins/broadcast/ClientSkinHandler.java
+++ b/forge-1.6.4/src/main/java/levosilimo/everlastingskins/broadcast/ClientSkinHandler.java
@@ -1,0 +1,76 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.broadcast;
+
+import cpw.mods.fml.common.network.IPacketHandler;
+import cpw.mods.fml.common.network.Player;
+import levosilimo.everlastingskins.client.ClientSkinApplier;
+import net.minecraft.src.AbstractClientPlayer;
+import net.minecraft.src.EntityPlayer;
+import net.minecraft.src.INetworkManager;
+import net.minecraft.src.Minecraft;
+import net.minecraft.src.Packet250CustomPayload;
+import net.minecraft.src.ThreadDownloadImageData;
+
+import java.awt.image.BufferedImage;
+
+/**
+ * 1.6.4 client-side skin receiver (lib-5 Option B: joint client side inside
+ * the same jar). Registered by the {@code @NetworkMod} joint pattern
+ * (clientPacketHandlerSpec on the @Mod class — FML registers the client spec
+ * only on a client process, so the same jar works on both sides).
+ *
+ * <p>Decodes the existing {@link SkinMessage} wire format and injects the PNG
+ * into the player's skin {@link ThreadDownloadImageData} via
+ * {@link ClientSkinApplier} — no ASM. The player is resolved by name from
+ * {@code World.playerEntities} (1.6.4 has no UUID on the wire).
+ *
+ * <p>Re-injection on join: the server re-broadcasts the stored skin on every
+ * login, so a packet that arrives before the player entity spawns is simply
+ * dropped here (the join broadcast re-delivers it). Caveat (documented, not
+ * hardened): if the vanilla skin-download thread completes AFTER the
+ * injection, it overwrites the pixels with the default skin — the ASM
+ * hardening that would prevent this (shielding the download) is a future
+ * upgrade, out of scope.
+ */
+public final class ClientSkinHandler implements IPacketHandler {
+
+    @Override
+    public void onPacketData(INetworkManager manager, Packet250CustomPayload packet, Player player) {
+        try {
+            SkinMessage message = SkinMessage.decode(packet.data);
+            byte[] png = message.getTexturePng();
+            if (png == null) {
+                // Notification-only broadcast from a pre-joint server.
+                return;
+            }
+            Minecraft mc = Minecraft.getMinecraft();
+            if (mc.theWorld == null) {
+                return;
+            }
+            EntityPlayer target = ClientSkinApplier.findPlayer(mc.theWorld, message.getPlayerName());
+            if (!(target instanceof AbstractClientPlayer)) {
+                // Not spawned yet — the join broadcast re-delivers.
+                return;
+            }
+            AbstractClientPlayer clientPlayer = (AbstractClientPlayer) target;
+            ThreadDownloadImageData imageData = clientPlayer.getTextureSkin();
+            if (imageData == null) {
+                return;
+            }
+            BufferedImage image = ClientSkinApplier.flattenToLegacy(ClientSkinApplier.decode(png));
+            ClientSkinApplier.apply(imageData, image);
+            // Re-upload the injected pixels into the existing GL texture:
+            // TextureManager.loadTexture re-runs the TDI's loadTexture, which
+            // uploads the new bufferedImage into the current gl id.
+            mc.getTextureManager().loadTexture(clientPlayer.getLocationSkin(), imageData);
+        } catch (Exception e) {
+            // Never crash the network thread on a malformed/undecodable payload.
+            System.err.println("EverlastingSkins: client skin apply failed: " + e);
+        }
+    }
+}

--- a/forge-1.6.4/src/main/java/levosilimo/everlastingskins/broadcast/ServerPacketHandler.java
+++ b/forge-1.6.4/src/main/java/levosilimo/everlastingskins/broadcast/ServerPacketHandler.java
@@ -1,0 +1,27 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.broadcast;
+
+import cpw.mods.fml.common.network.IPacketHandler;
+import cpw.mods.fml.common.network.Player;
+import net.minecraft.src.INetworkManager;
+import net.minecraft.src.Packet250CustomPayload;
+
+/**
+ * 1.6.4 server-side receiver for the {@code everlastingskins} channel,
+ * referenced by the {@code @NetworkMod} joint pattern
+ * (serverPacketHandlerSpec). FML dispatches server-side custom payloads to
+ * the server handler (registered with Side.SERVER) and client-side payloads
+ * to {@link ClientSkinHandler} — both handlers live in the same jar.
+ */
+public final class ServerPacketHandler implements IPacketHandler {
+
+    @Override
+    public void onPacketData(INetworkManager manager, Packet250CustomPayload packet, Player player) {
+        // No client→server traffic on this channel.
+    }
+}

--- a/forge-1.6.4/src/main/java/levosilimo/everlastingskins/broadcast/SkinBroadcaster.java
+++ b/forge-1.6.4/src/main/java/levosilimo/everlastingskins/broadcast/SkinBroadcaster.java
@@ -6,62 +6,50 @@
 
 package levosilimo.everlastingskins.broadcast;
 
-import cpw.mods.fml.common.network.IPacketHandler;
-import cpw.mods.fml.common.network.NetworkRegistry;
 import cpw.mods.fml.common.network.PacketDispatcher;
-import cpw.mods.fml.common.network.Player;
-import net.minecraft.src.EntityPlayer;
-import net.minecraft.src.INetworkManager;
 import net.minecraft.src.Packet;
-import net.minecraft.src.Packet250CustomPayload;
 
 /**
  * 1.6.4 skin-broadcast channel (FML 7.x custom-payload surface).
  *
  * <p>FML 7.x has no netty {@code SimpleNetworkWrapper} (that is 1.8+) and no
- * {@code newChannel} on {@link NetworkRegistry} — the 1.6.4 surface is
- * {@code NetworkRegistry.instance().registerChannel(IPacketHandler, String)}
- * with {@link Packet250CustomPayload} payloads, sent via
- * {@link PacketDispatcher}. The channel name must be ≤ 16 chars
- * (NetworkRegistry.java:100-105 throws beyond that); {@code everlastingskins}
- * is exactly 16 — at the ceiling, never lengthen it.
+ * {@code newChannel} — the 1.6.4 surface is
+ * {@code Packet250CustomPayload} payloads, sent via {@link PacketDispatcher}.
+ * The channel name must be ≤ 16 chars (NetworkRegistry.java:100-105 throws
+ * beyond that); {@code everlastingskins} is exactly 16 — at the ceiling,
+ * never lengthen it.
  *
- * <p>Payloads carry the target player's username
- * ({@link SkinMessage#encode(String, byte[])}); the client-side handler would
- * re-fetch the skin (server-side mod: the channel is the notification
- * surface, matching the sibling lanes' broadcast contract). The registered
- * {@link IPacketHandler} is a server-side no-op — 1.6.4 clients never send
- * on this channel.
+ * <p>CHANNEL OWNERSHIP: since the joint client side landed (lib-5, PR #422)
+ * the channel is registered by the {@code @NetworkMod} joint pattern on the
+ * @Mod class — {@link ClientSkinHandler} on client processes,
+ * {@link ServerPacketHandler} on server processes — NOT by a manual
+ * {@code registerChannel} here (a universal no-op registration would shadow
+ * the client-side dispatch). {@link #broadcastProfileChange} only sends.
+ *
+ * <p>Payloads carry the target player's username AND the flattened 64x32 PNG
+ * bytes ({@link SkinMessage#encode(String, byte[])}); the client handler
+ * decodes and injects the pixels. Payload cap: 32766 bytes
+ * (Packet250CustomPayload 2-byte length, MC-16910) — a flattened 64x32 PNG is
+ * ≈ 1-4 KB, far under the cap; oversized payloads are dropped defensively.
  */
 public final class SkinBroadcaster {
 
     public static final String CHANNEL = "everlastingskins";
 
-    private static volatile boolean registered;
+    /** Packet250CustomPayload 2-byte length cap (MC-16910). */
+    private static final int MAX_PAYLOAD_BYTES = 32766;
 
     private SkinBroadcaster() {}
 
-    /** Registers the channel; safe to call once per JVM (idempotent). */
-    public static void init() {
-        if (registered) {
+    /** Broadcasts a skin-change payload for {@code playerName} to all players. */
+    public static void broadcastProfileChange(String playerName, byte[] pngBytes) {
+        byte[] payload = SkinMessage.encode(playerName, pngBytes);
+        if (payload.length > MAX_PAYLOAD_BYTES) {
+            System.err.println("EverlastingSkins: skin payload for '" + playerName
+                + "' exceeds " + MAX_PAYLOAD_BYTES + " bytes — dropped");
             return;
         }
-        NetworkRegistry.instance().registerChannel(new ServerPacketHandler(), CHANNEL);
-        registered = true;
-    }
-
-    /** Broadcasts a skin-change notification for {@code target} to all players. */
-    public static void broadcastProfileChange(EntityPlayer target) {
-        byte[] payload = SkinMessage.encode(target.getCommandSenderName(), null);
         Packet packet = PacketDispatcher.getPacket(CHANNEL, payload);
         PacketDispatcher.sendPacketToAllPlayers(packet);
-    }
-
-    /** Server-side no-op: the mod is serverSideOnly (FML 7.x). */
-    private static final class ServerPacketHandler implements IPacketHandler {
-        @Override
-        public void onPacketData(INetworkManager manager, Packet250CustomPayload packet, Player player) {
-            // No client→server traffic on this channel.
-        }
     }
 }

--- a/forge-1.6.4/src/main/java/levosilimo/everlastingskins/broadcast/SkinMessage.java
+++ b/forge-1.6.4/src/main/java/levosilimo/everlastingskins/broadcast/SkinMessage.java
@@ -45,6 +45,12 @@ public final class SkinMessage {
     /**
      * Wire format: [utf8 username][int png length][png bytes]. A null PNG
      * encodes as length 0 (notification-only broadcast).
+     *
+     * <p>Every length prefix is bounds-checked against the remaining unread
+     * payload BEFORE allocation ({@link #checkLength}), so a corrupted or
+     * malicious prefix fails with {@link IllegalArgumentException} instead
+     * of an {@link OutOfMemoryError} on the packet thread (lib-18 audit
+     * remediation).
      */
     public static byte[] encode(String playerName, byte[] texturePng) {
         try {
@@ -70,9 +76,11 @@ public final class SkinMessage {
         try {
             DataInputStream in = new DataInputStream(new ByteArrayInputStream(payload));
             int nameLen = in.readInt();
+            checkLength(nameLen, payload.length - 4, "name");
             byte[] name = new byte[nameLen];
             in.readFully(name);
             int pngLen = in.readInt();
+            checkLength(pngLen, payload.length - 8 - nameLen, "png");
             byte[] png = null;
             if (pngLen > 0) {
                 png = new byte[pngLen];
@@ -81,6 +89,20 @@ public final class SkinMessage {
             return new SkinMessage(new String(name, StandardCharsets.UTF_8), png);
         } catch (IOException e) {
             throw new IllegalArgumentException("Malformed SkinMessage payload", e);
+        }
+    }
+
+    /**
+     * Bounds guard for a length-prefixed field: rejects any length prefix
+     * that is negative or exceeds the remaining unread payload BEFORE the
+     * array allocation. The client handler catches
+     * {@link IllegalArgumentException}; an {@link OutOfMemoryError} would
+     * escape {@code catch (Exception)} and kill the network thread.
+     */
+    private static void checkLength(int len, int remaining, String field) {
+        if (len < 0 || len > remaining) {
+            throw new IllegalArgumentException("Malformed SkinMessage payload: " + field
+                + " length " + len + " exceeds remaining " + remaining + " bytes");
         }
     }
 }

--- a/forge-1.6.4/src/main/java/levosilimo/everlastingskins/client/ClientSkinApplier.java
+++ b/forge-1.6.4/src/main/java/levosilimo/everlastingskins/client/ClientSkinApplier.java
@@ -1,0 +1,92 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.client;
+
+import levosilimo.everlastingskins.skinchanger.TextureDecoder;
+import net.minecraft.src.EntityPlayer;
+import net.minecraft.src.ThreadDownloadImageData;
+import net.minecraft.src.World;
+
+import java.awt.Graphics;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+
+/**
+ * Pure-Java client-side skin application for the 1.6.4 lane (lib-5 Option B:
+ * the joint jar carries a client handler that makes skins ACTUALLY RENDER on
+ * pre-1.8 clients). Decode / flatten / apply are separated from the network
+ * and renderer bindings so they are unit-testable without a client.
+ *
+ * <p>Flatten contract: the 1.6.4 renderer uses the legacy 64x32 model whose
+ * left limbs MIRROR the right-limb regions (ModelBiped samples both arms from
+ * textureOffset(40,16) and both legs from (0,16) — spike-verified against the
+ * vanilla client jar). The correct 64x64 → 64x32 conversion is therefore the
+ * vanilla crop (1.6.4 {@code ImageBufferDownload.parseUserSkin} draws the
+ * source unscaled at (0,0)): the modern top half IS the legacy layout, and the
+ * modern bottom-left regions (left arm / left leg) are dropped.
+ */
+public final class ClientSkinApplier {
+
+    private ClientSkinApplier() {}
+
+    /**
+     * Decodes PNG bytes into an ARGB {@link BufferedImage}.
+     *
+     * @throws IOException if the bytes are not a decodable image
+     */
+    public static BufferedImage decode(byte[] png) throws IOException {
+        return TextureDecoder.decode(png);
+    }
+
+    /**
+     * Converts any skin to the legacy 64x32 model. 64x32 (and smaller-height
+     * 64-wide) inputs pass through unchanged; a 64x64 modern skin is cropped
+     * to its top half (vanilla 1.6.4 parity); any other size is drawn
+     * unscaled at (0,0) exactly like the vanilla download pipeline.
+     */
+    public static BufferedImage flattenToLegacy(BufferedImage source) {
+        if (source.getWidth() == 64 && source.getHeight() <= 32) {
+            return source;
+        }
+        BufferedImage legacy = new BufferedImage(64, 32, BufferedImage.TYPE_INT_ARGB);
+        Graphics g = legacy.getGraphics();
+        g.drawImage(source, 0, 0, null);
+        g.dispose();
+        return legacy;
+    }
+
+    /**
+     * Finds a spawned player by {@code getCommandSenderName()} in the client
+     * world ({@code World.playerEntities}), or null when not spawned yet.
+     */
+    public static EntityPlayer findPlayer(World world, String playerName) {
+        if (world == null || world.playerEntities == null) {
+            return null;
+        }
+        for (Object o : world.playerEntities) {
+            if (o instanceof EntityPlayer) {
+                EntityPlayer candidate = (EntityPlayer) o;
+                if (candidate.getCommandSenderName().equals(playerName)) {
+                    return candidate;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Injects the flattened image into the player's skin
+     * {@link ThreadDownloadImageData}. 1.6.4 (MCP 8.11) has the image field
+     * PRIVATE; the public surface is {@code getBufferedImage(BufferedImage)}
+     * (the {@code setBufferedImage} name is the later 1.7.x MCP rename).
+     * The re-upload into the GL texture is triggered by the caller
+     * (TextureManager.loadTexture).
+     */
+    public static void apply(ThreadDownloadImageData target, BufferedImage image) {
+        target.getBufferedImage(image);
+    }
+}

--- a/forge-1.6.4/src/main/java/levosilimo/everlastingskins/command/SkinRestorerCommand.java
+++ b/forge-1.6.4/src/main/java/levosilimo/everlastingskins/command/SkinRestorerCommand.java
@@ -184,8 +184,10 @@ public class SkinRestorerCommand implements ICommand {
         if (!checkPermission(sender, targetsAreSelfOnly(sender, targets) ? NODE_SKIN : NODE_SKIN_OTHER)) {
             return;
         }
+        // #426: the broadcast is keyed by the TARGET player's name (the entity
+        // clients render), not the skin source's — real-PNG live update.
         for (EntityPlayerMP target : targets) {
-            setSkin(sender, SkinRestorer.uuidOf(target.getCommandSenderName()), args[1]);
+            setSkin(sender, SkinRestorer.uuidOf(target.getCommandSenderName()), target.getCommandSenderName(), args[1]);
         }
     }
 
@@ -217,7 +219,7 @@ public class SkinRestorerCommand implements ICommand {
             return;
         }
         for (EntityPlayerMP target : targets) {
-            setSkin(sender, SkinRestorer.uuidOf(target.getCommandSenderName()), username);
+            setSkin(sender, SkinRestorer.uuidOf(target.getCommandSenderName()), target.getCommandSenderName(), username);
         }
     }
 
@@ -312,7 +314,7 @@ public class SkinRestorerCommand implements ICommand {
             MetricsFormat.human(SkinMetrics.INSTANCE.snapshot())));
     }
 
-    private void setSkin(ICommandSender sender, UUID uuid, String username) {
+    private void setSkin(ICommandSender sender, UUID uuid, String targetName, String username) {
         // 1.6.4 has no per-player permission nodes beyond the op model; the
         // vanilla Mojang lookup is the only authoritative source (no
         // MineSkin/URL generation on this legacy surface).
@@ -331,7 +333,11 @@ public class SkinRestorerCommand implements ICommand {
         }
         CustomSkinProperty skin = result.get().skinProperty();
         seenProfiles.put(username, skin);
-        SkinRestorer.applySkin(uuid, skin);
+        // Username-keyed variant: stores the skin AND broadcasts the real PNG
+        // bytes to all clients (lib-5 joint client side — live update). The
+        // broadcast is keyed by the TARGET player's name (the entity clients
+        // render), not the skin source's.
+        SkinRestorer.applySkin(targetName, skin);
         SkinMetrics.INSTANCE.recordRefreshCompleted(uuid, startNanos, System.nanoTime() - startNanos, 0, 0);
         sender.sendChatToPlayer(ChatMessageComponent.createFromText("Skin applied."));
     }

--- a/forge-1.6.4/src/main/java/levosilimo/everlastingskins/forge164/EverlastingSkins.java
+++ b/forge-1.6.4/src/main/java/levosilimo/everlastingskins/forge164/EverlastingSkins.java
@@ -6,14 +6,18 @@
 
 package levosilimo.everlastingskins.forge164;
 
+import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLServerStartingEvent;
 import cpw.mods.fml.common.event.FMLServerStoppingEvent;
 import cpw.mods.fml.common.network.IConnectionHandler;
+import cpw.mods.fml.common.network.NetworkMod;
 import cpw.mods.fml.common.network.NetworkRegistry;
 import levosilimo.everlastingskins.e2e.E2E;
 import cpw.mods.fml.common.network.Player;
+import levosilimo.everlastingskins.broadcast.ClientSkinHandler;
+import levosilimo.everlastingskins.broadcast.ServerPacketHandler;
 import levosilimo.everlastingskins.broadcast.SkinBroadcaster;
 import levosilimo.everlastingskins.permission.forge.ForgePermissionService;
 import levosilimo.everlastingskins.skinchanger.SkinRestorer;
@@ -38,16 +42,33 @@ import net.minecraft.src.Packet1Login;
  * UUID from {@code getCommandSenderName()} and :common never sees a player
  * object (memory #1123 contract, unchanged).
  *
- * <p>Network surface: FML 7.x {@code Packet250CustomPayload} custom-payload
- * channel, registered in {@link #init} via
- * {@code NetworkRegistry.instance().registerChannel(...)} — the channel name
- * {@code everlastingskins} is exactly 16 chars, at the 1.6.4 hard cap.
+ * <p>Network surface: JOINT jar (lib-5 Option B, PR #422) — the channel
+ * {@code everlastingskins} (exactly 16 chars, at the 1.6.4 hard cap) is
+ * registered by the {@link NetworkMod} joint pattern below, NOT by a manual
+ * {@code registerChannel}: FML's {@code NetworkModHandler.configureNetworkMod}
+ * registers the client spec ({@link ClientSkinHandler}) only when
+ * {@code FMLCommonHandler.instance().getSide().isClient()} and the server spec
+ * ({@link ServerPacketHandler}) on both sides (dispatch is side-separated via
+ * {@code NetworkRegistry.handlePacket}'s EntityPlayerMP check), so one jar
+ * declares both and each process runs only its own receiver.
+ *
+ * <p>Side guard: FML loads the jar on both processes, so {@link #init} keeps
+ * the server bootstrap behind {@code getSide().isServer()} — on a client the
+ * only client-side surface is the @NetworkMod-registered client handler.
  */
 @Mod(
     modid = EverlastingSkins.MOD_ID,
     name = EverlastingSkins.MOD_NAME,
     version = EverlastingSkins.VERSION,
     acceptedMinecraftVersions = "[1.6.4]"
+)
+@NetworkMod(
+    clientPacketHandlerSpec = @NetworkMod.SidedPacketHandler(
+        channels = {SkinBroadcaster.CHANNEL},
+        packetHandler = ClientSkinHandler.class),
+    serverPacketHandlerSpec = @NetworkMod.SidedPacketHandler(
+        channels = {SkinBroadcaster.CHANNEL},
+        packetHandler = ServerPacketHandler.class)
 )
 public class EverlastingSkins {
     public static final String MOD_ID = "everlastingskins";
@@ -58,15 +79,21 @@ public class EverlastingSkins {
 
     @Mod.EventHandler
     public void init(FMLInitializationEvent event) {
+        if (!FMLCommonHandler.instance().getSide().isServer()) {
+            // Client process: the client handler is registered by @NetworkMod;
+            // no server bootstrap here (the physical side is authoritative —
+            // an integrated server's SERVER lifecycle still fires
+            // serverStarting/serverStopping below).
+            return;
+        }
         // :common removed init() — per-version bootstrap registers candidates
         // itself; highest priority wins (Forge ops 10 > vanilla fallback 0).
         ForgePermissionService.register();
         // In-jar E2E support (shipped-gated by -Deverlastingskins.e2e=true;
         // no-op in production).
         E2E.install();
-        // 1.6.4 skin-broadcast channel (FML 7.x custom-payload surface).
-        SkinBroadcaster.init();
-        // Pre-1.7 player join/leave hook (no PlayerEvent on this line).
+        // Pre-1.7 player join/leave hook (no PlayerEvent on this line). The
+        // broadcast channel itself is owned by @NetworkMod.
         NetworkRegistry.instance().registerConnectionHandler(new ConnectionHandler());
     }
 

--- a/forge-1.6.4/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRestorer.java
+++ b/forge-1.6.4/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRestorer.java
@@ -38,8 +38,10 @@ import java.util.UUID;
  * <p>Restore mechanism: 1.6.4 has no GameProfile textures to inject — the
  * legacy skins.minecraft.net username-keyed path is dead (Mojang shutdown),
  * so the lane re-broadcasts the stored skin over the FML 7.x channel on
- * login ({@link SkinBroadcaster}), the notification surface for companion
- * clients. This is the lane's net-new adapter logic (no sibling lane has it).
+ * login ({@link SkinBroadcaster}) with the REAL flattened PNG bytes (lib-5
+ * joint client side, PR #422): the companion client handler in the same jar
+ * decodes the payload and injects the pixels into the era renderer. This is
+ * the lane's net-new adapter logic (no sibling lane has it).
  */
 public final class SkinRestorer {
 
@@ -95,8 +97,9 @@ public final class SkinRestorer {
     }
 
     /**
-     * Player-keyed login: re-broadcast the stored skin over the channel when
-     * one exists (the 1.6.4 restore surface — no GameProfile to mutate).
+     * Player-keyed login: re-broadcast the stored skin (with its PNG bytes)
+     * over the channel when one exists (the 1.6.4 restore surface — no
+     * GameProfile to mutate).
      */
     public static void onPlayerLoggedIn(EntityPlayer player) {
         SkinStorage s = storage;
@@ -106,7 +109,8 @@ public final class SkinRestorer {
         UUID uuid = uuidOf(player.getCommandSenderName());
         CustomSkinProperty skin = s.getSkin(uuid);
         if (skin != null) {
-            SkinBroadcaster.broadcastProfileChange(player);
+            SkinBroadcaster.broadcastProfileChange(player.getCommandSenderName(),
+                SkinTextureFetcher.fetchLegacyPng(skin));
         }
     }
 
@@ -146,6 +150,23 @@ public final class SkinRestorer {
             return;
         }
         s.setSkin(uuid, skin);
+    }
+
+    /**
+     * Command-layer accessor: stores the skin AND broadcasts the real PNG
+     * bytes to all clients (live update — no re-login needed). Username-keyed
+     * variant of {@link #applySkin(UUID, CustomSkinProperty)}: 1.6.4 has no
+     * account UUID, the offline bridge derives the storage key.
+     */
+    public static void applySkin(String username, CustomSkinProperty skin) {
+        applySkin(uuidOf(username), skin);
+        if (skin == null || skin.isEmpty()) {
+            return; // cleared — nothing to render
+        }
+        byte[] png = SkinTextureFetcher.fetchLegacyPng(skin);
+        if (png != null) {
+            SkinBroadcaster.broadcastProfileChange(username, png);
+        }
     }
 
     /** Command-layer accessor: removes the stored skin. */

--- a/forge-1.6.4/src/main/java/levosilimo/everlastingskins/skinchanger/SkinTextureFetcher.java
+++ b/forge-1.6.4/src/main/java/levosilimo/everlastingskins/skinchanger/SkinTextureFetcher.java
@@ -1,0 +1,100 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import levosilimo.everlastingskins.client.ClientSkinApplier;
+import levosilimo.everlastingskins.util.CustomSkinProperty;
+import levosilimo.everlastingskins.util.PropertyUtils;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+/**
+ * Server-side skin texture fetch for the joint client broadcast (lib-5,
+ * PR #422): the server stores only the textures property (base64 JSON with a
+ * URL), so the PNG bytes must be fetched over HTTP before they can ride in
+ * the {@code SkinMessage} payload.
+ *
+ * <p>The :common {@code HttpClient} is JSON/String-body-only and frozen
+ * (shared by every lane), so this lane-local fetch is byte-returning and
+ * HTTPS-only, mirroring the :common client's policy including its
+ * {@code everlastingskins.allowHttp} test escape hatch. The 64x64 modern skin
+ * is flattened to the pre-1.7.8 64x32 model via
+ * {@link ClientSkinApplier#flattenToLegacy} so every client payload is
+ * already in the era renderer's native layout.
+ *
+ * <p>Fail-soft: any fetch/decode/encode failure returns null (the broadcast
+ * degrades to the legacy notification-only payload rather than crashing the
+ * command/login path).
+ */
+public final class SkinTextureFetcher {
+
+    private static final String USER_AGENT = "EverlastingSkins/1.6.4";
+    private static final int TIMEOUT_MS = 10000;
+
+    private SkinTextureFetcher() {}
+
+    /**
+     * Fetches the skin PNG from the property's texture URL and returns it
+     * flattened to the legacy 64x32 model, re-encoded as PNG. Null when the
+     * fetch/decode fails or the property has no skin URL.
+     */
+    public static byte[] fetchLegacyPng(CustomSkinProperty skin) {
+        try {
+            byte[] png = fetchBytes(PropertyUtils.getSkinTextureUrl(skin));
+            if (png == null) {
+                return null;
+            }
+            BufferedImage image = ClientSkinApplier.decode(png);
+            BufferedImage legacy = ClientSkinApplier.flattenToLegacy(image);
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            ImageIO.write(legacy, "png", bos);
+            return bos.toByteArray();
+        } catch (Exception e) {
+            System.err.println("EverlastingSkins: skin texture fetch failed: " + e);
+            return null;
+        }
+    }
+
+    private static byte[] fetchBytes(String urlString) throws IOException {
+        URL url = new URL(urlString);
+        // textures.minecraft.net is https; mirror the :common HttpClient's
+        // https-only policy with the same controlled-testing escape hatch.
+        if (!"https".equals(url.getProtocol()) && !Boolean.getBoolean("everlastingskins.allowHttp")) {
+            throw new IOException("Only HTTPS is supported: " + urlString);
+        }
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        try {
+            connection.setConnectTimeout(TIMEOUT_MS);
+            connection.setReadTimeout(TIMEOUT_MS);
+            connection.setRequestProperty("User-Agent", USER_AGENT);
+            int code = connection.getResponseCode();
+            if (code < 200 || code >= 300) {
+                throw new IOException("HTTP " + code + " for " + urlString);
+            }
+            InputStream in = connection.getInputStream();
+            try {
+                ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                byte[] buf = new byte[8192];
+                int n;
+                while ((n = in.read(buf)) > 0) {
+                    bos.write(buf, 0, n);
+                }
+                return bos.toByteArray();
+            } finally {
+                in.close();
+            }
+        } finally {
+            connection.disconnect();
+        }
+    }
+}

--- a/forge-1.6.4/src/test/java/levosilimo/everlastingskins/broadcast/SkinMessageTest.java
+++ b/forge-1.6.4/src/test/java/levosilimo/everlastingskins/broadcast/SkinMessageTest.java
@@ -13,6 +13,7 @@ import java.nio.charset.StandardCharsets;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * 1.6.4 broadcast payload tests (pure Java — no server, no netty).
@@ -35,6 +36,23 @@ public class SkinMessageTest {
     @Test
     public void encodeDecodeRoundTripsWithPng() {
         byte[] png = new byte[]{1, 2, 3, 4, 5};
+        SkinMessage message = SkinMessage.decode(SkinMessage.encode("Steve", png));
+        assertEquals("Steve", message.getPlayerName());
+        assertArrayEquals(png, message.getTexturePng());
+    }
+
+    @Test
+    public void encodeDecodeRoundTripsRealPngBytes() throws Exception {
+        // A real PNG payload (the joint client broadcast now carries actual
+        // texture bytes — lib-5, PR #422), well under the 32766-byte
+        // Packet250CustomPayload cap (MC-16910).
+        java.awt.image.BufferedImage image =
+            new java.awt.image.BufferedImage(64, 32, java.awt.image.BufferedImage.TYPE_INT_ARGB);
+        java.io.ByteArrayOutputStream bos = new java.io.ByteArrayOutputStream();
+        javax.imageio.ImageIO.write(image, "png", bos);
+        byte[] png = bos.toByteArray();
+        assertTrue(png.length < 32766);
+
         SkinMessage message = SkinMessage.decode(SkinMessage.encode("Steve", png));
         assertEquals("Steve", message.getPlayerName());
         assertArrayEquals(png, message.getTexturePng());

--- a/forge-1.6.4/src/test/java/levosilimo/everlastingskins/broadcast/SkinMessageTest.java
+++ b/forge-1.6.4/src/test/java/levosilimo/everlastingskins/broadcast/SkinMessageTest.java
@@ -8,6 +8,8 @@ package levosilimo.everlastingskins.broadcast;
 
 import org.junit.Test;
 
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
 import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -68,6 +70,38 @@ public class SkinMessageTest {
     @Test(expected = IllegalArgumentException.class)
     public void malformedPayloadThrows() {
         SkinMessage.decode(new byte[]{0, 1, 2, 3});
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void malformedNameLengthRejectedBeforeAllocation() throws Exception {
+        // nameLen = 2^31-1: the bounds guard must reject it (an
+        // IllegalArgumentException the client handler catches), not
+        // allocate ~2 GiB and OOM the packet thread (lib-18 audit).
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        new DataOutputStream(bos).writeInt(Integer.MAX_VALUE);
+        SkinMessage.decode(bos.toByteArray());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void negativeNameLengthRejectedBeforeAllocation() throws Exception {
+        // nameLen = -1 (unsigned 0xFFFFFFFF): the len >= 0 half of the guard.
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        new DataOutputStream(bos).writeInt(-1);
+        SkinMessage.decode(bos.toByteArray());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void malformedPngLengthRejectedBeforeAllocation() throws Exception {
+        // pngLen = 2^31-1: the bounds guard must reject it before the
+        // allocation (lib-18 audit).
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bos);
+        byte[] name = "Legacy".getBytes(StandardCharsets.UTF_8);
+        out.writeInt(name.length);
+        out.write(name);
+        out.writeInt(Integer.MAX_VALUE);
+        out.flush();
+        SkinMessage.decode(bos.toByteArray());
     }
 
     @Test

--- a/forge-1.6.4/src/test/java/levosilimo/everlastingskins/client/ClientSkinApplierTest.java
+++ b/forge-1.6.4/src/test/java/levosilimo/everlastingskins/client/ClientSkinApplierTest.java
@@ -1,0 +1,157 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.client;
+
+import levosilimo.everlastingskins.skinchanger.TextureDecoder;
+import net.minecraft.src.EntityPlayer;
+import net.minecraft.src.ImageBufferDownload;
+import net.minecraft.src.ResourceLocation;
+import net.minecraft.src.ThreadDownloadImageData;
+import net.minecraft.src.World;
+import org.junit.Test;
+
+import javax.imageio.ImageIO;
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * 1.6.4 client-side skin applier tests (lib-5 joint client side): pure-Java
+ * decode/flatten/findPlayer plus the TDI injection surface, with mocked
+ * client classes (mockito + reflection setField, mirroring the lane's
+ * existing test pattern — memory #1115: no live client, no GL).
+ */
+public class ClientSkinApplierTest {
+
+    @Test
+    public void decodeReturnsPngPixels() throws Exception {
+        BufferedImage source = solid(4, 4, 0xFF112233);
+        BufferedImage decoded = ClientSkinApplier.decode(png(source));
+        assertNotNull(decoded);
+        assertEquals(4, decoded.getWidth());
+        assertEquals(0xFF112233, decoded.getRGB(2, 2));
+    }
+
+    @Test(expected = java.io.IOException.class)
+    public void decodeRejectsGarbage() throws Exception {
+        ClientSkinApplier.decode(new byte[]{1, 2, 3});
+    }
+
+    @Test
+    public void flattenPassesLegacy64x32Through() {
+        BufferedImage legacy = solid(64, 32, 0xFF445566);
+        assertSame(legacy, ClientSkinApplier.flattenToLegacy(legacy));
+    }
+
+    @Test
+    public void flattenCropsModern64x64ToTopHalf() {
+        // 64x64 modern skin: the top half IS the legacy 64x32 layout; the
+        // bottom-left regions (left arm / left leg) are dropped because the
+        // pre-1.8 model mirrors the left limbs from the right-limb regions.
+        BufferedImage modern = new BufferedImage(64, 64, BufferedImage.TYPE_INT_ARGB);
+        for (int x = 0; x < 64; x++) {
+            for (int y = 0; y < 64; y++) {
+                modern.setRGB(x, y, 0xFF000000);
+            }
+        }
+        modern.setRGB(10, 10, 0xFFAA0000); // head region — kept
+        modern.setRGB(5, 25, 0xFF00BB00);  // right leg region — kept
+        modern.setRGB(45, 55, 0xFF0000CC); // left arm region — dropped
+
+        BufferedImage legacy = ClientSkinApplier.flattenToLegacy(modern);
+
+        assertEquals(64, legacy.getWidth());
+        assertEquals(32, legacy.getHeight());
+        assertEquals(0xFFAA0000, legacy.getRGB(10, 10));
+        assertEquals(0xFF00BB00, legacy.getRGB(5, 25));
+        // The dropped region must not leak into the canvas.
+        assertEquals(0xFF000000, legacy.getRGB(45, 25));
+    }
+
+    @Test
+    public void flattenDraws32x32UnscaledLikeVanilla() {
+        BufferedImage small = solid(32, 32, 0xFF123456);
+        small.setRGB(8, 8, 0xFFAABBCC);
+        BufferedImage legacy = ClientSkinApplier.flattenToLegacy(small);
+        assertEquals(64, legacy.getWidth());
+        assertEquals(32, legacy.getHeight());
+        assertEquals(0xFFAABBCC, legacy.getRGB(8, 8));
+        assertEquals(0xFF123456, legacy.getRGB(20, 20));
+    }
+
+    @Test
+    public void findPlayerMatchesByCommandSenderName() throws Exception {
+        World world = mock(World.class);
+        EntityPlayer notch = mock(EntityPlayer.class);
+        when(notch.getCommandSenderName()).thenReturn("Notch");
+        EntityPlayer steve = mock(EntityPlayer.class);
+        when(steve.getCommandSenderName()).thenReturn("Steve");
+        setField(world, "playerEntities", Arrays.asList(notch, steve));
+
+        assertSame(notch, ClientSkinApplier.findPlayer(world, "Notch"));
+        assertSame(steve, ClientSkinApplier.findPlayer(world, "Steve"));
+    }
+
+    @Test
+    public void findPlayerReturnsNullForUnknownOrEmptyWorld() throws Exception {
+        World world = mock(World.class);
+        setField(world, "playerEntities", Collections.emptyList());
+        assertNull(ClientSkinApplier.findPlayer(world, "Notch"));
+        assertNull(ClientSkinApplier.findPlayer(null, "Notch"));
+    }
+
+    @Test
+    public void applyInjectsImageIntoThreadDownloadImageData() throws Exception {
+        // Real TDI from the deobf'd client jar (no GL involved in the setter).
+        ThreadDownloadImageData tdi = new ThreadDownloadImageData(
+            "https://example.invalid/skin.png",
+            new ResourceLocation("minecraft", "skins/x"),
+            new ImageBufferDownload());
+        BufferedImage image = solid(64, 32, 0xFF010203);
+
+        ClientSkinApplier.apply(tdi, image);
+
+        // MCP 8.11: the public setter is getBufferedImage(BufferedImage); the
+        // backing field is private on this line — read it back via reflection.
+        Field field = ThreadDownloadImageData.class.getDeclaredField("bufferedImage");
+        field.setAccessible(true);
+        assertSame(image, field.get(tdi));
+    }
+
+    private static void setField(Object target, String name, Object value) throws Exception {
+        Field field = target.getClass().getField(name);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    private static BufferedImage solid(int width, int height, int argb) {
+        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+        for (int x = 0; x < width; x++) {
+            for (int y = 0; y < height; y++) {
+                image.setRGB(x, y, argb);
+            }
+        }
+        return image;
+    }
+
+    private static byte[] png(BufferedImage image) throws Exception {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ImageIO.write(image, "png", bos);
+        return bos.toByteArray();
+    }
+}

--- a/forge-1.6.4/src/test/java/levosilimo/everlastingskins/skinchanger/SkinTextureFetcherTest.java
+++ b/forge-1.6.4/src/test/java/levosilimo/everlastingskins/skinchanger/SkinTextureFetcherTest.java
@@ -1,0 +1,135 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.skinchanger;
+
+import com.sun.net.httpserver.HttpServer;
+import levosilimo.everlastingskins.util.CustomSkinProperty;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * 1.6.4 server-side skin texture fetch tests (lib-5 joint broadcast): the
+ * textures property is fetched over HTTP, decoded and flattened to the legacy
+ * 64x32 model. Deterministic fixtures only (memory #1115) — an in-process
+ * HttpServer serves a generated PNG on localhost; the lane-local fetch's
+ * {@code everlastingskins.allowHttp} escape hatch mirrors the :common
+ * client's controlled-testing policy.
+ */
+public class SkinTextureFetcherTest {
+
+    private HttpServer server;
+    private String baseUrl;
+
+    @Before
+    public void setUp() throws Exception {
+        System.setProperty("everlastingskins.allowHttp", "true");
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.start();
+        baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        System.clearProperty("everlastingskins.allowHttp");
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    public void fetchesAndFlattensModern64x64Skin() throws Exception {
+        BufferedImage modern = new BufferedImage(64, 64, BufferedImage.TYPE_INT_ARGB);
+        for (int x = 0; x < 64; x++) {
+            for (int y = 0; y < 64; y++) {
+                modern.setRGB(x, y, 0xFF445566);
+            }
+        }
+        modern.setRGB(10, 10, 0xFFAA0000);
+        serve("/skin64.png", png(modern));
+
+        byte[] result = SkinTextureFetcher.fetchLegacyPng(property("textures", baseUrl + "/skin64.png"));
+
+        assertNotNull(result);
+        BufferedImage flattened = ImageIO.read(new java.io.ByteArrayInputStream(result));
+        assertEquals(64, flattened.getWidth());
+        assertEquals(32, flattened.getHeight());
+        assertEquals(0xFFAA0000, flattened.getRGB(10, 10));
+    }
+
+    @Test
+    public void passesLegacy64x32Through() throws Exception {
+        serve("/skin32.png", png(new BufferedImage(64, 32, BufferedImage.TYPE_INT_ARGB)));
+
+        byte[] result = SkinTextureFetcher.fetchLegacyPng(property("textures", baseUrl + "/skin32.png"));
+
+        assertNotNull(result);
+        BufferedImage flattened = ImageIO.read(new java.io.ByteArrayInputStream(result));
+        assertEquals(64, flattened.getWidth());
+        assertEquals(32, flattened.getHeight());
+    }
+
+    @Test
+    public void httpStatusErrorYieldsNull() throws Exception {
+        serve("/missing.png", new byte[]{1, 2, 3});
+        server.createContext("/missing404", exchange -> {
+            exchange.sendResponseHeaders(404, -1);
+            exchange.close();
+        });
+
+        byte[] result = SkinTextureFetcher.fetchLegacyPng(property("textures", baseUrl + "/missing404"));
+
+        assertNull(result);
+    }
+
+    @Test
+    public void httpsOnlyWithoutEscapeHatch() throws Exception {
+        System.clearProperty("everlastingskins.allowHttp");
+        byte[] result = SkinTextureFetcher.fetchLegacyPng(property("textures", baseUrl + "/skin64.png"));
+        assertNull(result);
+    }
+
+    @Test
+    public void undecodableBodyYieldsNull() throws Exception {
+        serve("/garbage.png", new byte[]{0, 1, 2, 3, 4, 5});
+        byte[] result = SkinTextureFetcher.fetchLegacyPng(property("textures", baseUrl + "/garbage.png"));
+        assertNull(result);
+    }
+
+    private void serve(String path, byte[] body) {
+        server.createContext(path, exchange -> {
+            byte[] payload = body;
+            exchange.sendResponseHeaders(200, payload.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(payload);
+            }
+        });
+    }
+
+    /** Textures property whose base64 value is the JSON {"textures":{"SKIN":{"url":...}}}. */
+    private static CustomSkinProperty property(String name, String url) {
+        String json = "{\"textures\":{\"SKIN\":{\"url\":\"" + url + "\"}}}";
+        String value = java.util.Base64.getEncoder().encodeToString(json.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        return new CustomSkinProperty(name, value, null, "test");
+    }
+
+    private static byte[] png(BufferedImage image) throws Exception {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ImageIO.write(image, "png", bos);
+        return bos.toByteArray();
+    }
+}

--- a/harness/specialsource-harness.gradle
+++ b/harness/specialsource-harness.gradle
@@ -7,7 +7,10 @@
 //
 //   ext {
 //       harnessConfig = [
-//           vendoredInputs: [ ... ],   // 3 maps: [name, url, algo, digest]
+//           vendoredInputs: [ ... ],   // 3-4 maps: [name, url, algo, digest]
+//                                    // (optional 4th: the vanilla CLIENT jar,
+//                                    // name starting with 'minecraft_client',
+//                                    // for joint client-side jars — PR #422)
 //           mcpVersion: '8.11',        // asserted from version.cfg
 //           archiveBaseName: 'everlastingskins-1.6.4',
 //           mergeOrder: 'serverFirst', // 'serverFirst' | 'universalFirst'
@@ -21,8 +24,9 @@
 // The script derives the lane-local bits from archiveBaseName
 // ('everlastingskins-<ver>' -> vendored cache key '<ver>', ModVersion package
 // 'levosilimo.everlastingskins.forge<ver-nodot>') and from mcpVersion (mcp
-// conf dir '$buildDir/mcp<ver-nodot>'); the three vendored artifacts are
-// located from vendoredInputs by name pattern (src zip / universal / server).
+// conf dir '$buildDir/mcp<ver-nodot>'); the vendored artifacts are
+// located from vendoredInputs by name pattern (src zip / universal / server /
+// optional vanilla client jar).
 //
 // Gradle 4.4.1-compatible (pure Groovy, no Kotlin DSL, no buildSrc). Defines
 // the 7 harness tasks: resolveVendored, extractMcpConf, deobfClasspath,
@@ -76,10 +80,13 @@ def nameDomainTokens = cfg.containsKey('nameDomainTokens') ? cfg.nameDomainToken
 ]
 def testRuntimeDeps = cfg.containsKey('testRuntimeDeps') ? cfg.testRuntimeDeps : []
 
-// Locate the three vendored artifacts by name pattern (config stays pure data).
+// Locate the vendored artifacts by name pattern (config stays pure data).
+// The vanilla CLIENT jar is OPTIONAL (joint client-side jars, PR #422); lanes
+// without client code omit it.
 def srcZipInput = vendoredInputs.find { it.name.endsWith('-src.zip') }
 def universalInput = vendoredInputs.find { it.name.contains('universal') }
 def serverInput = vendoredInputs.find { it.name.startsWith('minecraft_server') }
+def clientInput = vendoredInputs.find { it.name.startsWith('minecraft_client') }
 if (srcZipInput == null || universalInput == null || serverInput == null) {
     throw new GradleException("harness/specialsource-harness.gradle: vendoredInputs must include a forge '-src.zip', a forge 'universal' artifact, and a 'minecraft_server' jar — got: ${vendoredInputs*.name}")
 }
@@ -123,6 +130,7 @@ def obfToDeobfSrg = file("$mappingDir/obf-to-deobf.srg")
 def deobfToObfSrg = file("$mappingDir/deobf-to-obf.srg")
 def deobfServerJar = file("$buildDir/deobf/server-deobf.jar")
 def deobfUniversalJar = file("$buildDir/deobf/universal-deobf.jar")
+def clientDeobfJar = file("$buildDir/deobf/client-deobf.jar")
 def mergedDeobfJar = file("$buildDir/deobf/merged-deobf.jar")
 
 dependencies {
@@ -154,6 +162,15 @@ dependencies {
     // The merged-deobf jar (MC + FML + Forge) is produced by deobfClasspath;
     // `compile files(...)` resolves lazily, after the producing task runs.
     compile files(mergedDeobfJar)
+
+    // Joint client-side jars (PR #422): the vanilla CLIENT jar is remapped
+    // obf->deobf with the SAME obf-to-deobf.srg and added SEPARATELY after the
+    // merged jar, so shared classes (EntityPlayer, World, ...) resolve from
+    // the server-first merged jar and only client-only classes come from the
+    // client leg. Lanes without a clientInput never declare this file.
+    if (clientInput != null) {
+        compile files(clientDeobfJar)
+    }
 
     // Rule 4 lane decision: JUnit 4.13.2 + mockito-core 2.28.2, mirroring
     // forge-1.7.10 (Gradle 4.4.1 floor; 4.4.1 lanes use JUnit 4).
@@ -201,7 +218,7 @@ def digestOf = { File f, String algo ->
 
 task resolveVendored {
     group = 'everlastingskins'
-    description = 'Download + checksum-verify the vendored inputs (forge src zip, forge universal artifact, vanilla server jar) into a cache dir; pre-seed the dir or pass -Pvendored.offline for offline builds.'
+    description = 'Download + checksum-verify the vendored inputs (forge src zip, forge universal artifact, vanilla server jar, optional vanilla client jar) into a cache dir; pre-seed the dir or pass -Pvendored.offline for offline builds.'
     outputs.dir vendoredDir
     doLast {
         def offline = project.hasProperty('vendored.offline')
@@ -472,13 +489,15 @@ def expandSubclassMethods = { Map mdMapC, Map hier, Map clRevMap ->
 // ---------------------------------------------------------------------------
 task deobfClasspath(dependsOn: extractMcpConf) {
     group = 'everlastingskins'
-    description = "Compose the obf->deobf mapping from the MCP ${mcpVersion} conf, run SpecialSource on the server jar AND the FML universal artifact (both reference MC classes/fields by obf names), and merge them into build/deobf/merged-deobf.jar — the FG \"minecraft\" classpath equivalent. Merge order is harnessConfig.mergeOrder (${mergeOrder})."
+    description = "Compose the obf->deobf mapping from the MCP ${mcpVersion} conf, run SpecialSource on the server jar AND the FML universal artifact (both reference MC classes/fields by obf names), and merge them into build/deobf/merged-deobf.jar — the FG \"minecraft\" classpath equivalent. Merge order is harnessConfig.mergeOrder (${mergeOrder}). When a vanilla client jar is vendored, it is remapped with the same obf->deobf srg into build/deobf/client-deobf.jar (joint client-side jars, PR #422)."
     inputs.dir mcpConfDir
     inputs.files {
-        [new File(vendoredDir, serverInput.name),
-         new File(vendoredDir, universalInput.name)]
+        def files = [new File(vendoredDir, serverInput.name),
+                     new File(vendoredDir, universalInput.name)]
+        if (clientInput != null) files << new File(vendoredDir, clientInput.name)
+        files
     }
-    outputs.files mergedDeobfJar, deobfServerJar, deobfUniversalJar, obfToDeobfSrg, deobfToObfSrg
+    outputs.files mergedDeobfJar, deobfServerJar, deobfUniversalJar, clientDeobfJar, obfToDeobfSrg, deobfToObfSrg
     doLast {
         def methods = parseCsvMappings(new File(mcpConfDir, 'methods.csv'))
         def fields = parseCsvMappings(new File(mcpConfDir, 'fields.csv'))
@@ -512,6 +531,13 @@ task deobfClasspath(dependsOn: extractMcpConf) {
             deobfServerJar.absolutePath, obfToDeobfSrg.absolutePath)
         runSpecialSource(new File(vendoredDir, universalInput.name).absolutePath,
             deobfUniversalJar.absolutePath, obfToDeobfSrg.absolutePath)
+        if (clientInput != null) {
+            // Joint client-side jars (PR #422): same obf->deobf srg; the
+            // client leg stays SEPARATE from the merge so shared classes keep
+            // resolving from the server-first merged jar.
+            runSpecialSource(new File(vendoredDir, clientInput.name).absolutePath,
+                clientDeobfJar.absolutePath, obfToDeobfSrg.absolutePath)
+        }
 
         // Merge order is a per-lane behavioral fork (harnessConfig.mergeOrder,
         // fork #1):
@@ -574,7 +600,8 @@ task deobfClasspath(dependsOn: extractMcpConf) {
         }
         writeSrgMapping(deobfToObfSrg, clRevMap, mdMapC, fdMapC)
 
-        logger.lifecycle("deobfClasspath: ${mergedDeobfJar.name} built (server obf->deobf + universal obf->deobf, merge ${mergeOrder})")
+        def clientLeg = clientInput != null ? " + client obf->deobf" : ""
+        logger.lifecycle("deobfClasspath: ${mergedDeobfJar.name} built (server obf->deobf + universal obf->deobf${clientLeg}, merge ${mergeOrder})")
     }
 }
 


### PR DESCRIPTION
Per client-side implementation research (lib-5 + exp-2): @NetworkMod dual-spec joint jar — client handler decodes the existing SkinMessage wire format and injects the PNG (public ThreadDownloadImageData.image 1.4.7/1.5.2; public setBufferedImage 1.6.4), no ASM. Server now sends real PNG bytes (byte-fetch via PropertyUtils URL + 64x32 flatten). Build: client jar vendored + deobf'd on the compile classpath; ship reobf unchanged (obf valid on both sides — client runtime-deobf passes obf through). Unit tests per lane.