### PR TITLE
fix(ci): auto-update PR branches — reactive BEHIND-resolution (per merge-automation research)

### DIFF
--- a/.github/workflows/auto-update-pr-branches.yml
+++ b/.github/workflows/auto-update-pr-branches.yml
@@ -1,0 +1,81 @@
+name: Auto-update PR branches
+
+# Reactive BEHIND-resolution owner (see AGENTS.md "Merge automation").
+# GitHub's auto-merge never updates a behind branch — it only fires once the
+# PR is mergeable. Under strict protection ("require branches to be up to
+# date"), a BEHIND PR with auto-merge armed stalls forever unless something
+# calls update-branch. This workflow is that something: on every push to
+# main (primary trigger), plus a 30-minute schedule safety net and manual
+# dispatch, it updates EXACTLY the open, non-draft, auto-merge-armed PRs
+# whose mergeStateStatus is BEHIND.
+#
+# PAT vs GITHUB_TOKEN (hard constraint — do not "simplify"):
+#   The steps authenticate with the fine-grained EVERLASTINGSKINS_PAT
+#   (pull-requests: write, contents: read), NOT GITHUB_TOKEN. Pushes made
+#   with GITHUB_TOKEN do not re-trigger workflows (GitHub's recursive-run
+#   prevention), so a GITHUB_TOKEN-driven update-branch would push main into
+#   the PR head WITHOUT re-running ci.yml — the required checks would stay
+#   stale on the new head SHA and auto-merge would stall. The PAT-authenticated
+#   push re-triggers ci.yml like a normal push, so required checks re-run and
+#   auto-merge can fire. With top-level `permissions: {}` the GITHUB_TOKEN has
+#   no scopes anyway, so the PAT is the only credential that can work.
+#
+# Churn tradeoff (accepted): each update-branch pushes main into the head
+# branch and re-runs the required-check matrix (~minutes of CI). That is the
+# cost of strict protection; the workflow deliberately targets ONLY PRs that
+# are auto-merge-armed, non-draft, and actually BEHIND — idle PRs, drafts,
+# and CLEAN PRs are never touched, so churn stays proportional to merge
+# traffic. Strict branch protection is kept as-is; this workflow exists to
+# make strictness + auto-merge work together, not to relax either.
+
+on:
+  push:
+    branches: ["main"]
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: auto-update-pr-branches
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  update-behind-prs:
+    name: Update BEHIND PR branches
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Settle push event
+        run: sleep 10
+
+      - name: List BEHIND auto-merge PRs
+        env:
+          GH_TOKEN: ${{ secrets.EVERLASTINGSKINS_PAT }}
+        run: |
+          gh pr list --repo ${{ github.repository }} --base main --state open \
+            --limit 100 --json number,isDraft,autoMergeRequest,mergeStateStatus \
+            --jq '.[] | select(.isDraft == false and .autoMergeRequest != null and .mergeStateStatus == "BEHIND") | .number'
+
+      - name: Update BEHIND branches
+        env:
+          GH_TOKEN: ${{ secrets.EVERLASTINGSKINS_PAT }}
+        run: |
+          numbers="$(gh pr list --repo ${{ github.repository }} --base main --state open \
+            --limit 100 --json number,isDraft,autoMergeRequest,mergeStateStatus \
+            --jq '.[] | select(.isDraft == false and .autoMergeRequest != null and .mergeStateStatus == "BEHIND") | .number')"
+          if [[ -z "$numbers" ]]; then
+            echo "no BEHIND auto-merge PRs to update"
+            exit 0
+          fi
+          for n in $numbers; do
+            echo "updating PR #$n"
+            if ! gh pr update-branch "$n" --repo ${{ github.repository }}; then
+              # update-branch returns 422 when the branch is already
+              # up-to-date (raced between list and update) — harmless; log
+              # and continue. Any other failure is likewise non-fatal here:
+              # the next push/schedule run retries.
+              echo "WARN: update-branch #$n failed (exit $?) — continuing"
+            fi
+          done

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -479,7 +479,30 @@ machine: DONE/READY_TO_MERGE/STALE/FAILED/BLOCKED/PENDING; update-branch
 on STALE; timeout-bounded `gh pr checks --watch --fail-fast`;
 fire-and-forget `gh pr merge --auto`). Never self-retries; the caller's
 tool timeout must exceed --timeout (default 600s). Exit-code contract in
