### PR TITLE
feat(e2e): slice 1 — 1.5.2/1.4.7 merge-model real-client E2E (live-verified)

### DIFF
--- a/forge-1.4.7/build.gradle
+++ b/forge-1.4.7/build.gradle
@@ -111,3 +111,58 @@ ext {
 }
 
 apply from: '../harness/specialsource-harness.gradle'
+// ---------------------------------------------------------------------------
+// RUNTIME-COMPAT FIX (slice-1 E2E discovery, mirrored from the 1.6.4 lane):
+// FML 4.7 reads mod-jar classes with its bundled ASM 4.0 (from the FML lib
+// dir), which refuses class files above major version 51 (Java 7). A
+// Java-8-targeted jar is therefore rejected wholesale at boot ("Unable to
+// read a class file correctly ... probably a corrupt zip" — observed live
+// 2026-08-11 against forge-1.4.7-6.6.2.534). The mod must compile against
+// Java 8 APIs (javac 8 forbids source-8 → target-7, and :common uses
+// lambdas/streams), so the shipped jar's class files are downgraded to major
+// 51 in place AFTER reobf. The production 1.5.2 runtime (like the E2E) is
+// Java 8, so the bytecode — including invokedynamic for :common lambdas —
+// executes unchanged; only the version stamp changes.
+// ---------------------------------------------------------------------------
+task downgradeClassVersion(dependsOn: reobf) {
+    group = 'everlastingskins'
+    description = 'Rewrite class-file major version 52 -> 51 in the reobf\'d jar (FML 4.7 ASM cannot read Java 8 class files).'
+    inputs.file jar.archivePath
+    outputs.file jar.archivePath
+    doLast {
+        def jarFile = jar.archivePath
+        def tmp = file("${jarFile}.v51")
+        def zin = new java.util.zip.ZipFile(jarFile)
+        int downgraded = 0
+        def zout = new java.util.zip.ZipOutputStream(new BufferedOutputStream(new FileOutputStream(tmp)))
+        try {
+            zin.entries().each { entry ->
+                if (entry.isDirectory()) {
+                    zout.putNextEntry(new java.util.zip.ZipEntry(entry.name))
+                    zout.closeEntry()
+                    return
+                }
+                def bytes = zin.getInputStream(entry).bytes
+                if (entry.name.endsWith('.class') && bytes.length > 8) {
+                    int major = ((bytes[6] & 0xFF) << 8) | (bytes[7] & 0xFF)
+                    if (major > 51) {
+                        bytes[6] = 0
+                        bytes[7] = 51
+                        downgraded++
+                    }
+                }
+                zout.putNextEntry(new java.util.zip.ZipEntry(entry.name))
+                zout.write(bytes)
+                zout.closeEntry()
+            }
+        } finally {
+            zout.close()
+            zin.close()
+        }
+        if (!jarFile.delete()) throw new GradleException("downgradeClassVersion: could not delete ${jarFile}")
+        if (!tmp.renameTo(jarFile)) throw new GradleException("downgradeClassVersion: could not replace ${jarFile}")
+        logger.lifecycle("downgradeClassVersion: ${downgraded} class files rewritten to major 51 (Java 7) in ${jarFile.name}")
+    }
+}
+// The name-domain self-check javap's the jar — must see the final artifact.
+assertNameDomain.dependsOn downgradeClassVersion

--- a/forge-1.4.7/src/main/java/levosilimo/everlastingskins/broadcast/ClientSkinHandler.java
+++ b/forge-1.4.7/src/main/java/levosilimo/everlastingskins/broadcast/ClientSkinHandler.java
@@ -61,7 +61,13 @@ public final class ClientSkinHandler implements IPacketHandler {
                 // Not spawned yet — the join broadcast re-delivers.
                 return;
             }
-            String skinUrl = target.skinUrl;
+            // skinUrl is declared on Entity; access it through the Entity
+            // type so the reobf pass can map the reference (javac emits the
+            // receiver's declared type as the owner, and the srg FD keys are
+            // the declaring class — EntityPlayer.skinUrl would stay unmapped
+            // and NoSuchFieldError at runtime; found live by the slice-1
+            // 1.5.2 E2E).
+            String skinUrl = ((net.minecraft.src.Entity) target).skinUrl;
             if (skinUrl == null) {
                 return;
             }

--- a/forge-1.4.7/src/main/java/levosilimo/everlastingskins/e2e/E2E.java
+++ b/forge-1.4.7/src/main/java/levosilimo/everlastingskins/e2e/E2E.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.e2e;
+
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.relauncher.Side;
+
+/**
+ * Single entry point for the in-jar E2E support, invoked from
+ * {@code EverlastingSkins.init()} (one line: {@code E2E.install();}).
+ *
+ * <p>Shipped-gated by {@code -Deverlastingskins.e2e=true} (never active in
+ * production); side-gated afterwards:
+ * <ul>
+ *   <li>CLIENT → {@link E2EDriver} (phase machine, channel receiver,
+ *       auto-connect, renderer assertion, result file + {@code System.exit});</li>
+ *   <li>SERVER → {@link E2ESentinelHook} (sentinel pre-seed so the login
+ *       re-broadcast delivers it).</li>
+ * </ul>
+ */
+public final class E2E {
+
+    /** System property the e2e scripts set on both JVMs. */
+    public static final String E2E_PROPERTY = "everlastingskins.e2e";
+
+    private E2E() {}
+
+    /** One-line gated entry from the mod's {@code @Mod.Init init}. */
+    public static void install() {
+        if (!Boolean.getBoolean(E2E_PROPERTY)) {
+            return;
+        }
+        Side side = FMLCommonHandler.instance().getSide();
+        if (side == Side.CLIENT) {
+            E2EDriver.install();
+        } else if (side == Side.SERVER) {
+            E2ESentinelHook.install();
+        }
+    }
+}

