### PR TITLE
fix(forge-1.6.4/1.5.2/1.4.7): bounds-guard SkinMessage.decode length prefixes (audit remediation)

### DIFF
--- a/forge-1.4.7/src/main/java/levosilimo/everlastingskins/broadcast/SkinMessage.java
+++ b/forge-1.4.7/src/main/java/levosilimo/everlastingskins/broadcast/SkinMessage.java
@@ -122,11 +122,18 @@ public final class SkinMessage {
      * payload with a real PNG always fails that attempt (its length int
      * over-reads into the PNG magic, exceeding the remaining bytes), so it
      * falls back cleanly to the legacy parse.
+     *
+     * <p>Every length prefix is bounds-checked against the remaining unread
+     * payload BEFORE allocation ({@link #checkLength}), so a corrupted or
+     * malicious prefix fails with {@link IllegalArgumentException} (which
+     * the client handler catches) instead of an {@link OutOfMemoryError}
+     * on the packet thread (lib-18 audit remediation).
      */
     public static SkinMessage decode(byte[] payload) {
         try {
             DataInputStream in = new DataInputStream(new ByteArrayInputStream(payload));
             int nameLen = in.readInt();
+            checkLength(nameLen, payload.length - 4, "name");
             byte[] name = new byte[nameLen];
             in.readFully(name);
             String playerName = new String(name, StandardCharsets.UTF_8);
@@ -142,6 +149,7 @@ public final class SkinMessage {
                 in.readFully(name);
             }
             int pngLen = in.readInt();
+            checkLength(pngLen, payload.length - 8 - nameLen, "png");
             byte[] png = null;
             if (pngLen > 0) {
                 png = new byte[pngLen];
@@ -154,6 +162,20 @@ public final class SkinMessage {
     }
 
     /**
+     * Bounds guard for a length-prefixed field: rejects any length prefix
+     * that is negative or exceeds the remaining unread payload BEFORE the
+     * array allocation. The client handler catches
+     * {@link IllegalArgumentException}; an {@link OutOfMemoryError} would
+     * escape {@code catch (Exception)} and kill the network thread.
+     */
+    private static void checkLength(int len, int remaining, String field) {
+        if (len < 0 || len > remaining) {
+            throw new IllegalArgumentException("Malformed SkinMessage payload: " + field
+                + " length " + len + " exceeds remaining " + remaining + " bytes");
+        }
+    }
+
+    /**
      * Attempts the extended-format parse; returns null (and the caller falls
      * back to the legacy shape) unless the extended parse consumes the whole
      * payload.
@@ -162,12 +184,14 @@ public final class SkinMessage {
         try {
             int flags = in.readUnsignedByte();
             int skinLen = in.readInt();
+            checkLength(skinLen, in.available(), "skin");
             byte[] skin = null;
             if (skinLen > 0) {
                 skin = new byte[skinLen];
                 in.readFully(skin);
             }
             int capeLen = in.readInt();
+            checkLength(capeLen, in.available(), "cape");
             byte[] cape = null;
             if (capeLen > 0) {
                 cape = new byte[capeLen];
@@ -177,7 +201,10 @@ public final class SkinMessage {
                 throw new EOFException("trailing bytes after extended payload");
             }
             return new SkinMessage(playerName, skin, cape);
-        } catch (IOException e) {
+        } catch (IOException | IllegalArgumentException e) {
+            // A guard violation makes this a failed extended attempt (a
+            // legacy payload's pngLen-derived skinLen always over-reads) —
+            // fall back to the legacy shape exactly as an EOF would.
             return null;
         }
     }

--- a/forge-1.4.7/src/test/java/levosilimo/everlastingskins/broadcast/SkinMessageTest.java
+++ b/forge-1.4.7/src/test/java/levosilimo/everlastingskins/broadcast/SkinMessageTest.java
@@ -152,6 +152,98 @@ public class SkinMessageTest {
         SkinMessage.decode(new byte[]{0, 1, 2, 3});
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void malformedNameLengthRejectedBeforeAllocation() throws Exception {
+        // nameLen = 2^31-1: the bounds guard must reject it (an
+        // IllegalArgumentException the client handler catches), not
+        // allocate ~2 GiB and OOM the packet thread (lib-18 audit).
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        new DataOutputStream(bos).writeInt(Integer.MAX_VALUE);
+        SkinMessage.decode(bos.toByteArray());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void negativeNameLengthRejectedBeforeAllocation() throws Exception {
+        // nameLen = -1 (unsigned 0xFFFFFFFF): the len >= 0 half of the guard.
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        new DataOutputStream(bos).writeInt(-1);
+        SkinMessage.decode(bos.toByteArray());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void malformedPngLengthRejectedBeforeAllocation() throws Exception {
+        // Legacy shape with pngLen = 2^31-1 (first byte 0x7F > 3, so no
+        // extended attempt): the guard must reject it before allocating.
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bos);
+        byte[] name = "Legacy".getBytes(StandardCharsets.UTF_8);
+        out.writeInt(name.length);
+        out.write(name);
+        out.writeInt(Integer.MAX_VALUE);
+        out.flush();
+        SkinMessage.decode(bos.toByteArray());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void malformedSkinLengthRejectedBeforeAllocation() throws Exception {
+        // Extended shape with skinLen = 2^31-1: the extended attempt's guard
+        // rejects it (then the legacy pngLen guard fires on the rewind).
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bos);
+        byte[] name = "Alex".getBytes(StandardCharsets.UTF_8);
+        out.writeInt(name.length);
+        out.write(name);
+        out.writeByte(3); // flags: hasSkin | hasCape
+        out.writeInt(Integer.MAX_VALUE);
+        out.writeInt(0);
+        out.writeInt(0);
+        out.flush();
+        SkinMessage.decode(bos.toByteArray());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void malformedCapeLengthRejectedBeforeAllocation() throws Exception {
+        // Extended shape with a valid skin and capeLen = 2^31-1.
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bos);
+        byte[] name = "Alex".getBytes(StandardCharsets.UTF_8);
+        out.writeInt(name.length);
+        out.write(name);
+        out.writeByte(3);
+        out.writeInt(1);
+        out.writeByte(9); // skin bytes
+        out.writeInt(Integer.MAX_VALUE);
+        out.flush();
+        SkinMessage.decode(bos.toByteArray());
+    }
+
+    @Test
+    public void legacyPayloadWithLargePngStillDecodesWhenExtendedAttemptGuardFires() throws Exception {
+        // A legacy payload with a large real PNG (~30 KB, under the 32766
+        // cap): the extended attempt reads a bogus skinLen (~pngLen*256 +
+        // first PNG byte) that the bounds guard rejects BEFORE allocation;
+        // the legacy fallback must still decode it (lib-18: the guard must
+        // not break the fallback).
+        byte[] png = new byte[30000];
+        for (int i = 0; i < png.length; i++) {
+            png[i] = (byte) (i & 0xFF);
+        }
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bos);
+        byte[] name = "Legacy".getBytes(StandardCharsets.UTF_8);
+        out.writeInt(name.length);
+        out.write(name);
+        out.writeInt(png.length);
+        out.write(png);
+        out.flush();
+
+        SkinMessage message = SkinMessage.decode(bos.toByteArray());
+
+        assertEquals("Legacy", message.getPlayerName());
+        assertArrayEquals(png, message.getTexturePng());
+        assertNull(message.getCapePng());
+    }
+
     @Test
     public void nameBytesAreUtf8Encoded() {
         byte[] payload = SkinMessage.encode("Notch", null);

--- a/forge-1.5.2/src/main/java/levosilimo/everlastingskins/broadcast/SkinMessage.java
+++ b/forge-1.5.2/src/main/java/levosilimo/everlastingskins/broadcast/SkinMessage.java
@@ -122,11 +122,18 @@ public final class SkinMessage {
      * payload with a real PNG always fails that attempt (its length int
      * over-reads into the PNG magic, exceeding the remaining bytes), so it
      * falls back cleanly to the legacy parse.
+     *
+     * <p>Every length prefix is bounds-checked against the remaining unread
+     * payload BEFORE allocation ({@link #checkLength}), so a corrupted or
+     * malicious prefix fails with {@link IllegalArgumentException} (which
+     * the client handler catches) instead of an {@link OutOfMemoryError}
+     * on the packet thread (lib-18 audit remediation).
      */
     public static SkinMessage decode(byte[] payload) {
         try {
             DataInputStream in = new DataInputStream(new ByteArrayInputStream(payload));
             int nameLen = in.readInt();
+            checkLength(nameLen, payload.length - 4, "name");
             byte[] name = new byte[nameLen];
             in.readFully(name);
             String playerName = new String(name, StandardCharsets.UTF_8);
@@ -142,6 +149,7 @@ public final class SkinMessage {
                 in.readFully(name);
             }
             int pngLen = in.readInt();
+            checkLength(pngLen, payload.length - 8 - nameLen, "png");
             byte[] png = null;
             if (pngLen > 0) {
                 png = new byte[pngLen];
@@ -154,6 +162,20 @@ public final class SkinMessage {
     }
 
     /**
+     * Bounds guard for a length-prefixed field: rejects any length prefix
+     * that is negative or exceeds the remaining unread payload BEFORE the
+     * array allocation. The client handler catches
+     * {@link IllegalArgumentException}; an {@link OutOfMemoryError} would
+     * escape {@code catch (Exception)} and kill the network thread.
+     */
+    private static void checkLength(int len, int remaining, String field) {
+        if (len < 0 || len > remaining) {
+            throw new IllegalArgumentException("Malformed SkinMessage payload: " + field
+                + " length " + len + " exceeds remaining " + remaining + " bytes");
+        }
+    }
+
+    /**
      * Attempts the extended-format parse; returns null (and the caller falls
      * back to the legacy shape) unless the extended parse consumes the whole
      * payload.
@@ -162,12 +184,14 @@ public final class SkinMessage {
         try {
             int flags = in.readUnsignedByte();
             int skinLen = in.readInt();
+            checkLength(skinLen, in.available(), "skin");
             byte[] skin = null;
             if (skinLen > 0) {
                 skin = new byte[skinLen];
                 in.readFully(skin);
             }
             int capeLen = in.readInt();
+            checkLength(capeLen, in.available(), "cape");
             byte[] cape = null;
             if (capeLen > 0) {
                 cape = new byte[capeLen];
@@ -177,7 +201,10 @@ public final class SkinMessage {
                 throw new EOFException("trailing bytes after extended payload");
             }
             return new SkinMessage(playerName, skin, cape);
-        } catch (IOException e) {
+        } catch (IOException | IllegalArgumentException e) {
+            // A guard violation makes this a failed extended attempt (a
+            // legacy payload's pngLen-derived skinLen always over-reads) —
+            // fall back to the legacy shape exactly as an EOF would.
             return null;
         }
     }

--- a/forge-1.5.2/src/test/java/levosilimo/everlastingskins/broadcast/SkinMessageTest.java
+++ b/forge-1.5.2/src/test/java/levosilimo/everlastingskins/broadcast/SkinMessageTest.java
@@ -152,6 +152,98 @@ public class SkinMessageTest {
         SkinMessage.decode(new byte[]{0, 1, 2, 3});
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void malformedNameLengthRejectedBeforeAllocation() throws Exception {
+        // nameLen = 2^31-1: the bounds guard must reject it (an
+        // IllegalArgumentException the client handler catches), not
+        // allocate ~2 GiB and OOM the packet thread (lib-18 audit).
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        new DataOutputStream(bos).writeInt(Integer.MAX_VALUE);
+        SkinMessage.decode(bos.toByteArray());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void negativeNameLengthRejectedBeforeAllocation() throws Exception {
+        // nameLen = -1 (unsigned 0xFFFFFFFF): the len >= 0 half of the guard.
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        new DataOutputStream(bos).writeInt(-1);
+        SkinMessage.decode(bos.toByteArray());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void malformedPngLengthRejectedBeforeAllocation() throws Exception {
+        // Legacy shape with pngLen = 2^31-1 (first byte 0x7F > 3, so no
+        // extended attempt): the guard must reject it before allocating.
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bos);
+        byte[] name = "Legacy".getBytes(StandardCharsets.UTF_8);
+        out.writeInt(name.length);
+        out.write(name);
+        out.writeInt(Integer.MAX_VALUE);
+        out.flush();
+        SkinMessage.decode(bos.toByteArray());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void malformedSkinLengthRejectedBeforeAllocation() throws Exception {
+        // Extended shape with skinLen = 2^31-1: the extended attempt's guard
+        // rejects it (then the legacy pngLen guard fires on the rewind).
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bos);
+        byte[] name = "Alex".getBytes(StandardCharsets.UTF_8);
+        out.writeInt(name.length);
+        out.write(name);
+        out.writeByte(3); // flags: hasSkin | hasCape
+        out.writeInt(Integer.MAX_VALUE);
+        out.writeInt(0);
+        out.writeInt(0);
+        out.flush();
+        SkinMessage.decode(bos.toByteArray());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void malformedCapeLengthRejectedBeforeAllocation() throws Exception {
+        // Extended shape with a valid skin and capeLen = 2^31-1.
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bos);
+        byte[] name = "Alex".getBytes(StandardCharsets.UTF_8);
+        out.writeInt(name.length);
+        out.write(name);
+        out.writeByte(3);
+        out.writeInt(1);
+        out.writeByte(9); // skin bytes
+        out.writeInt(Integer.MAX_VALUE);
+        out.flush();
+        SkinMessage.decode(bos.toByteArray());
+    }
+
+    @Test
+    public void legacyPayloadWithLargePngStillDecodesWhenExtendedAttemptGuardFires() throws Exception {
+        // A legacy payload with a large real PNG (~30 KB, under the 32766
+        // cap): the extended attempt reads a bogus skinLen (~pngLen*256 +
+        // first PNG byte) that the bounds guard rejects BEFORE allocation;
+        // the legacy fallback must still decode it (lib-18: the guard must
+        // not break the fallback).
+        byte[] png = new byte[30000];
+        for (int i = 0; i < png.length; i++) {
+            png[i] = (byte) (i & 0xFF);
+        }
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bos);
+        byte[] name = "Legacy".getBytes(StandardCharsets.UTF_8);
+        out.writeInt(name.length);
+        out.write(name);
+        out.writeInt(png.length);
+        out.write(png);
+        out.flush();
+
+        SkinMessage message = SkinMessage.decode(bos.toByteArray());
+
+        assertEquals("Legacy", message.getPlayerName());
+        assertArrayEquals(png, message.getTexturePng());
+        assertNull(message.getCapePng());
+    }
+
     @Test
     public void nameBytesAreUtf8Encoded() {
         byte[] payload = SkinMessage.encode("Notch", null);

--- a/forge-1.6.4/src/main/java/levosilimo/everlastingskins/broadcast/SkinMessage.java
+++ b/forge-1.6.4/src/main/java/levosilimo/everlastingskins/broadcast/SkinMessage.java
@@ -122,11 +122,18 @@ public final class SkinMessage {
      * payload with a real PNG always fails that attempt (its length int
      * over-reads into the PNG magic, exceeding the remaining bytes), so it
      * falls back cleanly to the legacy parse.
+     *
+     * <p>Every length prefix is bounds-checked against the remaining unread
+     * payload BEFORE allocation ({@link #checkLength}), so a corrupted or
+     * malicious prefix fails with {@link IllegalArgumentException} (which
+     * the client handler catches) instead of an {@link OutOfMemoryError}
+     * on the packet thread (lib-18 audit remediation).
      */
     public static SkinMessage decode(byte[] payload) {
         try {
             DataInputStream in = new DataInputStream(new ByteArrayInputStream(payload));
             int nameLen = in.readInt();
+            checkLength(nameLen, payload.length - 4, "name");
             byte[] name = new byte[nameLen];
             in.readFully(name);
             String playerName = new String(name, StandardCharsets.UTF_8);
@@ -142,6 +149,7 @@ public final class SkinMessage {
                 in.readFully(name);
             }
             int pngLen = in.readInt();
+            checkLength(pngLen, payload.length - 8 - nameLen, "png");
             byte[] png = null;
             if (pngLen > 0) {
                 png = new byte[pngLen];
@@ -154,6 +162,20 @@ public final class SkinMessage {
     }
 
     /**
+     * Bounds guard for a length-prefixed field: rejects any length prefix
+     * that is negative or exceeds the remaining unread payload BEFORE the
+     * array allocation. The client handler catches
+     * {@link IllegalArgumentException}; an {@link OutOfMemoryError} would
+     * escape {@code catch (Exception)} and kill the network thread.
+     */
+    private static void checkLength(int len, int remaining, String field) {
+        if (len < 0 || len > remaining) {
+            throw new IllegalArgumentException("Malformed SkinMessage payload: " + field
+                + " length " + len + " exceeds remaining " + remaining + " bytes");
+        }
+    }
+
+    /**
      * Attempts the extended-format parse; returns null (and the caller falls
      * back to the legacy shape) unless the extended parse consumes the whole
      * payload.
@@ -162,12 +184,14 @@ public final class SkinMessage {
         try {
             int flags = in.readUnsignedByte();
             int skinLen = in.readInt();
+            checkLength(skinLen, in.available(), "skin");
             byte[] skin = null;
             if (skinLen > 0) {
                 skin = new byte[skinLen];
                 in.readFully(skin);
             }
             int capeLen = in.readInt();
+            checkLength(capeLen, in.available(), "cape");
             byte[] cape = null;
             if (capeLen > 0) {
                 cape = new byte[capeLen];
@@ -177,7 +201,10 @@ public final class SkinMessage {
                 throw new EOFException("trailing bytes after extended payload");
             }
             return new SkinMessage(playerName, skin, cape);
-        } catch (IOException e) {
+        } catch (IOException | IllegalArgumentException e) {
+            // A guard violation makes this a failed extended attempt (a
+            // legacy payload's pngLen-derived skinLen always over-reads) —
+            // fall back to the legacy shape exactly as an EOF would.
             return null;
         }
     }

--- a/forge-1.6.4/src/test/java/levosilimo/everlastingskins/broadcast/SkinMessageTest.java
+++ b/forge-1.6.4/src/test/java/levosilimo/everlastingskins/broadcast/SkinMessageTest.java
@@ -152,6 +152,98 @@ public class SkinMessageTest {
         SkinMessage.decode(new byte[]{0, 1, 2, 3});
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void malformedNameLengthRejectedBeforeAllocation() throws Exception {
+        // nameLen = 2^31-1: the bounds guard must reject it (an
+        // IllegalArgumentException the client handler catches), not
+        // allocate ~2 GiB and OOM the packet thread (lib-18 audit).
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        new DataOutputStream(bos).writeInt(Integer.MAX_VALUE);
+        SkinMessage.decode(bos.toByteArray());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void negativeNameLengthRejectedBeforeAllocation() throws Exception {
+        // nameLen = -1 (unsigned 0xFFFFFFFF): the len >= 0 half of the guard.
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        new DataOutputStream(bos).writeInt(-1);
+        SkinMessage.decode(bos.toByteArray());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void malformedPngLengthRejectedBeforeAllocation() throws Exception {
+        // Legacy shape with pngLen = 2^31-1 (first byte 0x7F > 3, so no
+        // extended attempt): the guard must reject it before allocating.
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bos);
+        byte[] name = "Legacy".getBytes(StandardCharsets.UTF_8);
+        out.writeInt(name.length);
+        out.write(name);
+        out.writeInt(Integer.MAX_VALUE);
+        out.flush();
+        SkinMessage.decode(bos.toByteArray());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void malformedSkinLengthRejectedBeforeAllocation() throws Exception {
+        // Extended shape with skinLen = 2^31-1: the extended attempt's guard
+        // rejects it (then the legacy pngLen guard fires on the rewind).
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bos);
+        byte[] name = "Alex".getBytes(StandardCharsets.UTF_8);
+        out.writeInt(name.length);
+        out.write(name);
+        out.writeByte(3); // flags: hasSkin | hasCape
+        out.writeInt(Integer.MAX_VALUE);
+        out.writeInt(0);
+        out.writeInt(0);
+        out.flush();
+        SkinMessage.decode(bos.toByteArray());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void malformedCapeLengthRejectedBeforeAllocation() throws Exception {
+        // Extended shape with a valid skin and capeLen = 2^31-1.
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bos);
+        byte[] name = "Alex".getBytes(StandardCharsets.UTF_8);
+        out.writeInt(name.length);
+        out.write(name);
+        out.writeByte(3);
+        out.writeInt(1);
+        out.writeByte(9); // skin bytes
+        out.writeInt(Integer.MAX_VALUE);
+        out.flush();
+        SkinMessage.decode(bos.toByteArray());
+    }
+
+    @Test
+    public void legacyPayloadWithLargePngStillDecodesWhenExtendedAttemptGuardFires() throws Exception {
+        // A legacy payload with a large real PNG (~30 KB, under the 32766
+        // cap): the extended attempt reads a bogus skinLen (~pngLen*256 +
+        // first PNG byte) that the bounds guard rejects BEFORE allocation;
+        // the legacy fallback must still decode it (lib-18: the guard must
+        // not break the fallback).
+        byte[] png = new byte[30000];
+        for (int i = 0; i < png.length; i++) {
+            png[i] = (byte) (i & 0xFF);
+        }
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bos);
+        byte[] name = "Legacy".getBytes(StandardCharsets.UTF_8);
+        out.writeInt(name.length);
+        out.write(name);
+        out.writeInt(png.length);
+        out.write(png);
+        out.flush();
+
+        SkinMessage message = SkinMessage.decode(bos.toByteArray());
+
+        assertEquals("Legacy", message.getPlayerName());
+        assertArrayEquals(png, message.getTexturePng());
+        assertNull(message.getCapePng());
+    }
+
     @Test
     public void nameBytesAreUtf8Encoded() {
         byte[] payload = SkinMessage.encode("Notch", null);


### PR DESCRIPTION
Audit remediation (lib-18): unbounded byte[] allocation on length prefixes (nameLen/skinLen/capeLen/pngLen) → OOM on the packet thread. Bounds-guarded against the remaining payload; legacy-fallback behavior preserved (tests).