### PR TITLE
feat(e2e): slice 1 CI wiring (informational) + 1.5.2/1.4.7 wrappers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -512,7 +512,6 @@ jobs:
     env:
       LIBGL_ALWAYS_SOFTWARE: "1"
       GALLIUM_DRIVER: llvmpipe
-      RUNNER_TMP: ${{ runner.temp }}/everlastingskins-e2e
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Set up JDK 8
@@ -544,7 +543,13 @@ jobs:
           restore-keys: |
             e2e-${{ runner.os }}-
       - name: Run real-client E2E (server boot + xvfb client + sentinel)
+        # RUNNER_TMP must be a STEP env: the runner context is not available
+        # in job-level env (invalid workflow file -> zero jobs on push). The
+        # shared orchestrator (scripts/e2e/e2e-common.sh) reads it for the
+        # server dir + result copy; the upload step below globs the same dir.
         run: bash ${{ matrix.lane }}/test-infrastructure/run-e2e.sh
+        env:
+          RUNNER_TMP: ${{ runner.temp }}/everlastingskins-e2e
       - name: Upload E2E logs + result (always)
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -481,6 +481,80 @@ jobs:
       - name: Run vendored harness diff-guard
         run: bash scripts/ci-vendored-harness-diff-guard.sh
 
+  # ── E2E (pre-1.8 real-client, informational) ──────────────────
+  # Slice-1 real-client E2E for the vendored-harness pre-1.8 lanes
+  # (lib-12). INFORMATIONAL — NOT part of the 22-context required-check
+  # contract (no gh-api-bump); informational jobs never gate a merge.
+  # forge-1.6.4 is the active lane (tweaker-model driver, slice-1 proven
+  # in #430). The merge-model eras (forge-1.5.2 / forge-1.4.7: obf client
+  # + universal.zip MERGED into the client jar, main
+  # net.minecraft.client.Minecraft, CWD=gameDir) are ERA-UNTESTED — the
+  # driver implements only the 1.6.4 tweaker model and the merge-model
+  # boot was not live-verified, so their matrix entries stay commented
+  # (wrappers exist and exit 3 with the documented note; never fake a
+  # pass). Mesa software GL (llvmpipe) is required for the pre-1.8
+  # real-GL client; xvfb is preinstalled on ubuntu-24.04.
+  e2e-pre18:
+    name: E2E (${{ matrix.lane }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    needs: lint-yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        lane:
+          - forge-1.6.4
+          # ERA-UNTESTED (merge-model boot not implemented/live-verified;
+          # wrapper exits 3 with the documented note — see the lane's
+          # test-infrastructure/run-e2e.sh header):
+          # - forge-1.5.2
+          # - forge-1.4.7
+    env:
+      LIBGL_ALWAYS_SOFTWARE: "1"
+      GALLIUM_DRIVER: llvmpipe
+      RUNNER_TMP: ${{ runner.temp }}/everlastingskins-e2e
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - name: Set up JDK 8
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961  # v5
+        with:
+          java-version: "8"
+          distribution: temurin
+      - name: Install Mesa software GL (llvmpipe for the real pre-1.8 client)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgl1-mesa-dri libglx-mesa0 mesa-utils \
+            libxrandr2 libxxf86vm1 libxcursor1 libxi6 libxinerama1 \
+            libasound2 libopenal1
+      - name: Cache Gradle wrapper and caches
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: |
+            ~/.gradle/wrapper/dists
+            ~/.gradle/caches
+            ~/.gradle/everlastingskins-vendored
+          key: gradle-${{ runner.os }}-${{ matrix.lane }}-${{ hashFiles('**/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-${{ matrix.lane }}-
+      - name: Cache E2E downloads (client jar, forge universal, libraries)
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.cache/everlastingskins
+          key: e2e-${{ matrix.lane }}-${{ runner.os }}
+          restore-keys: |
+            e2e-${{ runner.os }}-
+      - name: Run real-client E2E (server boot + xvfb client + sentinel)
+        run: bash ${{ matrix.lane }}/test-infrastructure/run-e2e.sh
+      - name: Upload E2E logs + result (always)
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: e2e-${{ matrix.lane }}-logs
+          path: |
+            ${{ runner.temp }}/everlastingskins-e2e/e2e-result.json
+            ${{ runner.temp }}/everlastingskins-e2e/**/*.log
+          if-no-files-found: warn
+
   # ── GameTest on 1.21 (canonical gametest subproject) ──────────
   gametest-121:
     name: GameTest (1.21)

--- a/forge-1.4.7/test-infrastructure/run-e2e.sh
+++ b/forge-1.4.7/test-infrastructure/run-e2e.sh
@@ -3,21 +3,24 @@
 # real-client E2E (master plan slice 1; shared logic lives in
 # scripts/e2e/e2e-common.sh + scripts/e2e/drivers/pre18-xvfb.sh).
 #
-# Flow: build the lane (vendored harness, Java 8) → export the lane's
-# server/artifact config → invoke the shared orchestrator.
-#
-# MERGE MODEL (lib-8 recipe): 1.4.7/1.5.2 boot the client as the obf client
-# jar with the FML universal zip MERGED in (universal's patched
-# net/minecraft/client/Minecraft + MinecraftApplet + ClientBrandRetriever
-# win), main net.minecraft.client.Minecraft, CWD + minecraft.applet
-# TargetDirectory = gameDir, NO launchwrapper/tweaker — the driver
-# auto-connects via Minecraft.setServer at @Mod.Init. The server boots as
-# net.minecraft.server.MinecraftServer nogui with the universal zip FIRST on
-# the classpath (its patched MinecraftServer FML-bootstraps the process).
+# ERA-UNTESTED (slice 1, 2026-08-11): this lane is a MERGE-MODEL era.
+# 1.4.7/1.5.2 boot the client as: obf client.jar + forge universal.zip
+# MERGED into the client jar, main net.minecraft.client.Minecraft,
+# CWD=gameDir — NOT the 1.6.4 launchwrapper tweaker model that
+# scripts/e2e/drivers/pre18-xvfb.sh implements (hardcoded 1.6.4 client
+# jar pins + net.minecraft.launchwrapper.Launch --tweakClass FMLTweaker).
+# The merge-model client boot is NOT implemented and was NOT live-verified
+# in the wiring session, so this wrapper mirrors the 1.6.4 wrapper's lane
+# mechanics (Java 8 discovery, lane build, mod jar, vendored server jar)
+# and then exits 3 with this documented note instead of invoking the
+# 1.6.4-only orchestrator. Do NOT fake a pass: the CI matrix entry for
+# this lane stays commented until a merge-model driver lands (lib-8
+# recipe: .slim/deepwork/real-client-e2e-plan.md, open item: pin pre-1.8
+# CLIENT jar URLs).
 #
 # Usage: JAVA_HOME=<jdk8> ./run-e2e.sh
 # Exit codes (master-plan contract): 0 all green | 1 assertion failed |
-# 2 retryable infra | 3 build/hard failure.
+# 2 retryable infra | 3 build/hard failure (era-untested exits 3).
 
 set -euo pipefail
 
@@ -26,9 +29,8 @@ LANE_DIR="$(dirname "$SCRIPT_DIR")"
 REPO_ROOT="$(cd "$LANE_DIR/.." && pwd)"
 
 # ---------------------------------------------------------------------------
-# Java 8 (hard requirement: Gradle 4.4.1 dies on 9+; the merge-model client
-# boot needs Java 8 too — the client bytecode is major 49 but FML 5.2's ASM
-# refuses anything newer than Java 7 class files, and :common needs 8)
+# Java 8 (hard requirement: Gradle 4.4.1 dies on 9+; the future merge-model
+# client boot needs Java 8 too — launchwrapper-era JVM semantics)
 # ---------------------------------------------------------------------------
 if [ -n "${JAVA_HOME:-}" ] && [ -x "$JAVA_HOME/bin/java" ]; then
     E2E_JAVA8="$JAVA_HOME/bin/java"
@@ -69,14 +71,7 @@ if [ ! -f "$SERVER_JAR" ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Invoke the shared orchestrator (merge model)
+# ERA-UNTESTED guard (merge-model boot not implemented)
 # ---------------------------------------------------------------------------
-export E2E_LANE="1.4.7"
-export E2E_ERA="merge"
-export E2E_MOD_JAR="$MOD_JAR"
-export E2E_SERVER_JAR="$SERVER_JAR"
-export E2E_DRIVER_SCRIPT="$REPO_ROOT/scripts/e2e/drivers/pre18-xvfb.sh"
-export E2E_JAVA8
-export E2E_SENTINEL_PNG="$REPO_ROOT/common/src/test/resources/e2e/sentinel-64x32.png"
-
-exec bash "$REPO_ROOT/scripts/e2e/e2e-common.sh"
+echo "[e2e:1.4.7][era-untested] merge-model client boot NOT implemented: 1.4.7 needs obf client.jar + universal.zip MERGED into the client jar (main net.minecraft.client.Minecraft, CWD=gameDir); scripts/e2e/drivers/pre18-xvfb.sh implements only the 1.6.4 tweaker model, and the merge-model boot was not live-verified in the wiring session. Lane mechanics above (build + artifact discovery) are verified; the client/server E2E is not. Enable CI only after a merge-model driver lands per lib-8 (.slim/deepwork/real-client-e2e-plan.md). Exiting 3 — not a pass." >&2
+exit 3

--- a/forge-1.5.2/test-infrastructure/run-e2e.sh
+++ b/forge-1.5.2/test-infrastructure/run-e2e.sh
@@ -3,21 +3,24 @@
 # real-client E2E (master plan slice 1; shared logic lives in
 # scripts/e2e/e2e-common.sh + scripts/e2e/drivers/pre18-xvfb.sh).
 #
-# Flow: build the lane (vendored harness, Java 8) → export the lane's
-# server/artifact config → invoke the shared orchestrator.
-#
-# MERGE MODEL (lib-8 recipe): 1.4.7/1.5.2 boot the client as the obf client
-# jar with the FML universal zip MERGED in (universal's patched
-# net/minecraft/client/Minecraft + MinecraftApplet + ClientBrandRetriever
-# win), main net.minecraft.client.Minecraft, CWD + minecraft.applet
-# TargetDirectory = gameDir, NO launchwrapper/tweaker — the driver
-# auto-connects via Minecraft.setServer at @Mod.Init. The server boots as
-# net.minecraft.server.MinecraftServer nogui with the universal zip FIRST on
-# the classpath (its patched MinecraftServer FML-bootstraps the process).
+# ERA-UNTESTED (slice 1, 2026-08-11): this lane is a MERGE-MODEL era.
+# 1.4.7/1.5.2 boot the client as: obf client.jar + forge universal.zip
+# MERGED into the client jar, main net.minecraft.client.Minecraft,
+# CWD=gameDir — NOT the 1.6.4 launchwrapper tweaker model that
+# scripts/e2e/drivers/pre18-xvfb.sh implements (hardcoded 1.6.4 client
+# jar pins + net.minecraft.launchwrapper.Launch --tweakClass FMLTweaker).
+# The merge-model client boot is NOT implemented and was NOT live-verified
+# in the wiring session, so this wrapper mirrors the 1.6.4 wrapper's lane
+# mechanics (Java 8 discovery, lane build, mod jar, vendored server jar)
+# and then exits 3 with this documented note instead of invoking the
+# 1.6.4-only orchestrator. Do NOT fake a pass: the CI matrix entry for
+# this lane stays commented until a merge-model driver lands (lib-8
+# recipe: .slim/deepwork/real-client-e2e-plan.md, open item: pin pre-1.8
+# CLIENT jar URLs).
 #
 # Usage: JAVA_HOME=<jdk8> ./run-e2e.sh
 # Exit codes (master-plan contract): 0 all green | 1 assertion failed |
-# 2 retryable infra | 3 build/hard failure.
+# 2 retryable infra | 3 build/hard failure (era-untested exits 3).
 
 set -euo pipefail
 
@@ -26,9 +29,8 @@ LANE_DIR="$(dirname "$SCRIPT_DIR")"
 REPO_ROOT="$(cd "$LANE_DIR/.." && pwd)"
 
 # ---------------------------------------------------------------------------
-# Java 8 (hard requirement: Gradle 4.4.1 dies on 9+; the merge-model client
-# boot needs Java 8 too — the client bytecode is major 49 but FML 5.2's ASM
-# refuses anything newer than Java 7 class files, and :common needs 8)
+# Java 8 (hard requirement: Gradle 4.4.1 dies on 9+; the future merge-model
+# client boot needs Java 8 too — launchwrapper-era JVM semantics)
 # ---------------------------------------------------------------------------
 if [ -n "${JAVA_HOME:-}" ] && [ -x "$JAVA_HOME/bin/java" ]; then
     E2E_JAVA8="$JAVA_HOME/bin/java"
@@ -69,14 +71,7 @@ if [ ! -f "$SERVER_JAR" ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Invoke the shared orchestrator (merge model)
+# ERA-UNTESTED guard (merge-model boot not implemented)
 # ---------------------------------------------------------------------------
-export E2E_LANE="1.5.2"
-export E2E_ERA="merge"
-export E2E_MOD_JAR="$MOD_JAR"
-export E2E_SERVER_JAR="$SERVER_JAR"
-export E2E_DRIVER_SCRIPT="$REPO_ROOT/scripts/e2e/drivers/pre18-xvfb.sh"
-export E2E_JAVA8
-export E2E_SENTINEL_PNG="$REPO_ROOT/common/src/test/resources/e2e/sentinel-64x32.png"
-
-exec bash "$REPO_ROOT/scripts/e2e/e2e-common.sh"
+echo "[e2e:1.5.2][era-untested] merge-model client boot NOT implemented: 1.5.2 needs obf client.jar + universal.zip MERGED into the client jar (main net.minecraft.client.Minecraft, CWD=gameDir); scripts/e2e/drivers/pre18-xvfb.sh implements only the 1.6.4 tweaker model, and the merge-model boot was not live-verified in the wiring session. Lane mechanics above (build + artifact discovery) are verified; the client/server E2E is not. Enable CI only after a merge-model driver lands per lib-8 (.slim/deepwork/real-client-e2e-plan.md). Exiting 3 — not a pass." >&2
+exit 3


### PR DESCRIPTION
## Summary

Slice-1 CI wiring for the pre-1.8 real-client E2E (master plan, lib-12), plus sibling lane wrappers. Gate #430 (forge-1.6.4 E2E infra) is merged, so this lands the CI half.

## What lands

**`E2E (${{ matrix.lane }})` — INFORMATIONAL job** (ci.yml):
- NOT part of the 22-context required-check contract — informational only, no gh-api-bump, never gates a merge (gh-merge-bot ignores it).
- Matrix lane `forge-1.6.4` ACTIVE (slice-1 proven driver, tweaker model).
- ubuntu-24.04; setup-java temurin 8; apt Mesa software-GL set per lib-12 (`libgl1-mesa-dri libglx-mesa0 mesa-utils libxrandr2 libxxf86vm1 libxcursor1 libxi6 libxinerama1 libasound2 libopenal1`); `LIBGL_ALWAYS_SOFTWARE=1 GALLIUM_DRIVER=llvmpipe`.
- Cache: gradle (`~/.gradle/wrapper/dists`, `~/.gradle/caches`, `~/.gradle/everlastingskins-vendored`, key `gradle-${{ runner.os }}-${{ matrix.lane }}-${{ hashFiles('**/gradle-wrapper.properties') }}`) + E2E downloads (`~/.cache/everlastingskins`, key `e2e-${{ matrix.lane }}-${{ runner.os }}`).
- 45-min timeout; `if: always()` log upload (e2e-result.json + server/client `*.log` under `${{ runner.temp }}/everlastingskins-e2e`).
- Runs `bash ${{ matrix.lane }}/test-infrastructure/run-e2e.sh`.

**Sibling wrappers** (forge-1.5.2 + forge-1.4.7 `test-infrastructure/run-e2e.sh`): thin wrappers mirroring the 1.6.4 one — Java 8 discovery, lane build, mod jar, vendored server jar — then a documented ERA-UNTESTED guard (exit 3).

## ERA-UNTESTED note (merge-model eras)

1.5.2/1.4.7 boot the client via the MERGE MODEL (obf client.jar + forge universal.zip MERGED into the client jar, main `net.minecraft.client.Minecraft`, CWD=gameDir) — NOT the 1.6.4 launchwrapper tweaker model `scripts/e2e/drivers/pre18-xvfb.sh` implements (hardcoded 1.6.4 client jar pins + `--tweakClass FMLTweaker`). The merge-model client boot is not implemented and was not live-verified in this session (lib-8 open item: pin pre-1.8 CLIENT jar URLs). Per the slice-1 policy, their matrix entries stay COMMENTED with the note — the wrappers exit 3 (never a fake pass) until a merge-model driver lands.

## Validation

- yamllint strict: PASS
- bash -n + shellcheck (same warning set as the 1.6.4 reference wrapper): PASS
- vendored-harness diff-guard: PASS (no build.gradle touched)
- root pre-commit gates: aislop 0 issues, test-count 433, verifyNoMixin PASS, compile PASS