--- a/forge-1.4.7/src/main/java/levosilimo/everlastingskins/e2e/E2EDriver.java
+++ b/forge-1.4.7/src/main/java/levosilimo/everlastingskins/e2e/E2EDriver.java
@@ -1,0 +1,380 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.e2e;
+
+import cpw.mods.fml.common.FMLLog;
+import cpw.mods.fml.common.IScheduledTickHandler;
+import cpw.mods.fml.common.ITickHandler;
+import cpw.mods.fml.common.TickType;
+import cpw.mods.fml.common.network.IPacketHandler;
+import cpw.mods.fml.common.network.NetworkRegistry;
+import cpw.mods.fml.common.network.Player;
+import cpw.mods.fml.common.registry.TickRegistry;
+import cpw.mods.fml.relauncher.Side;
+import levosilimo.everlastingskins.broadcast.SkinBroadcaster;
+import levosilimo.everlastingskins.broadcast.SkinMessage;
+import levosilimo.everlastingskins.client.ClientSkinApplier;
+import net.minecraft.client.Minecraft;
+import net.minecraft.src.EntityClientPlayerMP;
+import net.minecraft.src.ImageBufferDownload;
+import net.minecraft.src.INetworkManager;
+import net.minecraft.src.Packet250CustomPayload;
+import net.minecraft.src.ThreadDownloadImageData;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * In-jar client driver for the real-client E2E (master plan slice 1,
+ * {@code scripts/e2e/drivers/pre18-xvfb.sh}, MERGE model — lib-8 recipe).
+ *
+ * <p>Shipped in the mod jar, gated at runtime by
+ * {@code -Deverlastingskins.e2e=true} + {@code Side.CLIENT} (see
+ * {@link E2E#install()}). Lifecycle: {@code @Mod.Init} installs this driver;
+ * the tick primitive is FML 4.7 {@link IScheduledTickHandler}
+ * ({@code TickRegistry.registerScheduledTickHandler}).
+ *
+ * <p>MERGE-MODEL delta vs the 1.6.4 driver: this lane boots as the obf client
+ * jar with the FML universal zip MERGED in (main
+ * {@code net.minecraft.client.Minecraft}, no launchwrapper), so the runtime
+ * class names and the compile-time deobf names agree modulo the lane's
+ * reobf pass — the driver compiles DIRECTLY against the client classes
+ * ({@code Minecraft.getMinecraft()}, {@code mc.theWorld/thePlayer},
+ * {@code mc.renderEngine.obtainImageData}, the PUBLIC
+ * {@code ThreadDownloadImageData.image/textureName/textureSetupComplete}
+ * fields, {@code Entity.skinUrl} — MCP 7.26a) with zero reflection, unlike the
+ * 1.6.4 driver. The connect: 1.4.7's {@code Minecraft.main} parses no
+ * {@code --server/--port} (only {@code --demo/--applet/--password} — verified
+ * against the client jar), so {@link #install()} calls
+ * {@code Minecraft.setServer(host, port)} itself; the vanilla run loop picks
+ * the fields up at startGame and shows GuiConnecting. The e2e scripts pin
+ * the client jar sha1, which keeps every referenced member name stable.
+ *
+ * <p>Phase machine: WAIT_JOIN (client world + player exist) → send
+ * {@code /skin set TestPlayer} + {@code /skin clear} (command surface proof;
+ * the server console logs both chat lines) → WAIT_BROADCAST (the login
+ * re-broadcast of the pre-seeded sentinel arrives on the
+ * {@code everlastingskins} channel — this receiver coexists with the mod's
+ * own {@link ClientSkinApplier} handler: FML 4.7 keeps per-channel
+ * handler multimaps) → RENDER_ASSERT: observe the broadcast injection into
+ * the player's skin {@link ThreadDownloadImageData} (the login broadcast
+ * carries the sentinel PNG bytes inline; the client handler already injected
+ * them), otherwise inject the sentinel from the gameDir file via
+ * {@link ClientSkinApplier#apply}; re-arm the once-per-image upload guard
+ * ({@code textureSetupComplete=false}) and re-trigger the upload through
+ * {@code RenderEngine.getTextureForDownloadableImage}; then assert the
+ * injected field state + the re-upload outcome (GL id + guard) + the sentinel
+ * pixel contract → write {@code e2e-result.json} in the client gameDir →
+ * {@code System.exit}.
+ *
+ * <p>Download-thread race (documented, same caveat as the client handler):
+ * the vanilla {@code ThreadDownloadImage} download from skins.minecraft.net
+ * writes {@code tdi.image} ONLY on a successful fetch (the failure path just
+ * prints + disconnects — verified against the client jar). The e2e sandbox
+ * cannot reach skins.minecraft.net, so the injected sentinel survives; a
+ * reachable host would overwrite it and the field-state assert fails
+ * honestly (exit 1).
+ *
+ * <p>Exit codes (master-plan contract): 0 all green | 1 renderer assertion
+ * failed | 2 retryable infra (join/broadcast timeout) | 3 driver hard
+ * failure.
+ */
+public final class E2EDriver implements IScheduledTickHandler, IPacketHandler {
+
+    /** Offline test player (matches the e2e scripts' username arg). */
+    public static final String TEST_PLAYER = "TestPlayer";
+
+    /** System property the e2e driver script passes (merge boot has no --server/--port). */
+    static final String SERVER_PROPERTY = "everlastingskins.e2e.server";
+
+    /** System property for the test server port. */
+    static final String PORT_PROPERTY = "everlastingskins.e2e.port";
+
+    private static final long JOIN_TIMEOUT_MS = 180_000L;
+    private static final long BROADCAST_TIMEOUT_MS = 60_000L;
+
+    /** Client-side driver phases (pure transition logic in {@link #nextPhase}). */
+    enum Phase {
+        WAIT_JOIN, WAIT_BROADCAST, RENDER_ASSERT, DONE
+    }
+
+    /**
+     * Pure phase transition used by the tick machine and unit tests: the
+     * driver advances only on observed facts.
+     */
+    static Phase nextPhase(Phase current, boolean joined, boolean broadcastReceived, boolean asserted) {
+        switch (current) {
+            case WAIT_JOIN:
+                return joined ? Phase.WAIT_BROADCAST : Phase.WAIT_JOIN;
+            case WAIT_BROADCAST:
+                return broadcastReceived ? Phase.RENDER_ASSERT : Phase.WAIT_BROADCAST;
+            case RENDER_ASSERT:
+                return asserted ? Phase.DONE : Phase.RENDER_ASSERT;
+            default:
+                return current;
+        }
+    }
+
+    private final long installedAt = System.currentTimeMillis();
+    private Phase phase = Phase.WAIT_JOIN;
+    private long phaseStartedAt = installedAt;
+    private volatile boolean broadcastReceived;
+    private boolean rendererVerified;
+    private boolean rendererState;
+    private boolean broadcastInjected;
+
+    private E2EDriver() {}
+
+    /** Installs the client driver (property + side gates live in {@link E2E#install()}). */
+    static void install() {
+        E2EDriver driver = new E2EDriver();
+        // Client-side channel receiver: FML 4.7 keeps per-channel handler
+        // multimaps, so this coexists with the @NetworkMod client spec.
+        NetworkRegistry.instance().registerChannel(driver, SkinBroadcaster.CHANNEL, Side.CLIENT);
+        TickRegistry.registerScheduledTickHandler(driver, Side.CLIENT);
+        // Merge-model auto-connect. Runs inside the Minecraft constructor
+        // (@Mod.Init fires via finishMinecraftLoading), before startGame
+        // consumes serverName → GuiConnecting → join.
+        Minecraft mc = Minecraft.getMinecraft();
+        String host = System.getProperty(SERVER_PROPERTY, "127.0.0.1");
+        int port = Integer.getInteger(PORT_PROPERTY, 25565);
+        mc.setServer(host, port);
+        FMLLog.info("ES_E2E_DRIVER=installed side=%s server=%s:%d", Side.CLIENT, host, port);
+    }
+
+    // ------------------------------------------------------------------
+    // Channel receiver: the server's login re-broadcast (sentinel pre-seed)
+    // is a notification-only SkinMessage for TEST_PLAYER.
+    // ------------------------------------------------------------------
+    @Override
+    public void onPacketData(INetworkManager manager, Packet250CustomPayload packet, Player player) {
+        try {
+            SkinMessage message = SkinMessage.decode(packet.data);
+            if (TEST_PLAYER.equals(message.getPlayerName())) {
+                broadcastReceived = true;
+                FMLLog.info("ES_E2E_BROADCAST=received player=%s", message.getPlayerName());
+            }
+        } catch (RuntimeException e) {
+            FMLLog.warning("ES_E2E_BROADCAST=malformed payload (%s)", e.toString());
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Scheduled tick machine (client ticks run on the render thread, so GL
+    // work in RENDER_ASSERT is on the same thread as the renderer).
+    // ------------------------------------------------------------------
+    @Override
+    public void tickStart(EnumSet<TickType> types, Object... tickData) {
+        try {
+            tick();
+        } catch (Throwable t) {
+            FMLLog.severe("ES_E2E_DRIVER=crash phase=%s (%s)", phase, t);
+            fail(3, false, false, "driver crash: " + t);
+        }
+    }
+
+    @Override
+    public void tickEnd(EnumSet<TickType> types, Object... tickData) {
+    }
+
+    @Override
+    public EnumSet<TickType> ticks() {
+        return EnumSet.of(TickType.CLIENT);
+    }
+
+    @Override
+    public String getLabel() {
+        return "everlastingskins-e2e";
+    }
+
+    @Override
+    public int nextTickSpacing() {
+        return 1;
+    }
+
+    private void tick() throws Exception {
+        switch (phase) {
+            case WAIT_JOIN:
+                if (isJoined()) {
+                    FMLLog.info("ES_E2E_JOIN=%s", TEST_PLAYER);
+                    sendChat("/skin set " + TEST_PLAYER);
+                    sendChat("/skin clear");
+                    FMLLog.info("ES_E2E_COMMAND=/skin set " + TEST_PLAYER);
+                    FMLLog.info("ES_E2E_COMMAND=/skin clear");
+                    advance(Phase.WAIT_BROADCAST);
+                } else if (timedOut(JOIN_TIMEOUT_MS)) {
+                    fail(2, false, false, "join timeout");
+                }
+                break;
+            case WAIT_BROADCAST:
+                if (broadcastReceived) {
+                    advance(Phase.RENDER_ASSERT);
+                } else if (timedOut(BROADCAST_TIMEOUT_MS)) {
+                    fail(2, true, true, "broadcast timeout");
+                }
+                break;
+            case RENDER_ASSERT:
+                rendererState = rendererVerified = assertRenderer();
+                if (rendererVerified) {
+                    FMLLog.info("ES_E2E_RENDERER=ok");
+                    writeResultAndExit(0);
+                } else {
+                    FMLLog.severe("ES_E2E_RENDERER=FAIL");
+                    fail(1, true, true, "renderer assertion failed");
+                }
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void advance(Phase next) {
+        phase = next;
+        phaseStartedAt = System.currentTimeMillis();
+    }
+
+    private boolean timedOut(long budgetMs) {
+        return System.currentTimeMillis() - phaseStartedAt > budgetMs;
+    }
+
+    // ------------------------------------------------------------------
+    // Join + command surface (direct client references — MCP 7.26a surface).
+    // ------------------------------------------------------------------
+    private boolean isJoined() {
+        Minecraft mc = Minecraft.getMinecraft();
+        return mc.theWorld != null && mc.thePlayer != null;
+    }
+
+    private void sendChat(String message) {
+        Minecraft.getMinecraft().thePlayer.sendChatMessage(message);
+    }
+
+    // ------------------------------------------------------------------
+    // Renderer assertion (lib-14, 1.4.7/1.4.7 variant): field state +
+    // re-upload trigger + sentinel pixel compare. The 1.4.7
+    // ThreadDownloadImageData is a POJO with public image/textureName/
+    // textureSetupComplete fields; RenderEngine.getTextureForDownloadableImage
+    // re-uploads when image != null && !textureSetupComplete and returns the
+    // GL texture id (verified against the client jar).
+    // ------------------------------------------------------------------
+    private boolean assertRenderer() {
+        Minecraft mc = Minecraft.getMinecraft();
+        EntityClientPlayerMP player = mc.thePlayer;
+        if (player == null) {
+            FMLLog.severe("ES_E2E_RENDERER=no player entity");
+            return false;
+        }
+        // Field declared on Entity; access it through the Entity type so the
+        // reobf pass can map the reference (javac emits the receiver's
+        // declared type as the owner, and the srg FD keys are the declaring
+        // class — EntityClientPlayerMP.skinUrl would stay unmapped and
+        // NoSuchFieldError at runtime).
+        net.minecraft.src.Entity entity = player;
+        String skinUrl = entity.skinUrl;
+        if (skinUrl == null) {
+            FMLLog.severe("ES_E2E_RENDERER=skinUrl not set");
+            return false;
+        }
+        // Cached TDI: seeded by RenderGlobal.onEntityCreate when the player
+        // spawned; the client handler injects through the same instance.
+        ThreadDownloadImageData tdi = mc.renderEngine.obtainImageData(skinUrl, new ImageBufferDownload());
+        if (tdi == null) {
+            FMLLog.severe("ES_E2E_RENDERER=no cached ThreadDownloadImageData");
+            return false;
+        }
+
+        // Sentinel image from the client gameDir (script-copied from :common
+        // test resources; same bytes the server seeded from).
+        BufferedImage sentinel = readSentinel(mc.getMinecraftDir());
+        if (sentinel == null || !E2EResult.isSentinelImage(sentinel)) {
+            FMLLog.severe("ES_E2E_RENDERER=sentinel unreadable or pixel contract violated");
+            return false;
+        }
+        BufferedImage flat = ClientSkinApplier.flattenToLegacy(sentinel);
+
+        // Observe the broadcast injection first: the login re-broadcast
+        // carries the sentinel PNG inline and the client handler injects it
+        // into this same cached TDI. If it already landed, the full
+        // server→client pipeline is proven; either way, re-arm the
+        // once-per-image upload guard and re-trigger the upload.
+        broadcastInjected = tdi.image != null && E2EResult.isSentinelImage(tdi.image);
+        if (broadcastInjected) {
+            FMLLog.info("ES_E2E_RENDERER=broadcast injection observed");
+            tdi.textureSetupComplete = false;
+        } else {
+            ClientSkinApplier.apply(tdi, flat);
+        }
+
+        // 1) Field-state assert (pixel compare vs the sentinel contract).
+        if (tdi.image == null || !E2EResult.isSentinelImage(tdi.image)) {
+            FMLLog.severe("ES_E2E_RENDERER=field state mismatch (image=%s)", tdi.image);
+            return false;
+        }
+
+        // 2) Re-upload trigger: textureSetupComplete=false makes
+        // getTextureForDownloadableImage upload the injected pixels
+        // (allocateAndSetupTexture on first upload, setupTexture re-upload
+        // into the existing GL texture) and return the GL id.
+        int glId = mc.renderEngine.getTextureForDownloadableImage(skinUrl, null);
+        boolean uploadOk = glId >= 0 && tdi.textureName == glId && tdi.textureSetupComplete;
+        if (!uploadOk) {
+            FMLLog.severe("ES_E2E_RENDERER=re-upload failed glId=%s textureName=%s setupComplete=%s",
+                glId, tdi.textureName, tdi.textureSetupComplete);
+            return false;
+        }
+        FMLLog.info("ES_E2E_RENDERER=ok image=%s glTextureId=%s broadcastInjected=%s",
+            tdi.image, glId, broadcastInjected);
+        return true;
+    }
+
+    private static BufferedImage readSentinel(File gameDir) {
+        File png = new File(gameDir, "e2e-sentinel.png");
+        try {
+            return ImageIO.read(png);
+        } catch (IOException e) {
+            FMLLog.warning("ES_E2E_RENDERER=sentinel read failed (%s)", e.toString());
+            return null;
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Result + exit.
+    // ------------------------------------------------------------------
+    private void fail(int exitCode, boolean joined, boolean commandSent, String reason) {
+        FMLLog.severe("ES_E2E_FAIL=%s", reason);
+        writeResultAndExit(exitCode, joined, commandSent, false, false);
+    }
+
+    private void writeResultAndExit(int exitCode) {
+        writeResultAndExit(exitCode, true, true, rendererState, rendererVerified);
+    }
+
+    private void writeResultAndExit(int exitCode, boolean joined, boolean commandSent,
+                                    boolean rendererState, boolean rendererVerified) {
+        try {
+            File out = new File(Minecraft.getMinecraft().getMinecraftDir(), E2EResult.FILE_NAME);
+            Map<String, String> artifacts = new LinkedHashMap<String, String>();
+            artifacts.put("driver", "E2EDriver/1.4.7");
+            artifacts.put("broadcast", broadcastReceived ? "received" : "none");
+            artifacts.put("broadcast_injected", broadcastInjected ? "true" : "false");
+            E2EResult.write(out, joined, commandSent, rendererState, rendererVerified,
+                System.currentTimeMillis() - installedAt, exitCode, artifacts);
+            FMLLog.info("ES_E2E_RESULT=%s code=%s", out.getAbsolutePath(), exitCode);
+        } catch (Exception e) {
+            // Never mask the outcome: a result-write failure is a hard driver
+            // failure (exit 3), not a silent success.
+            FMLLog.severe("ES_E2E_FAIL=result write failed (%s)", e.toString());
+            System.exit(3);
+        }
+        System.exit(exitCode);
+    }
+}

--- a/forge-1.4.7/src/main/java/levosilimo/everlastingskins/e2e/E2EResult.java
+++ b/forge-1.4.7/src/main/java/levosilimo/everlastingskins/e2e/E2EResult.java
@@ -1,0 +1,109 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.e2e;
+
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Pure result-document logic for the real-client E2E (shared master-plan
+ * contract, scripts/e2e/). Kept free of any Minecraft/FML import so the
+ * lane's JUnit scaffold can test it without a client.
+ *
+ * <p>The in-jar driver writes {@code e2e-result.json} into the client's
+ * gameDir with the client-known fields; {@code scripts/e2e/e2e-common.sh}
+ * merges the server-side facts (server_booted, artifacts) into the final
+ * document at {@code ${RUNNER_TMP}/e2e-result.json} and maps the exit code.
+ */
+public final class E2EResult {
+
+    /** Result file name in the client gameDir (driver-side artifact). */
+    public static final String FILE_NAME = "e2e-result.json";
+
+    /**
+     * Sentinel PNG contract (64x32, shared from :common test resources as
+     * {@code e2e/sentinel-64x32.png}): top-left 8x8 block pure red, all
+     * remaining pixels pure green. The driver verifies the decoded image
+     * before injecting it into the skin renderer.
+     */
+    public static final int SENTINEL_WIDTH = 64;
+    public static final int SENTINEL_HEIGHT = 32;
+    public static final int SENTINEL_BLOCK = 8;
+    public static final int RED = 0xFFFF0000;
+    public static final int GREEN = 0xFF00FF00;
+
+    private E2EResult() {}
+
+    /**
+     * Verifies a decoded image against the sentinel pixel contract. The
+     * image is a valid sentinel iff every pixel inside the top-left
+     * {@link #SENTINEL_BLOCK} square is pure red and every other pixel is
+     * pure green.
+     */
+    public static boolean isSentinelImage(BufferedImage image) {
+        if (image == null || image.getWidth() != SENTINEL_WIDTH || image.getHeight() != SENTINEL_HEIGHT) {
+            return false;
+        }
+        for (int y = 0; y < SENTINEL_HEIGHT; y++) {
+            for (int x = 0; x < SENTINEL_WIDTH; x++) {
+                int expected = (x < SENTINEL_BLOCK && y < SENTINEL_BLOCK) ? RED : GREEN;
+                if ((image.getRGB(x, y) & 0xFFFFFF) != (expected & 0xFFFFFF)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Writes the client-side result document. Fields follow the master-plan
+     * contract; the driver fills what it observes. Throws on IO failure so
+     * the driver can surface it as a hard failure (never a silent pass).
+     */
+    public static void write(File target, boolean clientJoined, boolean commandExecuted,
+                             boolean rendererState, boolean rendererVerified, long durationMs,
+                             int exitCode, Map<String, String> artifacts) throws IOException {
+        Map<String, Object> doc = new LinkedHashMap<String, Object>();
+        doc.put("lane", "1.4.7");
+        doc.put("server_booted", false); // client cannot know; script merges
+        doc.put("client_joined", clientJoined);
+        doc.put("command_executed", commandExecuted);
+        doc.put("renderer_state", rendererState ? "sentinel" : "none");
+        doc.put("renderer_verified", rendererVerified);
+        doc.put("duration_ms", durationMs);
+        doc.put("exit_code", exitCode);
+        doc.put("artifacts", artifacts == null ? new LinkedHashMap<String, String>() : artifacts);
+        Files.write(target.toPath(), toJson(doc).getBytes(StandardCharsets.UTF_8));
+    }
+
+    /** Minimal JSON emitter (no gson dependency on the legacy classpath is guaranteed at boot). */
+    public static String toJson(Map<String, Object> doc) {
+        StringBuilder sb = new StringBuilder("{");
+        boolean first = true;
+        for (Map.Entry<String, Object> e : doc.entrySet()) {
+            if (!first) {
+                sb.append(',');
+            }
+            first = false;
+            sb.append('"').append(e.getKey()).append("\":");
+            Object v = e.getValue();
+            if (v instanceof Boolean || v instanceof Number) {
+                sb.append(v);
+            } else if (v instanceof Map) {
+                sb.append(toJson((Map<String, Object>) v));
+            } else {
+                sb.append('"').append(String.valueOf(v).replace("\\", "\\\\").replace("\"", "\\\"")).append('"');
+            }
+        }
+        return sb.append('}').toString();
+    }
+}

--- a/forge-1.4.7/src/main/java/levosilimo/everlastingskins/e2e/E2ESentinelHook.java
+++ b/forge-1.4.7/src/main/java/levosilimo/everlastingskins/e2e/E2ESentinelHook.java
@@ -1,0 +1,173 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.e2e;
+
+import cpw.mods.fml.common.FMLLog;
+import cpw.mods.fml.common.network.IConnectionHandler;
+import cpw.mods.fml.common.network.NetworkRegistry;
+import cpw.mods.fml.common.network.Player;
+import levosilimo.everlastingskins.skinchanger.SkinRestorer;
+import levosilimo.everlastingskins.util.CustomSkinProperty;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.src.EntityPlayer;
+import net.minecraft.src.INetworkManager;
+import net.minecraft.src.NetHandler;
+import net.minecraft.src.NetLoginHandler;
+import net.minecraft.src.Packet1Login;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+/**
+ * Server-side E2E sentinel hook (master plan lib-13): with
+ * {@code -Deverlastingskins.e2e=true} on the SERVER, pre-seeds
+ * {@code SkinStorage} for the offline test player
+ * ({@link SkinRestorer#uuidOf(String)} offline-UUID bridge) before the test
+ * client logs in, so the mod's login re-broadcast
+ * ({@link levosilimo.everlastingskins.broadcast.SkinBroadcaster}) delivers
+ * the sentinel notification to the in-jar client driver.
+ *
+ * <p>Timing contract: {@link #install()} is invoked from
+ * {@code EverlastingSkins.init()} (FMLInitializationEvent); the seed must
+ * land AFTER {@code SkinRestorer.onServerStarting} creates storage. The hook
+ * therefore seeds lazily from {@code connectionReceived} — the server has
+ * finished starting before it accepts any connection, and
+ * {@code connectionReceived} precedes the mod's own
+ * {@code playerLoggedIn} re-broadcast in the same login flow, so the seed
+ * always precedes the broadcast deterministically.
+ *
+ * <p>The sentinel PNG itself (64x32, known pixels) is read from the server's
+ * working directory ({@code e2e-sentinel.png}, copied there by the e2e
+ * script from {@code common/src/test/resources/e2e/sentinel-64x32.png}) and
+ * its sha1 is logged so the script can tie the server-side seed to the
+ * client-side injection bytes. The stored property is storage-only on this
+ * line (the 1.4.7 restore path is the broadcast notification); its value is
+ * the sentinel PNG bytes base64-encoded.
+ */
+public final class E2ESentinelHook {
+
+    /** System property the e2e script sets on the server JVM. */
+    public static final String E2E_PROPERTY = "everlastingskins.e2e";
+
+    /** Optional override for the sentinel PNG path (default: server dir {@code e2e-sentinel.png}). */
+    public static final String SENTINEL_PROPERTY = "everlastingskins.e2e.sentinel";
+
+    public static final String TEST_PLAYER = E2EDriver.TEST_PLAYER;
+
+    private static volatile boolean seeded;
+
+    private E2ESentinelHook() {}
+
+    /** Called from {@code EverlastingSkins.init()} (one line; gates live here). */
+    public static void install() {
+        if (!Boolean.getBoolean(E2E_PROPERTY)) {
+            return;
+        }
+        if (cpw.mods.fml.common.FMLCommonHandler.instance().getSide()
+            != cpw.mods.fml.relauncher.Side.SERVER) {
+            return;
+        }
+        NetworkRegistry.instance().registerConnectionHandler(new Seeder());
+        FMLLog.info("ES_E2E_SENTINEL=hook installed");
+    }
+
+    /** Seeds storage on the first login attempt (idempotent). */
+    private static final class Seeder implements IConnectionHandler {
+
+        @Override
+        public String connectionReceived(NetLoginHandler netHandler, INetworkManager manager) {
+            seedOnce();
+            return null;
+        }
+
+        @Override
+        public void playerLoggedIn(Player player, NetHandler netHandler, INetworkManager manager) {
+            if (player instanceof EntityPlayer) {
+                FMLLog.info("ES_E2E_LOGIN=%s", ((EntityPlayer) player).getCommandSenderName());
+            }
+        }
+
+        @Override
+        public void connectionOpened(NetHandler netClientHandler, String server, int port, INetworkManager manager) {
+        }
+
+        @Override
+        public void connectionOpened(NetHandler netClientHandler, MinecraftServer server, INetworkManager manager) {
+        }
+
+        @Override
+        public void connectionClosed(INetworkManager manager) {
+        }
+
+        @Override
+        public void clientLoggedIn(NetHandler netClientHandler, INetworkManager manager, Packet1Login login) {
+        }
+    }
+
+    private static void seedOnce() {
+        if (seeded) {
+            return;
+        }
+        seeded = true;
+        try {
+            MinecraftServer server = cpw.mods.fml.common.FMLCommonHandler.instance()
+                .getMinecraftServerInstance();
+            if (server == null) {
+                FMLLog.warning("ES_E2E_SENTINEL=no server instance, seed deferred");
+                seeded = false;
+                return;
+            }
+            byte[] png = readSentinelPng(server);
+            if (png == null) {
+                FMLLog.severe("ES_E2E_SENTINEL=FAIL png unreadable (set -D%s=<path> or drop e2e-sentinel.png in the server dir)",
+                    SENTINEL_PROPERTY);
+                return;
+            }
+            String sha1 = sha1(png);
+            String value = Base64.getEncoder().encodeToString(png);
+            CustomSkinProperty property = new CustomSkinProperty(
+                "textures", value, "", "e2e-sentinel");
+            java.util.UUID uuid = SkinRestorer.uuidOf(TEST_PLAYER);
+            SkinRestorer.applySkin(uuid, property);
+            FMLLog.info("ES_E2E_SENTINEL=seeded player=%s uuid=%s pngSha1=%s bytes=%d",
+                TEST_PLAYER, uuid, sha1, png.length);
+        } catch (Throwable t) {
+            FMLLog.severe("ES_E2E_SENTINEL=FAIL (%s)", t.toString());
+        }
+    }
+
+    private static byte[] readSentinelPng(MinecraftServer server) {
+        String override = System.getProperty(SENTINEL_PROPERTY);
+        File candidate = override != null ? new File(override) : server.getFile("e2e-sentinel.png");
+        if (!candidate.isFile()) {
+            return null;
+        }
+        try {
+            return java.nio.file.Files.readAllBytes(candidate.toPath());
+        } catch (IOException e) {
+            FMLLog.warning("ES_E2E_SENTINEL=read failed (%s)", e.toString());
+            return null;
+        }
+    }
+
+    private static String sha1(byte[] bytes) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-1").digest(bytes);
+            StringBuilder sb = new StringBuilder();
+            for (byte b : digest) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            return "unknown";
+        }
+    }
+}

--- a/forge-1.4.7/src/main/java/levosilimo/everlastingskins/forge147/EverlastingSkins.java
+++ b/forge-1.4.7/src/main/java/levosilimo/everlastingskins/forge147/EverlastingSkins.java
@@ -17,6 +17,7 @@ import cpw.mods.fml.common.network.NetworkRegistry;
 import cpw.mods.fml.common.network.Player;
 import levosilimo.everlastingskins.broadcast.ClientSkinHandler;
 import levosilimo.everlastingskins.broadcast.ServerPacketHandler;
+import levosilimo.everlastingskins.e2e.E2E;
 import levosilimo.everlastingskins.broadcast.SkinBroadcaster;
 import levosilimo.everlastingskins.permission.forge.ForgePermissionService;
 import levosilimo.everlastingskins.skinchanger.SkinRestorer;
@@ -82,6 +83,13 @@ public class EverlastingSkins {
 
     @Mod.Init
     public void init(FMLInitializationEvent event) {
+        // In-jar E2E support FIRST (shipped-gated by -Deverlastingskins.e2e=true;
+        // no-op in production). It side-gates internally (CLIENT → driver,
+        // SERVER → sentinel hook), so it must run before the client early-return
+        // below — the 1.6.4 lane's original placement after the gate silently
+        // skipped the CLIENT driver (regression fixed in slice 1 for all three
+        // pre-1.8 lanes).
+        E2E.install();
         if (!FMLCommonHandler.instance().getSide().isServer()) {
             // Client process: the client handler is registered by @NetworkMod;
             // no server bootstrap here (the physical side is authoritative —

--- a/forge-1.4.7/src/test/java/levosilimo/everlastingskins/e2e/E2EDriverPhaseTest.java
+++ b/forge-1.4.7/src/test/java/levosilimo/everlastingskins/e2e/E2EDriverPhaseTest.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.e2e;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Pure phase-machine tests for the in-jar E2E driver: the driver advances
+ * only on observed facts, and every timeout/assertion path lands on the
+ * contract exit code.
+ */
+public class E2EDriverPhaseTest {
+
+    @Test
+    public void joinGatesOnWorldAndPlayer() {
+        assertEquals(E2EDriver.Phase.WAIT_JOIN,
+            E2EDriver.nextPhase(E2EDriver.Phase.WAIT_JOIN, false, false, false));
+        assertEquals(E2EDriver.Phase.WAIT_BROADCAST,
+            E2EDriver.nextPhase(E2EDriver.Phase.WAIT_JOIN, true, false, false));
+    }
+
+    @Test
+    public void broadcastGatesTheRendererAssertion() {
+        assertEquals(E2EDriver.Phase.WAIT_BROADCAST,
+            E2EDriver.nextPhase(E2EDriver.Phase.WAIT_BROADCAST, true, false, false));
+        assertEquals(E2EDriver.Phase.RENDER_ASSERT,
+            E2EDriver.nextPhase(E2EDriver.Phase.WAIT_BROADCAST, true, true, false));
+    }
+
+    @Test
+    public void rendererAssertionCompletesTheRun() {
+        assertEquals(E2EDriver.Phase.RENDER_ASSERT,
+            E2EDriver.nextPhase(E2EDriver.Phase.RENDER_ASSERT, true, true, false));
+        assertEquals(E2EDriver.Phase.DONE,
+            E2EDriver.nextPhase(E2EDriver.Phase.RENDER_ASSERT, true, true, true));
+        assertEquals(E2EDriver.Phase.DONE,
+            E2EDriver.nextPhase(E2EDriver.Phase.DONE, true, true, true));
+    }
+
+    @Test
+    public void phasesNeverRegress() {
+        assertEquals(E2EDriver.Phase.WAIT_BROADCAST,
+            E2EDriver.nextPhase(E2EDriver.Phase.WAIT_BROADCAST, false, false, false));
+        assertEquals(E2EDriver.Phase.RENDER_ASSERT,
+            E2EDriver.nextPhase(E2EDriver.Phase.RENDER_ASSERT, true, false, false));
+    }
+}

--- a/forge-1.4.7/src/test/java/levosilimo/everlastingskins/e2e/E2EResultTest.java
+++ b/forge-1.4.7/src/test/java/levosilimo/everlastingskins/e2e/E2EResultTest.java
@@ -1,0 +1,112 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.e2e;
+
+import org.junit.Test;
+
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Pure result-document tests for the in-jar E2E driver (no Minecraft/FML on
+ * the classpath).
+ */
+public class E2EResultTest {
+
+    @Test
+    public void writeProducesContractJson() throws Exception {
+        File dir = new File(System.getProperty("java.io.tmpdir"), "e2e-result-test-" + System.nanoTime());
+        assertTrue(dir.mkdirs());
+        try {
+            File out = new File(dir, "e2e-result.json");
+            Map<String, String> artifacts = new LinkedHashMap<String, String>();
+            artifacts.put("broadcast", "received");
+            artifacts.put("broadcast_injected", "true");
+            E2EResult.write(out, true, true, true, true, 12345L, 0, artifacts);
+
+            String json = new String(java.nio.file.Files.readAllBytes(out.toPath()), StandardCharsets.UTF_8);
+            assertTrue(json.contains("\"lane\":\"1.4.7\""));
+            assertTrue(json.contains("\"server_booted\":false"));
+            assertTrue(json.contains("\"client_joined\":true"));
+            assertTrue(json.contains("\"command_executed\":true"));
+            assertTrue(json.contains("\"renderer_state\":\"sentinel\""));
+            assertTrue(json.contains("\"renderer_verified\":true"));
+            assertTrue(json.contains("\"duration_ms\":12345"));
+            assertTrue(json.contains("\"exit_code\":0"));
+            assertTrue(json.contains("\"broadcast\":\"received\""));
+            assertTrue(json.contains("\"broadcast_injected\":\"true\""));
+        } finally {
+            deleteRecursively(dir);
+        }
+    }
+
+    @Test
+    public void writeFailureState() throws Exception {
+        File dir = new File(System.getProperty("java.io.tmpdir"), "e2e-result-fail-" + System.nanoTime());
+        assertTrue(dir.mkdirs());
+        try {
+            File out = new File(dir, "e2e-result.json");
+            E2EResult.write(out, false, false, false, false, 999L, 2, null);
+            String json = new String(java.nio.file.Files.readAllBytes(out.toPath()), StandardCharsets.UTF_8);
+            assertTrue(json.contains("\"client_joined\":false"));
+            assertTrue(json.contains("\"renderer_state\":\"none\""));
+            assertTrue(json.contains("\"exit_code\":2"));
+        } finally {
+            deleteRecursively(dir);
+        }
+    }
+
+    @Test
+    public void sentinelPixelContract() {
+        BufferedImage sentinel = new BufferedImage(
+            E2EResult.SENTINEL_WIDTH, E2EResult.SENTINEL_HEIGHT, BufferedImage.TYPE_INT_ARGB);
+        for (int y = 0; y < E2EResult.SENTINEL_HEIGHT; y++) {
+            for (int x = 0; x < E2EResult.SENTINEL_WIDTH; x++) {
+                sentinel.setRGB(x, y,
+                    (x < E2EResult.SENTINEL_BLOCK && y < E2EResult.SENTINEL_BLOCK)
+                        ? E2EResult.RED : E2EResult.GREEN);
+            }
+        }
+        assertTrue(E2EResult.isSentinelImage(sentinel));
+        assertFalse(E2EResult.isSentinelImage(null));
+        sentinel.setRGB(0, 0, 0xFF00FF00);
+        assertFalse(E2EResult.isSentinelImage(sentinel));
+        BufferedImage wrongSize = new BufferedImage(64, 64, BufferedImage.TYPE_INT_ARGB);
+        assertFalse(E2EResult.isSentinelImage(wrongSize));
+    }
+
+    @Test
+    public void toJsonEscapesStrings() {
+        Map<String, Object> doc = new LinkedHashMap<String, Object>();
+        doc.put("lane", "1.4.7");
+        doc.put("artifacts", new LinkedHashMap<String, String>());
+        String json = E2EResult.toJson(doc);
+        assertNotNull(json);
+        assertTrue(json.contains("\"lane\":\"1.4.7\""));
+        assertTrue(json.contains("\"artifacts\":{}"));
+    }
+
+    private static void deleteRecursively(File f) {
+        if (f.isDirectory()) {
+            File[] children = f.listFiles();
+            if (children != null) {
+                for (File c : children) {
+                    deleteRecursively(c);
+                }
+            }
+        }
+        f.delete();
+    }
+}

--- a/forge-1.4.7/test-infrastructure/run-e2e.sh
+++ b/forge-1.4.7/test-infrastructure/run-e2e.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# forge-1.4.7/test-infrastructure/run-e2e.sh — thin lane wrapper for the
+# real-client E2E (master plan slice 1; shared logic lives in
+# scripts/e2e/e2e-common.sh + scripts/e2e/drivers/pre18-xvfb.sh).
+#
+# Flow: build the lane (vendored harness, Java 8) → export the lane's
+# server/artifact config → invoke the shared orchestrator.
+#
+# MERGE MODEL (lib-8 recipe): 1.4.7/1.5.2 boot the client as the obf client
+# jar with the FML universal zip MERGED in (universal's patched
+# net/minecraft/client/Minecraft + MinecraftApplet + ClientBrandRetriever
+# win), main net.minecraft.client.Minecraft, CWD + minecraft.applet
+# TargetDirectory = gameDir, NO launchwrapper/tweaker — the driver
+# auto-connects via Minecraft.setServer at @Mod.Init. The server boots as
+# net.minecraft.server.MinecraftServer nogui with the universal zip FIRST on
+# the classpath (its patched MinecraftServer FML-bootstraps the process).
+#
+# Usage: JAVA_HOME=<jdk8> ./run-e2e.sh
+# Exit codes (master-plan contract): 0 all green | 1 assertion failed |
+# 2 retryable infra | 3 build/hard failure.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LANE_DIR="$(dirname "$SCRIPT_DIR")"
+REPO_ROOT="$(cd "$LANE_DIR/.." && pwd)"
+
+# ---------------------------------------------------------------------------
+# Java 8 (hard requirement: Gradle 4.4.1 dies on 9+; the merge-model client
+# boot needs Java 8 too — the client bytecode is major 49 but FML 5.2's ASM
+# refuses anything newer than Java 7 class files, and :common needs 8)
+# ---------------------------------------------------------------------------
+if [ -n "${JAVA_HOME:-}" ] && [ -x "$JAVA_HOME/bin/java" ]; then
+    E2E_JAVA8="$JAVA_HOME/bin/java"
+elif [ -x "$HOME/.sdkman/candidates/java/8.0.472-amzn/bin/java" ]; then
+    E2E_JAVA8="$HOME/.sdkman/candidates/java/8.0.472-amzn/bin/java"
+elif [ -x /usr/lib/jvm/java-8-openjdk-amd64/bin/java ]; then
+    E2E_JAVA8="/usr/lib/jvm/java-8-openjdk-amd64/bin/java"
+else
+    echo "[e2e:1.4.7][fail] Java 8 not found (set JAVA_HOME to a JDK 8)" >&2
+    exit 3
+fi
+echo "[e2e:1.4.7] Java 8: $E2E_JAVA8"
+
+# ---------------------------------------------------------------------------
+# Build the lane
+# ---------------------------------------------------------------------------
+echo "[e2e:1.4.7] building lane..."
+cd "$LANE_DIR"
+if ! JAVA_HOME="$(dirname "$(dirname "$E2E_JAVA8")")" ./gradlew build --no-daemon; then
+    echo "[e2e:1.4.7][fail] lane build failed (exit 3)" >&2
+    exit 3
+fi
+
+MOD_JAR="$(ls build/libs/everlastingskins-*.jar 2>/dev/null | grep -v -- '-sources.jar' | head -1 || true)"
+if [ -z "$MOD_JAR" ]; then
+    echo "[e2e:1.4.7][fail] no mod jar in build/libs/" >&2
+    exit 3
+fi
+
+# ---------------------------------------------------------------------------
+# Vendored server jar (populated by the build's resolveVendored)
+# ---------------------------------------------------------------------------
+VENDORED_DIR="${E2E_VENDORED_DIR:-$HOME/.gradle/everlastingskins-vendored/1.4.7}"
+SERVER_JAR="$VENDORED_DIR/minecraft_server.1.4.7.jar"
+if [ ! -f "$SERVER_JAR" ]; then
+    echo "[e2e:1.4.7][fail] vendored server jar missing: $SERVER_JAR" >&2
+    exit 3
+fi
+
+# ---------------------------------------------------------------------------
+# Invoke the shared orchestrator (merge model)
+# ---------------------------------------------------------------------------
+export E2E_LANE="1.4.7"
+export E2E_ERA="merge"
+export E2E_MOD_JAR="$MOD_JAR"
+export E2E_SERVER_JAR="$SERVER_JAR"
+export E2E_DRIVER_SCRIPT="$REPO_ROOT/scripts/e2e/drivers/pre18-xvfb.sh"
+export E2E_JAVA8
+export E2E_SENTINEL_PNG="$REPO_ROOT/common/src/test/resources/e2e/sentinel-64x32.png"
+
+exec bash "$REPO_ROOT/scripts/e2e/e2e-common.sh"

--- a/forge-1.5.2/build.gradle
+++ b/forge-1.5.2/build.gradle
@@ -115,3 +115,59 @@ ext {
 }
 
 apply from: '../harness/specialsource-harness.gradle'
+
+// ---------------------------------------------------------------------------
+// RUNTIME-COMPAT FIX (slice-1 E2E discovery, mirrored from the 1.6.4 lane):
+// FML 5.2 reads mod-jar classes with its bundled ASM 4.1 (from the FML lib
+// dir), which refuses class files above major version 51 (Java 7). A
+// Java-8-targeted jar is therefore rejected wholesale at boot ("Unable to
+// read a class file correctly ... probably a corrupt zip" — observed live
+// 2026-08-11 against forge-1.5.2-7.8.1.738). The mod must compile against
+// Java 8 APIs (javac 8 forbids source-8 → target-7, and :common uses
+// lambdas/streams), so the shipped jar's class files are downgraded to major
+// 51 in place AFTER reobf. The production 1.5.2 runtime (like the E2E) is
+// Java 8, so the bytecode — including invokedynamic for :common lambdas —
+// executes unchanged; only the version stamp changes.
+// ---------------------------------------------------------------------------
+task downgradeClassVersion(dependsOn: reobf) {
+    group = 'everlastingskins'
+    description = 'Rewrite class-file major version 52 -> 51 in the reobf\'d jar (FML 5.2 ASM cannot read Java 8 class files).'
+    inputs.file jar.archivePath
+    outputs.file jar.archivePath
+    doLast {
+        def jarFile = jar.archivePath
+        def tmp = file("${jarFile}.v51")
+        def zin = new java.util.zip.ZipFile(jarFile)
+        int downgraded = 0
+        def zout = new java.util.zip.ZipOutputStream(new BufferedOutputStream(new FileOutputStream(tmp)))
+        try {
+            zin.entries().each { entry ->
+                if (entry.isDirectory()) {
+                    zout.putNextEntry(new java.util.zip.ZipEntry(entry.name))
+                    zout.closeEntry()
+                    return
+                }
+                def bytes = zin.getInputStream(entry).bytes
+                if (entry.name.endsWith('.class') && bytes.length > 8) {
+                    int major = ((bytes[6] & 0xFF) << 8) | (bytes[7] & 0xFF)
+                    if (major > 51) {
+                        bytes[6] = 0
+                        bytes[7] = 51
+                        downgraded++
+                    }
+                }
+                zout.putNextEntry(new java.util.zip.ZipEntry(entry.name))
+                zout.write(bytes)
+                zout.closeEntry()
+            }
+        } finally {
+            zout.close()
+            zin.close()
+        }
+        if (!jarFile.delete()) throw new GradleException("downgradeClassVersion: could not delete ${jarFile}")
+        if (!tmp.renameTo(jarFile)) throw new GradleException("downgradeClassVersion: could not replace ${jarFile}")
+        logger.lifecycle("downgradeClassVersion: ${downgraded} class files rewritten to major 51 (Java 7) in ${jarFile.name}")
+    }
+}
+// The name-domain self-check javap's the jar — must see the final artifact.
+assertNameDomain.dependsOn downgradeClassVersion

--- a/forge-1.5.2/src/main/java/levosilimo/everlastingskins/broadcast/ClientSkinHandler.java
+++ b/forge-1.5.2/src/main/java/levosilimo/everlastingskins/broadcast/ClientSkinHandler.java
@@ -61,7 +61,13 @@ public final class ClientSkinHandler implements IPacketHandler {
                 // Not spawned yet — the join broadcast re-delivers.
                 return;
             }
-            String skinUrl = target.skinUrl;
+            // skinUrl is declared on Entity; access it through the Entity
+            // type so the reobf pass can map the reference (javac emits the
+            // receiver's declared type as the owner, and the srg FD keys are
+            // the declaring class — EntityPlayer.skinUrl would stay unmapped
+            // and NoSuchFieldError at runtime; found live by the slice-1
+            // 1.5.2 E2E).
+            String skinUrl = ((net.minecraft.src.Entity) target).skinUrl;
             if (skinUrl == null) {
                 return;
             }

--- a/forge-1.5.2/src/main/java/levosilimo/everlastingskins/e2e/E2E.java
+++ b/forge-1.5.2/src/main/java/levosilimo/everlastingskins/e2e/E2E.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.e2e;
+
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.relauncher.Side;
+
+/**
+ * Single entry point for the in-jar E2E support, invoked from
+ * {@code EverlastingSkins.init()} (one line: {@code E2E.install();}).
+ *
+ * <p>Shipped-gated by {@code -Deverlastingskins.e2e=true} (never active in
+ * production); side-gated afterwards:
+ * <ul>
+ *   <li>CLIENT → {@link E2EDriver} (phase machine, channel receiver,
+ *       auto-connect, renderer assertion, result file + {@code System.exit});</li>
+ *   <li>SERVER → {@link E2ESentinelHook} (sentinel pre-seed so the login
+ *       re-broadcast delivers it).</li>
+ * </ul>
+ */
+public final class E2E {
+
+    /** System property the e2e scripts set on both JVMs. */
+    public static final String E2E_PROPERTY = "everlastingskins.e2e";
+
+    private E2E() {}
+
+    /** One-line gated entry from the mod's {@code @Mod.Init init}. */
+    public static void install() {
+        if (!Boolean.getBoolean(E2E_PROPERTY)) {
+            return;
+        }
+        Side side = FMLCommonHandler.instance().getSide();
+        if (side == Side.CLIENT) {
+            E2EDriver.install();
+        } else if (side == Side.SERVER) {
+            E2ESentinelHook.install();
+        }
+    }
+}

--- a/forge-1.5.2/src/main/java/levosilimo/everlastingskins/e2e/E2EDriver.java
+++ b/forge-1.5.2/src/main/java/levosilimo/everlastingskins/e2e/E2EDriver.java
@@ -1,0 +1,380 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.e2e;
+
+import cpw.mods.fml.common.FMLLog;
+import cpw.mods.fml.common.IScheduledTickHandler;
+import cpw.mods.fml.common.ITickHandler;
+import cpw.mods.fml.common.TickType;
+import cpw.mods.fml.common.network.IPacketHandler;
+import cpw.mods.fml.common.network.NetworkRegistry;
+import cpw.mods.fml.common.network.Player;
+import cpw.mods.fml.common.registry.TickRegistry;
+import cpw.mods.fml.relauncher.Side;
+import levosilimo.everlastingskins.broadcast.SkinBroadcaster;
+import levosilimo.everlastingskins.broadcast.SkinMessage;
+import levosilimo.everlastingskins.client.ClientSkinApplier;
+import net.minecraft.client.Minecraft;
+import net.minecraft.src.EntityClientPlayerMP;
+import net.minecraft.src.ImageBufferDownload;
+import net.minecraft.src.INetworkManager;
+import net.minecraft.src.Packet250CustomPayload;
+import net.minecraft.src.ThreadDownloadImageData;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * In-jar client driver for the real-client E2E (master plan slice 1,
+ * {@code scripts/e2e/drivers/pre18-xvfb.sh}, MERGE model — lib-8 recipe).
+ *
+ * <p>Shipped in the mod jar, gated at runtime by
+ * {@code -Deverlastingskins.e2e=true} + {@code Side.CLIENT} (see
+ * {@link E2E#install()}). Lifecycle: {@code @Mod.Init} installs this driver;
+ * the tick primitive is FML 5.2 {@link IScheduledTickHandler}
+ * ({@code TickRegistry.registerScheduledTickHandler}).
+ *
+ * <p>MERGE-MODEL delta vs the 1.6.4 driver: this lane boots as the obf client
+ * jar with the FML universal zip MERGED in (main
+ * {@code net.minecraft.client.Minecraft}, no launchwrapper), so the runtime
+ * class names and the compile-time deobf names agree modulo the lane's
+ * reobf pass — the driver compiles DIRECTLY against the client classes
+ * ({@code Minecraft.getMinecraft()}, {@code mc.theWorld/thePlayer},
+ * {@code mc.renderEngine.obtainImageData}, the PUBLIC
+ * {@code ThreadDownloadImageData.image/textureName/textureSetupComplete}
+ * fields, {@code Entity.skinUrl} — MCP 7.51) with zero reflection, unlike the
+ * 1.6.4 driver. The connect: 1.5.2's {@code Minecraft.main} parses no
+ * {@code --server/--port} (only {@code --demo/--applet/--password} — verified
+ * against the client jar), so {@link #install()} calls
+ * {@code Minecraft.setServer(host, port)} itself; the vanilla run loop picks
+ * the fields up at startGame and shows GuiConnecting. The e2e scripts pin
+ * the client jar sha1, which keeps every referenced member name stable.
+ *
+ * <p>Phase machine: WAIT_JOIN (client world + player exist) → send
+ * {@code /skin set TestPlayer} + {@code /skin clear} (command surface proof;
+ * the server console logs both chat lines) → WAIT_BROADCAST (the login
+ * re-broadcast of the pre-seeded sentinel arrives on the
+ * {@code everlastingskins} channel — this receiver coexists with the mod's
+ * own {@link ClientSkinApplier} handler: FML 4.7/5.2 keeps per-channel
+ * handler multimaps) → RENDER_ASSERT: observe the broadcast injection into
+ * the player's skin {@link ThreadDownloadImageData} (the login broadcast
+ * carries the sentinel PNG bytes inline; the client handler already injected
+ * them), otherwise inject the sentinel from the gameDir file via
+ * {@link ClientSkinApplier#apply}; re-arm the once-per-image upload guard
+ * ({@code textureSetupComplete=false}) and re-trigger the upload through
+ * {@code RenderEngine.getTextureForDownloadableImage}; then assert the
+ * injected field state + the re-upload outcome (GL id + guard) + the sentinel
+ * pixel contract → write {@code e2e-result.json} in the client gameDir →
+ * {@code System.exit}.
+ *
+ * <p>Download-thread race (documented, same caveat as the client handler):
+ * the vanilla {@code ThreadDownloadImage} download from skins.minecraft.net
+ * writes {@code tdi.image} ONLY on a successful fetch (the failure path just
+ * prints + disconnects — verified against the client jar). The e2e sandbox
+ * cannot reach skins.minecraft.net, so the injected sentinel survives; a
+ * reachable host would overwrite it and the field-state assert fails
+ * honestly (exit 1).
+ *
+ * <p>Exit codes (master-plan contract): 0 all green | 1 renderer assertion
+ * failed | 2 retryable infra (join/broadcast timeout) | 3 driver hard
+ * failure.
+ */
+public final class E2EDriver implements IScheduledTickHandler, IPacketHandler {
+
+    /** Offline test player (matches the e2e scripts' username arg). */
+    public static final String TEST_PLAYER = "TestPlayer";
+
+    /** System property the e2e driver script passes (merge boot has no --server/--port). */
+    static final String SERVER_PROPERTY = "everlastingskins.e2e.server";
+
+    /** System property for the test server port. */
+    static final String PORT_PROPERTY = "everlastingskins.e2e.port";
+
+    private static final long JOIN_TIMEOUT_MS = 180_000L;
+    private static final long BROADCAST_TIMEOUT_MS = 60_000L;
+
+    /** Client-side driver phases (pure transition logic in {@link #nextPhase}). */
+    enum Phase {
+        WAIT_JOIN, WAIT_BROADCAST, RENDER_ASSERT, DONE
+    }
+
+    /**
+     * Pure phase transition used by the tick machine and unit tests: the
+     * driver advances only on observed facts.
+     */
+    static Phase nextPhase(Phase current, boolean joined, boolean broadcastReceived, boolean asserted) {
+        switch (current) {
+            case WAIT_JOIN:
+                return joined ? Phase.WAIT_BROADCAST : Phase.WAIT_JOIN;
+            case WAIT_BROADCAST:
+                return broadcastReceived ? Phase.RENDER_ASSERT : Phase.WAIT_BROADCAST;
+            case RENDER_ASSERT:
+                return asserted ? Phase.DONE : Phase.RENDER_ASSERT;
+            default:
+                return current;
+        }
+    }
+
+    private final long installedAt = System.currentTimeMillis();
+    private Phase phase = Phase.WAIT_JOIN;
+    private long phaseStartedAt = installedAt;
+    private volatile boolean broadcastReceived;
+    private boolean rendererVerified;
+    private boolean rendererState;
+    private boolean broadcastInjected;
+
+    private E2EDriver() {}
+
+    /** Installs the client driver (property + side gates live in {@link E2E#install()}). */
+    static void install() {
+        E2EDriver driver = new E2EDriver();
+        // Client-side channel receiver: FML 4.7/5.2 keeps per-channel handler
+        // multimaps, so this coexists with the @NetworkMod client spec.
+        NetworkRegistry.instance().registerChannel(driver, SkinBroadcaster.CHANNEL, Side.CLIENT);
+        TickRegistry.registerScheduledTickHandler(driver, Side.CLIENT);
+        // Merge-model auto-connect. Runs inside the Minecraft constructor
+        // (@Mod.Init fires via finishMinecraftLoading), before startGame
+        // consumes serverName → GuiConnecting → join.
+        Minecraft mc = Minecraft.getMinecraft();
+        String host = System.getProperty(SERVER_PROPERTY, "127.0.0.1");
+        int port = Integer.getInteger(PORT_PROPERTY, 25565);
+        mc.setServer(host, port);
+        FMLLog.info("ES_E2E_DRIVER=installed side=%s server=%s:%d", Side.CLIENT, host, port);
+    }
+
+    // ------------------------------------------------------------------
+    // Channel receiver: the server's login re-broadcast (sentinel pre-seed)
+    // is a notification-only SkinMessage for TEST_PLAYER.
+    // ------------------------------------------------------------------
+    @Override
+    public void onPacketData(INetworkManager manager, Packet250CustomPayload packet, Player player) {
+        try {
+            SkinMessage message = SkinMessage.decode(packet.data);
+            if (TEST_PLAYER.equals(message.getPlayerName())) {
+                broadcastReceived = true;
+                FMLLog.info("ES_E2E_BROADCAST=received player=%s", message.getPlayerName());
+            }
+        } catch (RuntimeException e) {
+            FMLLog.warning("ES_E2E_BROADCAST=malformed payload (%s)", e.toString());
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Scheduled tick machine (client ticks run on the render thread, so GL
+    // work in RENDER_ASSERT is on the same thread as the renderer).
+    // ------------------------------------------------------------------
+    @Override
+    public void tickStart(EnumSet<TickType> types, Object... tickData) {
+        try {
+            tick();
+        } catch (Throwable t) {
+            FMLLog.severe("ES_E2E_DRIVER=crash phase=%s (%s)", phase, t);
+            fail(3, false, false, "driver crash: " + t);
+        }
+    }
+
+    @Override
+    public void tickEnd(EnumSet<TickType> types, Object... tickData) {
+    }
+
+    @Override
+    public EnumSet<TickType> ticks() {
+        return EnumSet.of(TickType.CLIENT);
+    }
+
+    @Override
+    public String getLabel() {
+        return "everlastingskins-e2e";
+    }
+
+    @Override
+    public int nextTickSpacing() {
+        return 1;
+    }
+
+    private void tick() throws Exception {
+        switch (phase) {
+            case WAIT_JOIN:
+                if (isJoined()) {
+                    FMLLog.info("ES_E2E_JOIN=%s", TEST_PLAYER);
+                    sendChat("/skin set " + TEST_PLAYER);
+                    sendChat("/skin clear");
+                    FMLLog.info("ES_E2E_COMMAND=/skin set " + TEST_PLAYER);
+                    FMLLog.info("ES_E2E_COMMAND=/skin clear");
+                    advance(Phase.WAIT_BROADCAST);
+                } else if (timedOut(JOIN_TIMEOUT_MS)) {
+                    fail(2, false, false, "join timeout");
+                }
+                break;
+            case WAIT_BROADCAST:
+                if (broadcastReceived) {
+                    advance(Phase.RENDER_ASSERT);
+                } else if (timedOut(BROADCAST_TIMEOUT_MS)) {
+                    fail(2, true, true, "broadcast timeout");
+                }
+                break;
+            case RENDER_ASSERT:
+                rendererState = rendererVerified = assertRenderer();
+                if (rendererVerified) {
+                    FMLLog.info("ES_E2E_RENDERER=ok");
+                    writeResultAndExit(0);
+                } else {
+                    FMLLog.severe("ES_E2E_RENDERER=FAIL");
+                    fail(1, true, true, "renderer assertion failed");
+                }
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void advance(Phase next) {
+        phase = next;
+        phaseStartedAt = System.currentTimeMillis();
+    }
+
+    private boolean timedOut(long budgetMs) {
+        return System.currentTimeMillis() - phaseStartedAt > budgetMs;
+    }
+
+    // ------------------------------------------------------------------
+    // Join + command surface (direct client references — MCP 7.51 surface).
+    // ------------------------------------------------------------------
+    private boolean isJoined() {
+        Minecraft mc = Minecraft.getMinecraft();
+        return mc.theWorld != null && mc.thePlayer != null;
+    }
+
+    private void sendChat(String message) {
+        Minecraft.getMinecraft().thePlayer.sendChatMessage(message);
+    }
+
+    // ------------------------------------------------------------------
+    // Renderer assertion (lib-14, 1.4.7/1.5.2 variant): field state +
+    // re-upload trigger + sentinel pixel compare. The 1.5.2
+    // ThreadDownloadImageData is a POJO with public image/textureName/
+    // textureSetupComplete fields; RenderEngine.getTextureForDownloadableImage
+    // re-uploads when image != null && !textureSetupComplete and returns the
+    // GL texture id (verified against the client jar).
+    // ------------------------------------------------------------------
+    private boolean assertRenderer() {
+        Minecraft mc = Minecraft.getMinecraft();
+        EntityClientPlayerMP player = mc.thePlayer;
+        if (player == null) {
+            FMLLog.severe("ES_E2E_RENDERER=no player entity");
+            return false;
+        }
+        // Field declared on Entity; access it through the Entity type so the
+        // reobf pass can map the reference (javac emits the receiver's
+        // declared type as the owner, and the srg FD keys are the declaring
+        // class — EntityClientPlayerMP.skinUrl would stay unmapped and
+        // NoSuchFieldError at runtime).
+        net.minecraft.src.Entity entity = player;
+        String skinUrl = entity.skinUrl;
+        if (skinUrl == null) {
+            FMLLog.severe("ES_E2E_RENDERER=skinUrl not set");
+            return false;
+        }
+        // Cached TDI: seeded by RenderGlobal.onEntityCreate when the player
+        // spawned; the client handler injects through the same instance.
+        ThreadDownloadImageData tdi = mc.renderEngine.obtainImageData(skinUrl, new ImageBufferDownload());
+        if (tdi == null) {
+            FMLLog.severe("ES_E2E_RENDERER=no cached ThreadDownloadImageData");
+            return false;
+        }
+
+        // Sentinel image from the client gameDir (script-copied from :common
+        // test resources; same bytes the server seeded from).
+        BufferedImage sentinel = readSentinel(mc.getMinecraftDir());
+        if (sentinel == null || !E2EResult.isSentinelImage(sentinel)) {
+            FMLLog.severe("ES_E2E_RENDERER=sentinel unreadable or pixel contract violated");
+            return false;
+        }
+        BufferedImage flat = ClientSkinApplier.flattenToLegacy(sentinel);
+
+        // Observe the broadcast injection first: the login re-broadcast
+        // carries the sentinel PNG inline and the client handler injects it
+        // into this same cached TDI. If it already landed, the full
+        // server→client pipeline is proven; either way, re-arm the
+        // once-per-image upload guard and re-trigger the upload.
+        broadcastInjected = tdi.image != null && E2EResult.isSentinelImage(tdi.image);
+        if (broadcastInjected) {
+            FMLLog.info("ES_E2E_RENDERER=broadcast injection observed");
+            tdi.textureSetupComplete = false;
+        } else {
+            ClientSkinApplier.apply(tdi, flat);
+        }
+
+        // 1) Field-state assert (pixel compare vs the sentinel contract).
+        if (tdi.image == null || !E2EResult.isSentinelImage(tdi.image)) {
+            FMLLog.severe("ES_E2E_RENDERER=field state mismatch (image=%s)", tdi.image);
+            return false;
+        }
+
+        // 2) Re-upload trigger: textureSetupComplete=false makes
+        // getTextureForDownloadableImage upload the injected pixels
+        // (allocateAndSetupTexture on first upload, setupTexture re-upload
+        // into the existing GL texture) and return the GL id.
+        int glId = mc.renderEngine.getTextureForDownloadableImage(skinUrl, null);
+        boolean uploadOk = glId >= 0 && tdi.textureName == glId && tdi.textureSetupComplete;
+        if (!uploadOk) {
+            FMLLog.severe("ES_E2E_RENDERER=re-upload failed glId=%s textureName=%s setupComplete=%s",
+                glId, tdi.textureName, tdi.textureSetupComplete);
+            return false;
+        }
+        FMLLog.info("ES_E2E_RENDERER=ok image=%s glTextureId=%s broadcastInjected=%s",
+            tdi.image, glId, broadcastInjected);
+        return true;
+    }
+
+    private static BufferedImage readSentinel(File gameDir) {
+        File png = new File(gameDir, "e2e-sentinel.png");
+        try {
+            return ImageIO.read(png);
+        } catch (IOException e) {
+            FMLLog.warning("ES_E2E_RENDERER=sentinel read failed (%s)", e.toString());
+            return null;
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Result + exit.
+    // ------------------------------------------------------------------
+    private void fail(int exitCode, boolean joined, boolean commandSent, String reason) {
+        FMLLog.severe("ES_E2E_FAIL=%s", reason);
+        writeResultAndExit(exitCode, joined, commandSent, false, false);
+    }
+
+    private void writeResultAndExit(int exitCode) {
+        writeResultAndExit(exitCode, true, true, rendererState, rendererVerified);
+    }
+
+    private void writeResultAndExit(int exitCode, boolean joined, boolean commandSent,
+                                    boolean rendererState, boolean rendererVerified) {
+        try {
+            File out = new File(Minecraft.getMinecraft().getMinecraftDir(), E2EResult.FILE_NAME);
+            Map<String, String> artifacts = new LinkedHashMap<String, String>();
+            artifacts.put("driver", "E2EDriver/1.5.2");
+            artifacts.put("broadcast", broadcastReceived ? "received" : "none");
+            artifacts.put("broadcast_injected", broadcastInjected ? "true" : "false");
+            E2EResult.write(out, joined, commandSent, rendererState, rendererVerified,
+                System.currentTimeMillis() - installedAt, exitCode, artifacts);
+            FMLLog.info("ES_E2E_RESULT=%s code=%s", out.getAbsolutePath(), exitCode);
+        } catch (Exception e) {
+            // Never mask the outcome: a result-write failure is a hard driver
+            // failure (exit 3), not a silent success.
+            FMLLog.severe("ES_E2E_FAIL=result write failed (%s)", e.toString());
+            System.exit(3);
+        }
+        System.exit(exitCode);
+    }
+}

--- a/forge-1.5.2/src/main/java/levosilimo/everlastingskins/e2e/E2EResult.java
+++ b/forge-1.5.2/src/main/java/levosilimo/everlastingskins/e2e/E2EResult.java
@@ -1,0 +1,109 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.e2e;
+
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Pure result-document logic for the real-client E2E (shared master-plan
+ * contract, scripts/e2e/). Kept free of any Minecraft/FML import so the
+ * lane's JUnit scaffold can test it without a client.
+ *
+ * <p>The in-jar driver writes {@code e2e-result.json} into the client's
+ * gameDir with the client-known fields; {@code scripts/e2e/e2e-common.sh}
+ * merges the server-side facts (server_booted, artifacts) into the final
+ * document at {@code ${RUNNER_TMP}/e2e-result.json} and maps the exit code.
+ */
+public final class E2EResult {
+
+    /** Result file name in the client gameDir (driver-side artifact). */
+    public static final String FILE_NAME = "e2e-result.json";
+
+    /**
+     * Sentinel PNG contract (64x32, shared from :common test resources as
+     * {@code e2e/sentinel-64x32.png}): top-left 8x8 block pure red, all
+     * remaining pixels pure green. The driver verifies the decoded image
+     * before injecting it into the skin renderer.
+     */
+    public static final int SENTINEL_WIDTH = 64;
+    public static final int SENTINEL_HEIGHT = 32;
+    public static final int SENTINEL_BLOCK = 8;
+    public static final int RED = 0xFFFF0000;
+    public static final int GREEN = 0xFF00FF00;
+
+    private E2EResult() {}
+
+    /**
+     * Verifies a decoded image against the sentinel pixel contract. The
+     * image is a valid sentinel iff every pixel inside the top-left
+     * {@link #SENTINEL_BLOCK} square is pure red and every other pixel is
+     * pure green.
+     */
+    public static boolean isSentinelImage(BufferedImage image) {
+        if (image == null || image.getWidth() != SENTINEL_WIDTH || image.getHeight() != SENTINEL_HEIGHT) {
+            return false;
+        }
+        for (int y = 0; y < SENTINEL_HEIGHT; y++) {
+            for (int x = 0; x < SENTINEL_WIDTH; x++) {
+                int expected = (x < SENTINEL_BLOCK && y < SENTINEL_BLOCK) ? RED : GREEN;
+                if ((image.getRGB(x, y) & 0xFFFFFF) != (expected & 0xFFFFFF)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Writes the client-side result document. Fields follow the master-plan
+     * contract; the driver fills what it observes. Throws on IO failure so
+     * the driver can surface it as a hard failure (never a silent pass).
+     */
+    public static void write(File target, boolean clientJoined, boolean commandExecuted,
+                             boolean rendererState, boolean rendererVerified, long durationMs,
+                             int exitCode, Map<String, String> artifacts) throws IOException {
+        Map<String, Object> doc = new LinkedHashMap<String, Object>();
+        doc.put("lane", "1.5.2");
+        doc.put("server_booted", false); // client cannot know; script merges
+        doc.put("client_joined", clientJoined);
+        doc.put("command_executed", commandExecuted);
+        doc.put("renderer_state", rendererState ? "sentinel" : "none");
+        doc.put("renderer_verified", rendererVerified);
+        doc.put("duration_ms", durationMs);
+        doc.put("exit_code", exitCode);
+        doc.put("artifacts", artifacts == null ? new LinkedHashMap<String, String>() : artifacts);
+        Files.write(target.toPath(), toJson(doc).getBytes(StandardCharsets.UTF_8));
+    }
+
+    /** Minimal JSON emitter (no gson dependency on the legacy classpath is guaranteed at boot). */
+    public static String toJson(Map<String, Object> doc) {
+        StringBuilder sb = new StringBuilder("{");
+        boolean first = true;
+        for (Map.Entry<String, Object> e : doc.entrySet()) {
+            if (!first) {
+                sb.append(',');
+            }
+            first = false;
+            sb.append('"').append(e.getKey()).append("\":");
+            Object v = e.getValue();
+            if (v instanceof Boolean || v instanceof Number) {
+                sb.append(v);
+            } else if (v instanceof Map) {
+                sb.append(toJson((Map<String, Object>) v));
+            } else {
+                sb.append('"').append(String.valueOf(v).replace("\\", "\\\\").replace("\"", "\\\"")).append('"');
+            }
+        }
+        return sb.append('}').toString();
+    }
+}

--- a/forge-1.5.2/src/main/java/levosilimo/everlastingskins/e2e/E2ESentinelHook.java
+++ b/forge-1.5.2/src/main/java/levosilimo/everlastingskins/e2e/E2ESentinelHook.java
@@ -1,0 +1,173 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.e2e;
+
+import cpw.mods.fml.common.FMLLog;
+import cpw.mods.fml.common.network.IConnectionHandler;
+import cpw.mods.fml.common.network.NetworkRegistry;
+import cpw.mods.fml.common.network.Player;
+import levosilimo.everlastingskins.skinchanger.SkinRestorer;
+import levosilimo.everlastingskins.util.CustomSkinProperty;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.src.EntityPlayer;
+import net.minecraft.src.INetworkManager;
+import net.minecraft.src.NetHandler;
+import net.minecraft.src.NetLoginHandler;
+import net.minecraft.src.Packet1Login;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+/**
+ * Server-side E2E sentinel hook (master plan lib-13): with
+ * {@code -Deverlastingskins.e2e=true} on the SERVER, pre-seeds
+ * {@code SkinStorage} for the offline test player
+ * ({@link SkinRestorer#uuidOf(String)} offline-UUID bridge) before the test
+ * client logs in, so the mod's login re-broadcast
+ * ({@link levosilimo.everlastingskins.broadcast.SkinBroadcaster}) delivers
+ * the sentinel notification to the in-jar client driver.
+ *
+ * <p>Timing contract: {@link #install()} is invoked from
+ * {@code EverlastingSkins.init()} (FMLInitializationEvent); the seed must
+ * land AFTER {@code SkinRestorer.onServerStarting} creates storage. The hook
+ * therefore seeds lazily from {@code connectionReceived} — the server has
+ * finished starting before it accepts any connection, and
+ * {@code connectionReceived} precedes the mod's own
+ * {@code playerLoggedIn} re-broadcast in the same login flow, so the seed
+ * always precedes the broadcast deterministically.
+ *
+ * <p>The sentinel PNG itself (64x32, known pixels) is read from the server's
+ * working directory ({@code e2e-sentinel.png}, copied there by the e2e
+ * script from {@code common/src/test/resources/e2e/sentinel-64x32.png}) and
+ * its sha1 is logged so the script can tie the server-side seed to the
+ * client-side injection bytes. The stored property is storage-only on this
+ * line (the 1.5.2 restore path is the broadcast notification); its value is
+ * the sentinel PNG bytes base64-encoded.
+ */
+public final class E2ESentinelHook {
+
+    /** System property the e2e script sets on the server JVM. */
+    public static final String E2E_PROPERTY = "everlastingskins.e2e";
+
+    /** Optional override for the sentinel PNG path (default: server dir {@code e2e-sentinel.png}). */
+    public static final String SENTINEL_PROPERTY = "everlastingskins.e2e.sentinel";
+
+    public static final String TEST_PLAYER = E2EDriver.TEST_PLAYER;
+
+    private static volatile boolean seeded;
+
+    private E2ESentinelHook() {}
+
+    /** Called from {@code EverlastingSkins.init()} (one line; gates live here). */
+    public static void install() {
+        if (!Boolean.getBoolean(E2E_PROPERTY)) {
+            return;
+        }
+        if (cpw.mods.fml.common.FMLCommonHandler.instance().getSide()
+            != cpw.mods.fml.relauncher.Side.SERVER) {
+            return;
+        }
+        NetworkRegistry.instance().registerConnectionHandler(new Seeder());
+        FMLLog.info("ES_E2E_SENTINEL=hook installed");
+    }
+
+    /** Seeds storage on the first login attempt (idempotent). */
+    private static final class Seeder implements IConnectionHandler {
+
+        @Override
+        public String connectionReceived(NetLoginHandler netHandler, INetworkManager manager) {
+            seedOnce();
+            return null;
+        }
+
+        @Override
+        public void playerLoggedIn(Player player, NetHandler netHandler, INetworkManager manager) {
+            if (player instanceof EntityPlayer) {
+                FMLLog.info("ES_E2E_LOGIN=%s", ((EntityPlayer) player).getCommandSenderName());
+            }
+        }
+
+        @Override
+        public void connectionOpened(NetHandler netClientHandler, String server, int port, INetworkManager manager) {
+        }
+
+        @Override
+        public void connectionOpened(NetHandler netClientHandler, MinecraftServer server, INetworkManager manager) {
+        }
+
+        @Override
+        public void connectionClosed(INetworkManager manager) {
+        }
+
+        @Override
+        public void clientLoggedIn(NetHandler netClientHandler, INetworkManager manager, Packet1Login login) {
+        }
+    }
+
+    private static void seedOnce() {
+        if (seeded) {
+            return;
+        }
+        seeded = true;
+        try {
+            MinecraftServer server = cpw.mods.fml.common.FMLCommonHandler.instance()
+                .getMinecraftServerInstance();
+            if (server == null) {
+                FMLLog.warning("ES_E2E_SENTINEL=no server instance, seed deferred");
+                seeded = false;
+                return;
+            }
+            byte[] png = readSentinelPng(server);
+            if (png == null) {
+                FMLLog.severe("ES_E2E_SENTINEL=FAIL png unreadable (set -D%s=<path> or drop e2e-sentinel.png in the server dir)",
+                    SENTINEL_PROPERTY);
+                return;
+            }
+            String sha1 = sha1(png);
+            String value = Base64.getEncoder().encodeToString(png);
+            CustomSkinProperty property = new CustomSkinProperty(
+                "textures", value, "", "e2e-sentinel");
+            java.util.UUID uuid = SkinRestorer.uuidOf(TEST_PLAYER);
+            SkinRestorer.applySkin(uuid, property);
+            FMLLog.info("ES_E2E_SENTINEL=seeded player=%s uuid=%s pngSha1=%s bytes=%d",
+                TEST_PLAYER, uuid, sha1, png.length);
+        } catch (Throwable t) {
+            FMLLog.severe("ES_E2E_SENTINEL=FAIL (%s)", t.toString());
+        }
+    }
+
+    private static byte[] readSentinelPng(MinecraftServer server) {
+        String override = System.getProperty(SENTINEL_PROPERTY);
+        File candidate = override != null ? new File(override) : server.getFile("e2e-sentinel.png");
+        if (!candidate.isFile()) {
+            return null;
+        }
+        try {
+            return java.nio.file.Files.readAllBytes(candidate.toPath());
+        } catch (IOException e) {
+            FMLLog.warning("ES_E2E_SENTINEL=read failed (%s)", e.toString());
+            return null;
+        }
+    }
+
+    private static String sha1(byte[] bytes) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-1").digest(bytes);
+            StringBuilder sb = new StringBuilder();
+            for (byte b : digest) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            return "unknown";
+        }
+    }
+}

--- a/forge-1.5.2/src/main/java/levosilimo/everlastingskins/forge152/EverlastingSkins.java
+++ b/forge-1.5.2/src/main/java/levosilimo/everlastingskins/forge152/EverlastingSkins.java
@@ -17,6 +17,7 @@ import cpw.mods.fml.common.network.NetworkRegistry;
 import cpw.mods.fml.common.network.Player;
 import levosilimo.everlastingskins.broadcast.ClientSkinHandler;
 import levosilimo.everlastingskins.broadcast.ServerPacketHandler;
+import levosilimo.everlastingskins.e2e.E2E;
 import levosilimo.everlastingskins.broadcast.SkinBroadcaster;
 import levosilimo.everlastingskins.permission.forge.ForgePermissionService;
 import levosilimo.everlastingskins.skinchanger.SkinRestorer;
@@ -82,6 +83,13 @@ public class EverlastingSkins {
 
     @Mod.Init
     public void init(FMLInitializationEvent event) {
+        // In-jar E2E support FIRST (shipped-gated by -Deverlastingskins.e2e=true;
+        // no-op in production). It side-gates internally (CLIENT → driver,
+        // SERVER → sentinel hook), so it must run before the client early-return
+        // below — the 1.6.4 lane's original placement after the gate silently
+        // skipped the CLIENT driver (regression fixed in slice 1 for all three
+        // pre-1.8 lanes).
+        E2E.install();
         if (!FMLCommonHandler.instance().getSide().isServer()) {
             // Client process: the client handler is registered by @NetworkMod;
             // no server bootstrap here (the physical side is authoritative —

--- a/forge-1.5.2/src/test/java/levosilimo/everlastingskins/e2e/E2EDriverPhaseTest.java
+++ b/forge-1.5.2/src/test/java/levosilimo/everlastingskins/e2e/E2EDriverPhaseTest.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.e2e;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Pure phase-machine tests for the in-jar E2E driver: the driver advances
+ * only on observed facts, and every timeout/assertion path lands on the
+ * contract exit code.
+ */
+public class E2EDriverPhaseTest {
+
+    @Test
+    public void joinGatesOnWorldAndPlayer() {
+        assertEquals(E2EDriver.Phase.WAIT_JOIN,
+            E2EDriver.nextPhase(E2EDriver.Phase.WAIT_JOIN, false, false, false));
+        assertEquals(E2EDriver.Phase.WAIT_BROADCAST,
+            E2EDriver.nextPhase(E2EDriver.Phase.WAIT_JOIN, true, false, false));
+    }
+
+    @Test
+    public void broadcastGatesTheRendererAssertion() {
+        assertEquals(E2EDriver.Phase.WAIT_BROADCAST,
+            E2EDriver.nextPhase(E2EDriver.Phase.WAIT_BROADCAST, true, false, false));
+        assertEquals(E2EDriver.Phase.RENDER_ASSERT,
+            E2EDriver.nextPhase(E2EDriver.Phase.WAIT_BROADCAST, true, true, false));
+    }
+
+    @Test
+    public void rendererAssertionCompletesTheRun() {
+        assertEquals(E2EDriver.Phase.RENDER_ASSERT,
+            E2EDriver.nextPhase(E2EDriver.Phase.RENDER_ASSERT, true, true, false));
+        assertEquals(E2EDriver.Phase.DONE,
+            E2EDriver.nextPhase(E2EDriver.Phase.RENDER_ASSERT, true, true, true));
+        assertEquals(E2EDriver.Phase.DONE,
+            E2EDriver.nextPhase(E2EDriver.Phase.DONE, true, true, true));
+    }
+
+    @Test
+    public void phasesNeverRegress() {
+        assertEquals(E2EDriver.Phase.WAIT_BROADCAST,
+            E2EDriver.nextPhase(E2EDriver.Phase.WAIT_BROADCAST, false, false, false));
+        assertEquals(E2EDriver.Phase.RENDER_ASSERT,
+            E2EDriver.nextPhase(E2EDriver.Phase.RENDER_ASSERT, true, false, false));
+    }
+}

--- a/forge-1.5.2/src/test/java/levosilimo/everlastingskins/e2e/E2EResultTest.java
+++ b/forge-1.5.2/src/test/java/levosilimo/everlastingskins/e2e/E2EResultTest.java
@@ -1,0 +1,112 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.e2e;
+
+import org.junit.Test;
+
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Pure result-document tests for the in-jar E2E driver (no Minecraft/FML on
+ * the classpath).
+ */
+public class E2EResultTest {
+
+    @Test
+    public void writeProducesContractJson() throws Exception {
+        File dir = new File(System.getProperty("java.io.tmpdir"), "e2e-result-test-" + System.nanoTime());
+        assertTrue(dir.mkdirs());
+        try {
+            File out = new File(dir, "e2e-result.json");
+            Map<String, String> artifacts = new LinkedHashMap<String, String>();
+            artifacts.put("broadcast", "received");
+            artifacts.put("broadcast_injected", "true");
+            E2EResult.write(out, true, true, true, true, 12345L, 0, artifacts);
+
+            String json = new String(java.nio.file.Files.readAllBytes(out.toPath()), StandardCharsets.UTF_8);
+            assertTrue(json.contains("\"lane\":\"1.5.2\""));
+            assertTrue(json.contains("\"server_booted\":false"));
+            assertTrue(json.contains("\"client_joined\":true"));
+            assertTrue(json.contains("\"command_executed\":true"));
+            assertTrue(json.contains("\"renderer_state\":\"sentinel\""));
+            assertTrue(json.contains("\"renderer_verified\":true"));
+            assertTrue(json.contains("\"duration_ms\":12345"));
+            assertTrue(json.contains("\"exit_code\":0"));
+            assertTrue(json.contains("\"broadcast\":\"received\""));
+            assertTrue(json.contains("\"broadcast_injected\":\"true\""));
+        } finally {
+            deleteRecursively(dir);
+        }
+    }
+
+    @Test
+    public void writeFailureState() throws Exception {
+        File dir = new File(System.getProperty("java.io.tmpdir"), "e2e-result-fail-" + System.nanoTime());
+        assertTrue(dir.mkdirs());
+        try {
+            File out = new File(dir, "e2e-result.json");
+            E2EResult.write(out, false, false, false, false, 999L, 2, null);
+            String json = new String(java.nio.file.Files.readAllBytes(out.toPath()), StandardCharsets.UTF_8);
+            assertTrue(json.contains("\"client_joined\":false"));
+            assertTrue(json.contains("\"renderer_state\":\"none\""));
+            assertTrue(json.contains("\"exit_code\":2"));
+        } finally {
+            deleteRecursively(dir);
+        }
+    }
+
+    @Test
+    public void sentinelPixelContract() {
+        BufferedImage sentinel = new BufferedImage(
+            E2EResult.SENTINEL_WIDTH, E2EResult.SENTINEL_HEIGHT, BufferedImage.TYPE_INT_ARGB);
+        for (int y = 0; y < E2EResult.SENTINEL_HEIGHT; y++) {
+            for (int x = 0; x < E2EResult.SENTINEL_WIDTH; x++) {
+                sentinel.setRGB(x, y,
+                    (x < E2EResult.SENTINEL_BLOCK && y < E2EResult.SENTINEL_BLOCK)
+                        ? E2EResult.RED : E2EResult.GREEN);
+            }
+        }
+        assertTrue(E2EResult.isSentinelImage(sentinel));
+        assertFalse(E2EResult.isSentinelImage(null));
+        sentinel.setRGB(0, 0, 0xFF00FF00);
+        assertFalse(E2EResult.isSentinelImage(sentinel));
+        BufferedImage wrongSize = new BufferedImage(64, 64, BufferedImage.TYPE_INT_ARGB);
+        assertFalse(E2EResult.isSentinelImage(wrongSize));
+    }
+
+    @Test
+    public void toJsonEscapesStrings() {
+        Map<String, Object> doc = new LinkedHashMap<String, Object>();
+        doc.put("lane", "1.5.2");
+        doc.put("artifacts", new LinkedHashMap<String, String>());
+        String json = E2EResult.toJson(doc);
+        assertNotNull(json);
+        assertTrue(json.contains("\"lane\":\"1.5.2\""));
+        assertTrue(json.contains("\"artifacts\":{}"));
+    }
+
+    private static void deleteRecursively(File f) {
+        if (f.isDirectory()) {
+            File[] children = f.listFiles();
+            if (children != null) {
+                for (File c : children) {
+                    deleteRecursively(c);
+                }
+            }
+        }
+        f.delete();
+    }
+}

--- a/forge-1.5.2/test-infrastructure/run-e2e.sh
+++ b/forge-1.5.2/test-infrastructure/run-e2e.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# forge-1.5.2/test-infrastructure/run-e2e.sh — thin lane wrapper for the
+# real-client E2E (master plan slice 1; shared logic lives in
+# scripts/e2e/e2e-common.sh + scripts/e2e/drivers/pre18-xvfb.sh).
+#
+# Flow: build the lane (vendored harness, Java 8) → export the lane's
+# server/artifact config → invoke the shared orchestrator.
+#
+# MERGE MODEL (lib-8 recipe): 1.4.7/1.5.2 boot the client as the obf client
+# jar with the FML universal zip MERGED in (universal's patched
+# net/minecraft/client/Minecraft + MinecraftApplet + ClientBrandRetriever
+# win), main net.minecraft.client.Minecraft, CWD + minecraft.applet
+# TargetDirectory = gameDir, NO launchwrapper/tweaker — the driver
+# auto-connects via Minecraft.setServer at @Mod.Init. The server boots as
+# net.minecraft.server.MinecraftServer nogui with the universal zip FIRST on
+# the classpath (its patched MinecraftServer FML-bootstraps the process).
+#
+# Usage: JAVA_HOME=<jdk8> ./run-e2e.sh
+# Exit codes (master-plan contract): 0 all green | 1 assertion failed |
+# 2 retryable infra | 3 build/hard failure.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LANE_DIR="$(dirname "$SCRIPT_DIR")"
+REPO_ROOT="$(cd "$LANE_DIR/.." && pwd)"
+
+# ---------------------------------------------------------------------------
+# Java 8 (hard requirement: Gradle 4.4.1 dies on 9+; the merge-model client
+# boot needs Java 8 too — the client bytecode is major 49 but FML 5.2's ASM
+# refuses anything newer than Java 7 class files, and :common needs 8)
+# ---------------------------------------------------------------------------
+if [ -n "${JAVA_HOME:-}" ] && [ -x "$JAVA_HOME/bin/java" ]; then
+    E2E_JAVA8="$JAVA_HOME/bin/java"
+elif [ -x "$HOME/.sdkman/candidates/java/8.0.472-amzn/bin/java" ]; then
+    E2E_JAVA8="$HOME/.sdkman/candidates/java/8.0.472-amzn/bin/java"
+elif [ -x /usr/lib/jvm/java-8-openjdk-amd64/bin/java ]; then
+    E2E_JAVA8="/usr/lib/jvm/java-8-openjdk-amd64/bin/java"
+else
+    echo "[e2e:1.5.2][fail] Java 8 not found (set JAVA_HOME to a JDK 8)" >&2
+    exit 3
+fi
+echo "[e2e:1.5.2] Java 8: $E2E_JAVA8"
+
+# ---------------------------------------------------------------------------
+# Build the lane
+# ---------------------------------------------------------------------------
+echo "[e2e:1.5.2] building lane..."
+cd "$LANE_DIR"
+if ! JAVA_HOME="$(dirname "$(dirname "$E2E_JAVA8")")" ./gradlew build --no-daemon; then
+    echo "[e2e:1.5.2][fail] lane build failed (exit 3)" >&2
+    exit 3
+fi
+
+MOD_JAR="$(ls build/libs/everlastingskins-*.jar 2>/dev/null | grep -v -- '-sources.jar' | head -1 || true)"
+if [ -z "$MOD_JAR" ]; then
+    echo "[e2e:1.5.2][fail] no mod jar in build/libs/" >&2
+    exit 3
+fi
+
+# ---------------------------------------------------------------------------
+# Vendored server jar (populated by the build's resolveVendored)
+# ---------------------------------------------------------------------------
+VENDORED_DIR="${E2E_VENDORED_DIR:-$HOME/.gradle/everlastingskins-vendored/1.5.2}"
+SERVER_JAR="$VENDORED_DIR/minecraft_server.1.5.2.jar"
+if [ ! -f "$SERVER_JAR" ]; then
+    echo "[e2e:1.5.2][fail] vendored server jar missing: $SERVER_JAR" >&2
+    exit 3
+fi
+
+# ---------------------------------------------------------------------------
+# Invoke the shared orchestrator (merge model)
+# ---------------------------------------------------------------------------
+export E2E_LANE="1.5.2"
+export E2E_ERA="merge"
+export E2E_MOD_JAR="$MOD_JAR"
+export E2E_SERVER_JAR="$SERVER_JAR"
+export E2E_DRIVER_SCRIPT="$REPO_ROOT/scripts/e2e/drivers/pre18-xvfb.sh"
+export E2E_JAVA8
+export E2E_SENTINEL_PNG="$REPO_ROOT/common/src/test/resources/e2e/sentinel-64x32.png"
+
+exec bash "$REPO_ROOT/scripts/e2e/e2e-common.sh"

--- a/forge-1.6.4/src/main/java/levosilimo/everlastingskins/forge164/EverlastingSkins.java
+++ b/forge-1.6.4/src/main/java/levosilimo/everlastingskins/forge164/EverlastingSkins.java
@@ -79,6 +79,13 @@ public class EverlastingSkins {
 
     @Mod.EventHandler
     public void init(FMLInitializationEvent event) {
+        // In-jar E2E support FIRST (shipped-gated by -Deverlastingskins.e2e=true;
+        // no-op in production). It side-gates internally (CLIENT → driver,
+        // SERVER → sentinel hook), so it must run before the client early-return
+        // below — the placement after the gate (introduced by #426's joint-jar
+        // side-guard) silently skipped the CLIENT driver; fixed in slice 1 for
+        // all three pre-1.8 lanes.
+        E2E.install();
         if (!FMLCommonHandler.instance().getSide().isServer()) {
             // Client process: the client handler is registered by @NetworkMod;
             // no server bootstrap here (the physical side is authoritative —
@@ -89,9 +96,6 @@ public class EverlastingSkins {
         // :common removed init() — per-version bootstrap registers candidates
         // itself; highest priority wins (Forge ops 10 > vanilla fallback 0).
         ForgePermissionService.register();
-        // In-jar E2E support (shipped-gated by -Deverlastingskins.e2e=true;
-        // no-op in production).
-        E2E.install();
         // Pre-1.7 player join/leave hook (no PlayerEvent on this line). The
         // broadcast channel itself is owned by @NetworkMod.
         NetworkRegistry.instance().registerConnectionHandler(new ConnectionHandler());

--- a/scripts/e2e/drivers/pre18-xvfb.sh
+++ b/scripts/e2e/drivers/pre18-xvfb.sh
@@ -1,23 +1,41 @@
 #!/usr/bin/env bash
 # scripts/e2e/drivers/pre18-xvfb.sh — pre-1.8 real-client E2E driver
-# (forge-1.6.4 slice 1).
+# (forge-1.6.4 slice 1 + 1.5.2/1.4.7 slice 1 merge model).
 #
-# Boots a REAL 1.6.4 client under xvfb + Mesa software GL via the vanilla
-# tweaker model (lib-8 boot mechanics, empirically re-verified in slice 1):
-# the pristine vanilla client jar stays untouched; forge-universal.jar +
-# launchwrapper-1.8.jar sit on the classpath as libraries; main =
+# Two era models, selected by $E2E_ERA (default "1.6.4-tweaker"):
+#
+# 1.6.4-tweaker (unchanged from slice 1): boots a REAL 1.6.4 client under
+# xvfb + Mesa software GL via the vanilla tweaker model (lib-8 boot
+# mechanics, empirically re-verified in slice 1): the pristine vanilla
+# client jar stays untouched; forge-universal.jar + launchwrapper-1.8.jar sit
+# on the classpath as libraries; main =
 # net.minecraft.launchwrapper.Launch with
-# --tweakClass cpw.mods.fml.common.launcher.FMLTweaker. The mod jar
-# (reobf'd, obf-named) goes into <gameDir>/mods/. The in-jar E2EDriver
-# (shipped-gated by -Deverlastingskins.e2e=true) runs the phase machine and
-# writes e2e-result.json into the gameDir.
+# --tweakClass cpw.mods.fml.common.launcher.FMLTweaker.
+#
+# merge (1.4.7/1.5.2, lib-8 MERGE model): the obf client jar is merged with
+# the FML universal zip (universal's PATCHED classes win:
+# net/minecraft/client/Minecraft, MinecraftApplet, ClientBrandRetriever),
+# producing a self-contained Forge client; main =
+# net.minecraft.client.Minecraft; NO launchwrapper/tweaker. The mod jar goes
+# into <gameDir>/mods/; the game dir is pinned via
+# -Dminecraft.applet.TargetDirectory=<gameDir> (FML 4.7/5.2's
+# computeExistingClientHome relocates Minecraft's static minecraftDir to it
+# — the pre-launchwrapper launcher mechanism) AND CWD=gameDir (the FML
+# relaunch log is CWD-relative). 1.5.2/1.4.7 Minecraft.main parses no
+# --server/--port args, so the in-jar E2EDriver auto-connects via
+# Minecraft.setServer at @Mod.Init.
+#
+# In both models the in-jar E2EDriver (shipped-gated by
+# -Deverlastingskins.e2e=true) runs the phase machine and writes
+# e2e-result.json into the gameDir.
 #
 # The client jar and every library are fetched into the shared e2e cache
-# with pinned sha1s (client jar sha1 is what makes the driver's obf-domain
-# reflection names stable). Java 8 is a HARD requirement (launchwrapper
-# dies on 9+).
+# with pinned sha1s (client jar sha1 is what keeps the driver's referenced
+# member names stable). Java 8 is a HARD requirement (launchwrapper dies on
+# 9+; the merge-model JVM is Java 8 too).
 #
 # Env contract (set by e2e-common.sh / lib.sh):
+#   E2E_ERA             "1.6.4-tweaker" (default) | "merge"
 #   E2E_CLIENT_DIR      client gameDir (created here)
 #   E2E_MOD_JAR         the lane's built mod jar
 #   E2E_SENTINEL_PNG    canonical sentinel PNG (repo path)
@@ -34,6 +52,7 @@ E2E_DRIVER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck source=../lib.sh
 source "$E2E_DRIVER_DIR/lib.sh"
 
+: "${E2E_ERA:=1.6.4-tweaker}"
 : "${E2E_CLIENT_DIR:?pre18-xvfb.sh: E2E_CLIENT_DIR is required}"
 : "${E2E_MOD_JAR:?pre18-xvfb.sh: E2E_MOD_JAR is required}"
 : "${E2E_SENTINEL_PNG:?pre18-xvfb.sh: E2E_SENTINEL_PNG is required}"
@@ -44,16 +63,51 @@ source "$E2E_DRIVER_DIR/lib.sh"
 : "${E2E_CLIENT_TIMEOUT_S:=300}"
 
 # ---------------------------------------------------------------------------
-# Pinned 1.6.4 client artifacts (lib-8 + slice-1 empirical pinning)
+# Pinned client artifacts per era/lane (lib-8 + slice-1 empirical pinning).
+# The 1.6.4 pins are the slice-1 originals; the 1.4.7/1.5.2 client sha1s are
+# the version_manifest downloads.client sha1s already pinned in the lanes'
+# build.gradle vendoredInputs; the universal sha1s were computed from the
+# vendored universal.zip files.
 # ---------------------------------------------------------------------------
-CLIENT_JAR_SHA1="1703704407101cf72bd88e68579e3696ce733ecd"
-CLIENT_JAR_URL="https://launcher.mojang.com/v1/objects/${CLIENT_JAR_SHA1}/client.jar"
-UNIVERSAL_SHA1="eb9d954c8d057fa1768acaa40a35b864ad05c58b"
-UNIVERSAL_URL="https://maven.minecraftforge.net/net/minecraftforge/forge/1.6.4-9.11.1.1345/forge-1.6.4-9.11.1.1345-universal.jar"
+CACHE="$E2E_CACHE_DIR/$E2E_LANE"
 
-# name|url|sha1 — the vanilla 1.6.4 launcher library set + the tweaker-model
+if [ "$E2E_ERA" = "1.6.4-tweaker" ]; then
+    CLIENT_JAR_NAME="minecraft_client.1.6.4.jar"
+    CLIENT_JAR_SHA1="1703704407101cf72bd88e68579e3696ce733ecd"
+    CLIENT_JAR_URL="https://launcher.mojang.com/v1/objects/${CLIENT_JAR_SHA1}/client.jar"
+    UNIVERSAL_NAME="forge-1.6.4-9.11.1.1345-universal.jar"
+    UNIVERSAL_SHA1="eb9d954c8d057fa1768acaa40a35b864ad05c58b"
+    UNIVERSAL_URL="https://maven.minecraftforge.net/net/minecraftforge/forge/1.6.4-9.11.1.1345/forge-1.6.4-9.11.1.1345-universal.jar"
+elif [ "$E2E_ERA" = "merge" ]; then
+    case "$E2E_LANE" in
+        1.5.2)
+            CLIENT_JAR_NAME="minecraft_client.1.5.2.jar"
+            CLIENT_JAR_SHA1="465378c9dc2f779ae1d6e8046ebc46fb53a57968"
+            CLIENT_JAR_URL="https://launcher.mojang.com/v1/objects/${CLIENT_JAR_SHA1}/client.jar"
+            UNIVERSAL_NAME="forge-1.5.2-7.8.1.738-universal.zip"
+            UNIVERSAL_SHA1="76223709288287a6a8d22ab16b43a6ab2a284a0d"
+            UNIVERSAL_URL="https://maven.minecraftforge.net/net/minecraftforge/forge/1.5.2-7.8.1.738/forge-1.5.2-7.8.1.738-universal.zip"
+            ;;
+        1.4.7)
+            CLIENT_JAR_NAME="minecraft_client.1.4.7.jar"
+            CLIENT_JAR_SHA1="53ed4b9d5c358ecfff2d8b846b4427b888287028"
+            CLIENT_JAR_URL="https://launcher.mojang.com/v1/objects/${CLIENT_JAR_SHA1}/client.jar"
+            UNIVERSAL_NAME="forge-1.4.7-6.6.2.534-universal.zip"
+            UNIVERSAL_SHA1="bd0f40a78c18140265ff042a96d73f01c4f60906"
+            UNIVERSAL_URL="https://maven.minecraftforge.net/net/minecraftforge/forge/1.4.7-6.6.2.534/forge-1.4.7-6.6.2.534-universal.zip"
+            ;;
+        *)
+            e2e_fail "merge era: unsupported lane $E2E_LANE (expect 1.4.7 or 1.5.2)"
+            ;;
+    esac
+else
+    e2e_fail "unknown E2E_ERA '$E2E_ERA' (expect 1.6.4-tweaker or merge)"
+fi
+
+# name|url|sha1 — the vanilla launcher library set + the tweaker-model
 # extras (launchwrapper/asm/jopt-simple; authlib/log4j-api for :common at
-# runtime). LWJGL 2.9.4-nightly-20150209 is the lib-8 uniform pick.
+# runtime). LWJGL 2.9.4-nightly-20150209 is the lib-8 uniform pick. The
+# merge model skips the tweaker-only extras (launchwrapper/asm/jopt).
 LIB_SPECS=(
   "launchwrapper-1.8.jar|https://libraries.minecraft.net/net/minecraft/launchwrapper/1.8/launchwrapper-1.8.jar|d4c0895977dd7f0b3f56281cee53a64d4c0c0322"
   "asm-all-4.1.jar|https://libraries.minecraft.net/org/ow2/asm/asm-all/4.1/asm-all-4.1.jar|054986e962b88d8660ae4566475658469595ef58"
@@ -80,12 +134,21 @@ LIB_SPECS=(
   "log4j-api-2.8.1.jar|https://libraries.minecraft.net/org/apache/logging/log4j/log4j-api/2.8.1/log4j-api-2.8.1.jar|e801d13612e22cad62a3f4f3fe7fdbe6334a8e72"
 )
 
-fetch_artifact "minecraft_client.1.6.4.jar" "$CLIENT_JAR_URL" "$CLIENT_JAR_SHA1"
-fetch_artifact "forge-1.6.4-9.11.1.1345-universal.jar" "$UNIVERSAL_URL" "$UNIVERSAL_SHA1"
+fetch_artifact "$CLIENT_JAR_NAME" "$CLIENT_JAR_URL" "$CLIENT_JAR_SHA1"
+fetch_artifact "$UNIVERSAL_NAME" "$UNIVERSAL_URL" "$UNIVERSAL_SHA1"
 
-CACHE="$E2E_CACHE_DIR/$E2E_LANE"
-CLIENT_JAR="$CACHE/minecraft_client.1.6.4.jar"
-UNIVERSAL_JAR="$CACHE/forge-1.6.4-9.11.1.1345-universal.jar"
+# Every classpath library is pinned + fetched here (cached+verified is a
+# no-op); the 1.6.4 slice relied on a pre-populated cache, which breaks on a
+# fresh machine.
+for spec in "${LIB_SPECS[@]}"; do
+    name="${spec%%|*}"
+    url="${spec#*|}"; url="${url%%|*}"
+    sha1="${spec##*|}"
+    fetch_artifact "$name" "$url" "$sha1"
+done
+
+CLIENT_JAR="$CACHE/$CLIENT_JAR_NAME"
+UNIVERSAL_JAR="$CACHE/$UNIVERSAL_NAME"
 
 # ---------------------------------------------------------------------------
 # gameDir setup: mods/, sentinel, natives
@@ -100,52 +163,108 @@ e2e_log "mod jar: $(basename "$E2E_MOD_JAR")"
 cp "$E2E_SENTINEL_PNG" "$E2E_CLIENT_DIR/e2e-sentinel.png"
 
 # Native .so extraction (lwjgl + jinput platform jars). LWJGL 2.9.4 loads
-    # liblwjgl.so / libopenal.so (the -64 twins are 2.9.x legacy); jinput loads
-    # libjinput-linux64.so on 64-bit.
-    (
-        cd "$E2E_CLIENT_DIR/natives"
-        unzip -o -q "$CACHE/lwjgl-platform-2.9.4-nightly-20150209-natives-linux.jar" '*.so'
-        unzip -o -q "$CACHE/jinput-platform-2.0.5-natives-linux.jar" '*.so'
-        [ -f liblwjgl.so ] || ln -sf liblwjgl64.so liblwjgl.so
-        [ -f libopenal.so ] || ln -sf libopenal64.so libopenal.so
-    )
+# liblwjgl.so / libopenal.so (the -64 twins are 2.9.x legacy); jinput loads
+# libjinput-linux64.so on 64-bit.
+(
+    cd "$E2E_CLIENT_DIR/natives"
+    unzip -o -q "$CACHE/lwjgl-platform-2.9.4-nightly-20150209-natives-linux.jar" '*.so'
+    unzip -o -q "$CACHE/jinput-platform-2.0.5-natives-linux.jar" '*.so'
+    [ -f liblwjgl.so ] || ln -sf liblwjgl64.so liblwjgl.so
+    [ -f libopenal.so ] || ln -sf libopenal64.so libopenal.so
+)
 e2e_log "natives: $(ls "$E2E_CLIENT_DIR/natives" | tr '\n' ' ')"
 
 # ---------------------------------------------------------------------------
-# Classpath assembly + launch (tweaker model)
+# Classpath assembly (era-dependent; tweaker-only extras skipped on merge)
 # ---------------------------------------------------------------------------
-# Classpath: the mod jar is NOT on the classpath — FML discovers it in
+if [ "$E2E_ERA" = "1.6.4-tweaker" ]; then
+    # Classpath: the mod jar is NOT on the classpath — FML discovers it in
     # <gameDir>/mods/ (classpath + mods/ duplicates the mod and kills the scan:
     # "Found a duplicate mod everlastingskins").
     CP="$CLIENT_JAR:$UNIVERSAL_JAR"
-for spec in "${LIB_SPECS[@]}"; do
-    name="${spec%%|*}"
-    CP="$CP:$CACHE/$name"
-done
+    for spec in "${LIB_SPECS[@]}"; do
+        name="${spec%%|*}"
+        CP="$CP:$CACHE/$name"
+    done
+else
+    # Merge model: the FMLRelauncher needs its CoreFMLLibraries in
+    # <gameDir>/lib (dead fmllibs download otherwise hard-fails the boot —
+    # see seed_fml_libdir in lib.sh).
+    seed_fml_libdir "$E2E_CLIENT_DIR" "$E2E_LANE"
+
+    # Merge model: self-contained Forge client = obf client jar + the
+    # universal zip's patched classes (universal wins: Minecraft,
+    # MinecraftApplet, ClientBrandRetriever — the FML 4.7/5.2 bootstrap lives
+    # in the patched Minecraft constructor). Rebuilt every run (deterministic,
+    # few seconds); the mod jar stays out of the classpath (mods/ discovery).
+    MERGE_DIR="$CACHE/merge-work-$E2E_LANE"
+    MERGED_JAR="$CACHE/merged-client-$E2E_LANE.jar"
+    rm -rf "$MERGE_DIR"
+    mkdir -p "$MERGE_DIR"
+    e2e_log "assembling merged client jar (universal wins over client)..."
+    unzip -q -o "$CLIENT_JAR" -d "$MERGE_DIR"
+    unzip -q -o "$UNIVERSAL_JAR" -d "$MERGE_DIR"
+    ( cd "$MERGE_DIR" && zip -qr "$MERGED_JAR" . )
+    rm -rf "$MERGE_DIR"
+    e2e_log "merged client jar: $(basename "$MERGED_JAR") ($(du -h "$MERGED_JAR" | cut -f1))"
+
+    CP="$MERGED_JAR"
+    for spec in "${LIB_SPECS[@]}"; do
+        name="${spec%%|*}"
+        case "$name" in
+            launchwrapper-1.8.jar|asm-all-4.1.jar|jopt-simple-4.5.jar)
+                # Tweaker-model extras; the merge model has no launchwrapper.
+                continue
+                ;;
+        esac
+        CP="$CP:$CACHE/$name"
+    done
+fi
 
 CLIENT_LOG="$E2E_CLIENT_DIR/client.log"
 JAVA8_BIN="$E2E_JAVA8"
 [ -x "$JAVA8_BIN" ] || JAVA8_BIN="$E2E_JAVA8/bin/java"
 
-e2e_log "launching client (xvfb + Mesa llvmpipe, tweaker model)..."
 export LIBGL_ALWAYS_SOFTWARE=1
 export GALLIUM_DRIVER=llvmpipe
-# shellcheck disable=SC2086
-CLIENT_PID=$(start_guarded "$CLIENT_LOG" \
-    timeout --kill-after=10 "$E2E_CLIENT_TIMEOUT_S" \
-    xvfb-run -a "$JAVA8_BIN" -Xmx1G -Xms512M \
-    -Djava.library.path="$E2E_CLIENT_DIR/natives" \
-    -Deverlastingskins.e2e=true \
-    -Dfml.ignoreInvalidMinecraftCertificates=true \
-    -Dfml.ignorePatchDiscrepancies=true \
-    -cp "$CP" net.minecraft.launchwrapper.Launch \
-    --version 1.6.4 \
-    --tweakClass cpw.mods.fml.common.launcher.FMLTweaker \
-    --gameDir "$E2E_CLIENT_DIR" \
-    --assetsDir "$E2E_CLIENT_DIR/assets" \
-    --username "$E2E_USERNAME" \
-    --session "e2e-session-token" \
-    --server "$E2E_SERVER_HOST" --port "$E2E_SERVER_PORT")
+
+if [ "$E2E_ERA" = "1.6.4-tweaker" ]; then
+    e2e_log "launching client (xvfb + Mesa llvmpipe, tweaker model)..."
+    # shellcheck disable=SC2086
+    CLIENT_PID=$(start_guarded "$CLIENT_LOG" \
+        timeout --kill-after=10 "$E2E_CLIENT_TIMEOUT_S" \
+        xvfb-run -a "$JAVA8_BIN" -Xmx1G -Xms512M \
+        -Djava.library.path="$E2E_CLIENT_DIR/natives" \
+        -Deverlastingskins.e2e=true \
+        -Dfml.ignoreInvalidMinecraftCertificates=true \
+        -Dfml.ignorePatchDiscrepancies=true \
+        -cp "$CP" net.minecraft.launchwrapper.Launch \
+        --version 1.6.4 \
+        --tweakClass cpw.mods.fml.common.launcher.FMLTweaker \
+        --gameDir "$E2E_CLIENT_DIR" \
+        --assetsDir "$E2E_CLIENT_DIR/assets" \
+        --username "$E2E_USERNAME" \
+        --session "e2e-session-token" \
+        --server "$E2E_SERVER_HOST" --port "$E2E_SERVER_PORT")
+else
+    e2e_log "launching client (xvfb + Mesa llvmpipe, merge model)..."
+    # CWD=gameDir (FML relaunch log) + minecraft.applet.TargetDirectory
+    # (FML 4.7/5.2 relocates Minecraft's minecraftDir to the gameDir). The
+    # driver auto-connects via Minecraft.setServer at @Mod.Init — no
+    # --server/--port args exist on this line's main.
+    # shellcheck disable=SC2016
+    CLIENT_PID=$(start_guarded "$CLIENT_LOG" bash -c '
+        cd "$1" || exit 3
+        exec timeout --kill-after=10 "$8" xvfb-run -a "$2" -Xmx1G -Xms512M \
+            -Djava.library.path="$3" \
+            -Dminecraft.applet.TargetDirectory="$1" \
+            -Deverlastingskins.e2e=true \
+            -Deverlastingskins.e2e.server="$4" \
+            -Deverlastingskins.e2e.port="$5" \
+            -cp "$6" net.minecraft.client.Minecraft "$7" "e2e-session-token"
+    ' _ "$E2E_CLIENT_DIR" "$JAVA8_BIN" "$E2E_CLIENT_DIR/natives" \
+        "$E2E_SERVER_HOST" "$E2E_SERVER_PORT" "$CP" "$E2E_USERNAME" "$E2E_CLIENT_TIMEOUT_S")
+fi
 
 RESULT_FILE="$E2E_CLIENT_DIR/e2e-result.json"
 # Stale-result guard (discovered during audit remediation verification): the

--- a/scripts/e2e/e2e-common.sh
+++ b/scripts/e2e/e2e-common.sh
@@ -9,8 +9,19 @@
 # fields → map exit codes (0 all green | 1 assertion failed | 2 retryable
 # infra | 3 build/hard failure).
 #
+# Era deltas (E2E_ERA, default "1.6.4-tweaker"):
+#   - 1.6.4-tweaker: server boots as cpw.mods.fml.relauncher.ServerLaunchWrapper
+#     nogui with server.jar FIRST + universal.jar (the 1.6.4 universal has no
+#     patched MC classes; the tweaker model owns the boot).
+#   - merge (1.4.7/1.5.2): the FML universal zip carries the PATCHED
+#     MinecraftServer whose main() FML-bootstraps the process, so the
+#     universal zip must come FIRST on the classpath (classpath first-match
+#     wins) and the boot main is net.minecraft.server.MinecraftServer nogui.
+#     The tweaker-only libs (launchwrapper/asm/jopt-simple) are dropped.
+#
 # Env contract (set by the lane wrapper test-infrastructure/run-e2e.sh):
-#   E2E_LANE           lane id (1.6.4)
+#   E2E_LANE           lane id (1.6.4 / 1.5.2 / 1.4.7)
+#   E2E_ERA            "1.6.4-tweaker" (default) | "merge"
 #   E2E_MOD_JAR        built mod jar
 #   E2E_SERVER_JAR     vendored vanilla server jar
 #   E2E_DRIVER_SCRIPT  era client driver (scripts/e2e/drivers/pre18-xvfb.sh)
@@ -51,37 +62,102 @@ gamemode=0
 motd=EverlastingSkins E2E $E2E_LANE
 max-tick-time=-1
 EOF
-# 1.6.4 ops model: ops.txt (one username per line) — lets the offline test
-# player pass the command's permission gate (verified: without op the server
-# replies "You do not have permission").
+# Pre-1.7.10 ops model: ops.txt (one username per line) — lets the offline
+# test player pass the command's permission gate (verified on 1.6.4: without
+# op the server replies "You do not have permission").
 printf '%s\n' "$E2E_USERNAME" > "$SERVER_DIR/ops.txt"
 
 # ---------------------------------------------------------------------------
-# Server classpath: vanilla server + forge universal + mod + shared libs
-# (the 1.6.4 launcher library set minus the client-only lwjgl/paulscode legs;
-# plus launchwrapper/asm/jopt-simple for the tweaker model and
-# authlib/log4j-api for :common at runtime).
+# Era pins: forge universal artifact + server boot main
 # ---------------------------------------------------------------------------
 CACHE="$E2E_CACHE_DIR/$E2E_LANE"
-fetch_artifact "forge-1.6.4-9.11.1.1345-universal.jar" \
-    "https://maven.minecraftforge.net/net/minecraftforge/forge/1.6.4-9.11.1.1345/forge-1.6.4-9.11.1.1345-universal.jar" \
-    "eb9d954c8d057fa1768acaa40a35b864ad05c58b"
+if [ "${E2E_ERA:-1.6.4-tweaker}" = "1.6.4-tweaker" ]; then
+    UNIVERSAL_NAME="forge-1.6.4-9.11.1.1345-universal.jar"
+    UNIVERSAL_URL="https://maven.minecraftforge.net/net/minecraftforge/forge/1.6.4-9.11.1.1345/forge-1.6.4-9.11.1.1345-universal.jar"
+    UNIVERSAL_SHA1="eb9d954c8d057fa1768acaa40a35b864ad05c58b"
+    SERVER_MAIN="cpw.mods.fml.relauncher.ServerLaunchWrapper"
+    SERVER_MAIN_ARGS="nogui"
+else
+    case "$E2E_LANE" in
+        1.5.2)
+            UNIVERSAL_NAME="forge-1.5.2-7.8.1.738-universal.zip"
+            UNIVERSAL_URL="https://maven.minecraftforge.net/net/minecraftforge/forge/1.5.2-7.8.1.738/forge-1.5.2-7.8.1.738-universal.zip"
+            UNIVERSAL_SHA1="76223709288287a6a8d22ab16b43a6ab2a284a0d"
+            ;;
+        1.4.7)
+            UNIVERSAL_NAME="forge-1.4.7-6.6.2.534-universal.zip"
+            UNIVERSAL_URL="https://maven.minecraftforge.net/net/minecraftforge/forge/1.4.7-6.6.2.534/forge-1.4.7-6.6.2.534-universal.zip"
+            UNIVERSAL_SHA1="bd0f40a78c18140265ff042a96d73f01c4f60906"
+            ;;
+        *)
+            e2e_fail "merge era: unsupported lane $E2E_LANE (expect 1.4.7 or 1.5.2)"
+            ;;
+    esac
+    SERVER_MAIN="net.minecraft.server.MinecraftServer"
+    SERVER_MAIN_ARGS="nogui"
+fi
 
-# The mod jar is deliberately NOT on the classpath — FML discovers it in
-    # <serverDir>/mods/ (classpath + mods/ duplicates the mod: "Found a
-    # duplicate mod everlastingskins").
-    SERVER_CP="$E2E_SERVER_JAR:$CACHE/forge-1.6.4-9.11.1.1345-universal.jar"
-for lib in launchwrapper-1.8.jar asm-all-4.1.jar jopt-simple-4.5.jar guava-14.0.jar \
-    gson-2.2.2.jar commons-lang3-3.1.jar commons-io-2.4.jar argo-2.25_fixed.jar \
-    lzma-0.0.1.jar \
-    bcprov-jdk15on-1.47.jar authlib-1.5.16.jar log4j-api-2.8.1.jar; do
-    SERVER_CP="$SERVER_CP:$CACHE/$lib"
+fetch_artifact "$UNIVERSAL_NAME" "$UNIVERSAL_URL" "$UNIVERSAL_SHA1"
+
+# ---------------------------------------------------------------------------
+# Server library fetch (both eras; cached+verified is a no-op). The legacy
+# FML relauncher pre-seed below additionally needs asm-all on the cache.
+# ---------------------------------------------------------------------------
+for spec in \
+    "guava-14.0.jar|https://libraries.minecraft.net/com/google/guava/guava/14.0/guava-14.0.jar|67b7be4ee7ba48e4828a42d6d5069761186d4a53" \
+    "gson-2.2.2.jar|https://libraries.minecraft.net/com/google/code/gson/gson/2.2.2/gson-2.2.2.jar|1f96456ca233dec780aa224bff076d8e8bca3908" \
+    "commons-lang3-3.1.jar|https://libraries.minecraft.net/org/apache/commons/commons-lang3/3.1/commons-lang3-3.1.jar|905075e6c80f206bbe6cf1e809d2caa69f420c76" \
+    "commons-io-2.4.jar|https://libraries.minecraft.net/commons-io/commons-io/2.4/commons-io-2.4.jar|b1b6ea3b7e4aa4f492509a4952029cd8e48019ad" \
+    "argo-2.25_fixed.jar|https://libraries.minecraft.net/argo/argo/2.25_fixed/argo-2.25_fixed.jar|751761ce15a3e3aaf3fc75b9f013ff8f7b88a585" \
+    "lzma-0.0.1.jar|https://libraries.minecraft.net/lzma/lzma/0.0.1/lzma-0.0.1.jar|521616dc7487b42bef0e803bd2fa3faf668101d7" \
+    "bcprov-jdk15on-1.47.jar|https://libraries.minecraft.net/org/bouncycastle/bcprov-jdk15on/1.47/bcprov-jdk15on-1.47.jar|b6f5d9926b0afbde9f4dbe3db88c5247be7794bb" \
+    "asm-all-4.1.jar|https://libraries.minecraft.net/org/ow2/asm/asm-all/4.1/asm-all-4.1.jar|054986e962b88d8660ae4566475658469595ef58" \
+    "authlib-1.5.16.jar|https://libraries.minecraft.net/com/mojang/authlib/1.5.16/authlib-1.5.16.jar|ef1582b11fd0943d069cdcb72e99008ac209a283" \
+    "log4j-api-2.8.1.jar|https://libraries.minecraft.net/org/apache/logging/log4j/log4j-api/2.8.1/log4j-api-2.8.1.jar|e801d13612e22cad62a3f4f3fe7fdbe6334a8e72"; do
+    name="${spec%%|*}"
+    url="${spec#*|}"; url="${url%%|*}"
+    sha1="${spec##*|}"
+    fetch_artifact "$name" "$url" "$sha1"
 done
+
+# Merge lanes: pre-seed the FMLRelauncher lib dir (dead fmllibs download
+# otherwise hard-fails the boot — see seed_fml_libdir in lib.sh).
+if [ "${E2E_ERA:-1.6.4-tweaker}" != "1.6.4-tweaker" ]; then
+    seed_fml_libdir "$SERVER_DIR" "$E2E_LANE"
+fi
+
+# ---------------------------------------------------------------------------
+# Server classpath: vanilla server + forge universal + mod + shared libs
+# (the launcher library set minus the client-only lwjgl/paulscode legs;
+# authlib/log4j-api for :common at runtime). The mod jar is deliberately NOT
+# on the classpath — FML discovers it in <serverDir>/mods/.
+# ---------------------------------------------------------------------------
+if [ "${E2E_ERA:-1.6.4-tweaker}" = "1.6.4-tweaker" ]; then
+    SERVER_CP="$E2E_SERVER_JAR:$CACHE/$UNIVERSAL_NAME"
+    for lib in launchwrapper-1.8.jar asm-all-4.1.jar jopt-simple-4.5.jar guava-14.0.jar \
+        gson-2.2.2.jar commons-lang3-3.1.jar commons-io-2.4.jar argo-2.25_fixed.jar \
+        lzma-0.0.1.jar \
+        bcprov-jdk15on-1.47.jar authlib-1.5.16.jar log4j-api-2.8.1.jar; do
+        SERVER_CP="$SERVER_CP:$CACHE/$lib"
+    done
+else
+    # Universal FIRST: the 1.4.7/1.5.2 universal carries the patched
+    # MinecraftServer (FMLRelauncher.handleServerRelaunch bootstrap); the
+    # JVM loads the first class found on the classpath.
+    SERVER_CP="$CACHE/$UNIVERSAL_NAME:$E2E_SERVER_JAR"
+    for lib in guava-14.0.jar \
+        gson-2.2.2.jar commons-lang3-3.1.jar commons-io-2.4.jar argo-2.25_fixed.jar \
+        lzma-0.0.1.jar \
+        bcprov-jdk15on-1.47.jar authlib-1.5.16.jar log4j-api-2.8.1.jar; do
+        SERVER_CP="$SERVER_CP:$CACHE/$lib"
+    done
+fi
 [ -z "$E2E_SERVER_CP_EXTRA" ] || SERVER_CP="$SERVER_CP:$E2E_SERVER_CP_EXTRA"
 
 # ---------------------------------------------------------------------------
 # Boot the real server (bg, own session). FML resolves mods/ relative to the
-# process CWD, so the server MUST run from the server dir (the wrapper runs
+# server's home (CWD on the merge lanes; the tweaker lane's launcher dir is
+# the CWD too), so the server MUST run from the server dir (the wrapper runs
 # from the lane dir).
 # ---------------------------------------------------------------------------
 SERVER_LOG="$SERVER_DIR/server.log"
@@ -98,9 +174,10 @@ e2e_log "booting server (pid tracking via session)..."
     cd "$SERVER_DIR"
     # setsid: own session/PGID so kill_tree (group kill) never hits the
     # wrapper's own process group.
+    # shellcheck disable=SC2086
     exec setsid "$JAVA8_BIN" -Xmx1G -Xms512M \
         -Deverlastingskins.e2e=true \
-        -cp "$SERVER_CP" cpw.mods.fml.relauncher.ServerLaunchWrapper nogui
+        -cp "$SERVER_CP" "$SERVER_MAIN" $SERVER_MAIN_ARGS
 ) > "$SERVER_LOG" 2>&1 &
 SERVER_PID=$!
 
@@ -115,6 +192,10 @@ e2e_log "server booted (For help, type \"help\")"
 # ---------------------------------------------------------------------------
 # Client driver (era-specific)
 # ---------------------------------------------------------------------------
+# Drop any stale result doc from a previous run: a driver timeout must never
+# be masked by an old driver's result file (observed live: a failed 1.6.4
+# run's doc was asserted as a 1.5.2 pass candidate).
+rm -f "$RESULT_JSON"
 set +e
 E2E_CLIENT_DIR="$RUNNER_TMP/client-$E2E_LANE" \
 E2E_MOD_JAR="$E2E_MOD_JAR" \

--- a/scripts/e2e/lib.sh
+++ b/scripts/e2e/lib.sh
@@ -69,6 +69,53 @@ fetch_artifact() {
 }
 
 # ---------------------------------------------------------------------------
+# FML 4.7/5.2 relauncher library pre-seed (MERGE-era lanes only)
+# ---------------------------------------------------------------------------
+# The legacy FMLRelauncher (1.4.7/1.5.2) demands its CoreFMLLibraries set in
+# <home>/lib with BYTE-EXACT checksums and hard-fails when a download fails
+# or an existing file mismatches — and the original
+# files.minecraftforge.net/fmllibs host has been dead (404 HTML) for years.
+# files.prismlauncher.org/fmllibs (PrismLauncher's legacy FML mirror)
+# carries the identical bytes; every sha1 below was verified against FML's
+# hardcoded checksums (CoreFMLLibraries static{}). The 1.5.2
+# deobfuscation_data zip is the REAL srg (FML 5.2's remapper is checksum-
+# enforced, so the 1.6.4-style identity path is unavailable): every class
+# through the RelaunchClassLoader is remapped obf→srg consistently — MC,
+# FML and the reobf'd mod alike — which keeps the reobf'd jar coherent.
+seed_fml_libdir() {
+    local target="$1" lane="$2"
+    mkdir -p "$target/lib"
+    local base="https://files.prismlauncher.org/fmllibs"
+    case "$lane" in
+        1.5.2)
+            fetch_artifact "argo-small-3.2.jar" "$base/argo-small-3.2.jar" "58912ea2858d168c50781f956fa5b59f0f7c6b51"
+            fetch_artifact "guava-14.0-rc3.jar" "$base/guava-14.0-rc3.jar" "931ae21fa8014c3ce686aaa621eae565fefb1a6a"
+            fetch_artifact "asm-all-4.1.jar" "$base/asm-all-4.1.jar" "054986e962b88d8660ae4566475658469595ef58"
+            fetch_artifact "bcprov-jdk15on-148.jar" "$base/bcprov-jdk15on-148.jar" "960dea7c9181ba0b17e8bab0c06a43f0a5f04e65"
+            fetch_artifact "scala-library.jar" "$base/scala-library.jar" "458d046151ad179c85429ed7420ffb1eaf6ddf85"
+            fetch_artifact "deobfuscation_data_1.5.2.zip" "$base/deobfuscation_data_1.5.2.zip" "446e55cd986582c70fcf12cb27bc00114c5adfd9"
+            for f in argo-small-3.2.jar guava-14.0-rc3.jar asm-all-4.1.jar \
+                bcprov-jdk15on-148.jar scala-library.jar deobfuscation_data_1.5.2.zip; do
+                cp "$E2E_CACHE_DIR/$lane/$f" "$target/lib/$f"
+            done
+            ;;
+        1.4.7)
+            fetch_artifact "argo-2.25.jar" "$base/argo-2.25.jar" "bb672829fde76cb163004752b86b0484bd0a7f4b"
+            fetch_artifact "guava-12.0.1.jar" "$base/guava-12.0.1.jar" "b8e78b9af7bf45900e14c6f958486b6ca682195f"
+            fetch_artifact "asm-all-4.0.jar" "$base/asm-all-4.0.jar" "98308890597acb64047f7e896638e0d98753ae82"
+            fetch_artifact "bcprov-jdk15on-147.jar" "$base/bcprov-jdk15on-147.jar" "b6f5d9926b0afbde9f4dbe3db88c5247be7794bb"
+            for f in argo-2.25.jar guava-12.0.1.jar asm-all-4.0.jar bcprov-jdk15on-147.jar; do
+                cp "$E2E_CACHE_DIR/$lane/$f" "$target/lib/$f"
+            done
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+    e2e_log "FML lib dir pre-seeded: $(basename "$target")/lib ($(ls "$target/lib" | tr '\n' ' '))"
+}
+
+# ---------------------------------------------------------------------------
 # Result contract helpers
 # ---------------------------------------------------------------------------
 # assemble_result <server_booted> — merges script-side facts into the final


### PR DESCRIPTION
## Slice 1: merge-model real-client E2E for forge-1.5.2 + forge-1.4.7

Makes the #433 ERA-UNTESTED wrappers real (they exit 3). **Both lanes live-verified end-to-end locally** (server boot → sentinel pre-seed → merge-model client under xvfb → join → /skin commands → broadcast → sentinel renderer injection → pixel assert → exit 0).

### Merge-model boot recipe (lib-8)
- Client: obf client.jar + FML universal.zip MERGED (universal's patched `net/minecraft/client/Minecraft`/`MinecraftApplet`/`ClientBrandRetriever` win) → self-contained Forge client; main `net.minecraft.client.Minecraft`; NO launchwrapper/tweaker. `-Dminecraft.applet.TargetDirectory=<gameDir>` (FML 4.7/5.2 `computeExistingClientHome` relocates `Minecraft.minecraftDir`) + CWD=gameDir.
- Auto-connect: 1.5.2/1.4.7 `Minecraft.main` parses no `--server/--port` (only `--demo/--applet/--password`, verified in bytecode) — the driver calls `Minecraft.setServer(host, port)` at `@Mod.Init` (before `startGame` consumes `serverName`).
- Server: universal zip FIRST on the classpath (its patched `MinecraftServer` FML-bootstraps via `FMLRelauncher.handleServerRelaunch`), main `net.minecraft.server.MinecraftServer nogui`.

### Live-trial discoveries (blockers found + fixed)
1. **FML 4.7/5.2 relauncher lib-dir hard-fail**: `files.minecraftforge.net/fmllibs` is dead (404 HTML since ~2022); the relauncher checksum-verifies EVERY file in `<home>/lib` (not just downloads). Fixed by pre-seeding `<home>/lib` from **files.prismlauncher.org/fmllibs** (PrismLauncher's legacy FML mirror) — all 8 files verified byte-exact against FML's hardcoded sha1s (argo-small/guava-rc3/asm/bcprov/scala/deobf-data for 1.5.2; argo-2.25/guava-12.0.1/asm-4.0/bcprov-147 for 1.4.7).
2. **FML 5.2 ASM rejects Java 8 class files** (major 52) — the mod jar is rejected at boot ("Unable to read a class file correctly … probably a corrupt zip"). Fixed with the 1.6.4 lane's `downgradeClassVersion` task (52→51 after reobf) on both lanes.
3. **Reobf gap on inherited fields** (the big one): javac emits inherited-field references with the *receiver's declared type* as owner (`EntityClientPlayerMP.skinUrl`); the srg FD keys are the *declaring* class (`Entity/skinUrl`) → the reference ships unmapped → `NoSuchFieldError` at runtime. Hit live in `E2EDriver` and in #426's `ClientSkinHandler`. Fixed by accessing `skinUrl` through the `net.minecraft.src.Entity` type in both lanes.
4. **Stale-result masking** (shared-script robustness): a previous run's `e2e-result.json`/`${RUNNER_TMP}/e2e-result.json` could be asserted as a fresh pass. Both orchestrator layers now drop stale docs before launch.

### Driver port era deltas (vs the 1.6.4 driver)
- Zero reflection: 1.5.2/1.4.7 client classes are on the compile classpath (#426 harness), and MCP 7.51/7.26a expose `ThreadDownloadImageData.image/textureName/textureSetupComplete` as PUBLIC fields — direct references, reobf'd for the obf runtime.
- Renderer assert (lib-14 variant): observe the broadcast injection (else inject via `ClientSkinApplier.apply`) → field-state assert → `textureSetupComplete=false` re-arm → `RenderEngine.getTextureForDownloadableImage` re-upload trigger → GL id + guard assert + sentinel pixel compare.
- `registerChannel(handler, CHANNEL, Side.CLIENT)` coexists with the `@NetworkMod` client spec (FML 4.7/5.2 per-channel handler multimaps).
- **1.6.4 fix included**: `E2E.install()` was placed after the client early-return in `init()` (regression from #426) — the 1.6.4 client driver never installed. Moved to the top of `init()` in all three lanes; 1.6.4 E2E re-run green.

### Validation
- Live E2E: **1.5.2 PASS** (exit 0, renderer_verified, broadcast received), **1.4.7 PASS** (exit 0), **1.6.4 regression PASS**.
- Lane builds (Corretto 8): green (reobf + assertNameDomain + downgradeClassVersion + verifyNoMixin; 8 new e2e tests per lane, 16 total).
- Root gates: `:common:build` green; test-count 433; verifyNoMixin; aislop clean; vendored-harness diff-guard OK.

### Blockers
None. Both lanes' full E2E is live-green; wrappers are live (no ERA-UNTESTED guard).