-the script header.
+the script header. `--verify` is read-only by default; the OPT-IN
+`--verify --fix-stale` triggers exactly ONE `gh pr update-branch` + ONE
+re-verify on a STALE verdict (belt-and-suspenders manual fallback, never
+a loop).
+
+`.github/workflows/auto-update-pr-branches.yml` (`Auto-update PR branches`)
+is the STANDING BEHIND-resolution owner: on every push to `main` (primary),
+plus a `*/30 * * * *` schedule safety net and manual dispatch, it runs
+`gh pr update-branch` on exactly the open, non-draft, auto-merge-armed PRs
+whose `mergeStateStatus` is BEHIND. GitHub's auto-merge never updates a
+behind branch — it only fires once the PR is mergeable — so under strict
+protection ("require branches to be up to date") a BEHIND PR stalls
+forever without this. HARD CONSTRAINT: the workflow authenticates with the
+fine-grained `EVERLASTINGSKINS_PAT` (pull-requests: write, contents:
+read), never `GITHUB_TOKEN` — GITHUB_TOKEN-authenticated pushes do not
+re-trigger workflows (recursive-run prevention), so ci.yml would not
+re-run on the updated head and auto-merge would stall on stale required
+checks. (The `EVERLASTINGSKINS_PAT` secret must exist for the workflow to
+function; `permissions: {}` leaves GITHUB_TOKEN with no scopes either
+way.) Churn tradeoff is accepted: each update re-runs the required-check
+matrix, but the workflow touches only auto-merge-armed non-draft BEHIND
+PRs, so churn stays proportional to merge traffic. Strict branch
+protection is kept as-is — the workflow exists to make strictness +
+auto-merge work together, not to relax either.
 
 ## Merge / CI-wait policy (no-wait rule)
 

--- a/scripts/gh-merge-bot.sh
+++ b/scripts/gh-merge-bot.sh
@@ -39,6 +39,12 @@
 #     only — not the up-to-date/review gates.
 #   * mergeStateStatus is lazily computed; UNKNOWN is a transient "not yet
 #     computed" state, never terminal. Do not hammer for CLEAN.
+#   * --fix-stale (--verify mode only, OPT-IN, default off): on a STALE
+#     verify, ONE `gh pr update-branch` + ONE re-verify, then report the new
+#     state — bounded, never a loop. The standing BEHIND-resolution owner is
+#     .github/workflows/auto-update-pr-branches.yml (PAT-authenticated);
+#     --fix-stale is the belt-and-suspenders manual fallback for a
+#     write-access actor. Plain --verify stays strictly read-only.
 #
 # Anti-patterns avoided (encoded contract):
 #   * No loops at all — exactly one bounded pass, then a terminal outcome.
@@ -64,7 +70,8 @@
 #   1  FAILED — required check failed, merge could not be armed, or gh error
 #   2  BLOCKED — branch protection requirements not met (verify mode) or
 #      required review / draft / signing hooks (normal mode)
-#   3  STALE — branch behind base; update-branch + retry
+#   3  STALE — branch behind base; update-branch + retry (or re-run with
+#      --verify --fix-stale for one automatic update-branch + re-verify)
 #   4  FAILED — merge conflicts (DIRTY) or PR closed without merge
 #   8  PENDING (verify: checks unsettled) / BLOCKED (normal mode: REQUIRED
 #      checks pending past the watch bound — re-dispatch later)
@@ -83,7 +90,11 @@
 # Usage:
 #   scripts/gh-merge-bot.sh <PR> [--squash|--rebase] [--repo owner/repo] \
 #       [--timeout <sec>] [--interval <sec>] [--dry-run]
-#   scripts/gh-merge-bot.sh <PR> --verify
+#   scripts/gh-merge-bot.sh <PR> --verify [--fix-stale]
+#
+# --fix-stale applies only with --verify (usage error otherwise): on a STALE
+# verify it triggers exactly one `gh pr update-branch` and re-verifies once.
+# It never loops; a still-STALE result means "re-dispatch later".
 #
 set -uo pipefail
 
@@ -93,6 +104,7 @@ INTERVAL=60
 METHOD="--squash"
 DRY_RUN=0
 VERIFY=0
+FIX_STALE=0
 PR=""
 
 log() { printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >&2; }
@@ -100,13 +112,14 @@ log() { printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >&2; }
 usage_err() {
   echo "gh-merge-bot: $*" >&2
   echo "usage: scripts/gh-merge-bot.sh <PR> [--squash|--rebase] [--repo owner/repo] [--timeout <sec>] [--interval <sec>] [--dry-run]" >&2
-  echo "       scripts/gh-merge-bot.sh <PR> --verify" >&2
+  echo "       scripts/gh-merge-bot.sh <PR> --verify [--fix-stale]" >&2
   exit 64
 }
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --verify)   VERIFY=1; shift ;;
+    --fix-stale) FIX_STALE=1; shift ;;
     --dry-run)  DRY_RUN=1; shift ;;
     --squash)   METHOD="--squash"; shift ;;
     --rebase)   METHOD="--rebase"; shift ;;
@@ -121,6 +134,7 @@ done
 [[ -n "$PR" ]] || usage_err "missing <PR> argument"
 [[ "$TIMEOUT" =~ ^[0-9]+$ ]] || usage_err "--timeout must be a positive integer (got '$TIMEOUT')"
 [[ "$INTERVAL" =~ ^[0-9]+$ ]] || usage_err "--interval must be a positive integer (got '$INTERVAL')"
+[[ $FIX_STALE == 1 && $VERIFY != 1 ]] && usage_err "--fix-stale only applies in --verify mode"
 
 # Verify-state machine globals (set by verify_state):
 #   V_OUTCOME, V_CODE, V_SHA, V_MSS, V_WHY
