### PR TITLE
feat(client): pre-1.8 cape injection (1.4.7/1.5.2/1.6.4)

### DIFF
--- a/common/src/main/java/levosilimo/everlastingskins/skinchanger/responses/profile/MojangProfileTextures.java
+++ b/common/src/main/java/levosilimo/everlastingskins/skinchanger/responses/profile/MojangProfileTextures.java
@@ -7,9 +7,9 @@ import java.util.Objects;
 
 public final class MojangProfileTextures {
     private final MojangProfileTexture SKIN;
-    private final DecodedTextureProperty CAPE;
+    private final MojangProfileTexture CAPE;
 
-    public MojangProfileTextures(MojangProfileTexture SKIN, DecodedTextureProperty CAPE) {
+    public MojangProfileTextures(MojangProfileTexture SKIN, MojangProfileTexture CAPE) {
         this.SKIN = SKIN;
         this.CAPE = CAPE;
     }
@@ -18,7 +18,7 @@ public final class MojangProfileTextures {
         return SKIN;
     }
 
-    public DecodedTextureProperty CAPE() {
+    public MojangProfileTexture CAPE() {
         return CAPE;
     }
 

--- a/common/src/main/java/levosilimo/everlastingskins/util/PropertyUtils.java
+++ b/common/src/main/java/levosilimo/everlastingskins/util/PropertyUtils.java
@@ -9,6 +9,7 @@ package levosilimo.everlastingskins.util;
 import com.google.gson.Gson;
 import levosilimo.everlastingskins.enums.SkinVariant;
 import levosilimo.everlastingskins.skinchanger.responses.profile.DecodedTextureProperty;
+import levosilimo.everlastingskins.skinchanger.responses.profile.MojangProfileTexture;
 import levosilimo.everlastingskins.skinchanger.responses.profile.MojangProfileTextureMeta;
 
 import java.nio.charset.StandardCharsets;
@@ -30,6 +31,21 @@ public class PropertyUtils {
      */
     public static String getSkinTextureUrl(CustomSkinProperty property) {
         return getSkinProfileData(property).textures().SKIN().url();
+    }
+
+    /**
+     * Returns the <a href="https://textures.minecraft.net/id">Texture Url</a>
+     * for the property's cape, or null when the textures payload carries no
+     * CAPE entry (the common case — most skins have no cape). Mirrors
+     * {@link #getSkinTextureUrl(CustomSkinProperty)} for the pre-1.8 cape
+     * broadcast path.
+     *
+     * @param property Profile property
+     * @return full textures.minecraft.net cape url, or null when cape-less
+     */
+    public static String getCapeTextureUrl(CustomSkinProperty property) {
+        MojangProfileTexture cape = getSkinProfileData(property).textures().CAPE();
+        return cape == null ? null : cape.url();
     }
 
     public static SkinVariant getSkinVariant(CustomSkinProperty property) {

--- a/common/src/test/java/levosilimo/everlastingskins/util/PropertyUtilsTest.java
+++ b/common/src/test/java/levosilimo/everlastingskins/util/PropertyUtilsTest.java
@@ -86,6 +86,26 @@ class PropertyUtilsTest {
     }
 
     @Nested
+    @DisplayName("Cape texture URL")
+    class CapeTextureUrl {
+
+        @Test
+        @DisplayName("getCapeTextureUrl returns the CAPE url when present")
+        void capeUrlWhenPresent() {
+            String capeUrl = "https://textures.minecraft.net/texture/capeId";
+            CustomSkinProperty withCape = capeProperty(TEXTURE_URL, capeUrl);
+
+            assertEquals(capeUrl, PropertyUtils.getCapeTextureUrl(withCape));
+        }
+
+        @Test
+        @DisplayName("getCapeTextureUrl returns null when the payload has no CAPE")
+        void capeUrlNullWhenAbsent() {
+            assertNull(PropertyUtils.getCapeTextureUrl(createProperty(null)));
+        }
+    }
+
+    @Nested
     @DisplayName("Round-trip consistency")
     class RoundTrip {
 
@@ -109,6 +129,21 @@ class PropertyUtilsTest {
     private static CustomSkinProperty createProperty(String model) {
         String texturesJson = buildTexturesJson(model);
         String base64 = Base64.getEncoder().encodeToString(texturesJson.getBytes(StandardCharsets.UTF_8));
+        return new CustomSkinProperty("textures", base64, "signature==", null);
+    }
+
+    private static CustomSkinProperty capeProperty(String skinUrl, String capeUrl) {
+        String json = "{\n" +
+            "  \"timestamp\": 1234567890,\n" +
+            "  \"profileId\": \"f0000000000000000000000000000000\",\n" +
+            "  \"profileName\": \"TestPlayer\",\n" +
+            "  \"signatureRequired\": false,\n" +
+            "  \"textures\": {\n" +
+            "    \"SKIN\": {\"url\": \"" + skinUrl + "\"},\n" +
+            "    \"CAPE\": {\"url\": \"" + capeUrl + "\"}\n" +
+            "  }\n" +
+            "}";
+        String base64 = Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
         return new CustomSkinProperty("textures", base64, "signature==", null);
     }
 

--- a/forge-1.4.7/src/main/java/levosilimo/everlastingskins/broadcast/ClientSkinHandler.java
+++ b/forge-1.4.7/src/main/java/levosilimo/everlastingskins/broadcast/ClientSkinHandler.java
@@ -31,7 +31,17 @@ import java.awt.image.BufferedImage;
  * {@code World.playerEntities} (1.4.7 has no UUID on the wire); the cached
  * TDI is looked up by the player's {@code skinUrl} through
  * {@code RenderEngine.obtainImageData} (the cache keyed by skin URL, seeded
- * by {@code RenderGlobal.updateEntitySkin} when the entity spawned).
+ * by {@code RenderGlobal.obtainEntitySkin} when the entity spawned).
+ *
+ * <p>Cape injection (per cape research): the 1.4.7 client fetches
+ * {@code http://skins.minecraft.net/MinecraftCloaks/<name>.png} for EVERY
+ * player with no allowlist (the render gates are only image loaded/visible/
+ * not-sneaking), so byte injection suffices. The cape reuses the SAME
+ * {@link ThreadDownloadImageData} class as the skin, cached in the
+ * RenderEngine keyed by the player's {@code cloakUrl} — set for every player
+ * by the {@code EntityOtherPlayerMP}/{@code EntityPlayerSP} constructors —
+ * so the cape path mirrors the skin path with the cache key swapped from
+ * {@code skinUrl} to {@code cloakUrl}.
  *
  * <p>Re-injection on join: the server re-broadcasts the stored skin on every
  * login, so a packet that arrives before the player entity spawns is simply
@@ -48,7 +58,8 @@ public final class ClientSkinHandler implements IPacketHandler {
         try {
             SkinMessage message = SkinMessage.decode(packet.data);
             byte[] png = message.getTexturePng();
-            if (png == null) {
+            byte[] capePng = message.getCapePng();
+            if (png == null && capePng == null) {
                 // Notification-only broadcast from a pre-joint server.
                 return;
             }
@@ -61,24 +72,38 @@ public final class ClientSkinHandler implements IPacketHandler {
                 // Not spawned yet — the join broadcast re-delivers.
                 return;
             }
-            // skinUrl is declared on Entity; access it through the Entity
-            // type so the reobf pass can map the reference (javac emits the
-            // receiver's declared type as the owner, and the srg FD keys are
-            // the declaring class — EntityPlayer.skinUrl would stay unmapped
-            // and NoSuchFieldError at runtime; found live by the slice-1
-            // 1.5.2 E2E).
-            String skinUrl = ((net.minecraft.src.Entity) target).skinUrl;
-            if (skinUrl == null) {
-                return;
+            if (png != null) {
+                // skinUrl is declared on Entity; access it through the Entity
+                // type so the reobf pass can map the reference (javac emits the
+                // receiver's declared type as the owner, and the srg FD keys are
+                // the declaring class — EntityPlayer.skinUrl would stay unmapped
+                // and NoSuchFieldError at runtime; found live by the slice-1
+                // 1.5.2 E2E).
+                String skinUrl = ((net.minecraft.src.Entity) target).skinUrl;
+                if (skinUrl != null) {
+                    ThreadDownloadImageData imageData =
+                        mc.renderEngine.obtainImageData(skinUrl, new ImageBufferDownload());
+                    if (imageData != null) {
+                        BufferedImage image =
+                            ClientSkinApplier.flattenToLegacy(ClientSkinApplier.decode(png));
+                        ClientSkinApplier.apply(imageData, image);
+                        // textureSetupComplete=false makes the next render pass
+                        // re-upload the injected pixels into the existing GL texture.
+                    }
+                }
             }
-            ThreadDownloadImageData imageData = mc.renderEngine.obtainImageData(skinUrl, new ImageBufferDownload());
-            if (imageData == null) {
-                return;
+            if (capePng != null) {
+                String cloakUrl = target.cloakUrl;
+                if (cloakUrl != null) {
+                    ThreadDownloadImageData capeData =
+                        mc.renderEngine.obtainImageData(cloakUrl, new ImageBufferDownload());
+                    if (capeData != null) {
+                        BufferedImage capeImage =
+                            ClientSkinApplier.cropCapeToLegacy(ClientSkinApplier.decode(capePng));
+                        ClientSkinApplier.apply(capeData, capeImage);
+                    }
+                }
             }
-            BufferedImage image = ClientSkinApplier.flattenToLegacy(ClientSkinApplier.decode(png));
-            ClientSkinApplier.apply(imageData, image);
-            // textureSetupComplete=false makes the next render pass re-upload
-            // the injected pixels into the existing GL texture.
         } catch (Exception e) {
             // Never crash the network thread on a malformed/undecodable payload.
             System.err.println("EverlastingSkins: client skin apply failed: " + e);

--- a/forge-1.4.7/src/main/java/levosilimo/everlastingskins/broadcast/SkinBroadcaster.java
+++ b/forge-1.4.7/src/main/java/levosilimo/everlastingskins/broadcast/SkinBroadcaster.java
@@ -13,10 +13,11 @@ import net.minecraft.src.Packet;
  * 1.4.7 skin-broadcast channel (FML 4.7 custom-payload surface).
  *
  * <p>FML 4.7 has no netty {@code SimpleNetworkWrapper} (that is 1.8+) and no
- * {@code newChannel} — the 1.5.2 surface is {@code Packet250CustomPayload}
- * payloads, sent via {@link PacketDispatcher}. The channel name must be
- * ≤ 16 chars (NetworkRegistry.java throws beyond that);
- * {@code everlastingskins} is exactly 16 — at the ceiling, never lengthen it.
+ * {@code newChannel} — the 1.4.7 surface is
+ * {@code Packet250CustomPayload} payloads, sent via {@link PacketDispatcher}.
+ * The channel name must be ≤ 16 chars (NetworkRegistry.java:100-105 throws
+ * beyond that); {@code everlastingskins} is exactly 16 — at the ceiling,
+ * never lengthen it.
  *
  * <p>CHANNEL OWNERSHIP: since the joint client side landed (lib-5, PR #422)
  * the channel is registered by the {@code @NetworkMod} joint pattern on the
@@ -27,9 +28,12 @@ import net.minecraft.src.Packet;
  *
  * <p>Payloads carry the target player's username AND the flattened 64x32 PNG
  * bytes ({@link SkinMessage#encode(String, byte[])}); the client handler
- * decodes and injects the pixels. Payload cap: 32766 bytes
- * (Packet250CustomPayload 2-byte length, MC-16910) — a flattened 64x32 PNG is
- * ≈ 1-4 KB, far under the cap; oversized payloads are dropped defensively.
+ * decodes and injects the pixels. Since the cape extension the payload also
+ * carries the cropped 64x32 cape PNG when the stored skin has one
+ * ({@link SkinMessage#encode(String, byte[], byte[])}). Payload cap: 32766
+ * bytes (Packet250CustomPayload 2-byte length, MC-16910) — a flattened 64x32
+ * PNG is ≈ 1-4 KB (skin ≈ 0.5-3 KB + cape ≈ 0.3-2 KB), far under the cap;
+ * oversized payloads are dropped defensively.
  */
 public final class SkinBroadcaster {
 
@@ -42,7 +46,16 @@ public final class SkinBroadcaster {
 
     /** Broadcasts a skin-change payload for {@code playerName} to all players. */
     public static void broadcastProfileChange(String playerName, byte[] pngBytes) {
-        byte[] payload = SkinMessage.encode(playerName, pngBytes);
+        broadcastProfileChange(playerName, pngBytes, null);
+    }
+
+    /**
+     * Broadcasts a skin-change payload for {@code playerName} to all players,
+     * carrying the cape PNG alongside the skin when the stored property has
+     * one ({@code capeBytes} null for cape-less skins).
+     */
+    public static void broadcastProfileChange(String playerName, byte[] pngBytes, byte[] capeBytes) {
+        byte[] payload = SkinMessage.encode(playerName, pngBytes, capeBytes);
         if (payload.length > MAX_PAYLOAD_BYTES) {
             System.err.println("EverlastingSkins: skin payload for '" + playerName
                 + "' exceeds " + MAX_PAYLOAD_BYTES + " bytes — dropped");

--- a/forge-1.4.7/src/main/java/levosilimo/everlastingskins/broadcast/SkinMessage.java
+++ b/forge-1.4.7/src/main/java/levosilimo/everlastingskins/broadcast/SkinMessage.java
@@ -10,6 +10,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.io.EOFException;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
@@ -19,6 +20,14 @@ import java.nio.charset.StandardCharsets;
  * UUID exists on this line — 1.4.7 is pre-UUID-migration) and the raw PNG
  * texture bytes when a companion client wants the payload inline.
  *
+ * <p>Wire format (cape extension, per cape research — the 1.4.7 client
+ * fetches {@code http://skins.minecraft.net/MinecraftCloaks/<name>.png} for
+ * EVERY player with no allowlist, so byte injection is sufficient):
+ * {@code [int nameLen][utf8 name][byte flags][int skinLen][skinPng][int capeLen][capePng]}
+ * — flags bit 0 = hasSkin, bit 1 = hasCape. The old pre-cape format
+ * {@code [int nameLen][name][int pngLen][png]} still decodes (see
+ * {@link #decode(byte[])}).
+ *
  * <p>1.4.7 has no netty {@code IMessage} (1.8+) and no
  * {@code SimpleNetworkWrapper}; the payload is a length-prefixed byte blob
  * inside {@code Packet250CustomPayload.data}. Encode/decode are pure Java
@@ -26,12 +35,23 @@ import java.nio.charset.StandardCharsets;
  */
 public final class SkinMessage {
 
+    /** Flag bit 0: the payload carries a skin PNG. */
+    private static final int FLAG_HAS_SKIN = 1;
+    /** Flag bit 1: the payload carries a cape PNG. */
+    private static final int FLAG_HAS_CAPE = 2;
+
     private final String playerName;
     private final byte[] texturePng;
+    private final byte[] capePng;
 
     public SkinMessage(String playerName, byte[] texturePng) {
+        this(playerName, texturePng, null);
+    }
+
+    public SkinMessage(String playerName, byte[] texturePng, byte[] capePng) {
         this.playerName = playerName;
         this.texturePng = texturePng;
+        this.capePng = capePng;
     }
 
     public String getPlayerName() {
@@ -42,28 +62,44 @@ public final class SkinMessage {
         return texturePng;
     }
 
+    public byte[] getCapePng() {
+        return capePng;
+    }
+
     /**
-     * Wire format: [utf8 username][int png length][png bytes]. A null PNG
-     * encodes as length 0 (notification-only broadcast).
-     *
-     * <p>Every length prefix is bounds-checked against the remaining unread
-     * payload BEFORE allocation ({@link #checkLength}), so a corrupted or
-     * malicious prefix fails with {@link IllegalArgumentException} instead
-     * of an {@link OutOfMemoryError} on the packet thread (lib-18 audit
-     * remediation).
+     * Encodes a skin-only payload (pre-cape convenience, null PNG encodes as
+     * a notification-only broadcast).
      */
     public static byte[] encode(String playerName, byte[] texturePng) {
+        return encode(playerName, texturePng, null);
+    }
+
+    /**
+     * Wire format: {@code [utf8 username][byte flags][int skin length][skin
+     * png][int cape length][cape png]}. A null PNG encodes as length 0
+     * (notification-only broadcast when both are null).
+     */
+    public static byte[] encode(String playerName, byte[] texturePng, byte[] capePng) {
         try {
             ByteArrayOutputStream bos = new ByteArrayOutputStream();
             DataOutputStream out = new DataOutputStream(bos);
             byte[] name = playerName.getBytes(StandardCharsets.UTF_8);
             out.writeInt(name.length);
             out.write(name);
+            int flags = (texturePng != null ? FLAG_HAS_SKIN : 0)
+                | (capePng != null ? FLAG_HAS_CAPE : 0);
+            out.writeByte(flags);
             if (texturePng == null) {
                 out.writeInt(0);
             } else {
                 out.writeInt(texturePng.length);
                 out.write(texturePng);
+            }
+            if (capePng == null) {
+                out.writeInt(0);
+            } else {
+                out.writeInt(capePng.length);
+                out.write(capePng);
             }
             out.flush();
             return bos.toByteArray();
@@ -72,6 +108,21 @@ public final class SkinMessage {
         }
     }
 
+    /**
+     * Decodes both the extended (flags + cape) and the legacy pre-cape
+     * ({@code [nameLen][name][pngLen][png]}) formats. A legacy payload always
+     * yields a null cape.
+     *
+     * <p>Disambiguation: after the name, a legacy payload starts with the
+     * PNG length int (high byte 0, next byte 0 for real PNGs — the payload
+     * cap is 32766 bytes), while an extended payload starts with the flags
+     * byte (0-3) followed by the skin-length int. The extended parse is
+     * attempted first when the shape fits (first byte ≤ 3 and enough bytes
+     * remain); it only wins when it consumes the payload EXACTLY. A legacy
+     * payload with a real PNG always fails that attempt (its length int
+     * over-reads into the PNG magic, exceeding the remaining bytes), so it
+     * falls back cleanly to the legacy parse.
+     */
     public static SkinMessage decode(byte[] payload) {
         try {
             DataInputStream in = new DataInputStream(new ByteArrayInputStream(payload));
@@ -79,6 +130,18 @@ public final class SkinMessage {
             checkLength(nameLen, payload.length - 4, "name");
             byte[] name = new byte[nameLen];
             in.readFully(name);
+            String playerName = new String(name, StandardCharsets.UTF_8);
+            int remaining = payload.length - 4 - nameLen;
+            if (remaining >= 9 && (payload[4 + nameLen] & 0xFF) <= 3) {
+                SkinMessage extended = tryDecodeExtended(in, playerName);
+                if (extended != null) {
+                    return extended;
+                }
+                // Not an extended payload — rewind and parse the legacy shape.
+                in = new DataInputStream(new ByteArrayInputStream(payload));
+                in.readInt();
+                in.readFully(name);
+            }
             int pngLen = in.readInt();
             checkLength(pngLen, payload.length - 8 - nameLen, "png");
             byte[] png = null;
@@ -86,7 +149,7 @@ public final class SkinMessage {
                 png = new byte[pngLen];
                 in.readFully(png);
             }
-            return new SkinMessage(new String(name, StandardCharsets.UTF_8), png);
+            return new SkinMessage(playerName, png);
         } catch (IOException e) {
             throw new IllegalArgumentException("Malformed SkinMessage payload", e);
         }
@@ -103,6 +166,35 @@ public final class SkinMessage {
         if (len < 0 || len > remaining) {
             throw new IllegalArgumentException("Malformed SkinMessage payload: " + field
                 + " length " + len + " exceeds remaining " + remaining + " bytes");
+        }
+    }
+
+    /**
+     * Attempts the extended-format parse; returns null (and the caller falls
+     * back to the legacy shape) unless the extended parse consumes the whole
+     * payload.
+     */
+    private static SkinMessage tryDecodeExtended(DataInputStream in, String playerName) throws IOException {
+        try {
+            int flags = in.readUnsignedByte();
+            int skinLen = in.readInt();
+            byte[] skin = null;
+            if (skinLen > 0) {
+                skin = new byte[skinLen];
+                in.readFully(skin);
+            }
+            int capeLen = in.readInt();
+            byte[] cape = null;
+            if (capeLen > 0) {
+                cape = new byte[capeLen];
+                in.readFully(cape);
+            }
+            if (in.available() != 0) {
+                throw new EOFException("trailing bytes after extended payload");
+            }
+            return new SkinMessage(playerName, skin, cape);
+        } catch (IOException e) {
+            return null;
         }
     }
 }

--- a/forge-1.4.7/src/main/java/levosilimo/everlastingskins/broadcast/SkinMessage.java
+++ b/forge-1.4.7/src/main/java/levosilimo/everlastingskins/broadcast/SkinMessage.java
@@ -122,6 +122,12 @@ public final class SkinMessage {
      * payload with a real PNG always fails that attempt (its length int
      * over-reads into the PNG magic, exceeding the remaining bytes), so it
      * falls back cleanly to the legacy parse.
+     *
+     * <p>Every length prefix is bounds-checked against the remaining unread
+     * payload BEFORE allocation ({@link #checkLength}), so a corrupted or
+     * malicious prefix fails with {@link IllegalArgumentException} (which
+     * the client handler catches) instead of an {@link OutOfMemoryError}
+     * on the packet thread (lib-18 audit remediation).
      */
     public static SkinMessage decode(byte[] payload) {
         try {
@@ -178,12 +184,14 @@ public final class SkinMessage {
         try {
             int flags = in.readUnsignedByte();
             int skinLen = in.readInt();
+            checkLength(skinLen, in.available(), "skin");
             byte[] skin = null;
             if (skinLen > 0) {
                 skin = new byte[skinLen];
                 in.readFully(skin);
             }
             int capeLen = in.readInt();
+            checkLength(capeLen, in.available(), "cape");
             byte[] cape = null;
             if (capeLen > 0) {
                 cape = new byte[capeLen];
@@ -193,7 +201,10 @@ public final class SkinMessage {
                 throw new EOFException("trailing bytes after extended payload");
             }
             return new SkinMessage(playerName, skin, cape);
-        } catch (IOException e) {
+        } catch (IOException | IllegalArgumentException e) {
+            // A guard violation makes this a failed extended attempt (a
+            // legacy payload's pngLen-derived skinLen always over-reads) —
+            // fall back to the legacy shape exactly as an EOF would.
             return null;
         }
     }

--- a/forge-1.4.7/src/main/java/levosilimo/everlastingskins/client/ClientSkinApplier.java
+++ b/forge-1.4.7/src/main/java/levosilimo/everlastingskins/client/ClientSkinApplier.java
@@ -60,6 +60,21 @@ public final class ClientSkinApplier {
     }
 
     /**
+     * Converts any cape to the legacy 64x32 model: modern capes are 64x64
+     * canvases whose art lives in the top 64x32 rows (the pre-1.8
+     * {@code renderCloak} UVs sample only that region), so a 64x64 cape is
+     * cropped to its top half — the same vanilla crop the skin flatten
+     * performs (the pre-1.8 download pipeline passes capes through
+     * {@code ImageBufferDownload.parseUserSkin}). 64x32 inputs pass through
+     * unchanged; any other size is drawn unscaled at (0,0) like the vanilla
+     * pipeline. The server pre-crops before broadcast; this client-side pass
+     * is idempotent defense against an uncropped payload.
+     */
+    public static BufferedImage cropCapeToLegacy(BufferedImage source) {
+        return flattenToLegacy(source);
+    }
+
+    /**
      * Finds a spawned player by {@code getCommandSenderName()} in the client
      * world ({@code World.playerEntities}), or null when not spawned yet.
      */

--- a/forge-1.4.7/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRestorer.java
+++ b/forge-1.4.7/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRestorer.java
@@ -116,7 +116,8 @@ public final class SkinRestorer {
         CustomSkinProperty skin = s.getSkin(uuid);
         if (skin != null) {
             SkinBroadcaster.broadcastProfileChange(player.getCommandSenderName(),
-                SkinTextureFetcher.fetchLegacyPng(skin));
+                SkinTextureFetcher.fetchLegacyPng(skin),
+                SkinTextureFetcher.fetchLegacyCapePng(skin));
         }
     }
 
@@ -171,7 +172,8 @@ public final class SkinRestorer {
         }
         byte[] png = SkinTextureFetcher.fetchLegacyPng(skin);
         if (png != null) {
-            SkinBroadcaster.broadcastProfileChange(username, png);
+            SkinBroadcaster.broadcastProfileChange(username, png,
+                SkinTextureFetcher.fetchLegacyCapePng(skin));
         }
     }
 

--- a/forge-1.4.7/src/main/java/levosilimo/everlastingskins/skinchanger/SkinTextureFetcher.java
+++ b/forge-1.4.7/src/main/java/levosilimo/everlastingskins/skinchanger/SkinTextureFetcher.java
@@ -35,6 +35,13 @@ import java.net.URL;
  * <p>Fail-soft: any fetch/decode/encode failure returns null (the broadcast
  * degrades to the legacy notification-only payload rather than crashing the
  * command/login path).
+ *
+ * <p>Cape path ({@link #fetchLegacyCapePng}): the textures JSON carries the
+ * cape under {@code CAPE.url} (exposed via
+ * {@link PropertyUtils#getCapeTextureUrl}); modern capes are 64x64 canvases
+ * whose art lives in the top 64x32 rows, so the fetched cape is cropped to
+ * the top 64x32 region before broadcast (pre-1.8 renderCloak UVs). Cape-less
+ * properties yield null (no cape field on the wire).
  */
 public final class SkinTextureFetcher {
 
@@ -61,6 +68,33 @@ public final class SkinTextureFetcher {
             return bos.toByteArray();
         } catch (Exception e) {
             System.err.println("EverlastingSkins: skin texture fetch failed: " + e);
+            return null;
+        }
+    }
+
+    /**
+     * Fetches the cape PNG from the property's {@code CAPE.url} and returns it
+     * cropped to the legacy 64x32 model (top 64x32 rows of the modern 64x64
+     * canvas), re-encoded as PNG. Null when the property has no cape or the
+     * fetch/decode fails.
+     */
+    public static byte[] fetchLegacyCapePng(CustomSkinProperty skin) {
+        try {
+            String capeUrl = PropertyUtils.getCapeTextureUrl(skin);
+            if (capeUrl == null) {
+                return null;
+            }
+            byte[] png = fetchBytes(capeUrl);
+            if (png == null) {
+                return null;
+            }
+            BufferedImage image = ClientSkinApplier.decode(png);
+            BufferedImage legacy = ClientSkinApplier.cropCapeToLegacy(image);
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            ImageIO.write(legacy, "png", bos);
+            return bos.toByteArray();
+        } catch (Exception e) {
+            System.err.println("EverlastingSkins: cape texture fetch failed: " + e);
             return null;
         }
     }

--- a/forge-1.4.7/src/test/java/levosilimo/everlastingskins/broadcast/SkinMessageTest.java
+++ b/forge-1.4.7/src/test/java/levosilimo/everlastingskins/broadcast/SkinMessageTest.java
@@ -172,8 +172,8 @@ public class SkinMessageTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void malformedPngLengthRejectedBeforeAllocation() throws Exception {
-        // pngLen = 2^31-1: the bounds guard must reject it before the
-        // allocation (lib-18 audit).
+        // Legacy shape with pngLen = 2^31-1 (first byte 0x7F > 3, so no
+        // extended attempt): the guard must reject it before allocating.
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         DataOutputStream out = new DataOutputStream(bos);
         byte[] name = "Legacy".getBytes(StandardCharsets.UTF_8);
@@ -182,6 +182,66 @@ public class SkinMessageTest {
         out.writeInt(Integer.MAX_VALUE);
         out.flush();
         SkinMessage.decode(bos.toByteArray());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void malformedSkinLengthRejectedBeforeAllocation() throws Exception {
+        // Extended shape with skinLen = 2^31-1: the extended attempt's guard
+        // rejects it (then the legacy pngLen guard fires on the rewind).
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bos);
+        byte[] name = "Alex".getBytes(StandardCharsets.UTF_8);
+        out.writeInt(name.length);
+        out.write(name);
+        out.writeByte(3); // flags: hasSkin | hasCape
+        out.writeInt(Integer.MAX_VALUE);
+        out.writeInt(0);
+        out.writeInt(0);
+        out.flush();
+        SkinMessage.decode(bos.toByteArray());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void malformedCapeLengthRejectedBeforeAllocation() throws Exception {
+        // Extended shape with a valid skin and capeLen = 2^31-1.
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bos);
+        byte[] name = "Alex".getBytes(StandardCharsets.UTF_8);
+        out.writeInt(name.length);
+        out.write(name);
+        out.writeByte(3);
+        out.writeInt(1);
+        out.writeByte(9); // skin bytes
+        out.writeInt(Integer.MAX_VALUE);
+        out.flush();
+        SkinMessage.decode(bos.toByteArray());
+    }
+
+    @Test
+    public void legacyPayloadWithLargePngStillDecodesWhenExtendedAttemptGuardFires() throws Exception {
+        // A legacy payload with a large real PNG (~30 KB, under the 32766
+        // cap): the extended attempt reads a bogus skinLen (~pngLen*256 +
+        // first PNG byte) that the bounds guard rejects BEFORE allocation;
+        // the legacy fallback must still decode it (lib-18: the guard must
+        // not break the fallback).
+        byte[] png = new byte[30000];
+        for (int i = 0; i < png.length; i++) {
+            png[i] = (byte) (i & 0xFF);
+        }
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bos);
+        byte[] name = "Legacy".getBytes(StandardCharsets.UTF_8);
+        out.writeInt(name.length);
+        out.write(name);
+        out.writeInt(png.length);
+        out.write(png);
+        out.flush();
+
+        SkinMessage message = SkinMessage.decode(bos.toByteArray());
+
+        assertEquals("Legacy", message.getPlayerName());
+        assertArrayEquals(png, message.getTexturePng());
+        assertNull(message.getCapePng());
     }
 
     @Test

--- a/forge-1.4.7/src/test/java/levosilimo/everlastingskins/broadcast/SkinMessageTest.java
+++ b/forge-1.4.7/src/test/java/levosilimo/everlastingskins/broadcast/SkinMessageTest.java
@@ -58,6 +58,86 @@ public class SkinMessageTest {
         SkinMessage message = SkinMessage.decode(SkinMessage.encode("Steve", png));
         assertEquals("Steve", message.getPlayerName());
         assertArrayEquals(png, message.getTexturePng());
+        assertNull(message.getCapePng());
+    }
+
+    @Test
+    public void encodeDecodeRoundTripsSkinAndCape() {
+        byte[] skin = new byte[]{1, 2, 3, 4, 5};
+        byte[] cape = new byte[]{6, 7, 8};
+
+        SkinMessage message = SkinMessage.decode(SkinMessage.encode("Alex", skin, cape));
+
+        assertEquals("Alex", message.getPlayerName());
+        assertArrayEquals(skin, message.getTexturePng());
+        assertArrayEquals(cape, message.getCapePng());
+    }
+
+    @Test
+    public void encodeDecodeRoundTripsCapeOnly() {
+        byte[] cape = new byte[]{9, 9, 9};
+
+        SkinMessage message = SkinMessage.decode(SkinMessage.encode("Alex", null, cape));
+
+        assertEquals("Alex", message.getPlayerName());
+        assertNull(message.getTexturePng());
+        assertArrayEquals(cape, message.getCapePng());
+    }
+
+    @Test
+    public void flagsBitsReflectFieldPresence() {
+        // Wire layout: [int nameLen][utf8 name][byte flags][int skinLen]...
+        byte[] skin = new byte[]{1};
+        byte[] cape = new byte[]{2};
+        int flagsOffset = 4 + "Alex".length();
+
+        assertEquals(1, encodeFlagsByte("Alex", skin, null, flagsOffset)); // bit 0 = hasSkin
+        assertEquals(2, encodeFlagsByte("Alex", null, cape, flagsOffset)); // bit 1 = hasCape
+        assertEquals(3, encodeFlagsByte("Alex", skin, cape, flagsOffset));
+        assertEquals(0, encodeFlagsByte("Alex", null, null, flagsOffset));
+    }
+
+    @Test
+    public void legacyPayloadWithoutFlagsStillDecodes() throws Exception {
+        // Pre-cape wire format: [int nameLen][utf8 name][int pngLen][png]
+        // (the shape the joint client broadcast landed with, PR #426).
+        byte[] png = new byte[]{10, 11, 12, 13};
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bos);
+        byte[] name = "Legacy".getBytes(StandardCharsets.UTF_8);
+        out.writeInt(name.length);
+        out.write(name);
+        out.writeInt(png.length);
+        out.write(png);
+        out.flush();
+
+        SkinMessage message = SkinMessage.decode(bos.toByteArray());
+
+        assertEquals("Legacy", message.getPlayerName());
+        assertArrayEquals(png, message.getTexturePng());
+        assertNull(message.getCapePng());
+    }
+
+    @Test
+    public void legacyNotificationPayloadStillDecodes() throws Exception {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bos);
+        byte[] name = "Legacy".getBytes(StandardCharsets.UTF_8);
+        out.writeInt(name.length);
+        out.write(name);
+        out.writeInt(0);
+        out.flush();
+
+        SkinMessage message = SkinMessage.decode(bos.toByteArray());
+
+        assertEquals("Legacy", message.getPlayerName());
+        assertNull(message.getTexturePng());
+        assertNull(message.getCapePng());
+    }
+
+    private static int encodeFlagsByte(String name, byte[] skin, byte[] cape, int flagsOffset) {
+        byte[] payload = SkinMessage.encode(name, skin, cape);
+        return payload[flagsOffset] & 0xFF;
     }
 
     @Test

--- a/forge-1.4.7/src/test/java/levosilimo/everlastingskins/client/ClientSkinApplierTest.java
+++ b/forge-1.4.7/src/test/java/levosilimo/everlastingskins/client/ClientSkinApplierTest.java
@@ -92,6 +92,34 @@ public class ClientSkinApplierTest {
     }
 
     @Test
+    public void cropCapeCropsModern64x64ToTopHalf() {
+        // Modern capes are 64x64 canvases whose art lives in the top 64x32
+        // rows (the pre-1.8 renderCloak UVs sample only that region), so the
+        // crop keeps the top half and drops the bottom 32 rows.
+        BufferedImage modern = new BufferedImage(64, 64, BufferedImage.TYPE_INT_ARGB);
+        for (int x = 0; x < 64; x++) {
+            for (int y = 0; y < 64; y++) {
+                modern.setRGB(x, y, 0xFF000000);
+            }
+        }
+        modern.setRGB(10, 10, 0xFFAA0000); // top region — kept
+        modern.setRGB(50, 50, 0xFF0000CC); // bottom region — dropped
+
+        BufferedImage legacy = ClientSkinApplier.cropCapeToLegacy(modern);
+
+        assertEquals(64, legacy.getWidth());
+        assertEquals(32, legacy.getHeight());
+        assertEquals(0xFFAA0000, legacy.getRGB(10, 10));
+        assertEquals(0xFF000000, legacy.getRGB(50, 30)); // bottom row must not leak
+    }
+
+    @Test
+    public void cropCapePassesLegacy64x32Through() {
+        BufferedImage legacy = solid(64, 32, 0xFF778899);
+        assertSame(legacy, ClientSkinApplier.cropCapeToLegacy(legacy));
+    }
+
+    @Test
     public void findPlayerMatchesByCommandSenderName() throws Exception {
         World world = mock(World.class);
         EntityPlayer notch = mock(EntityPlayer.class);

--- a/forge-1.4.7/src/test/java/levosilimo/everlastingskins/skinchanger/SkinTextureFetcherTest.java
+++ b/forge-1.4.7/src/test/java/levosilimo/everlastingskins/skinchanger/SkinTextureFetcherTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 /**
- * 1.6.4 server-side skin texture fetch tests (lib-5 joint broadcast): the
+ * 1.4.7 server-side skin texture fetch tests (lib-5 joint broadcast): the
  * textures property is fetched over HTTP, decoded and flattened to the legacy
  * 64x32 model. Deterministic fixtures only (memory #1115) — an in-process
  * HttpServer serves a generated PNG on localhost; the lane-local fetch's
@@ -110,6 +110,35 @@ public class SkinTextureFetcherTest {
         assertNull(result);
     }
 
+    @Test
+    public void fetchesAndCropsModern64x64Cape() throws Exception {
+        // Modern capes are 64x64 canvases whose art lives in the top 64x32
+        // rows; the pre-1.8 renderCloak UVs need the 64x32 top region.
+        BufferedImage modern = new BufferedImage(64, 64, BufferedImage.TYPE_INT_ARGB);
+        for (int x = 0; x < 64; x++) {
+            for (int y = 0; y < 64; y++) {
+                modern.setRGB(x, y, 0xFF223344);
+            }
+        }
+        modern.setRGB(20, 20, 0xFFBB0000); // top region — kept
+        serve("/cape64.png", png(modern));
+
+        byte[] result = SkinTextureFetcher.fetchLegacyCapePng(capeProperty(baseUrl + "/cape64.png"));
+
+        assertNotNull(result);
+        BufferedImage cropped = ImageIO.read(new java.io.ByteArrayInputStream(result));
+        assertEquals(64, cropped.getWidth());
+        assertEquals(32, cropped.getHeight());
+        assertEquals(0xFFBB0000, cropped.getRGB(20, 20));
+    }
+
+    @Test
+    public void capeLessPropertyYieldsNull() throws Exception {
+        // A skin property without a CAPE entry must not produce cape bytes
+        // (the common case — most skins have no cape).
+        assertNull(SkinTextureFetcher.fetchLegacyCapePng(property("textures", baseUrl + "/skin64.png")));
+    }
+
     private void serve(String path, byte[] body) {
         server.createContext(path, exchange -> {
             byte[] payload = body;
@@ -125,6 +154,14 @@ public class SkinTextureFetcherTest {
         String json = "{\"textures\":{\"SKIN\":{\"url\":\"" + url + "\"}}}";
         String value = java.util.Base64.getEncoder().encodeToString(json.getBytes(java.nio.charset.StandardCharsets.UTF_8));
         return new CustomSkinProperty(name, value, null, "test");
+    }
+
+    /** Textures property with a CAPE entry (skin + cape URLs). */
+    private static CustomSkinProperty capeProperty(String capeUrl) {
+        String json = "{\"textures\":{\"SKIN\":{\"url\":\"https://textures.minecraft.net/texture/s\"},"
+            + "\"CAPE\":{\"url\":\"" + capeUrl + "\"}}}";
+        String value = java.util.Base64.getEncoder().encodeToString(json.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        return new CustomSkinProperty("textures", value, null, "test");
     }
 
     private static byte[] png(BufferedImage image) throws Exception {

--- a/forge-1.5.2/src/main/java/levosilimo/everlastingskins/broadcast/ClientSkinHandler.java
+++ b/forge-1.5.2/src/main/java/levosilimo/everlastingskins/broadcast/ClientSkinHandler.java
@@ -31,7 +31,17 @@ import java.awt.image.BufferedImage;
  * {@code World.playerEntities} (1.5.2 has no UUID on the wire); the cached
  * TDI is looked up by the player's {@code skinUrl} through
  * {@code RenderEngine.obtainImageData} (the cache keyed by skin URL, seeded
- * by {@code RenderGlobal.updateEntitySkin} when the entity spawned).
+ * by {@code RenderGlobal.obtainEntitySkin} when the entity spawned).
+ *
+ * <p>Cape injection (per cape research): the 1.5.2 client fetches
+ * {@code http://skins.minecraft.net/MinecraftCloaks/<name>.png} for EVERY
+ * player with no allowlist (the render gates are only image loaded/visible/
+ * not-sneaking), so byte injection suffices. The cape reuses the SAME
+ * {@link ThreadDownloadImageData} class as the skin, cached in the
+ * RenderEngine keyed by the player's {@code cloakUrl} — set for every player
+ * by the {@code EntityOtherPlayerMP}/{@code EntityPlayerSP} constructors —
+ * so the cape path mirrors the skin path with the cache key swapped from
+ * {@code skinUrl} to {@code cloakUrl}.
  *
  * <p>Re-injection on join: the server re-broadcasts the stored skin on every
  * login, so a packet that arrives before the player entity spawns is simply
@@ -48,7 +58,8 @@ public final class ClientSkinHandler implements IPacketHandler {
         try {
             SkinMessage message = SkinMessage.decode(packet.data);
             byte[] png = message.getTexturePng();
-            if (png == null) {
+            byte[] capePng = message.getCapePng();
+            if (png == null && capePng == null) {
                 // Notification-only broadcast from a pre-joint server.
                 return;
             }
@@ -61,24 +72,38 @@ public final class ClientSkinHandler implements IPacketHandler {
                 // Not spawned yet — the join broadcast re-delivers.
                 return;
             }
-            // skinUrl is declared on Entity; access it through the Entity
-            // type so the reobf pass can map the reference (javac emits the
-            // receiver's declared type as the owner, and the srg FD keys are
-            // the declaring class — EntityPlayer.skinUrl would stay unmapped
-            // and NoSuchFieldError at runtime; found live by the slice-1
-            // 1.5.2 E2E).
-            String skinUrl = ((net.minecraft.src.Entity) target).skinUrl;
-            if (skinUrl == null) {
-                return;
+            if (png != null) {
+                // skinUrl is declared on Entity; access it through the Entity
+                // type so the reobf pass can map the reference (javac emits the
+                // receiver's declared type as the owner, and the srg FD keys are
+                // the declaring class — EntityPlayer.skinUrl would stay unmapped
+                // and NoSuchFieldError at runtime; found live by the slice-1
+                // 1.5.2 E2E).
+                String skinUrl = ((net.minecraft.src.Entity) target).skinUrl;
+                if (skinUrl != null) {
+                    ThreadDownloadImageData imageData =
+                        mc.renderEngine.obtainImageData(skinUrl, new ImageBufferDownload());
+                    if (imageData != null) {
+                        BufferedImage image =
+                            ClientSkinApplier.flattenToLegacy(ClientSkinApplier.decode(png));
+                        ClientSkinApplier.apply(imageData, image);
+                        // textureSetupComplete=false makes the next render pass
+                        // re-upload the injected pixels into the existing GL texture.
+                    }
+                }
             }
-            ThreadDownloadImageData imageData = mc.renderEngine.obtainImageData(skinUrl, new ImageBufferDownload());
-            if (imageData == null) {
-                return;
+            if (capePng != null) {
+                String cloakUrl = target.cloakUrl;
+                if (cloakUrl != null) {
+                    ThreadDownloadImageData capeData =
+                        mc.renderEngine.obtainImageData(cloakUrl, new ImageBufferDownload());
+                    if (capeData != null) {
+                        BufferedImage capeImage =
+                            ClientSkinApplier.cropCapeToLegacy(ClientSkinApplier.decode(capePng));
+                        ClientSkinApplier.apply(capeData, capeImage);
+                    }
+                }
             }
-            BufferedImage image = ClientSkinApplier.flattenToLegacy(ClientSkinApplier.decode(png));
-            ClientSkinApplier.apply(imageData, image);
-            // textureSetupComplete=false makes the next render pass re-upload
-            // the injected pixels into the existing GL texture.
         } catch (Exception e) {
             // Never crash the network thread on a malformed/undecodable payload.
             System.err.println("EverlastingSkins: client skin apply failed: " + e);

--- a/forge-1.5.2/src/main/java/levosilimo/everlastingskins/broadcast/SkinBroadcaster.java
+++ b/forge-1.5.2/src/main/java/levosilimo/everlastingskins/broadcast/SkinBroadcaster.java
@@ -13,10 +13,11 @@ import net.minecraft.src.Packet;
  * 1.5.2 skin-broadcast channel (FML 5.2 custom-payload surface).
  *
  * <p>FML 5.2 has no netty {@code SimpleNetworkWrapper} (that is 1.8+) and no
- * {@code newChannel} — the 1.5.2 surface is {@code Packet250CustomPayload}
- * payloads, sent via {@link PacketDispatcher}. The channel name must be
- * ≤ 16 chars (NetworkRegistry.java throws beyond that);
- * {@code everlastingskins} is exactly 16 — at the ceiling, never lengthen it.
+ * {@code newChannel} — the 1.5.2 surface is
+ * {@code Packet250CustomPayload} payloads, sent via {@link PacketDispatcher}.
+ * The channel name must be ≤ 16 chars (NetworkRegistry.java:100-105 throws
+ * beyond that); {@code everlastingskins} is exactly 16 — at the ceiling,
+ * never lengthen it.
  *
  * <p>CHANNEL OWNERSHIP: since the joint client side landed (lib-5, PR #422)
  * the channel is registered by the {@code @NetworkMod} joint pattern on the
@@ -27,9 +28,12 @@ import net.minecraft.src.Packet;
  *
  * <p>Payloads carry the target player's username AND the flattened 64x32 PNG
  * bytes ({@link SkinMessage#encode(String, byte[])}); the client handler
- * decodes and injects the pixels. Payload cap: 32766 bytes
- * (Packet250CustomPayload 2-byte length, MC-16910) — a flattened 64x32 PNG is
- * ≈ 1-4 KB, far under the cap; oversized payloads are dropped defensively.
+ * decodes and injects the pixels. Since the cape extension the payload also
+ * carries the cropped 64x32 cape PNG when the stored skin has one
+ * ({@link SkinMessage#encode(String, byte[], byte[])}). Payload cap: 32766
+ * bytes (Packet250CustomPayload 2-byte length, MC-16910) — a flattened 64x32
+ * PNG is ≈ 1-4 KB (skin ≈ 0.5-3 KB + cape ≈ 0.3-2 KB), far under the cap;
+ * oversized payloads are dropped defensively.
  */
 public final class SkinBroadcaster {
 
@@ -42,7 +46,16 @@ public final class SkinBroadcaster {
 
     /** Broadcasts a skin-change payload for {@code playerName} to all players. */
     public static void broadcastProfileChange(String playerName, byte[] pngBytes) {
-        byte[] payload = SkinMessage.encode(playerName, pngBytes);
+        broadcastProfileChange(playerName, pngBytes, null);
+    }
+
+    /**
+     * Broadcasts a skin-change payload for {@code playerName} to all players,
+     * carrying the cape PNG alongside the skin when the stored property has
+     * one ({@code capeBytes} null for cape-less skins).
+     */
+    public static void broadcastProfileChange(String playerName, byte[] pngBytes, byte[] capeBytes) {
+        byte[] payload = SkinMessage.encode(playerName, pngBytes, capeBytes);
         if (payload.length > MAX_PAYLOAD_BYTES) {
             System.err.println("EverlastingSkins: skin payload for '" + playerName
                 + "' exceeds " + MAX_PAYLOAD_BYTES + " bytes — dropped");

--- a/forge-1.5.2/src/main/java/levosilimo/everlastingskins/broadcast/SkinMessage.java
+++ b/forge-1.5.2/src/main/java/levosilimo/everlastingskins/broadcast/SkinMessage.java
@@ -10,14 +10,23 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.io.EOFException;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 /**
  * Server-to-client skin broadcast payload for 1.5.2 (FML 5.2
  * {@code Packet250CustomPayload}): carries the target player's USERNAME (no
- * UUID exists on this line — 1.5.2 is pre-UUID) and the raw PNG texture
- * bytes when a companion client wants the payload inline.
+ * UUID exists on this line — 1.5.2 is pre-UUID-migration) and the raw PNG
+ * texture bytes when a companion client wants the payload inline.
+ *
+ * <p>Wire format (cape extension, per cape research — the 1.5.2 client
+ * fetches {@code http://skins.minecraft.net/MinecraftCloaks/<name>.png} for
+ * EVERY player with no allowlist, so byte injection is sufficient):
+ * {@code [int nameLen][utf8 name][byte flags][int skinLen][skinPng][int capeLen][capePng]}
+ * — flags bit 0 = hasSkin, bit 1 = hasCape. The old pre-cape format
+ * {@code [int nameLen][name][int pngLen][png]} still decodes (see
+ * {@link #decode(byte[])}).
  *
  * <p>1.5.2 has no netty {@code IMessage} (1.8+) and no
  * {@code SimpleNetworkWrapper}; the payload is a length-prefixed byte blob
@@ -26,12 +35,23 @@ import java.nio.charset.StandardCharsets;
  */
 public final class SkinMessage {
 
+    /** Flag bit 0: the payload carries a skin PNG. */
+    private static final int FLAG_HAS_SKIN = 1;
+    /** Flag bit 1: the payload carries a cape PNG. */
+    private static final int FLAG_HAS_CAPE = 2;
+
     private final String playerName;
     private final byte[] texturePng;
+    private final byte[] capePng;
 
     public SkinMessage(String playerName, byte[] texturePng) {
+        this(playerName, texturePng, null);
+    }
+
+    public SkinMessage(String playerName, byte[] texturePng, byte[] capePng) {
         this.playerName = playerName;
         this.texturePng = texturePng;
+        this.capePng = capePng;
     }
 
     public String getPlayerName() {
@@ -42,28 +62,44 @@ public final class SkinMessage {
         return texturePng;
     }
 
+    public byte[] getCapePng() {
+        return capePng;
+    }
+
     /**
-     * Wire format: [utf8 username][int png length][png bytes]. A null PNG
-     * encodes as length 0 (notification-only broadcast).
-     *
-     * <p>Every length prefix is bounds-checked against the remaining unread
-     * payload BEFORE allocation ({@link #checkLength}), so a corrupted or
-     * malicious prefix fails with {@link IllegalArgumentException} instead
-     * of an {@link OutOfMemoryError} on the packet thread (lib-18 audit
-     * remediation).
+     * Encodes a skin-only payload (pre-cape convenience, null PNG encodes as
+     * a notification-only broadcast).
      */
     public static byte[] encode(String playerName, byte[] texturePng) {
+        return encode(playerName, texturePng, null);
+    }
+
+    /**
+     * Wire format: {@code [utf8 username][byte flags][int skin length][skin
+     * png][int cape length][cape png]}. A null PNG encodes as length 0
+     * (notification-only broadcast when both are null).
+     */
+    public static byte[] encode(String playerName, byte[] texturePng, byte[] capePng) {
         try {
             ByteArrayOutputStream bos = new ByteArrayOutputStream();
             DataOutputStream out = new DataOutputStream(bos);
             byte[] name = playerName.getBytes(StandardCharsets.UTF_8);
             out.writeInt(name.length);
             out.write(name);
+            int flags = (texturePng != null ? FLAG_HAS_SKIN : 0)
+                | (capePng != null ? FLAG_HAS_CAPE : 0);
+            out.writeByte(flags);
             if (texturePng == null) {
                 out.writeInt(0);
             } else {
                 out.writeInt(texturePng.length);
                 out.write(texturePng);
+            }
+            if (capePng == null) {
+                out.writeInt(0);
+            } else {
+                out.writeInt(capePng.length);
+                out.write(capePng);
             }
             out.flush();
             return bos.toByteArray();
@@ -72,6 +108,21 @@ public final class SkinMessage {
         }
     }
 
+    /**
+     * Decodes both the extended (flags + cape) and the legacy pre-cape
+     * ({@code [nameLen][name][pngLen][png]}) formats. A legacy payload always
+     * yields a null cape.
+     *
+     * <p>Disambiguation: after the name, a legacy payload starts with the
+     * PNG length int (high byte 0, next byte 0 for real PNGs — the payload
+     * cap is 32766 bytes), while an extended payload starts with the flags
+     * byte (0-3) followed by the skin-length int. The extended parse is
+     * attempted first when the shape fits (first byte ≤ 3 and enough bytes
+     * remain); it only wins when it consumes the payload EXACTLY. A legacy
+     * payload with a real PNG always fails that attempt (its length int
+     * over-reads into the PNG magic, exceeding the remaining bytes), so it
+     * falls back cleanly to the legacy parse.
+     */
     public static SkinMessage decode(byte[] payload) {
         try {
             DataInputStream in = new DataInputStream(new ByteArrayInputStream(payload));
@@ -79,6 +130,18 @@ public final class SkinMessage {
             checkLength(nameLen, payload.length - 4, "name");
             byte[] name = new byte[nameLen];
             in.readFully(name);
+            String playerName = new String(name, StandardCharsets.UTF_8);
+            int remaining = payload.length - 4 - nameLen;
+            if (remaining >= 9 && (payload[4 + nameLen] & 0xFF) <= 3) {
+                SkinMessage extended = tryDecodeExtended(in, playerName);
+                if (extended != null) {
+                    return extended;
+                }
+                // Not an extended payload — rewind and parse the legacy shape.
+                in = new DataInputStream(new ByteArrayInputStream(payload));
+                in.readInt();
+                in.readFully(name);
+            }
             int pngLen = in.readInt();
             checkLength(pngLen, payload.length - 8 - nameLen, "png");
             byte[] png = null;
@@ -86,7 +149,7 @@ public final class SkinMessage {
                 png = new byte[pngLen];
                 in.readFully(png);
             }
-            return new SkinMessage(new String(name, StandardCharsets.UTF_8), png);
+            return new SkinMessage(playerName, png);
         } catch (IOException e) {
             throw new IllegalArgumentException("Malformed SkinMessage payload", e);
         }
@@ -103,6 +166,35 @@ public final class SkinMessage {
         if (len < 0 || len > remaining) {
             throw new IllegalArgumentException("Malformed SkinMessage payload: " + field
                 + " length " + len + " exceeds remaining " + remaining + " bytes");
+        }
+    }
+
+    /**
+     * Attempts the extended-format parse; returns null (and the caller falls
+     * back to the legacy shape) unless the extended parse consumes the whole
+     * payload.
+     */
+    private static SkinMessage tryDecodeExtended(DataInputStream in, String playerName) throws IOException {
+        try {
+            int flags = in.readUnsignedByte();
+            int skinLen = in.readInt();
+            byte[] skin = null;
+            if (skinLen > 0) {
+                skin = new byte[skinLen];
+                in.readFully(skin);
+            }
+            int capeLen = in.readInt();
+            byte[] cape = null;
+            if (capeLen > 0) {
+                cape = new byte[capeLen];
+                in.readFully(cape);
+            }
+            if (in.available() != 0) {
+                throw new EOFException("trailing bytes after extended payload");
+            }
+            return new SkinMessage(playerName, skin, cape);
+        } catch (IOException e) {
+            return null;
         }
     }
 }

--- a/forge-1.5.2/src/main/java/levosilimo/everlastingskins/broadcast/SkinMessage.java
+++ b/forge-1.5.2/src/main/java/levosilimo/everlastingskins/broadcast/SkinMessage.java
@@ -122,6 +122,12 @@ public final class SkinMessage {
      * payload with a real PNG always fails that attempt (its length int
      * over-reads into the PNG magic, exceeding the remaining bytes), so it
      * falls back cleanly to the legacy parse.
+     *
+     * <p>Every length prefix is bounds-checked against the remaining unread
+     * payload BEFORE allocation ({@link #checkLength}), so a corrupted or
+     * malicious prefix fails with {@link IllegalArgumentException} (which
+     * the client handler catches) instead of an {@link OutOfMemoryError}
+     * on the packet thread (lib-18 audit remediation).
      */
     public static SkinMessage decode(byte[] payload) {
         try {
@@ -178,12 +184,14 @@ public final class SkinMessage {
         try {
             int flags = in.readUnsignedByte();
             int skinLen = in.readInt();
+            checkLength(skinLen, in.available(), "skin");
             byte[] skin = null;
             if (skinLen > 0) {
                 skin = new byte[skinLen];
                 in.readFully(skin);
             }
             int capeLen = in.readInt();
+            checkLength(capeLen, in.available(), "cape");
             byte[] cape = null;
             if (capeLen > 0) {
                 cape = new byte[capeLen];
@@ -193,7 +201,10 @@ public final class SkinMessage {
                 throw new EOFException("trailing bytes after extended payload");
             }
             return new SkinMessage(playerName, skin, cape);
-        } catch (IOException e) {
+        } catch (IOException | IllegalArgumentException e) {
+            // A guard violation makes this a failed extended attempt (a
+            // legacy payload's pngLen-derived skinLen always over-reads) —
+            // fall back to the legacy shape exactly as an EOF would.
             return null;
         }
     }

--- a/forge-1.5.2/src/main/java/levosilimo/everlastingskins/client/ClientSkinApplier.java
+++ b/forge-1.5.2/src/main/java/levosilimo/everlastingskins/client/ClientSkinApplier.java
@@ -60,6 +60,21 @@ public final class ClientSkinApplier {
     }
 
     /**
+     * Converts any cape to the legacy 64x32 model: modern capes are 64x64
+     * canvases whose art lives in the top 64x32 rows (the pre-1.8
+     * {@code renderCloak} UVs sample only that region), so a 64x64 cape is
+     * cropped to its top half — the same vanilla crop the skin flatten
+     * performs (the pre-1.8 download pipeline passes capes through
+     * {@code ImageBufferDownload.parseUserSkin}). 64x32 inputs pass through
+     * unchanged; any other size is drawn unscaled at (0,0) like the vanilla
+     * pipeline. The server pre-crops before broadcast; this client-side pass
+     * is idempotent defense against an uncropped payload.
+     */
+    public static BufferedImage cropCapeToLegacy(BufferedImage source) {
+        return flattenToLegacy(source);
+    }
+
+    /**
      * Finds a spawned player by {@code getCommandSenderName()} in the client
      * world ({@code World.playerEntities}), or null when not spawned yet.
      */

--- a/forge-1.5.2/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRestorer.java
+++ b/forge-1.5.2/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRestorer.java
@@ -109,7 +109,8 @@ public final class SkinRestorer {
         CustomSkinProperty skin = s.getSkin(uuid);
         if (skin != null) {
             SkinBroadcaster.broadcastProfileChange(player.getCommandSenderName(),
-                SkinTextureFetcher.fetchLegacyPng(skin));
+                SkinTextureFetcher.fetchLegacyPng(skin),
+                SkinTextureFetcher.fetchLegacyCapePng(skin));
         }
     }
 
@@ -164,7 +165,8 @@ public final class SkinRestorer {
         }
         byte[] png = SkinTextureFetcher.fetchLegacyPng(skin);
         if (png != null) {
-            SkinBroadcaster.broadcastProfileChange(username, png);
+            SkinBroadcaster.broadcastProfileChange(username, png,
+                SkinTextureFetcher.fetchLegacyCapePng(skin));
         }
     }
 

--- a/forge-1.5.2/src/main/java/levosilimo/everlastingskins/skinchanger/SkinTextureFetcher.java
+++ b/forge-1.5.2/src/main/java/levosilimo/everlastingskins/skinchanger/SkinTextureFetcher.java
@@ -35,6 +35,13 @@ import java.net.URL;
  * <p>Fail-soft: any fetch/decode/encode failure returns null (the broadcast
  * degrades to the legacy notification-only payload rather than crashing the
  * command/login path).
+ *
+ * <p>Cape path ({@link #fetchLegacyCapePng}): the textures JSON carries the
+ * cape under {@code CAPE.url} (exposed via
+ * {@link PropertyUtils#getCapeTextureUrl}); modern capes are 64x64 canvases
+ * whose art lives in the top 64x32 rows, so the fetched cape is cropped to
+ * the top 64x32 region before broadcast (pre-1.8 renderCloak UVs). Cape-less
+ * properties yield null (no cape field on the wire).
  */
 public final class SkinTextureFetcher {
 
@@ -61,6 +68,33 @@ public final class SkinTextureFetcher {
             return bos.toByteArray();
         } catch (Exception e) {
             System.err.println("EverlastingSkins: skin texture fetch failed: " + e);
+            return null;
+        }
+    }
+
+    /**
+     * Fetches the cape PNG from the property's {@code CAPE.url} and returns it
+     * cropped to the legacy 64x32 model (top 64x32 rows of the modern 64x64
+     * canvas), re-encoded as PNG. Null when the property has no cape or the
+     * fetch/decode fails.
+     */
+    public static byte[] fetchLegacyCapePng(CustomSkinProperty skin) {
+        try {
+            String capeUrl = PropertyUtils.getCapeTextureUrl(skin);
+            if (capeUrl == null) {
+                return null;
+            }
+            byte[] png = fetchBytes(capeUrl);
+            if (png == null) {
+                return null;
+            }
+            BufferedImage image = ClientSkinApplier.decode(png);
+            BufferedImage legacy = ClientSkinApplier.cropCapeToLegacy(image);
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            ImageIO.write(legacy, "png", bos);
+            return bos.toByteArray();
+        } catch (Exception e) {
+            System.err.println("EverlastingSkins: cape texture fetch failed: " + e);
             return null;
         }
     }

--- a/forge-1.5.2/src/test/java/levosilimo/everlastingskins/broadcast/SkinMessageTest.java
+++ b/forge-1.5.2/src/test/java/levosilimo/everlastingskins/broadcast/SkinMessageTest.java
@@ -172,8 +172,8 @@ public class SkinMessageTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void malformedPngLengthRejectedBeforeAllocation() throws Exception {
-        // pngLen = 2^31-1: the bounds guard must reject it before the
-        // allocation (lib-18 audit).
+        // Legacy shape with pngLen = 2^31-1 (first byte 0x7F > 3, so no
+        // extended attempt): the guard must reject it before allocating.
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         DataOutputStream out = new DataOutputStream(bos);
         byte[] name = "Legacy".getBytes(StandardCharsets.UTF_8);
@@ -182,6 +182,66 @@ public class SkinMessageTest {
         out.writeInt(Integer.MAX_VALUE);
         out.flush();
         SkinMessage.decode(bos.toByteArray());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void malformedSkinLengthRejectedBeforeAllocation() throws Exception {
+        // Extended shape with skinLen = 2^31-1: the extended attempt's guard
+        // rejects it (then the legacy pngLen guard fires on the rewind).
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bos);
+        byte[] name = "Alex".getBytes(StandardCharsets.UTF_8);
+        out.writeInt(name.length);
+        out.write(name);
+        out.writeByte(3); // flags: hasSkin | hasCape
+        out.writeInt(Integer.MAX_VALUE);
+        out.writeInt(0);
+        out.writeInt(0);
+        out.flush();
+        SkinMessage.decode(bos.toByteArray());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void malformedCapeLengthRejectedBeforeAllocation() throws Exception {
+        // Extended shape with a valid skin and capeLen = 2^31-1.
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bos);
+        byte[] name = "Alex".getBytes(StandardCharsets.UTF_8);
+        out.writeInt(name.length);
+        out.write(name);
+        out.writeByte(3);
+        out.writeInt(1);
+        out.writeByte(9); // skin bytes
+        out.writeInt(Integer.MAX_VALUE);
+        out.flush();
+        SkinMessage.decode(bos.toByteArray());
+    }
+
+    @Test
+    public void legacyPayloadWithLargePngStillDecodesWhenExtendedAttemptGuardFires() throws Exception {
+        // A legacy payload with a large real PNG (~30 KB, under the 32766
+        // cap): the extended attempt reads a bogus skinLen (~pngLen*256 +
+        // first PNG byte) that the bounds guard rejects BEFORE allocation;
+        // the legacy fallback must still decode it (lib-18: the guard must
+        // not break the fallback).
+        byte[] png = new byte[30000];
+        for (int i = 0; i < png.length; i++) {
+            png[i] = (byte) (i & 0xFF);
+        }
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bos);
+        byte[] name = "Legacy".getBytes(StandardCharsets.UTF_8);
+        out.writeInt(name.length);
+        out.write(name);
+        out.writeInt(png.length);
+        out.write(png);
+        out.flush();
+
+        SkinMessage message = SkinMessage.decode(bos.toByteArray());
+
+        assertEquals("Legacy", message.getPlayerName());
+        assertArrayEquals(png, message.getTexturePng());
+        assertNull(message.getCapePng());
     }
 
     @Test

--- a/forge-1.5.2/src/test/java/levosilimo/everlastingskins/broadcast/SkinMessageTest.java
+++ b/forge-1.5.2/src/test/java/levosilimo/everlastingskins/broadcast/SkinMessageTest.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * 1.5.2 broadcast payload tests (pure Java — no server, no netty).
  *
- * <p>1.5.2 is pre-UUID: the payload is username-keyed (no
+ * <p>1.5.2 is pre-UUID-migration: the payload is username-keyed (no
  * {@code com.mojang.authlib.GameProfile} on this line) and rides inside a
  * {@code Packet250CustomPayload} data blob (FML 5.2 custom-payload surface —
  * no {@code IMessage} until 1.8).
@@ -58,6 +58,86 @@ public class SkinMessageTest {
         SkinMessage message = SkinMessage.decode(SkinMessage.encode("Steve", png));
         assertEquals("Steve", message.getPlayerName());
         assertArrayEquals(png, message.getTexturePng());
+        assertNull(message.getCapePng());
+    }
+
+    @Test
+    public void encodeDecodeRoundTripsSkinAndCape() {
+        byte[] skin = new byte[]{1, 2, 3, 4, 5};
+        byte[] cape = new byte[]{6, 7, 8};
+
+        SkinMessage message = SkinMessage.decode(SkinMessage.encode("Alex", skin, cape));
+
+        assertEquals("Alex", message.getPlayerName());
+        assertArrayEquals(skin, message.getTexturePng());
+        assertArrayEquals(cape, message.getCapePng());
+    }
+
+    @Test
+    public void encodeDecodeRoundTripsCapeOnly() {
+        byte[] cape = new byte[]{9, 9, 9};
+
+        SkinMessage message = SkinMessage.decode(SkinMessage.encode("Alex", null, cape));
+
+        assertEquals("Alex", message.getPlayerName());
+        assertNull(message.getTexturePng());
+        assertArrayEquals(cape, message.getCapePng());
+    }
+
+    @Test
+    public void flagsBitsReflectFieldPresence() {
+        // Wire layout: [int nameLen][utf8 name][byte flags][int skinLen]...
+        byte[] skin = new byte[]{1};
+        byte[] cape = new byte[]{2};
+        int flagsOffset = 4 + "Alex".length();
+
+        assertEquals(1, encodeFlagsByte("Alex", skin, null, flagsOffset)); // bit 0 = hasSkin
+        assertEquals(2, encodeFlagsByte("Alex", null, cape, flagsOffset)); // bit 1 = hasCape
+        assertEquals(3, encodeFlagsByte("Alex", skin, cape, flagsOffset));
+        assertEquals(0, encodeFlagsByte("Alex", null, null, flagsOffset));
+    }
+
+    @Test
+    public void legacyPayloadWithoutFlagsStillDecodes() throws Exception {
+        // Pre-cape wire format: [int nameLen][utf8 name][int pngLen][png]
+        // (the shape the joint client broadcast landed with, PR #426).
+        byte[] png = new byte[]{10, 11, 12, 13};
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bos);
+        byte[] name = "Legacy".getBytes(StandardCharsets.UTF_8);
+        out.writeInt(name.length);
+        out.write(name);
+        out.writeInt(png.length);
+        out.write(png);
+        out.flush();
+
+        SkinMessage message = SkinMessage.decode(bos.toByteArray());
+
+        assertEquals("Legacy", message.getPlayerName());
+        assertArrayEquals(png, message.getTexturePng());
+        assertNull(message.getCapePng());
+    }
+
+    @Test
+    public void legacyNotificationPayloadStillDecodes() throws Exception {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bos);
+        byte[] name = "Legacy".getBytes(StandardCharsets.UTF_8);
+        out.writeInt(name.length);
+        out.write(name);
+        out.writeInt(0);
+        out.flush();
+
+        SkinMessage message = SkinMessage.decode(bos.toByteArray());
+
+        assertEquals("Legacy", message.getPlayerName());
+        assertNull(message.getTexturePng());
+        assertNull(message.getCapePng());
+    }
+
+    private static int encodeFlagsByte(String name, byte[] skin, byte[] cape, int flagsOffset) {
+        byte[] payload = SkinMessage.encode(name, skin, cape);
+        return payload[flagsOffset] & 0xFF;
     }
 
     @Test

--- a/forge-1.5.2/src/test/java/levosilimo/everlastingskins/client/ClientSkinApplierTest.java
+++ b/forge-1.5.2/src/test/java/levosilimo/everlastingskins/client/ClientSkinApplierTest.java
@@ -92,6 +92,34 @@ public class ClientSkinApplierTest {
     }
 
     @Test
+    public void cropCapeCropsModern64x64ToTopHalf() {
+        // Modern capes are 64x64 canvases whose art lives in the top 64x32
+        // rows (the pre-1.8 renderCloak UVs sample only that region), so the
+        // crop keeps the top half and drops the bottom 32 rows.
+        BufferedImage modern = new BufferedImage(64, 64, BufferedImage.TYPE_INT_ARGB);
+        for (int x = 0; x < 64; x++) {
+            for (int y = 0; y < 64; y++) {
+                modern.setRGB(x, y, 0xFF000000);
+            }
+        }
+        modern.setRGB(10, 10, 0xFFAA0000); // top region — kept
+        modern.setRGB(50, 50, 0xFF0000CC); // bottom region — dropped
+
+        BufferedImage legacy = ClientSkinApplier.cropCapeToLegacy(modern);
+
+        assertEquals(64, legacy.getWidth());
+        assertEquals(32, legacy.getHeight());
+        assertEquals(0xFFAA0000, legacy.getRGB(10, 10));
+        assertEquals(0xFF000000, legacy.getRGB(50, 30)); // bottom row must not leak
+    }
+
+    @Test
+    public void cropCapePassesLegacy64x32Through() {
+        BufferedImage legacy = solid(64, 32, 0xFF778899);
+        assertSame(legacy, ClientSkinApplier.cropCapeToLegacy(legacy));
+    }
+
+    @Test
     public void findPlayerMatchesByCommandSenderName() throws Exception {
         World world = mock(World.class);
         EntityPlayer notch = mock(EntityPlayer.class);

--- a/forge-1.5.2/src/test/java/levosilimo/everlastingskins/skinchanger/SkinTextureFetcherTest.java
+++ b/forge-1.5.2/src/test/java/levosilimo/everlastingskins/skinchanger/SkinTextureFetcherTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 /**
- * 1.6.4 server-side skin texture fetch tests (lib-5 joint broadcast): the
+ * 1.5.2 server-side skin texture fetch tests (lib-5 joint broadcast): the
  * textures property is fetched over HTTP, decoded and flattened to the legacy
  * 64x32 model. Deterministic fixtures only (memory #1115) — an in-process
  * HttpServer serves a generated PNG on localhost; the lane-local fetch's
@@ -110,6 +110,35 @@ public class SkinTextureFetcherTest {
         assertNull(result);
     }
 
+    @Test
+    public void fetchesAndCropsModern64x64Cape() throws Exception {
+        // Modern capes are 64x64 canvases whose art lives in the top 64x32
+        // rows; the pre-1.8 renderCloak UVs need the 64x32 top region.
+        BufferedImage modern = new BufferedImage(64, 64, BufferedImage.TYPE_INT_ARGB);
+        for (int x = 0; x < 64; x++) {
+            for (int y = 0; y < 64; y++) {
+                modern.setRGB(x, y, 0xFF223344);
+            }
+        }
+        modern.setRGB(20, 20, 0xFFBB0000); // top region — kept
+        serve("/cape64.png", png(modern));
+
+        byte[] result = SkinTextureFetcher.fetchLegacyCapePng(capeProperty(baseUrl + "/cape64.png"));
+
+        assertNotNull(result);
+        BufferedImage cropped = ImageIO.read(new java.io.ByteArrayInputStream(result));
+        assertEquals(64, cropped.getWidth());
+        assertEquals(32, cropped.getHeight());
+        assertEquals(0xFFBB0000, cropped.getRGB(20, 20));
+    }
+
+    @Test
+    public void capeLessPropertyYieldsNull() throws Exception {
+        // A skin property without a CAPE entry must not produce cape bytes
+        // (the common case — most skins have no cape).
+        assertNull(SkinTextureFetcher.fetchLegacyCapePng(property("textures", baseUrl + "/skin64.png")));
+    }
+
     private void serve(String path, byte[] body) {
         server.createContext(path, exchange -> {
             byte[] payload = body;
@@ -125,6 +154,14 @@ public class SkinTextureFetcherTest {
         String json = "{\"textures\":{\"SKIN\":{\"url\":\"" + url + "\"}}}";
         String value = java.util.Base64.getEncoder().encodeToString(json.getBytes(java.nio.charset.StandardCharsets.UTF_8));
         return new CustomSkinProperty(name, value, null, "test");
+    }
+
+    /** Textures property with a CAPE entry (skin + cape URLs). */
+    private static CustomSkinProperty capeProperty(String capeUrl) {
+        String json = "{\"textures\":{\"SKIN\":{\"url\":\"https://textures.minecraft.net/texture/s\"},"
+            + "\"CAPE\":{\"url\":\"" + capeUrl + "\"}}}";
+        String value = java.util.Base64.getEncoder().encodeToString(json.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        return new CustomSkinProperty("textures", value, null, "test");
     }
 
     private static byte[] png(BufferedImage image) throws Exception {

--- a/forge-1.6.4/src/main/java/levosilimo/everlastingskins/broadcast/ClientSkinHandler.java
+++ b/forge-1.6.4/src/main/java/levosilimo/everlastingskins/broadcast/ClientSkinHandler.java
@@ -29,6 +29,17 @@ import java.awt.image.BufferedImage;
  * {@link ClientSkinApplier} — no ASM. The player is resolved by name from
  * {@code World.playerEntities} (1.6.4 has no UUID on the wire).
  *
+ * <p>Cape injection (per cape research): the 1.6.4 client fetches
+ * {@code http://skins.minecraft.net/MinecraftCloaks/<name>.png} for EVERY
+ * player with no allowlist — the render gates are only image-loaded/visible/
+ * not-sneaking, so injecting the bytes into the cape
+ * {@link ThreadDownloadImageData} (the public {@code getBufferedImage}
+ * setter, MCP 8.11) and re-uploading the GL texture renders the cape. When
+ * the payload carries cape bytes, they are injected into
+ * {@code AbstractClientPlayer.getTextureCape()} exactly like the skin path
+ * (the AbstractClientPlayer constructor's {@code setupCustomSkin()} seeds
+ * both TDIs via getDownloadImageSkin/getDownloadImageCape).
+ *
  * <p>Re-injection on join: the server re-broadcasts the stored skin on every
  * login, so a packet that arrives before the player entity spawns is simply
  * dropped here (the join broadcast re-delivers it). Caveat (documented, not
@@ -44,7 +55,8 @@ public final class ClientSkinHandler implements IPacketHandler {
         try {
             SkinMessage message = SkinMessage.decode(packet.data);
             byte[] png = message.getTexturePng();
-            if (png == null) {
+            byte[] capePng = message.getCapePng();
+            if (png == null && capePng == null) {
                 // Notification-only broadcast from a pre-joint server.
                 return;
             }
@@ -58,16 +70,29 @@ public final class ClientSkinHandler implements IPacketHandler {
                 return;
             }
             AbstractClientPlayer clientPlayer = (AbstractClientPlayer) target;
-            ThreadDownloadImageData imageData = clientPlayer.getTextureSkin();
-            if (imageData == null) {
-                return;
+            if (png != null) {
+                ThreadDownloadImageData imageData = clientPlayer.getTextureSkin();
+                if (imageData == null) {
+                    return;
+                }
+                BufferedImage image = ClientSkinApplier.flattenToLegacy(ClientSkinApplier.decode(png));
+                ClientSkinApplier.apply(imageData, image);
+                // Re-upload the injected pixels into the existing GL texture:
+                // TextureManager.loadTexture re-runs the TDI's loadTexture, which
+                // uploads the new bufferedImage into the current gl id.
+                mc.getTextureManager().loadTexture(clientPlayer.getLocationSkin(), imageData);
             }
-            BufferedImage image = ClientSkinApplier.flattenToLegacy(ClientSkinApplier.decode(png));
-            ClientSkinApplier.apply(imageData, image);
-            // Re-upload the injected pixels into the existing GL texture:
-            // TextureManager.loadTexture re-runs the TDI's loadTexture, which
-            // uploads the new bufferedImage into the current gl id.
-            mc.getTextureManager().loadTexture(clientPlayer.getLocationSkin(), imageData);
+            if (capePng != null) {
+                ThreadDownloadImageData capeData = clientPlayer.getTextureCape();
+                if (capeData == null) {
+                    return;
+                }
+                BufferedImage capeImage = ClientSkinApplier.cropCapeToLegacy(ClientSkinApplier.decode(capePng));
+                ClientSkinApplier.apply(capeData, capeImage);
+                // Re-upload into the cape's GL texture; the renderer's
+                // isTextureUploaded() gate then renders the injected pixels.
+                mc.getTextureManager().loadTexture(clientPlayer.getLocationCape(), capeData);
+            }
         } catch (Exception e) {
             // Never crash the network thread on a malformed/undecodable payload.
             System.err.println("EverlastingSkins: client skin apply failed: " + e);

--- a/forge-1.6.4/src/main/java/levosilimo/everlastingskins/broadcast/SkinBroadcaster.java
+++ b/forge-1.6.4/src/main/java/levosilimo/everlastingskins/broadcast/SkinBroadcaster.java
@@ -28,9 +28,12 @@ import net.minecraft.src.Packet;
  *
  * <p>Payloads carry the target player's username AND the flattened 64x32 PNG
  * bytes ({@link SkinMessage#encode(String, byte[])}); the client handler
- * decodes and injects the pixels. Payload cap: 32766 bytes
- * (Packet250CustomPayload 2-byte length, MC-16910) — a flattened 64x32 PNG is
- * ≈ 1-4 KB, far under the cap; oversized payloads are dropped defensively.
+ * decodes and injects the pixels. Since the cape extension the payload also
+ * carries the cropped 64x32 cape PNG when the stored skin has one
+ * ({@link SkinMessage#encode(String, byte[], byte[])}). Payload cap: 32766
+ * bytes (Packet250CustomPayload 2-byte length, MC-16910) — a flattened 64x32
+ * PNG is ≈ 1-4 KB (skin ≈ 0.5-3 KB + cape ≈ 0.3-2 KB), far under the cap;
+ * oversized payloads are dropped defensively.
  */
 public final class SkinBroadcaster {
 
@@ -43,7 +46,16 @@ public final class SkinBroadcaster {
 
     /** Broadcasts a skin-change payload for {@code playerName} to all players. */
     public static void broadcastProfileChange(String playerName, byte[] pngBytes) {
-        byte[] payload = SkinMessage.encode(playerName, pngBytes);
+        broadcastProfileChange(playerName, pngBytes, null);
+    }
+
+    /**
+     * Broadcasts a skin-change payload for {@code playerName} to all players,
+     * carrying the cape PNG alongside the skin when the stored property has
+     * one ({@code capeBytes} null for cape-less skins).
+     */
+    public static void broadcastProfileChange(String playerName, byte[] pngBytes, byte[] capeBytes) {
+        byte[] payload = SkinMessage.encode(playerName, pngBytes, capeBytes);
         if (payload.length > MAX_PAYLOAD_BYTES) {
             System.err.println("EverlastingSkins: skin payload for '" + playerName
                 + "' exceeds " + MAX_PAYLOAD_BYTES + " bytes — dropped");

--- a/forge-1.6.4/src/main/java/levosilimo/everlastingskins/broadcast/SkinMessage.java
+++ b/forge-1.6.4/src/main/java/levosilimo/everlastingskins/broadcast/SkinMessage.java
@@ -10,6 +10,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.io.EOFException;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
@@ -19,6 +20,14 @@ import java.nio.charset.StandardCharsets;
  * UUID exists on this line — 1.6.4 is pre-UUID-migration) and the raw PNG
  * texture bytes when a companion client wants the payload inline.
  *
+ * <p>Wire format (cape extension, per cape research — the 1.6.4 client
+ * fetches {@code http://skins.minecraft.net/MinecraftCloaks/<name>.png} for
+ * EVERY player with no allowlist, so byte injection is sufficient):
+ * {@code [int nameLen][utf8 name][byte flags][int skinLen][skinPng][int capeLen][capePng]}
+ * — flags bit 0 = hasSkin, bit 1 = hasCape. The old pre-cape format
+ * {@code [int nameLen][name][int pngLen][png]} still decodes (see
+ * {@link #decode(byte[])}).
+ *
  * <p>1.6.4 has no netty {@code IMessage} (1.8+) and no
  * {@code SimpleNetworkWrapper}; the payload is a length-prefixed byte blob
  * inside {@code Packet250CustomPayload.data}. Encode/decode are pure Java
@@ -26,12 +35,23 @@ import java.nio.charset.StandardCharsets;
  */
 public final class SkinMessage {
 
+    /** Flag bit 0: the payload carries a skin PNG. */
+    private static final int FLAG_HAS_SKIN = 1;
+    /** Flag bit 1: the payload carries a cape PNG. */
+    private static final int FLAG_HAS_CAPE = 2;
+
     private final String playerName;
     private final byte[] texturePng;
+    private final byte[] capePng;
 
     public SkinMessage(String playerName, byte[] texturePng) {
+        this(playerName, texturePng, null);
+    }
+
+    public SkinMessage(String playerName, byte[] texturePng, byte[] capePng) {
         this.playerName = playerName;
         this.texturePng = texturePng;
+        this.capePng = capePng;
     }
 
     public String getPlayerName() {
@@ -42,28 +62,44 @@ public final class SkinMessage {
         return texturePng;
     }
 
+    public byte[] getCapePng() {
+        return capePng;
+    }
+
     /**
-     * Wire format: [utf8 username][int png length][png bytes]. A null PNG
-     * encodes as length 0 (notification-only broadcast).
-     *
-     * <p>Every length prefix is bounds-checked against the remaining unread
-     * payload BEFORE allocation ({@link #checkLength}), so a corrupted or
-     * malicious prefix fails with {@link IllegalArgumentException} instead
-     * of an {@link OutOfMemoryError} on the packet thread (lib-18 audit
-     * remediation).
+     * Encodes a skin-only payload (pre-cape convenience, null PNG encodes as
+     * a notification-only broadcast).
      */
     public static byte[] encode(String playerName, byte[] texturePng) {
+        return encode(playerName, texturePng, null);
+    }
+
+    /**
+     * Wire format: {@code [utf8 username][byte flags][int skin length][skin
+     * png][int cape length][cape png]}. A null PNG encodes as length 0
+     * (notification-only broadcast when both are null).
+     */
+    public static byte[] encode(String playerName, byte[] texturePng, byte[] capePng) {
         try {
             ByteArrayOutputStream bos = new ByteArrayOutputStream();
             DataOutputStream out = new DataOutputStream(bos);
             byte[] name = playerName.getBytes(StandardCharsets.UTF_8);
             out.writeInt(name.length);
             out.write(name);
+            int flags = (texturePng != null ? FLAG_HAS_SKIN : 0)
+                | (capePng != null ? FLAG_HAS_CAPE : 0);
+            out.writeByte(flags);
             if (texturePng == null) {
                 out.writeInt(0);
             } else {
                 out.writeInt(texturePng.length);
                 out.write(texturePng);
+            }
+            if (capePng == null) {
+                out.writeInt(0);
+            } else {
+                out.writeInt(capePng.length);
+                out.write(capePng);
             }
             out.flush();
             return bos.toByteArray();
@@ -72,6 +108,21 @@ public final class SkinMessage {
         }
     }
 
+    /**
+     * Decodes both the extended (flags + cape) and the legacy pre-cape
+     * ({@code [nameLen][name][pngLen][png]}) formats. A legacy payload always
+     * yields a null cape.
+     *
+     * <p>Disambiguation: after the name, a legacy payload starts with the
+     * PNG length int (high byte 0, next byte 0 for real PNGs — the payload
+     * cap is 32766 bytes), while an extended payload starts with the flags
+     * byte (0-3) followed by the skin-length int. The extended parse is
+     * attempted first when the shape fits (first byte ≤ 3 and enough bytes
+     * remain); it only wins when it consumes the payload EXACTLY. A legacy
+     * payload with a real PNG always fails that attempt (its length int
+     * over-reads into the PNG magic, exceeding the remaining bytes), so it
+     * falls back cleanly to the legacy parse.
+     */
     public static SkinMessage decode(byte[] payload) {
         try {
             DataInputStream in = new DataInputStream(new ByteArrayInputStream(payload));
@@ -79,6 +130,18 @@ public final class SkinMessage {
             checkLength(nameLen, payload.length - 4, "name");
             byte[] name = new byte[nameLen];
             in.readFully(name);
+            String playerName = new String(name, StandardCharsets.UTF_8);
+            int remaining = payload.length - 4 - nameLen;
+            if (remaining >= 9 && (payload[4 + nameLen] & 0xFF) <= 3) {
+                SkinMessage extended = tryDecodeExtended(in, playerName);
+                if (extended != null) {
+                    return extended;
+                }
+                // Not an extended payload — rewind and parse the legacy shape.
+                in = new DataInputStream(new ByteArrayInputStream(payload));
+                in.readInt();
+                in.readFully(name);
+            }
             int pngLen = in.readInt();
             checkLength(pngLen, payload.length - 8 - nameLen, "png");
             byte[] png = null;
@@ -86,7 +149,7 @@ public final class SkinMessage {
                 png = new byte[pngLen];
                 in.readFully(png);
             }
-            return new SkinMessage(new String(name, StandardCharsets.UTF_8), png);
+            return new SkinMessage(playerName, png);
         } catch (IOException e) {
             throw new IllegalArgumentException("Malformed SkinMessage payload", e);
         }
@@ -103,6 +166,35 @@ public final class SkinMessage {
         if (len < 0 || len > remaining) {
             throw new IllegalArgumentException("Malformed SkinMessage payload: " + field
                 + " length " + len + " exceeds remaining " + remaining + " bytes");
+        }
+    }
+
+    /**
+     * Attempts the extended-format parse; returns null (and the caller falls
+     * back to the legacy shape) unless the extended parse consumes the whole
+     * payload.
+     */
+    private static SkinMessage tryDecodeExtended(DataInputStream in, String playerName) throws IOException {
+        try {
+            int flags = in.readUnsignedByte();
+            int skinLen = in.readInt();
+            byte[] skin = null;
+            if (skinLen > 0) {
+                skin = new byte[skinLen];
+                in.readFully(skin);
+            }
+            int capeLen = in.readInt();
+            byte[] cape = null;
+            if (capeLen > 0) {
+                cape = new byte[capeLen];
+                in.readFully(cape);
+            }
+            if (in.available() != 0) {
+                throw new EOFException("trailing bytes after extended payload");
+            }
+            return new SkinMessage(playerName, skin, cape);
+        } catch (IOException e) {
+            return null;
         }
     }
 }

--- a/forge-1.6.4/src/main/java/levosilimo/everlastingskins/broadcast/SkinMessage.java
+++ b/forge-1.6.4/src/main/java/levosilimo/everlastingskins/broadcast/SkinMessage.java
@@ -122,6 +122,12 @@ public final class SkinMessage {
      * payload with a real PNG always fails that attempt (its length int
      * over-reads into the PNG magic, exceeding the remaining bytes), so it
      * falls back cleanly to the legacy parse.
+     *
+     * <p>Every length prefix is bounds-checked against the remaining unread
+     * payload BEFORE allocation ({@link #checkLength}), so a corrupted or
+     * malicious prefix fails with {@link IllegalArgumentException} (which
+     * the client handler catches) instead of an {@link OutOfMemoryError}
+     * on the packet thread (lib-18 audit remediation).
      */
     public static SkinMessage decode(byte[] payload) {
         try {
@@ -178,12 +184,14 @@ public final class SkinMessage {
         try {
             int flags = in.readUnsignedByte();
             int skinLen = in.readInt();
+            checkLength(skinLen, in.available(), "skin");
             byte[] skin = null;
             if (skinLen > 0) {
                 skin = new byte[skinLen];
                 in.readFully(skin);
             }
             int capeLen = in.readInt();
+            checkLength(capeLen, in.available(), "cape");
             byte[] cape = null;
             if (capeLen > 0) {
                 cape = new byte[capeLen];
@@ -193,7 +201,10 @@ public final class SkinMessage {
                 throw new EOFException("trailing bytes after extended payload");
             }
             return new SkinMessage(playerName, skin, cape);
-        } catch (IOException e) {
+        } catch (IOException | IllegalArgumentException e) {
+            // A guard violation makes this a failed extended attempt (a
+            // legacy payload's pngLen-derived skinLen always over-reads) —
+            // fall back to the legacy shape exactly as an EOF would.
             return null;
         }
     }

--- a/forge-1.6.4/src/main/java/levosilimo/everlastingskins/client/ClientSkinApplier.java
+++ b/forge-1.6.4/src/main/java/levosilimo/everlastingskins/client/ClientSkinApplier.java
@@ -60,6 +60,21 @@ public final class ClientSkinApplier {
     }
 
     /**
+     * Converts any cape to the legacy 64x32 model: modern capes are 64x64
+     * canvases whose art lives in the top 64x32 rows (the pre-1.8
+     * {@code renderCloak} UVs sample only that region), so a 64x64 cape is
+     * cropped to its top half — the same vanilla crop the skin flatten
+     * performs (the pre-1.8 download pipeline passes capes through
+     * {@code ImageBufferDownload.parseUserSkin}). 64x32 inputs pass through
+     * unchanged; any other size is drawn unscaled at (0,0) like the vanilla
+     * pipeline. The server pre-crops before broadcast; this client-side pass
+     * is idempotent defense against an uncropped payload.
+     */
+    public static BufferedImage cropCapeToLegacy(BufferedImage source) {
+        return flattenToLegacy(source);
+    }
+
+    /**
      * Finds a spawned player by {@code getCommandSenderName()} in the client
      * world ({@code World.playerEntities}), or null when not spawned yet.
      */

--- a/forge-1.6.4/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRestorer.java
+++ b/forge-1.6.4/src/main/java/levosilimo/everlastingskins/skinchanger/SkinRestorer.java
@@ -110,7 +110,8 @@ public final class SkinRestorer {
         CustomSkinProperty skin = s.getSkin(uuid);
         if (skin != null) {
             SkinBroadcaster.broadcastProfileChange(player.getCommandSenderName(),
-                SkinTextureFetcher.fetchLegacyPng(skin));
+                SkinTextureFetcher.fetchLegacyPng(skin),
+                SkinTextureFetcher.fetchLegacyCapePng(skin));
         }
     }
 
@@ -165,7 +166,8 @@ public final class SkinRestorer {
         }
         byte[] png = SkinTextureFetcher.fetchLegacyPng(skin);
         if (png != null) {
-            SkinBroadcaster.broadcastProfileChange(username, png);
+            SkinBroadcaster.broadcastProfileChange(username, png,
+                SkinTextureFetcher.fetchLegacyCapePng(skin));
         }
     }
 

--- a/forge-1.6.4/src/main/java/levosilimo/everlastingskins/skinchanger/SkinTextureFetcher.java
+++ b/forge-1.6.4/src/main/java/levosilimo/everlastingskins/skinchanger/SkinTextureFetcher.java
@@ -35,6 +35,13 @@ import java.net.URL;
  * <p>Fail-soft: any fetch/decode/encode failure returns null (the broadcast
  * degrades to the legacy notification-only payload rather than crashing the
  * command/login path).
+ *
+ * <p>Cape path ({@link #fetchLegacyCapePng}): the textures JSON carries the
+ * cape under {@code CAPE.url} (exposed via
+ * {@link PropertyUtils#getCapeTextureUrl}); modern capes are 64x64 canvases
+ * whose art lives in the top 64x32 rows, so the fetched cape is cropped to
+ * the top 64x32 region before broadcast (pre-1.8 renderCloak UVs). Cape-less
+ * properties yield null (no cape field on the wire).
  */
 public final class SkinTextureFetcher {
 
@@ -61,6 +68,33 @@ public final class SkinTextureFetcher {
             return bos.toByteArray();
         } catch (Exception e) {
             System.err.println("EverlastingSkins: skin texture fetch failed: " + e);
+            return null;
+        }
+    }
+
+    /**
+     * Fetches the cape PNG from the property's {@code CAPE.url} and returns it
+     * cropped to the legacy 64x32 model (top 64x32 rows of the modern 64x64
+     * canvas), re-encoded as PNG. Null when the property has no cape or the
+     * fetch/decode fails.
+     */
+    public static byte[] fetchLegacyCapePng(CustomSkinProperty skin) {
+        try {
+            String capeUrl = PropertyUtils.getCapeTextureUrl(skin);
+            if (capeUrl == null) {
+                return null;
+            }
+            byte[] png = fetchBytes(capeUrl);
+            if (png == null) {
+                return null;
+            }
+            BufferedImage image = ClientSkinApplier.decode(png);
+            BufferedImage legacy = ClientSkinApplier.cropCapeToLegacy(image);
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            ImageIO.write(legacy, "png", bos);
+            return bos.toByteArray();
+        } catch (Exception e) {
+            System.err.println("EverlastingSkins: cape texture fetch failed: " + e);
             return null;
         }
     }

--- a/forge-1.6.4/src/test/java/levosilimo/everlastingskins/broadcast/SkinMessageTest.java
+++ b/forge-1.6.4/src/test/java/levosilimo/everlastingskins/broadcast/SkinMessageTest.java
@@ -172,8 +172,8 @@ public class SkinMessageTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void malformedPngLengthRejectedBeforeAllocation() throws Exception {
-        // pngLen = 2^31-1: the bounds guard must reject it before the
-        // allocation (lib-18 audit).
+        // Legacy shape with pngLen = 2^31-1 (first byte 0x7F > 3, so no
+        // extended attempt): the guard must reject it before allocating.
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         DataOutputStream out = new DataOutputStream(bos);
         byte[] name = "Legacy".getBytes(StandardCharsets.UTF_8);
@@ -182,6 +182,66 @@ public class SkinMessageTest {
         out.writeInt(Integer.MAX_VALUE);
         out.flush();
         SkinMessage.decode(bos.toByteArray());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void malformedSkinLengthRejectedBeforeAllocation() throws Exception {
+        // Extended shape with skinLen = 2^31-1: the extended attempt's guard
+        // rejects it (then the legacy pngLen guard fires on the rewind).
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bos);
+        byte[] name = "Alex".getBytes(StandardCharsets.UTF_8);
+        out.writeInt(name.length);
+        out.write(name);
+        out.writeByte(3); // flags: hasSkin | hasCape
+        out.writeInt(Integer.MAX_VALUE);
+        out.writeInt(0);
+        out.writeInt(0);
+        out.flush();
+        SkinMessage.decode(bos.toByteArray());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void malformedCapeLengthRejectedBeforeAllocation() throws Exception {
+        // Extended shape with a valid skin and capeLen = 2^31-1.
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bos);
+        byte[] name = "Alex".getBytes(StandardCharsets.UTF_8);
+        out.writeInt(name.length);
+        out.write(name);
+        out.writeByte(3);
+        out.writeInt(1);
+        out.writeByte(9); // skin bytes
+        out.writeInt(Integer.MAX_VALUE);
+        out.flush();
+        SkinMessage.decode(bos.toByteArray());
+    }
+
+    @Test
+    public void legacyPayloadWithLargePngStillDecodesWhenExtendedAttemptGuardFires() throws Exception {
+        // A legacy payload with a large real PNG (~30 KB, under the 32766
+        // cap): the extended attempt reads a bogus skinLen (~pngLen*256 +
+        // first PNG byte) that the bounds guard rejects BEFORE allocation;
+        // the legacy fallback must still decode it (lib-18: the guard must
+        // not break the fallback).
+        byte[] png = new byte[30000];
+        for (int i = 0; i < png.length; i++) {
+            png[i] = (byte) (i & 0xFF);
+        }
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bos);
+        byte[] name = "Legacy".getBytes(StandardCharsets.UTF_8);
+        out.writeInt(name.length);
+        out.write(name);
+        out.writeInt(png.length);
+        out.write(png);
+        out.flush();
+
+        SkinMessage message = SkinMessage.decode(bos.toByteArray());
+
+        assertEquals("Legacy", message.getPlayerName());
+        assertArrayEquals(png, message.getTexturePng());
+        assertNull(message.getCapePng());
     }
 
     @Test

--- a/forge-1.6.4/src/test/java/levosilimo/everlastingskins/broadcast/SkinMessageTest.java
+++ b/forge-1.6.4/src/test/java/levosilimo/everlastingskins/broadcast/SkinMessageTest.java
@@ -58,6 +58,86 @@ public class SkinMessageTest {
         SkinMessage message = SkinMessage.decode(SkinMessage.encode("Steve", png));
         assertEquals("Steve", message.getPlayerName());
         assertArrayEquals(png, message.getTexturePng());
+        assertNull(message.getCapePng());
+    }
+
+    @Test
+    public void encodeDecodeRoundTripsSkinAndCape() {
+        byte[] skin = new byte[]{1, 2, 3, 4, 5};
+        byte[] cape = new byte[]{6, 7, 8};
+
+        SkinMessage message = SkinMessage.decode(SkinMessage.encode("Alex", skin, cape));
+
+        assertEquals("Alex", message.getPlayerName());
+        assertArrayEquals(skin, message.getTexturePng());
+        assertArrayEquals(cape, message.getCapePng());
+    }
+
+    @Test
+    public void encodeDecodeRoundTripsCapeOnly() {
+        byte[] cape = new byte[]{9, 9, 9};
+
+        SkinMessage message = SkinMessage.decode(SkinMessage.encode("Alex", null, cape));
+
+        assertEquals("Alex", message.getPlayerName());
+        assertNull(message.getTexturePng());
+        assertArrayEquals(cape, message.getCapePng());
+    }
+
+    @Test
+    public void flagsBitsReflectFieldPresence() {
+        // Wire layout: [int nameLen][utf8 name][byte flags][int skinLen]...
+        byte[] skin = new byte[]{1};
+        byte[] cape = new byte[]{2};
+        int flagsOffset = 4 + "Alex".length();
+
+        assertEquals(1, encodeFlagsByte("Alex", skin, null, flagsOffset)); // bit 0 = hasSkin
+        assertEquals(2, encodeFlagsByte("Alex", null, cape, flagsOffset)); // bit 1 = hasCape
+        assertEquals(3, encodeFlagsByte("Alex", skin, cape, flagsOffset));
+        assertEquals(0, encodeFlagsByte("Alex", null, null, flagsOffset));
+    }
+
+    @Test
+    public void legacyPayloadWithoutFlagsStillDecodes() throws Exception {
+        // Pre-cape wire format: [int nameLen][utf8 name][int pngLen][png]
+        // (the shape the joint client broadcast landed with, PR #426).
+        byte[] png = new byte[]{10, 11, 12, 13};
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bos);
+        byte[] name = "Legacy".getBytes(StandardCharsets.UTF_8);
+        out.writeInt(name.length);
+        out.write(name);
+        out.writeInt(png.length);
+        out.write(png);
+        out.flush();
+
+        SkinMessage message = SkinMessage.decode(bos.toByteArray());
+
+        assertEquals("Legacy", message.getPlayerName());
+        assertArrayEquals(png, message.getTexturePng());
+        assertNull(message.getCapePng());
+    }
+
+    @Test
+    public void legacyNotificationPayloadStillDecodes() throws Exception {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bos);
+        byte[] name = "Legacy".getBytes(StandardCharsets.UTF_8);
+        out.writeInt(name.length);
+        out.write(name);
+        out.writeInt(0);
+        out.flush();
+
+        SkinMessage message = SkinMessage.decode(bos.toByteArray());
+
+        assertEquals("Legacy", message.getPlayerName());
+        assertNull(message.getTexturePng());
+        assertNull(message.getCapePng());
+    }
+
+    private static int encodeFlagsByte(String name, byte[] skin, byte[] cape, int flagsOffset) {
+        byte[] payload = SkinMessage.encode(name, skin, cape);
+        return payload[flagsOffset] & 0xFF;
     }
 
     @Test

--- a/forge-1.6.4/src/test/java/levosilimo/everlastingskins/client/ClientSkinApplierTest.java
+++ b/forge-1.6.4/src/test/java/levosilimo/everlastingskins/client/ClientSkinApplierTest.java
@@ -95,6 +95,34 @@ public class ClientSkinApplierTest {
     }
 
     @Test
+    public void cropCapeCropsModern64x64ToTopHalf() {
+        // Modern capes are 64x64 canvases whose art lives in the top 64x32
+        // rows (the pre-1.8 renderCloak UVs sample only that region), so the
+        // crop keeps the top half and drops the bottom 32 rows.
+        BufferedImage modern = new BufferedImage(64, 64, BufferedImage.TYPE_INT_ARGB);
+        for (int x = 0; x < 64; x++) {
+            for (int y = 0; y < 64; y++) {
+                modern.setRGB(x, y, 0xFF000000);
+            }
+        }
+        modern.setRGB(10, 10, 0xFFAA0000); // top region — kept
+        modern.setRGB(50, 50, 0xFF0000CC); // bottom region — dropped
+
+        BufferedImage legacy = ClientSkinApplier.cropCapeToLegacy(modern);
+
+        assertEquals(64, legacy.getWidth());
+        assertEquals(32, legacy.getHeight());
+        assertEquals(0xFFAA0000, legacy.getRGB(10, 10));
+        assertEquals(0xFF000000, legacy.getRGB(50, 30)); // bottom row must not leak
+    }
+
+    @Test
+    public void cropCapePassesLegacy64x32Through() {
+        BufferedImage legacy = solid(64, 32, 0xFF778899);
+        assertSame(legacy, ClientSkinApplier.cropCapeToLegacy(legacy));
+    }
+
+    @Test
     public void findPlayerMatchesByCommandSenderName() throws Exception {
         World world = mock(World.class);
         EntityPlayer notch = mock(EntityPlayer.class);

--- a/forge-1.6.4/src/test/java/levosilimo/everlastingskins/skinchanger/SkinTextureFetcherTest.java
+++ b/forge-1.6.4/src/test/java/levosilimo/everlastingskins/skinchanger/SkinTextureFetcherTest.java
@@ -110,6 +110,35 @@ public class SkinTextureFetcherTest {
         assertNull(result);
     }
 
+    @Test
+    public void fetchesAndCropsModern64x64Cape() throws Exception {
+        // Modern capes are 64x64 canvases whose art lives in the top 64x32
+        // rows; the pre-1.8 renderCloak UVs need the 64x32 top region.
+        BufferedImage modern = new BufferedImage(64, 64, BufferedImage.TYPE_INT_ARGB);
+        for (int x = 0; x < 64; x++) {
+            for (int y = 0; y < 64; y++) {
+                modern.setRGB(x, y, 0xFF223344);
+            }
+        }
+        modern.setRGB(20, 20, 0xFFBB0000); // top region — kept
+        serve("/cape64.png", png(modern));
+
+        byte[] result = SkinTextureFetcher.fetchLegacyCapePng(capeProperty(baseUrl + "/cape64.png"));
+
+        assertNotNull(result);
+        BufferedImage cropped = ImageIO.read(new java.io.ByteArrayInputStream(result));
+        assertEquals(64, cropped.getWidth());
+        assertEquals(32, cropped.getHeight());
+        assertEquals(0xFFBB0000, cropped.getRGB(20, 20));
+    }
+
+    @Test
+    public void capeLessPropertyYieldsNull() throws Exception {
+        // A skin property without a CAPE entry must not produce cape bytes
+        // (the common case — most skins have no cape).
+        assertNull(SkinTextureFetcher.fetchLegacyCapePng(property("textures", baseUrl + "/skin64.png")));
+    }
+
     private void serve(String path, byte[] body) {
         server.createContext(path, exchange -> {
             byte[] payload = body;
@@ -125,6 +154,14 @@ public class SkinTextureFetcherTest {
         String json = "{\"textures\":{\"SKIN\":{\"url\":\"" + url + "\"}}}";
         String value = java.util.Base64.getEncoder().encodeToString(json.getBytes(java.nio.charset.StandardCharsets.UTF_8));
         return new CustomSkinProperty(name, value, null, "test");
+    }
+
+    /** Textures property with a CAPE entry (skin + cape URLs). */
+    private static CustomSkinProperty capeProperty(String capeUrl) {
+        String json = "{\"textures\":{\"SKIN\":{\"url\":\"https://textures.minecraft.net/texture/s\"},"
+            + "\"CAPE\":{\"url\":\"" + capeUrl + "\"}}}";
+        String value = java.util.Base64.getEncoder().encodeToString(json.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        return new CustomSkinProperty("textures", value, null, "test");
     }
 
     private static byte[] png(BufferedImage image) throws Exception {


### PR DESCRIPTION
Per cape research (lib-16, primary-source verified): no client allowlist pre-1.8 — the client renders whatever MinecraftCloaks/<name>.png returns, so byte injection suffices. Extends SkinMessage with flags + cape PNG (same 16-char channel, within 32KB); per-era cape injection (1.6.4 getTextureCape setter; 1.4.7/1.5.2 ThreadDownloadImage keyed by cloakUrl); server-side cape byte-fetch via textures-JSON CAPE.url + 64x64→64x32 crop.