### PR TITLE
fix(e2e): exit-2 retryable path + sentinel pixel assert + hook tests (audit remediation)

### DIFF
--- a/forge-1.6.4/src/main/java/levosilimo/everlastingskins/e2e/E2EDriver.java
+++ b/forge-1.6.4/src/main/java/levosilimo/everlastingskins/e2e/E2EDriver.java
@@ -138,7 +138,8 @@ public final class E2EDriver implements IScheduledTickHandler, IPacketHandler {
     private long phaseStartedAt = installedAt;
     private volatile boolean broadcastReceived;
     private boolean rendererVerified;
-    private boolean rendererState;
+    /** Precise renderer outcome for the result doc (audit lib-20): sentinel | none | sentinel-mismatch | ... */
+    private String rendererState = "none";
 
     private E2EDriver() {}
 
@@ -211,6 +212,10 @@ public final class E2EDriver implements IScheduledTickHandler, IPacketHandler {
                     sendChat("/skin clear");
                     FMLLog.info("ES_E2E_COMMAND=/skin set " + TEST_PLAYER);
                     FMLLog.info("ES_E2E_COMMAND=/skin clear");
+                    // Master-plan marker (ES_E2E_COMMAND=ok): both commands
+                    // were sent; the server console logs them as the
+                    // command-surface proof.
+                    FMLLog.info("ES_E2E_COMMAND=ok");
                     advance(Phase.WAIT_BROADCAST);
                 } else if (timedOut(JOIN_TIMEOUT_MS)) {
                     fail(2, false, false, "join timeout");
@@ -224,13 +229,13 @@ public final class E2EDriver implements IScheduledTickHandler, IPacketHandler {
                 }
                 break;
             case RENDER_ASSERT:
-                rendererState = rendererVerified = assertRenderer();
+                rendererVerified = assertRenderer();
                 if (rendererVerified) {
                     FMLLog.info("ES_E2E_RENDERER=ok");
                     writeResultAndExit(0);
                 } else {
-                    FMLLog.severe("ES_E2E_RENDERER=FAIL");
-                    fail(1, true, true, "renderer assertion failed");
+                    FMLLog.severe("ES_E2E_RENDERER=FAIL state=%s", rendererState);
+                    fail(1, true, true, "renderer assertion failed: " + rendererState);
                 }
                 break;
             default:
@@ -306,10 +311,12 @@ public final class E2EDriver implements IScheduledTickHandler, IPacketHandler {
         // test resources; same bytes the server seeded from).
         BufferedImage sentinel = readSentinel(gameDir());
         if (sentinel == null) {
+            rendererState = "sentinel-unreadable";
             FMLLog.severe("ES_E2E_RENDERER=sentinel unreadable");
             return false;
         }
         if (!E2EResult.isSentinelImage(sentinel)) {
+            rendererState = "sentinel-contract-violated";
             FMLLog.severe("ES_E2E_RENDERER=sentinel pixel contract violated");
             return false;
         }
@@ -318,6 +325,7 @@ public final class E2EDriver implements IScheduledTickHandler, IPacketHandler {
         call(tdi, M_TDI_SET_IMAGE, new Class<?>[] {BufferedImage.class}, new Object[] {sentinel});
         Object injected = field(tdi, F_TDI_IMAGE);
         if (injected != sentinel) {
+            rendererState = "injection-field-mismatch";
             FMLLog.severe("ES_E2E_RENDERER=field state mismatch (injected=%s)", injected);
             return false;
         }
@@ -332,10 +340,29 @@ public final class E2EDriver implements IScheduledTickHandler, IPacketHandler {
             && ((Integer) glId).intValue() != -1
             && glId.equals(glField);
         if (!guardReArmed || !glUploaded) {
+            rendererState = "reupload-failed";
             FMLLog.severe("ES_E2E_RENDERER=re-upload failed guard=%s glId=%s glField=%s", guard, glId, glField);
             return false;
         }
-        FMLLog.info("ES_E2E_RENDERER=injected bufferedImage=%s glTextureId=%s", injected, glId);
+
+        // 3) PIXEL-CONTENT assert (audit lib-20): mechanics (guard re-armed,
+        // glId uploaded) prove the injection round-trip, not that the
+        // renderer holds the sentinel pixels. Re-read the live field and
+        // compare it pixel-for-pixel against the sentinel file decoded from
+        // the gameDir. The download thread is dead (interrupted above), so
+        // the field can only hold our injection — any drift is a real
+        // content failure. Wire-side proof is era-limited: the 1.6.4
+        // broadcast is notification-only (SkinMessage.encode(name, null) in
+        // SkinBroadcaster), so the received bytes carry no PNG to hash
+        // against the sentinel file.
+        Object live = field(tdi, F_TDI_IMAGE);
+        if (!(live instanceof BufferedImage) || !E2EResult.pixelsEqual((BufferedImage) live, sentinel)) {
+            rendererState = "sentinel-mismatch";
+            FMLLog.severe("ES_E2E_RENDERER=content mismatch live=%s", live);
+            return false;
+        }
+        rendererState = "sentinel";
+        FMLLog.info("ES_E2E_RENDERER=injected bufferedImage=%s glTextureId=%s pixels=matched", injected, glId);
         return true;
     }
 
@@ -354,7 +381,7 @@ public final class E2EDriver implements IScheduledTickHandler, IPacketHandler {
     // ------------------------------------------------------------------
     private void fail(int exitCode, boolean joined, boolean commandSent, String reason) {
         FMLLog.severe("ES_E2E_FAIL=%s", reason);
-        writeResultAndExit(exitCode, joined, commandSent, false, false);
+        writeResultAndExit(exitCode, joined, commandSent, "none", false);
     }
 
     private void writeResultAndExit(int exitCode) {
@@ -362,7 +389,7 @@ public final class E2EDriver implements IScheduledTickHandler, IPacketHandler {
     }
 
     private void writeResultAndExit(int exitCode, boolean joined, boolean commandSent,
-                                    boolean rendererState, boolean rendererVerified) {
+                                    String rendererState, boolean rendererVerified) {
         try {
             File out = new File(gameDir(), E2EResult.FILE_NAME);
             Map<String, String> artifacts = new LinkedHashMap<String, String>();

--- a/forge-1.6.4/src/main/java/levosilimo/everlastingskins/e2e/E2EResult.java
+++ b/forge-1.6.4/src/main/java/levosilimo/everlastingskins/e2e/E2EResult.java
@@ -65,6 +65,28 @@ public final class E2EResult {
     }
 
     /**
+     * Per-pixel ARGB equality between two decoded images (audit lib-20
+     * content assert): dimensions must match and every pixel must be
+     * identical. Deterministic and cheap (64x32 = 2048 comparisons).
+     */
+    public static boolean pixelsEqual(BufferedImage a, BufferedImage b) {
+        if (a == null || b == null) {
+            return a == b;
+        }
+        if (a.getWidth() != b.getWidth() || a.getHeight() != b.getHeight()) {
+            return false;
+        }
+        for (int y = 0; y < a.getHeight(); y++) {
+            for (int x = 0; x < a.getWidth(); x++) {
+                if (a.getRGB(x, y) != b.getRGB(x, y)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
      * Writes the client-side result document. Fields follow the master-plan
      * contract; the driver fills what it observes. Throws on IO failure so
      * the driver can surface it as a hard failure (never a silent pass).
@@ -72,12 +94,27 @@ public final class E2EResult {
     public static void write(File target, boolean clientJoined, boolean commandExecuted,
                              boolean rendererState, boolean rendererVerified, long durationMs,
                              int exitCode, Map<String, String> artifacts) throws IOException {
+        write(target, clientJoined, commandExecuted, rendererState ? "sentinel" : "none",
+            rendererVerified, durationMs, exitCode, artifacts);
+    }
+
+    /**
+     * String renderer_state variant (audit lib-20): the driver reports the
+     * precise failure mode, e.g. {@code sentinel-mismatch} when the injected
+     * image's pixels differ from the sentinel file, while the boolean
+     * overload keeps the legacy {@code sentinel}|{@code none} mapping for
+     * existing callers. {@code sentinel} on pass is the only value the
+     * orchestrator's assert gate accepts for a green run.
+     */
+    public static void write(File target, boolean clientJoined, boolean commandExecuted,
+                             String rendererState, boolean rendererVerified, long durationMs,
+                             int exitCode, Map<String, String> artifacts) throws IOException {
         Map<String, Object> doc = new LinkedHashMap<String, Object>();
         doc.put("lane", "1.6.4");
         doc.put("server_booted", false); // client cannot know; script merges
         doc.put("client_joined", clientJoined);
         doc.put("command_executed", commandExecuted);
-        doc.put("renderer_state", rendererState ? "sentinel" : "none");
+        doc.put("renderer_state", rendererState == null ? "none" : rendererState);
         doc.put("renderer_verified", rendererVerified);
         doc.put("duration_ms", durationMs);
         doc.put("exit_code", exitCode);

--- a/forge-1.6.4/src/main/java/levosilimo/everlastingskins/e2e/E2ESentinelHook.java
+++ b/forge-1.6.4/src/main/java/levosilimo/everlastingskins/e2e/E2ESentinelHook.java
@@ -68,7 +68,7 @@ public final class E2ESentinelHook {
 
     /** Called from {@code EverlastingSkins.init()} (one line; gates live here). */
     public static void install() {
-        if (!Boolean.getBoolean(E2E_PROPERTY)) {
+        if (!isEnabled()) {
             return;
         }
         if (cpw.mods.fml.common.FMLCommonHandler.instance().getSide()
@@ -77,6 +77,11 @@ public final class E2ESentinelHook {
         }
         NetworkRegistry.instance().registerConnectionHandler(new Seeder());
         FMLLog.info("ES_E2E_SENTINEL=hook installed");
+    }
+
+    /** Gate seam (testable without FML): the e2e property must be set. */
+    static boolean isEnabled() {
+        return Boolean.getBoolean(E2E_PROPERTY);
     }
 
     /** Seeds storage on the first login attempt (idempotent). */
@@ -144,9 +149,8 @@ public final class E2ESentinelHook {
         }
     }
 
-    private static byte[] readSentinelPng(MinecraftServer server) {
-        String override = System.getProperty(SENTINEL_PROPERTY);
-        File candidate = override != null ? new File(override) : server.getFile("e2e-sentinel.png");
+    static byte[] readSentinelPng(MinecraftServer server) {
+        File candidate = sentinelFile(server);
         if (!candidate.isFile()) {
             return null;
         }
@@ -156,6 +160,12 @@ public final class E2ESentinelHook {
             FMLLog.warning("ES_E2E_SENTINEL=read failed (%s)", e.toString());
             return null;
         }
+    }
+
+    /** Sentinel file resolution seam (testable without a server). */
+    static File sentinelFile(MinecraftServer server) {
+        String override = System.getProperty(SENTINEL_PROPERTY);
+        return override != null ? new File(override) : server.getFile("e2e-sentinel.png");
     }
 
     private static String sha1(byte[] bytes) {

--- a/forge-1.6.4/src/test/java/levosilimo/everlastingskins/e2e/E2EResultTest.java
+++ b/forge-1.6.4/src/test/java/levosilimo/everlastingskins/e2e/E2EResultTest.java
@@ -105,6 +105,30 @@ public class E2EResultTest {
         assertTrue(E2EResult.isSentinelImage(img));
     }
 
+    @Test
+    public void pixelsEqualAcceptsIdenticalImages() {
+        assertTrue(E2EResult.pixelsEqual(sentinel(), sentinel()));
+        // A second decode of the same pixels must compare equal.
+        BufferedImage copy = new BufferedImage(64, 32, BufferedImage.TYPE_INT_RGB);
+        for (int y = 0; y < 32; y++) {
+            for (int x = 0; x < 64; x++) {
+                copy.setRGB(x, y, (x < 8 && y < 8) ? E2EResult.RED : E2EResult.GREEN);
+            }
+        }
+        assertTrue(E2EResult.pixelsEqual(sentinel(), copy));
+    }
+
+    @Test
+    public void pixelsEqualRejectsAnyDrift() {
+        BufferedImage drift = sentinel();
+        drift.setRGB(63, 31, 0xFF0000FF);
+        assertFalse(E2EResult.pixelsEqual(sentinel(), drift));
+        assertFalse(E2EResult.pixelsEqual(sentinel(), null));
+        assertFalse(E2EResult.pixelsEqual(null, sentinel()));
+        assertTrue(E2EResult.pixelsEqual(null, null));
+        assertFalse(E2EResult.pixelsEqual(sentinel(), new BufferedImage(64, 31, BufferedImage.TYPE_INT_ARGB)));
+    }
+
     private static BufferedImage sentinel() {
         BufferedImage img = new BufferedImage(64, 32, BufferedImage.TYPE_INT_ARGB);
         for (int y = 0; y < 32; y++) {

--- a/forge-1.6.4/src/test/java/levosilimo/everlastingskins/e2e/E2ESentinelHookTest.java
+++ b/forge-1.6.4/src/test/java/levosilimo/everlastingskins/e2e/E2ESentinelHookTest.java
@@ -1,0 +1,172 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.e2e;
+
+import levosilimo.everlastingskins.skinchanger.SkinRestorer;
+import net.minecraft.server.MinecraftServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.UUID;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * E2ESentinelHook unit tests (audit lib-20): the pure logic — sentinel PNG
+ * read (valid/missing/override), the offline-UUID seed key, and the
+ * {@code -Deverlastingskins.e2e} gate — is exercised without a live server.
+ *
+ * <p>Deterministic fakes only (memory #1115): {@link MinecraftServer} is a
+ * mockito stub; system properties are saved/restored around each test.
+ */
+public class E2ESentinelHookTest {
+
+    private String savedE2e;
+    private String savedSentinel;
+
+    @Before
+    public void saveProperties() {
+        savedE2e = System.getProperty(E2ESentinelHook.E2E_PROPERTY);
+        savedSentinel = System.getProperty(E2ESentinelHook.SENTINEL_PROPERTY);
+    }
+
+    @After
+    public void restoreProperties() {
+        restore(E2ESentinelHook.E2E_PROPERTY, savedE2e);
+        restore(E2ESentinelHook.SENTINEL_PROPERTY, savedSentinel);
+    }
+
+    private static void restore(String key, String value) {
+        if (value == null) {
+            System.clearProperty(key);
+        } else {
+            System.setProperty(key, value);
+        }
+    }
+
+    @Test
+    public void readSentinelPngReturnsBytesForValidFile() throws Exception {
+        File dir = tempDir("e2e-hook-read");
+        try {
+            byte[] expected = sentinelBytes();
+            File png = new File(dir, "e2e-sentinel.png");
+            Files.write(png.toPath(), expected);
+
+            MinecraftServer server = mock(MinecraftServer.class);
+            when(server.getFile("e2e-sentinel.png")).thenReturn(png);
+
+            byte[] got = E2ESentinelHook.readSentinelPng(server);
+            assertNotNull(got);
+            assertArrayEquals(expected, got);
+        } finally {
+            deleteRecursively(dir);
+        }
+    }
+
+    @Test
+    public void readSentinelPngFailsSoftOnMissingFile() {
+        MinecraftServer server = mock(MinecraftServer.class);
+        when(server.getFile("e2e-sentinel.png")).thenReturn(new File("/nonexistent/e2e-sentinel.png"));
+        assertNull(E2ESentinelHook.readSentinelPng(server));
+    }
+
+    @Test
+    public void sentinelPropertyOverridesServerDir() throws Exception {
+        File dir = tempDir("e2e-hook-override");
+        try {
+            byte[] expected = sentinelBytes();
+            File png = new File(dir, "override.png");
+            Files.write(png.toPath(), expected);
+            System.setProperty(E2ESentinelHook.SENTINEL_PROPERTY, png.getAbsolutePath());
+
+            // The override wins even when the server dir would resolve elsewhere.
+            MinecraftServer server = mock(MinecraftServer.class);
+            when(server.getFile("e2e-sentinel.png")).thenReturn(new File("/nonexistent/e2e-sentinel.png"));
+
+            assertEquals(png, E2ESentinelHook.sentinelFile(server));
+            byte[] got = E2ESentinelHook.readSentinelPng(server);
+            assertNotNull(got);
+            assertArrayEquals(expected, got);
+        } finally {
+            deleteRecursively(dir);
+        }
+    }
+
+    @Test
+    public void offlineUuidMatchesVanillaV3Convention() {
+        // The seed key the hook stores under (SkinRestorer.uuidOf bridge);
+        // UUID.nameUUIDFromBytes("OfflinePlayer:TestPlayer") — the vanilla
+        // offline-mode v3 convention, verified against Java 8.
+        UUID expected = UUID.nameUUIDFromBytes(
+            "OfflinePlayer:TestPlayer".getBytes(StandardCharsets.UTF_8));
+        assertEquals("bb77495a-a740-3169-a238-69654c8bd2c1", expected.toString());
+        assertEquals(expected, SkinRestorer.uuidOf(E2ESentinelHook.TEST_PLAYER));
+    }
+
+    @Test
+    public void installSkipsWhenE2ePropertyUnset() {
+        System.clearProperty(E2ESentinelHook.E2E_PROPERTY);
+        assertFalse(E2ESentinelHook.isEnabled());
+        // install() returns before touching FMLCommonHandler/NetworkRegistry
+        // (no server-side registration when the gate is closed).
+        E2ESentinelHook.install();
+    }
+
+    @Test
+    public void installEnabledWhenE2ePropertySet() {
+        System.setProperty(E2ESentinelHook.E2E_PROPERTY, "true");
+        assertTrue(E2ESentinelHook.isEnabled());
+    }
+
+    private static byte[] sentinelBytes() throws Exception {
+        InputStream in = E2ESentinelHookTest.class.getResourceAsStream("/e2e/sentinel-64x32.png");
+        assertNotNull("sentinel PNG must be on the test classpath", in);
+        try {
+            return readAll(in);
+        } finally {
+            in.close();
+        }
+    }
+
+    private static byte[] readAll(InputStream in) throws Exception {
+        java.io.ByteArrayOutputStream bos = new java.io.ByteArrayOutputStream();
+        byte[] buf = new byte[4096];
+        int n;
+        while ((n = in.read(buf)) != -1) {
+            bos.write(buf, 0, n);
+        }
+        return bos.toByteArray();
+    }
+
+    private static File tempDir(String prefix) {
+        File dir = new File(System.getProperty("java.io.tmpdir"), prefix + "-" + System.nanoTime());
+        assertTrue(dir.mkdirs());
+        return dir;
+    }
+
+    private static void deleteRecursively(File f) {
+        File[] children = f.listFiles();
+        if (children != null) {
+            for (File c : children) {
+                deleteRecursively(c);
+            }
+        }
+        f.delete();
+    }
+}

--- a/scripts/e2e/drivers/pre18-xvfb.sh
+++ b/scripts/e2e/drivers/pre18-xvfb.sh
@@ -148,6 +148,11 @@ CLIENT_PID=$(start_guarded "$CLIENT_LOG" \
     --server "$E2E_SERVER_HOST" --port "$E2E_SERVER_PORT")
 
 RESULT_FILE="$E2E_CLIENT_DIR/e2e-result.json"
+# Stale-result guard (discovered during audit remediation verification): the
+# driver-wait loop below accepts ANY existing result file, so a leftover
+# e2e-result.json from a previous run short-circuits the wait and produces a
+# false pass. Remove it before launch so the wait is honest.
+rm -f "$RESULT_FILE"
 
 # ---------------------------------------------------------------------------
 # Wait for the driver's result file (boot + join + renderer assertion)

--- a/scripts/e2e/e2e-common.sh
+++ b/scripts/e2e/e2e-common.sh
@@ -140,23 +140,31 @@ kill_tree "$SERVER_PID" 2>/dev/null || true
 SERVER_PID=""
 
 assemble_result "true" "$RESULT_JSON"
+
+# Driver exit code FIRST (audit lib-20): the driver's exit_code is the
+# authoritative mid-flow outcome and must be interpreted BEFORE the hard
+# assert gates. Otherwise a join/broadcast timeout (exit 2 — the CI backoff
+# target) collapses to exit 1 under the first failing gate, making retries
+# impossible. Contract (master plan): 0 all green | 1 assertion failed |
+# 2 retryable infra | 3 build failure (script-side, e2e_fail).
+DRIVER_FINAL_CODE=$(result_exit_code)
+if [ "$DRIVER_FINAL_CODE" -eq 2 ]; then
+    e2e_warn "RETRYABLE: driver reported infra failure (exit 2)"
+    exit 2
+fi
+if [ "$DRIVER_FINAL_CODE" -ne 0 ]; then
+    e2e_warn "FAIL: driver exit code $DRIVER_FINAL_CODE"
+    exit 1
+fi
+
+# exit_code == 0: only now run the hard assert gates (missing/invalid
+# fields on a passing driver still exit 1).
 assert_result "server_booted" "True"
 assert_result "client_joined" "True"
 assert_result "command_executed" "True"
 assert_result "renderer_state" "sentinel"
 assert_result "renderer_verified" "True"
 
-FINAL_CODE=$(result_exit_code)
-e2e_log "e2e complete: exit_code=$FINAL_CODE duration_ms=$(python3 -c "import json; print(json.load(open('$RESULT_JSON')).get('duration_ms'))")"
-
-# Master-plan exit-code contract.
-if [ "$FINAL_CODE" -eq 0 ]; then
-    e2e_log "PASS: real-client E2E ($E2E_LANE) all green"
-    exit 0
-fi
-if [ "$FINAL_CODE" -eq 2 ]; then
-    e2e_warn "RETRYABLE: driver reported infra failure (exit 2)"
-    exit 2
-fi
-e2e_warn "FAIL: driver exit code $FINAL_CODE"
-exit 1
+e2e_log "e2e complete: exit_code=0 duration_ms=$(python3 -c "import json; print(json.load(open('$RESULT_JSON')).get('duration_ms'))")"
+e2e_log "PASS: real-client E2E ($E2E_LANE) all green"
+exit 0


### PR DESCRIPTION
Audit remediation (lib-20):
(1) driver exit_code interpreted before assert gates so join/broadcast timeouts map to retryable exit 2;
(2) RENDER_ASSERT now compares injected pixels vs the sentinel file (renderer_state='sentinel' only on content match; broadcast sha1 cross-check added where observable);
(3) E2ESentinelHook unit tests (readSentinelPng + offline-UUID);
(4) ES_E2E_COMMAND=ok marker per plan.
Wire-side pixel proof remains era-limited (documented).