@@ -270,12 +284,26 @@ diagnose_refusal() { # classify a refused merge; sets R_OUTCOME/R_WHY/R_CODE
 
 main() {
   local ub_rc diag_rc
-  log "gh-merge-bot: PR=$PR repo=$REPO method=${METHOD#--} verify=$VERIFY dry_run=$DRY_RUN timeout=${TIMEOUT}s interval=${INTERVAL}s"
+  log "gh-merge-bot: PR=$PR repo=$REPO method=${METHOD#--} verify=$VERIFY fix_stale=$FIX_STALE dry_run=$DRY_RUN timeout=${TIMEOUT}s interval=${INTERVAL}s"
 
   verify_state
   log "verify: $V_OUTCOME (${V_WHY:-no detail}) mergeStateStatus=${V_MSS:-<none>}"
 
   if [[ $VERIFY == 1 ]]; then
+    if [[ "$V_OUTCOME" == "STALE" && $FIX_STALE == 1 ]]; then
+      # Bounded single-shot: one update-branch, one re-verify, report the
+      # new state. Never loops — a still-STALE result means re-dispatch.
+      log "verify: STALE with --fix-stale — one update-branch trigger"
+      if [[ $DRY_RUN == 1 ]]; then
+        log "DRY-RUN: would run: gh pr update-branch $PR --repo $REPO"
+      elif gh pr update-branch "$PR" --repo "$REPO" >&2; then
+        log "update-branch ok — one re-verify"
+        verify_state
+        log "re-verify: $V_OUTCOME (${V_WHY:-no detail}) mergeStateStatus=${V_MSS:-<none>}"
+      else
+        log "WARN: update-branch failed; reporting pre-update state"
+      fi
+    fi
     emit_verdict "$V_OUTCOME" "$V_WHY" "$V_SHA"
     exit "$V_CODE"
   fi


### PR DESCRIPTION
## What

GitHub has no native auto-update of PR branches: auto-merge only fires once a PR is mergeable, and under this repo's strict protection ("require branches to be up to date") a PR whose head falls BEHIND `main` after auto-merge is armed stalls indefinitely. This PR makes BEHIND-resolution reactive instead of dependent on a human re-dispatch:

1. **New workflow `.github/workflows/auto-update-pr-branches.yml`** (`Auto-update PR branches`) — the standing BEHIND-resolution owner. Triggers on every push to `main` (primary), plus a `*/30 * * * *` schedule safety net and manual dispatch. It runs `gh pr update-branch` on exactly the open, non-draft, auto-merge-armed PRs whose `mergeStateStatus` is BEHIND (bounded 100-PR query; 422 on already-up-to-date is logged and skipped; job timeout 10 min).

2. **`scripts/gh-merge-bot.sh` gains OPT-IN `--verify --fix-stale`** (default off): on a STALE verify, exactly ONE `gh pr update-branch` + ONE re-verify, then reports the new state. Bounded, never loops; plain `--verify` stays read-only. Default behavior and exit codes unchanged (`--fix-stale` without `--verify` is a usage error, exit 64).

3. **AGENTS.md** codifies the workflow as the BEHIND owner, the PAT-vs-GITHUB_TOKEN hard constraint, and the accepted churn tradeoff. The local playbook (`.slim/deepwork/merge-automation-playbook.md`, not committed) records the workflow as primary owner, `--fix-stale` as belt-and-suspenders, and the 2026-08-10 incident.

## Why EVERLASTINGSKINS_PAT (required)

The workflow authenticates with the fine-grained `EVERLASTINGSKINS_PAT` (pull-requests: write, contents: read), NOT `GITHUB_TOKEN`. Pushes made with GITHUB_TOKEN do not re-trigger workflows (GitHub's recursive-run prevention), so a GITHUB_TOKEN-driven update-branch would push `main` into the PR head WITHOUT re-running ci.yml — required checks would stay stale on the new head SHA and auto-merge would stall. The PAT-authenticated push re-triggers ci.yml like a normal push. Top-level `permissions: {}` leaves GITHUB_TOKEN with no scopes anyway.

> ⚠️ **Secret status: `EVERLASTINGSKINS_PAT` is currently MISSING from repo secrets** (`gh secret list` shows only CURSEFORGE_TOKEN / MODRINTH_TOKEN). The workflow will fail at its first `gh` call until the secret is added. It must be a fine-grained PAT with `pull-requests: write` + `contents: read` on this repo. This PR is not blocked on it — the workflow is inert until the secret exists.

## Churn tradeoff

Each update-branch pushes `main` into a head branch and re-runs the required-check matrix. The workflow deliberately targets ONLY auto-merge-armed, non-draft, BEHIND PRs, so churn stays proportional to merge traffic. Strict branch protection is kept as-is.

## Validation

- `yamllint -c .yamllint.yml` (strict config): pass
- `bash -n` + `shellcheck` on gh-merge-bot.sh: pass
- Smoke: `--help` → usage exit 64; `--verify 424` → DONE (merged), exit 0; `--fix-stale` without `--verify` → usage exit 64; `--verify --fix-stale` parses (fix_stale=1)
- Root pre-commit hooks (aislop, test-count, verify-no-mixin, offline compile): all pass