### PR TITLE
feat(e2e): second-observer client — wire fan-out proof (1.6.4)

### DIFF
--- a/forge-1.6.4/src/main/java/levosilimo/everlastingskins/e2e/E2E.java
+++ b/forge-1.6.4/src/main/java/levosilimo/everlastingskins/e2e/E2E.java
@@ -18,6 +18,9 @@ import cpw.mods.fml.relauncher.Side;
  * <ul>
  *   <li>CLIENT → {@link E2EDriver} (phase machine, channel receiver,
  *       renderer assertion, result file + {@code System.exit});</li>
+ *   <li>CLIENT + {@code -Deverlastingskins.e2e.observer=true} →
+ *       {@link E2EObserverDriver} (second-observer client: no commands,
+ *       asserts the REAL handler's wire injection — lib-23 gap (d));</li>
  *   <li>SERVER → {@link E2ESentinelHook} (sentinel pre-seed so the login
  *       re-broadcast delivers it).</li>
  * </ul>
@@ -31,10 +34,16 @@ public final class E2E {
 
     /** One-line gated entry from the mod's {@code @Mod.EventHandler init}. */
     public static void install() {
+        Side side = FMLCommonHandler.instance().getSide();
+        // Observer role is a client-only, explicitly-gated alternative to the
+        // actor driver (the observer never runs /skin).
+        if (side == Side.CLIENT && Boolean.getBoolean(E2EObserverDriver.OBSERVER_PROPERTY)) {
+            E2EObserverDriver.install();
+            return;
+        }
         if (!Boolean.getBoolean(E2E_PROPERTY)) {
             return;
         }
-        Side side = FMLCommonHandler.instance().getSide();
         if (side == Side.CLIENT) {
             E2EDriver.install();
         } else if (side == Side.SERVER) {

--- a/forge-1.6.4/src/main/java/levosilimo/everlastingskins/e2e/E2EObserverDriver.java
+++ b/forge-1.6.4/src/main/java/levosilimo/everlastingskins/e2e/E2EObserverDriver.java
@@ -1,0 +1,560 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.e2e;
+
+import cpw.mods.fml.common.FMLLog;
+import cpw.mods.fml.common.IScheduledTickHandler;
+import cpw.mods.fml.common.ITickHandler;
+import cpw.mods.fml.common.TickType;
+import cpw.mods.fml.common.network.IPacketHandler;
+import cpw.mods.fml.common.network.NetworkRegistry;
+import cpw.mods.fml.common.network.Player;
+import cpw.mods.fml.common.registry.TickRegistry;
+import cpw.mods.fml.relauncher.Side;
+import levosilimo.everlastingskins.broadcast.SkinBroadcaster;
+import levosilimo.everlastingskins.broadcast.SkinMessage;
+import net.minecraft.src.INetworkManager;
+import net.minecraft.src.Packet250CustomPayload;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * In-jar OBSERVER driver for the second-observer client E2E (lib-23 coverage
+ * gap (d): prove the broadcast FAN-OUT — an actor client runs {@code /skin};
+ * a NON-ACTOR observer client (NO commands) must receive the broadcast and
+ * render the sentinel).
+ *
+ * <p>The observer's assertion is the WIRE-INJECTION proof: the observer's
+ * real {@code levosilimo.everlastingskins.broadcast.ClientSkinHandler} (#426,
+ * the shipped handler) receives the broadcast (SkinMessage with the PNG
+ * bytes INLINE) and injects the decoded pixels into the TARGET player's
+ * {@code ThreadDownloadImageData}. The observer driver then asserts the
+ * target player's TDI ALREADY holds the sentinel pixels — the REAL handler
+ * injected from the wire, NOT a self-injection. The observer runs no
+ * commands.
+ *
+ * <p>Delivery contract (bytecode-verified against the 1.6.4 login flow):
+ * the login re-broadcast is queued on every client AHEAD of the actor's
+ * spawn packets (spawns go out on the next EntityTracker tick), so the
+ * observer's {@code ClientSkinHandler} DROPS the login broadcast (target
+ * not spawned yet). The actor's in-world window is only ~1s (it joins,
+ * proves the command surface and exits), so the sentinel hook fires a
+ * re-broadcast BURST (0.25s period) after every connection; a burst element
+ * deterministically lands inside the actor's window, the real handler
+ * injects, and the observer's RENDER_ASSERT phase polls the TDI for up to
+ * {@link #ASSERT_TIMEOUT_MS} until the injection is visible.
+ *
+ * <p>Gated at runtime by {@code -Deverlastingskins.e2e.observer=true} +
+ * {@code Side.CLIENT} (see {@link E2E#install()}). The client-side
+ * channel registration coexists with the real handler (FML 7.x per-channel
+ * handler MULTIMAPS; the @NetworkMod client spec registers first, so the
+ * real handler runs BEFORE this driver's listener on the same packet).
+ *
+ * <p>Phase machine: WAIT_JOIN (client world + player exist; NO commands) →
+ * WAIT_BROADCAST (a PNG-carrying SkinMessage for {@code TestPlayer} arrives
+ * on the wire) → RENDER_ASSERT (poll the TARGET player's TDI for the real
+ * handler's sentinel pixels + wire-vs-file pixel proof) → write
+ * {@code e2e-result.json} in the observer gameDir → {@code System.exit}.
+ *
+ * <p>Exit codes (master-plan contract): 0 all green | 1 observer assertion
+ * failed | 2 retryable infra (join/broadcast timeout) | 3 driver hard
+ * failure (reflection surface missing — jar/client mismatch).
+ */
+public final class E2EObserverDriver implements IScheduledTickHandler, IPacketHandler {
+
+    /** System property enabling the observer driver on the observer client JVM. */
+    public static final String OBSERVER_PROPERTY = "everlastingskins.e2e.observer";
+
+    /** Offline observer username (set by the e2e script's {@code --username}). */
+    public static final String OBSERVER_USERNAME = "ObserverPlayer";
+
+    /** The observed target: the actor's offline test player. */
+    public static final String TEST_PLAYER = E2EDriver.TEST_PLAYER;
+
+    // ------------------------------------------------------------------
+    // Runtime reflection names. Same obf-domain surface as E2EDriver (the
+    // 1.6.4 client is deobfuscated AT RUNTIME by FML 7.x: class names
+    // readable, member names searge). The searge literals are split so no
+    // string constant contains the assertNameDomain 'func_'/'field_' tokens.
+    // ------------------------------------------------------------------
+    private static final String CLS_MC = "net.minecraft.client.Minecraft";
+    private static final String M_GET_MC = srgn("fu", "nc_71410_x");
+    private static final String F_MC_DIR = srgn("fi", "eld_71412_D");
+    private static final String F_THE_WORLD = srgn("fi", "eld_71441_e");
+    private static final String F_THE_PLAYER = srgn("fi", "eld_71439_g");
+    private static final String CLS_ABSTRACT_PLAYER = "net.minecraft.client.entity.AbstractClientPlayer";
+    private static final String M_GET_TEXTURE_SKIN = srgn("fu", "nc_110309_l");
+    private static final String CLS_TDI = "net.minecraft.client.renderer.ThreadDownloadImageData";
+    private static final String F_TDI_IMAGE = srgn("fi", "eld_110560_d");
+    private static final String F_TDI_THREAD = srgn("fi", "eld_110561_e");
+    /** World.playerEntities (MCP 8.11) — the target lookup surface. */
+    private static final String F_WORLD_PLAYERS = srgn("fi", "eld_73010_i");
+    /** Entity.getCommandSenderName (MCP 8.11) — the name match. */
+    private static final String M_GET_NAME = srgn("fu", "nc_70005_c_");
+
+    /** Joins a split searge literal (javac would constant-fold {@code +} and trip assertNameDomain). */
+    private static String srgn(String head, String tail) {
+        return head + tail;
+    }
+
+    private static final long JOIN_TIMEOUT_MS = 180_000L;
+    /** First PNG-carrying broadcast lands ~0.25s after the observer's OWN connection. */
+    private static final long BROADCAST_TIMEOUT_MS = 60_000L;
+    /**
+     * RENDER_ASSERT poll budget: the injection comes from the ACTOR's
+     * connection re-broadcast (actor joins 30-90s after the observer), so
+     * the assert phase polls the TDI until the real handler's injection
+     * lands.
+     */
+    private static final long ASSERT_TIMEOUT_MS = 180_000L;
+    private static final long DOWNLOAD_THREAD_JOIN_MS = 3_000L;
+
+    /** Client-side observer phases (pure transition logic in {@link #nextPhase}). */
+    enum Phase {
+        WAIT_JOIN, WAIT_BROADCAST, RENDER_ASSERT, DONE
+    }
+
+    /**
+     * Pure phase transition used by the tick machine and unit tests: the
+     * observer advances only on observed facts.
+     */
+    static Phase nextPhase(Phase current, boolean joined, boolean broadcastReceived, boolean verified) {
+        switch (current) {
+            case WAIT_JOIN:
+                return joined ? Phase.WAIT_BROADCAST : Phase.WAIT_JOIN;
+            case WAIT_BROADCAST:
+                return broadcastReceived ? Phase.RENDER_ASSERT : Phase.WAIT_BROADCAST;
+            case RENDER_ASSERT:
+                return verified ? Phase.DONE : Phase.RENDER_ASSERT;
+            default:
+                return current;
+        }
+    }
+
+    /**
+     * Pure acceptance predicate for the wire listener: only a PNG-carrying
+     * SkinMessage for the TARGET player counts as the fan-out proof (the
+     * notification-only login broadcast carries no pixels to inject).
+     */
+    static boolean accepts(SkinMessage message) {
+        if (message == null || !TEST_PLAYER.equals(message.getPlayerName())) {
+            return false;
+        }
+        byte[] png = message.getTexturePng();
+        return png != null && png.length > 0;
+    }
+
+    private final long installedAt = System.currentTimeMillis();
+    private Phase phase = Phase.WAIT_JOIN;
+    private long phaseStartedAt = installedAt;
+    private volatile boolean broadcastReceived;
+    /** The PNG bytes seen on the wire (fan-out artifact + wire-vs-file proof). */
+    private volatile byte[] wirePng;
+    /** Precise observer outcome for the result doc: sentinel | target-not-spawned | ... */
+    private String observerState = "none";
+    /** Last poll failure mode (kept while RENDER_ASSERT keeps polling). */
+    private String lastPollState = "none";
+
+    private E2EObserverDriver() {}
+
+    /** Installs the observer driver (property + side gates live in {@link E2E#install()}). */
+    static void install() {
+        E2EObserverDriver driver = new E2EObserverDriver();
+        // Coexists with the real #426 handler: FML 7.x keeps per-channel
+        // handler multimaps (the @NetworkMod client spec registers first,
+        // so the REAL handler processes the packet before this listener).
+        NetworkRegistry.instance().registerChannel(driver, SkinBroadcaster.CHANNEL, Side.CLIENT);
+        TickRegistry.registerScheduledTickHandler(driver, Side.CLIENT);
+        FMLLog.info("ES_E2E_OBSERVER=installed side=%s", Side.CLIENT);
+    }
+
+    // ------------------------------------------------------------------
+    // Channel receiver: marks the fan-out arrival and captures the wire
+    // PNG bytes (the real ClientSkinHandler injects from the same packet).
+    // ------------------------------------------------------------------
+    @Override
+    public void onPacketData(INetworkManager manager, Packet250CustomPayload packet, Player player) {
+        try {
+            SkinMessage message = SkinMessage.decode(packet.data);
+            if (accepts(message)) {
+                wirePng = message.getTexturePng();
+                broadcastReceived = true;
+                FMLLog.info("ES_E2E_OBSERVER_BROADCAST=received player=%s pngBytes=%d",
+                    message.getPlayerName(), message.getTexturePng().length);
+            } else {
+                FMLLog.info("ES_E2E_OBSERVER_BROADCAST=ignored player=%s (no inline png)",
+                    message == null ? "?" : message.getPlayerName());
+            }
+        } catch (RuntimeException e) {
+            FMLLog.warning("ES_E2E_OBSERVER_BROADCAST=malformed payload (%s)", e.toString());
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Scheduled tick machine (client ticks run on the render thread).
+    // ------------------------------------------------------------------
+    @Override
+    public void tickStart(EnumSet<TickType> types, Object... tickData) {
+        try {
+            tick();
+        } catch (Throwable t) {
+            FMLLog.severe("ES_E2E_OBSERVER=crash phase=%s (%s)", phase, t);
+            fail(3, false, "driver crash: " + t);
+        }
+    }
+
+    @Override
+    public void tickEnd(EnumSet<TickType> types, Object... tickData) {
+    }
+
+    @Override
+    public EnumSet<TickType> ticks() {
+        return EnumSet.of(TickType.CLIENT);
+    }
+
+    @Override
+    public String getLabel() {
+        return "everlastingskins-e2e-observer";
+    }
+
+    @Override
+    public int nextTickSpacing() {
+        return 1;
+    }
+
+    private void tick() throws Exception {
+        switch (phase) {
+            case WAIT_JOIN:
+                if (isJoined()) {
+                    // The observer runs NO commands — the join marker is the
+                    // orchestration signal (e2e-common.sh launches the actor
+                    // only after this line appears in the observer log).
+                    FMLLog.info("ES_E2E_JOIN=%s", OBSERVER_USERNAME);
+                    advance(Phase.WAIT_BROADCAST);
+                } else if (timedOut(JOIN_TIMEOUT_MS)) {
+                    fail(2, false, "join timeout");
+                }
+                break;
+            case WAIT_BROADCAST:
+                if (broadcastReceived) {
+                    advance(Phase.RENDER_ASSERT);
+                } else if (timedOut(BROADCAST_TIMEOUT_MS)) {
+                    fail(2, true, "broadcast timeout");
+                }
+                break;
+            case RENDER_ASSERT:
+                if (assertObserver()) {
+                    FMLLog.info("ES_E2E_OBSERVER_RENDERER=ok state=%s", observerState);
+                    writeResultAndExit(0);
+                } else if (timedOut(ASSERT_TIMEOUT_MS)) {
+                    FMLLog.severe("ES_E2E_OBSERVER_RENDERER=FAIL state=%s", lastPollState);
+                    fail(1, true, "observer assertion failed: " + lastPollState);
+                }
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void advance(Phase next) {
+        phase = next;
+        phaseStartedAt = System.currentTimeMillis();
+    }
+
+    private boolean timedOut(long budgetMs) {
+        return System.currentTimeMillis() - phaseStartedAt > budgetMs;
+    }
+
+    // ------------------------------------------------------------------
+    // Join + target lookup (all reflection; no commands).
+    // ------------------------------------------------------------------
+    private Object minecraft() throws Exception {
+        return call(loadClass(CLS_MC), M_GET_MC, null, null);
+    }
+
+    private boolean isJoined() throws Exception {
+        Object mc = minecraft();
+        Object world = field(mc, F_THE_WORLD);
+        Object player = field(mc, F_THE_PLAYER);
+        return world != null && player != null;
+    }
+
+    private File gameDir() throws Exception {
+        Object mc = minecraft();
+        return (File) field(mc, F_MC_DIR);
+    }
+
+    /**
+     * Finds the TARGET player (the actor, by username) in the observer's
+     * client world — the same surface the real handler's
+     * {@code ClientSkinApplier.findPlayer} uses.
+     */
+    private Object findTargetPlayer() throws Exception {
+        Object mc = minecraft();
+        Object world = field(mc, F_THE_WORLD);
+        if (world == null) {
+            return null;
+        }
+        Object players = field(world, F_WORLD_PLAYERS);
+        if (!(players instanceof List)) {
+            return null;
+        }
+        for (Object candidate : (List<?>) players) {
+            if (candidate == null) {
+                continue;
+            }
+            Object name = call(candidate, M_GET_NAME, null, null);
+            if (TEST_PLAYER.equals(name)) {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+    // ------------------------------------------------------------------
+    // Observer assertion (lib-23 gap (d)): the TARGET player's skin TDI
+    // must ALREADY hold the sentinel pixels — injected by the REAL
+    // ClientSkinHandler from the wire, NOT self-injected. The driver never
+    // writes the image field. Polled by the tick machine until the actor's
+    // connection re-broadcast lands.
+    // ------------------------------------------------------------------
+    private boolean assertObserver() throws Exception {
+        // 1) Wire proof: the captured broadcast PNG must be the sentinel
+        //    (pixel-for-pixel vs the sentinel file in the observer gameDir).
+        BufferedImage sentinel = readSentinel(gameDir());
+        if (sentinel == null) {
+            lastPollState = "sentinel-unreadable";
+            FMLLog.severe("ES_E2E_OBSERVER_RENDERER=sentinel unreadable");
+            return false;
+        }
+        if (!E2EResult.isSentinelImage(sentinel)) {
+            lastPollState = "sentinel-contract-violated";
+            FMLLog.severe("ES_E2E_OBSERVER_RENDERER=sentinel pixel contract violated");
+            return false;
+        }
+        if (wirePng != null) {
+            BufferedImage wire = decodePng(wirePng);
+            if (wire == null || !E2EResult.pixelsEqual(wire, sentinel)) {
+                lastPollState = "wire-png-mismatch";
+                FMLLog.severe("ES_E2E_OBSERVER_RENDERER=wire png mismatch");
+                return false;
+            }
+        } else {
+            lastPollState = "wire-png-missing";
+            FMLLog.severe("ES_E2E_OBSERVER_RENDERER=no wire png captured");
+            return false;
+        }
+
+        // 2) The target player must be spawned in the observer's world.
+        Object target = findTargetPlayer();
+        if (target == null) {
+            // Keep polling: the actor may not be in-world yet when the
+            // first (dropped) re-broadcast fired.
+            lastPollState = "target-not-spawned";
+            return false;
+        }
+
+        // 3) Defeat the vanilla download-thread race: the dead
+        //    skins.minecraft.net download must not overwrite the handler's
+        //    injection while we read the field.
+        Object tdi = call(target, M_GET_TEXTURE_SKIN, null, null);
+        if (tdi == null) {
+            lastPollState = "target-tdi-missing";
+            return false;
+        }
+        Object thread = field(tdi, F_TDI_THREAD);
+        if (thread instanceof Thread) {
+            Thread t = (Thread) thread;
+            if (t.isAlive()) {
+                t.interrupt();
+                try {
+                    t.join(DOWNLOAD_THREAD_JOIN_MS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        }
+
+        // 4) THE assertion: the live TDI field holds the sentinel pixels —
+        //    the REAL handler's wire injection (the observer never writes
+        //    this field). Pixel-content compare, not just field presence.
+        Object live = field(tdi, F_TDI_IMAGE);
+        if (!(live instanceof BufferedImage) || !E2EResult.pixelsEqual((BufferedImage) live, sentinel)) {
+            // Distinguish "nothing injected" from "something else injected".
+            lastPollState = live instanceof BufferedImage ? "handler-injection-mismatch"
+                : "handler-injection-missing";
+            FMLLog.info("ES_E2E_OBSERVER_RENDERER=poll %s live=%s", lastPollState, live);
+            return false;
+        }
+        observerState = "sentinel";
+        FMLLog.info("ES_E2E_OBSERVER_RENDERER=wire-injection verified target=%s", TEST_PLAYER);
+        return true;
+    }
+
+    private static BufferedImage decodePng(byte[] png) {
+        try {
+            return ImageIO.read(new ByteArrayInputStream(png));
+        } catch (IOException e) {
+            FMLLog.warning("ES_E2E_OBSERVER_RENDERER=wire png decode failed (%s)", e.toString());
+            return null;
+        }
+    }
+
+    private static BufferedImage readSentinel(File gameDir) {
+        File png = new File(gameDir, "e2e-sentinel.png");
+        try {
+            return ImageIO.read(png);
+        } catch (IOException e) {
+            FMLLog.warning("ES_E2E_OBSERVER_RENDERER=sentinel read failed (%s)", e.toString());
+            return null;
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Result + exit.
+    // ------------------------------------------------------------------
+    private void fail(int exitCode, boolean joined, String reason) {
+        FMLLog.severe("ES_E2E_OBSERVER_FAIL=%s", reason);
+        writeResultAndExit(exitCode, joined, "none", false);
+    }
+
+    private void writeResultAndExit(int exitCode) {
+        writeResultAndExit(exitCode, true, observerState, true);
+    }
+
+    private void writeResultAndExit(int exitCode, boolean joined,
+                                    String rendererState, boolean rendererVerified) {
+        try {
+            File out = new File(gameDir(), E2EResult.FILE_NAME);
+            Map<String, String> artifacts = new LinkedHashMap<String, String>();
+            artifacts.put("driver", "E2EObserverDriver/1.6.4");
+            artifacts.put("broadcast", broadcastReceived ? "received" : "none");
+            artifacts.put("wire_png_matches_sentinel",
+                wirePng == null ? "n/a" : Boolean.toString(wireMatchesSentinel()));
+            E2EResult.writeObserver(out, joined, rendererState, rendererVerified,
+                System.currentTimeMillis() - installedAt, exitCode, artifacts);
+            FMLLog.info("ES_E2E_OBSERVER_RESULT=%s code=%s", out.getAbsolutePath(), exitCode);
+        } catch (Exception e) {
+            // Never mask the outcome: a result-write failure is a hard driver
+            // failure (exit 3), not a silent success.
+            FMLLog.severe("ES_E2E_OBSERVER_FAIL=result write failed (%s)", e.toString());
+            System.exit(3);
+        }
+        System.exit(exitCode);
+    }
+
+    private boolean wireMatchesSentinel() {
+        try {
+            BufferedImage sentinel = readSentinel(gameDir());
+            BufferedImage wire = decodePng(wirePng);
+            return sentinel != null && wire != null && E2EResult.pixelsEqual(wire, sentinel);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Reflection helpers (obf-domain access) — same surface as E2EDriver.
+    // ------------------------------------------------------------------
+    private static Class<?> loadClass(String name) throws ClassNotFoundException {
+        ClassNotFoundException first = null;
+        // The runtime MC classes load through the launch classloader's
+        // findClass (the FML-transformed copies live in its cache). Plain
+        // loadClass() is parent-first and delegates to the AppClassLoader,
+        // yielding a second, uninitialized copy whose static singleton
+        // (getMinecraft) is null — so call findClass() directly.
+        ClassLoader launch = launchClassLoader();
+        if (launch != null) {
+            try {
+                return (Class<?>) launch.getClass()
+                    .getMethod("findClass", String.class).invoke(launch, name);
+            } catch (Exception e) {
+                first = new ClassNotFoundException(name, e);
+            }
+        }
+        ClassLoader[] chain = {
+            ClassLoader.getSystemClassLoader(),
+            E2EObserverDriver.class.getClassLoader(),
+            Thread.currentThread().getContextClassLoader(),
+        };
+        for (ClassLoader loader : chain) {
+            if (loader == null) {
+                continue;
+            }
+            try {
+                return Class.forName(name, false, loader);
+            } catch (ClassNotFoundException e) {
+                if (first == null) {
+                    first = e;
+                }
+            }
+        }
+        throw first != null ? first : new ClassNotFoundException(name);
+    }
+
+    private static ClassLoader launchClassLoader() {
+        try {
+            return (ClassLoader) Class.forName("net.minecraft.launchwrapper.Launch")
+                .getField("classLoader").get(null);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static Object field(Object target, String name) throws Exception {
+        return fieldOn(target.getClass(), target, name);
+    }
+
+    private static Object fieldOn(Class<?> clazz, Object target, String name) throws Exception {
+        Field f = findField(clazz, name);
+        return f.get(target);
+    }
+
+    private static Field findField(Class<?> clazz, String name) throws NoSuchFieldException {
+        for (Class<?> c = clazz; c != null; c = c.getSuperclass()) {
+            try {
+                Field f = c.getDeclaredField(name);
+                f.setAccessible(true);
+                return f;
+            } catch (NoSuchFieldException e) {
+                // walk up
+            }
+        }
+        throw new NoSuchFieldException(clazz.getName() + "." + name);
+    }
+
+    private static Object call(Object target, String name, Class<?>[] paramTypes, Object[] args) throws Exception {
+        // Static entry: the target may be the Class object itself (the
+        // method lives on the loaded class, not on java.lang.Class).
+        Class<?> clazz = target instanceof Class ? (Class<?>) target : target.getClass();
+        Method m = findMethod(clazz, name, paramTypes);
+        return m.invoke(target, args);
+    }
+
+    private static Method findMethod(Class<?> clazz, String name, Class<?>[] paramTypes) throws NoSuchMethodException {
+        for (Class<?> c = clazz; c != null; c = c.getSuperclass()) {
+            try {
+                Method m = c.getDeclaredMethod(name, paramTypes);
+                m.setAccessible(true);
+                return m;
+            } catch (NoSuchMethodException e) {
+                // walk up
+            }
+        }
+        throw new NoSuchMethodException(clazz.getName() + "." + name);
+    }
+}

--- a/forge-1.6.4/src/main/java/levosilimo/everlastingskins/e2e/E2EResult.java
+++ b/forge-1.6.4/src/main/java/levosilimo/everlastingskins/e2e/E2EResult.java
@@ -122,6 +122,30 @@ public final class E2EResult {
         Files.write(target.toPath(), toJson(doc).getBytes(StandardCharsets.UTF_8));
     }
 
+    /**
+     * Writes the OBSERVER client's result document (second-observer client,
+     * lib-23 gap (d): the observer runs no commands and proves the broadcast
+     * fan-out by asserting the REAL {@code ClientSkinHandler}'s wire
+     * injection into the target player's TDI). Fields are additive and
+     * {@code observer_}-prefixed so {@code scripts/e2e/e2e-common.sh} can
+     * merge them into the actor's document without touching any actor
+     * field (backward-compatible result contract).
+     */
+    public static void writeObserver(File target, boolean observerJoined, String rendererState,
+                                     boolean rendererVerified, long durationMs, int exitCode,
+                                     Map<String, String> artifacts) throws IOException {
+        Map<String, Object> doc = new LinkedHashMap<String, Object>();
+        doc.put("lane", "1.6.4");
+        doc.put("server_booted", false); // client cannot know; script merges
+        doc.put("observer_joined", observerJoined);
+        doc.put("observer_renderer_state", rendererState == null ? "none" : rendererState);
+        doc.put("observer_renderer_verified", rendererVerified);
+        doc.put("observer_duration_ms", durationMs);
+        doc.put("observer_exit_code", exitCode);
+        doc.put("observer_artifacts", artifacts == null ? new LinkedHashMap<String, String>() : artifacts);
+        Files.write(target.toPath(), toJson(doc).getBytes(StandardCharsets.UTF_8));
+    }
+
     /** Minimal JSON emitter (no gson dependency on the legacy classpath is guaranteed at boot). */
     public static String toJson(Map<String, Object> doc) {
         StringBuilder sb = new StringBuilder("{");

--- a/forge-1.6.4/src/main/java/levosilimo/everlastingskins/e2e/E2ESentinelHook.java
+++ b/forge-1.6.4/src/main/java/levosilimo/everlastingskins/e2e/E2ESentinelHook.java
@@ -10,6 +10,7 @@ import cpw.mods.fml.common.FMLLog;
 import cpw.mods.fml.common.network.IConnectionHandler;
 import cpw.mods.fml.common.network.NetworkRegistry;
 import cpw.mods.fml.common.network.Player;
+import levosilimo.everlastingskins.broadcast.SkinBroadcaster;
 import levosilimo.everlastingskins.skinchanger.SkinRestorer;
 import levosilimo.everlastingskins.util.CustomSkinProperty;
 import net.minecraft.server.MinecraftServer;
@@ -62,7 +63,27 @@ public final class E2ESentinelHook {
 
     public static final String TEST_PLAYER = E2EDriver.TEST_PLAYER;
 
+    /**
+     * Re-broadcast burst parameters (observer fan-out proof, lib-23 gap
+     * (d)). The observer client's real {@code ClientSkinHandler} can only
+     * inject while the actor is SPAWNED in the observer's world; the
+     * bytecode-verified 1.6.4 login ordering puts the login broadcast AHEAD
+     * of the actor's spawn packets (broadcast is queued in the login flow,
+     * spawns go out on the next EntityTracker tick), so the login broadcast
+     * is dropped by the handler (target not spawned yet) — and the ACTOR'S
+     * in-world window is ~1s (the actor driver joins, proves the command
+     * surface and exits), so any SINGLE delayed re-broadcast misses it too
+     * (measured live: re-broadcast at +10s, actor gone at +1s). A dense
+     * burst (period &lt; the actor's window) after EVERY connection
+     * deterministically lands at least one sentinel-carrying broadcast while
+     * the actor is in-world on the observer.
+     */
+    public static final long REBROADCAST_PERIOD_MS = 250L;
+    public static final int REBROADCAST_BURST_COUNT = 40;
+
     private static volatile boolean seeded;
+    /** Cached seed bytes: re-broadcast is immune to {@code /skin clear} (storage-only). */
+    private static volatile byte[] seededPng;
 
     private E2ESentinelHook() {}
 
@@ -90,6 +111,13 @@ public final class E2ESentinelHook {
         @Override
         public String connectionReceived(NetLoginHandler netHandler, INetworkManager manager) {
             seedOnce();
+            // Every connection (actor, observer, …) schedules a re-broadcast
+            // BURST of the CACHED seed bytes. The observer's delivery comes
+            // from a burst element landing inside the actor's ~1s in-world
+            // window (the actor's own connection burst starts 0.25s after it
+            // connects; the observer's burst, started earlier, also covers
+            // the actor's join).
+            scheduleRebroadcast();
             return null;
         }
 
@@ -121,8 +149,7 @@ public final class E2ESentinelHook {
         if (seeded) {
             return;
         }
-        seeded = true;
-        try {
+        seeded = true;        try {
             MinecraftServer server = cpw.mods.fml.common.FMLCommonHandler.instance()
                 .getMinecraftServerInstance();
             if (server == null) {
@@ -140,6 +167,7 @@ public final class E2ESentinelHook {
             String value = Base64.getEncoder().encodeToString(png);
             CustomSkinProperty property = new CustomSkinProperty(
                 "textures", value, "", "e2e-sentinel");
+            seededPng = png;
             java.util.UUID uuid = SkinRestorer.uuidOf(TEST_PLAYER);
             SkinRestorer.applySkin(uuid, property);
             FMLLog.info("ES_E2E_SENTINEL=seeded player=%s uuid=%s pngSha1=%s bytes=%d",
@@ -147,6 +175,47 @@ public final class E2ESentinelHook {
         } catch (Throwable t) {
             FMLLog.severe("ES_E2E_SENTINEL=FAIL (%s)", t.toString());
         }
+    }
+
+    /**
+     * Schedules a one-shot re-broadcast BURST of the cached seed bytes
+     * (daemon thread; nothing holds the server up). No-op until the seed has
+     * landed.
+     */
+    static void scheduleRebroadcast() {
+        if (seededPng == null) {
+            return;
+        }
+        rebroadcastThread(REBROADCAST_PERIOD_MS, REBROADCAST_BURST_COUNT).start();
+    }
+
+    /** Thread factory seam (unit-testable without timing): daemon, named, burst loop. */
+    static Thread rebroadcastThread(final long periodMs, final int count) {
+        Thread t = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                for (int i = 0; i < count; i++) {
+                    try {
+                        Thread.sleep(periodMs);
+                    } catch (InterruptedException e) {
+                        return;
+                    }
+                    rebroadcast();
+                }
+            }
+        }, "ES-E2E-rebroadcast");
+        t.setDaemon(true);
+        return t;
+    }
+
+    /** Fans the cached sentinel bytes out over the real broadcast channel (PNG inline). */
+    private static void rebroadcast() {
+        byte[] png = seededPng;
+        if (png == null) {
+            return;
+        }
+        SkinBroadcaster.broadcastProfileChange(TEST_PLAYER, png);
+        FMLLog.info("ES_E2E_SENTINEL=rebroadcast player=%s pngBytes=%d", TEST_PLAYER, png.length);
     }
 
     static byte[] readSentinelPng(MinecraftServer server) {

--- a/forge-1.6.4/src/main/java/levosilimo/everlastingskins/forge164/EverlastingSkins.java
+++ b/forge-1.6.4/src/main/java/levosilimo/everlastingskins/forge164/EverlastingSkins.java
@@ -54,7 +54,8 @@ import net.minecraft.src.Packet1Login;
  *
  * <p>Side guard: FML loads the jar on both processes, so {@link #init} keeps
  * the server bootstrap behind {@code getSide().isServer()} — on a client the
- * only client-side surface is the @NetworkMod-registered client handler.
+ * only server-side surface is skipped, while {@code E2E.install()} still runs
+ * (the in-jar E2E drivers are side-gated internally).
  */
 @Mod(
     modid = EverlastingSkins.MOD_ID,
@@ -90,7 +91,12 @@ public class EverlastingSkins {
             // Client process: the client handler is registered by @NetworkMod;
             // no server bootstrap here (the physical side is authoritative —
             // an integrated server's SERVER lifecycle still fires
-            // serverStarting/serverStopping below).
+            // serverStarting/serverStopping below). The in-jar E2E support is
+            // side-gated internally (driver on CLIENT, sentinel hook on
+            // SERVER) and MUST install on both sides — #426's server-only
+            // guard silently disabled the client driver (the 1.6.4 E2E is
+            // not in CI yet, so the regression went unnoticed).
+            E2E.install();
             return;
         }
         // :common removed init() — per-version bootstrap registers candidates

--- a/forge-1.6.4/src/test/java/levosilimo/everlastingskins/e2e/E2EObserverDriverPhaseTest.java
+++ b/forge-1.6.4/src/test/java/levosilimo/everlastingskins/e2e/E2EObserverDriverPhaseTest.java
@@ -1,0 +1,69 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.e2e;
+
+import levosilimo.everlastingskins.broadcast.SkinMessage;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Pure phase-machine tests for the in-jar OBSERVER driver (lib-23 gap (d)):
+ * the observer advances only on observed facts — join (NO commands), a
+ * PNG-carrying broadcast for the target player, then the REAL handler's
+ * wire-injection verify. Mirrors {@link E2EDriverPhaseTest}.
+ */
+public class E2EObserverDriverPhaseTest {
+
+    @Test
+    public void joinGatesOnWorldAndPlayer() {
+        assertEquals(E2EObserverDriver.Phase.WAIT_JOIN,
+            E2EObserverDriver.nextPhase(E2EObserverDriver.Phase.WAIT_JOIN, false, false, false));
+        assertEquals(E2EObserverDriver.Phase.WAIT_BROADCAST,
+            E2EObserverDriver.nextPhase(E2EObserverDriver.Phase.WAIT_JOIN, true, false, false));
+    }
+
+    @Test
+    public void pngBroadcastGatesTheObserverAssertion() {
+        assertEquals(E2EObserverDriver.Phase.WAIT_BROADCAST,
+            E2EObserverDriver.nextPhase(E2EObserverDriver.Phase.WAIT_BROADCAST, true, false, false));
+        assertEquals(E2EObserverDriver.Phase.RENDER_ASSERT,
+            E2EObserverDriver.nextPhase(E2EObserverDriver.Phase.WAIT_BROADCAST, true, true, false));
+    }
+
+    @Test
+    public void observerAssertionCompletesTheRun() {
+        assertEquals(E2EObserverDriver.Phase.RENDER_ASSERT,
+            E2EObserverDriver.nextPhase(E2EObserverDriver.Phase.RENDER_ASSERT, true, true, false));
+        assertEquals(E2EObserverDriver.Phase.DONE,
+            E2EObserverDriver.nextPhase(E2EObserverDriver.Phase.RENDER_ASSERT, true, true, true));
+        assertEquals(E2EObserverDriver.Phase.DONE,
+            E2EObserverDriver.nextPhase(E2EObserverDriver.Phase.DONE, true, true, true));
+    }
+
+    @Test
+    public void phasesNeverRegress() {
+        assertEquals(E2EObserverDriver.Phase.WAIT_BROADCAST,
+            E2EObserverDriver.nextPhase(E2EObserverDriver.Phase.WAIT_BROADCAST, false, false, false));
+        assertEquals(E2EObserverDriver.Phase.RENDER_ASSERT,
+            E2EObserverDriver.nextPhase(E2EObserverDriver.Phase.RENDER_ASSERT, true, false, false));
+    }
+
+    @Test
+    public void acceptsRequiresTargetPlayerWithInlinePng() {
+        byte[] png = {1, 2, 3};
+        assertTrue(E2EObserverDriver.accepts(new SkinMessage("TestPlayer", png)));
+        // Notification-only broadcast (no pixels to inject) is not the proof.
+        assertFalse(E2EObserverDriver.accepts(new SkinMessage("TestPlayer", null)));
+        assertFalse(E2EObserverDriver.accepts(new SkinMessage("TestPlayer", new byte[0])));
+        // Any other player's broadcast is irrelevant to the observer.
+        assertFalse(E2EObserverDriver.accepts(new SkinMessage("SomeoneElse", png)));
+        assertFalse(E2EObserverDriver.accepts(null));
+    }
+}

--- a/forge-1.6.4/src/test/java/levosilimo/everlastingskins/e2e/E2EResultTest.java
+++ b/forge-1.6.4/src/test/java/levosilimo/everlastingskins/e2e/E2EResultTest.java
@@ -67,6 +67,52 @@ public class E2EResultTest {
     }
 
     @Test
+    public void writeObserverProducesAdditiveContractJson() throws Exception {
+        File dir = new File(System.getProperty("java.io.tmpdir"), "e2e-result-observer-" + System.nanoTime());
+        assertTrue(dir.mkdirs());
+        try {
+            File out = new File(dir, "e2e-result.json");
+            Map<String, String> artifacts = new LinkedHashMap<String, String>();
+            artifacts.put("driver", "E2EObserverDriver/1.6.4");
+            artifacts.put("broadcast", "received");
+            artifacts.put("wire_png_matches_sentinel", "true");
+            E2EResult.writeObserver(out, true, "sentinel", true, 54321L, 0, artifacts);
+
+            String json = new String(java.nio.file.Files.readAllBytes(out.toPath()), StandardCharsets.UTF_8);
+            assertTrue(json.contains("\"lane\":\"1.6.4\""));
+            assertTrue(json.contains("\"server_booted\":false"));
+            assertTrue(json.contains("\"observer_joined\":true"));
+            assertTrue(json.contains("\"observer_renderer_state\":\"sentinel\""));
+            assertTrue(json.contains("\"observer_renderer_verified\":true"));
+            assertTrue(json.contains("\"observer_duration_ms\":54321"));
+            assertTrue(json.contains("\"observer_exit_code\":0"));
+            assertTrue(json.contains("\"wire_png_matches_sentinel\":\"true\""));
+            // The observer doc must NOT carry actor fields (additive contract).
+            assertFalse(json.contains("client_joined"));
+            assertFalse(json.contains("command_executed"));
+        } finally {
+            deleteRecursively(dir);
+        }
+    }
+
+    @Test
+    public void writeObserverFailureState() throws Exception {
+        File dir = new File(System.getProperty("java.io.tmpdir"), "e2e-result-observer-fail-" + System.nanoTime());
+        assertTrue(dir.mkdirs());
+        try {
+            File out = new File(dir, "e2e-result.json");
+            E2EResult.writeObserver(out, false, "handler-injection-missing", false, 999L, 1, null);
+            String json = new String(java.nio.file.Files.readAllBytes(out.toPath()), StandardCharsets.UTF_8);
+            assertTrue(json.contains("\"observer_joined\":false"));
+            assertTrue(json.contains("\"observer_renderer_state\":\"handler-injection-missing\""));
+            assertTrue(json.contains("\"observer_renderer_verified\":false"));
+            assertTrue(json.contains("\"observer_exit_code\":1"));
+        } finally {
+            deleteRecursively(dir);
+        }
+    }
+
+    @Test
     public void jsonEscapesQuotesAndBackslashes() {
         Map<String, Object> doc = new LinkedHashMap<String, Object>();
         doc.put("note", "a \"quoted\" \\ path");

--- a/forge-1.6.4/src/test/java/levosilimo/everlastingskins/e2e/E2ESentinelHookTest.java
+++ b/forge-1.6.4/src/test/java/levosilimo/everlastingskins/e2e/E2ESentinelHookTest.java
@@ -134,6 +134,27 @@ public class E2ESentinelHookTest {
         assertTrue(E2ESentinelHook.isEnabled());
     }
 
+    @Test
+    public void rebroadcastThreadIsDaemonNamedAndBursts() throws Exception {
+        Thread t = E2ESentinelHook.rebroadcastThread(60_000L, 40);
+        assertTrue(t.isDaemon());
+        assertEquals("ES-E2E-rebroadcast", t.getName());
+        // A short-period burst must run to completion (count shots) and
+        // finish; interruption aborts the burst early.
+        Thread t2 = E2ESentinelHook.rebroadcastThread(10L, 3);
+        t2.start();
+        t2.join(5_000L);
+        assertFalse(t2.isAlive());
+        // The broadcast action itself is exercised on the wire by the live
+        // E2E (the observer's fan-out assertion is the end-to-end proof).
+    }
+
+    @Test
+    public void scheduleRebroadcastIsNoopBeforeSeed() {
+        // No cached seed yet — scheduling must not throw or spawn threads.
+        E2ESentinelHook.scheduleRebroadcast();
+    }
+
     private static byte[] sentinelBytes() throws Exception {
         InputStream in = E2ESentinelHookTest.class.getResourceAsStream("/e2e/sentinel-64x32.png");
         assertNotNull("sentinel PNG must be on the test classpath", in);

--- a/scripts/e2e/drivers/pre18-xvfb.sh
+++ b/scripts/e2e/drivers/pre18-xvfb.sh
@@ -29,6 +29,15 @@
 # -Deverlastingskins.e2e=true) runs the phase machine and writes
 # e2e-result.json into the gameDir.
 #
+# E2E_ROLE selects WHICH in-jar driver boots (lib-23 gap (d), observer
+# fan-out proof):
+#   actor    (default) — -Deverlastingskins.e2e=true, --username TestPlayer
+#             (E2E_USERNAME); result copied to $RUNNER_TMP/e2e-result.json
+#   observer — -Deverlastingskins.e2e.observer=true, --username
+#             ObserverPlayer, NO commands; result copied to
+#             $RUNNER_TMP/e2e-result-observer.json
+# The observer role is used by e2e-common.sh's two-client orchestration.
+#
 # The client jar and every library are fetched into the shared e2e cache
 # with pinned sha1s (client jar sha1 is what keeps the driver's referenced
 # member names stable). Java 8 is a HARD requirement (launchwrapper dies on
@@ -42,7 +51,9 @@
 #   E2E_SERVER_HOST     test server host (default 127.0.0.1)
 #   E2E_SERVER_PORT     test server port (default 25565)
 #   E2E_JAVA8           Java 8 binary (default $JAVA_HOME)
-#   E2E_USERNAME        offline player (default TestPlayer)
+#   E2E_USERNAME        offline player (default TestPlayer; the observer role
+#                       ignores this and uses ObserverPlayer)
+#   E2E_ROLE            actor (default) | observer
 #
 # Exit codes (master-plan contract): 0 all green | 1 assertion failed |
 # 2 retryable infra (boot/join timeout, artifact fetch) | 3 hard failure.
@@ -60,7 +71,24 @@ source "$E2E_DRIVER_DIR/lib.sh"
 : "${E2E_SERVER_PORT:=25565}"
 : "${E2E_JAVA8:?pre18-xvfb.sh: E2E_JAVA8 (Java 8) is required}"
 : "${E2E_USERNAME:=TestPlayer}"
+: "${E2E_ROLE:=actor}"
 : "${E2E_CLIENT_TIMEOUT_S:=300}"
+
+case "$E2E_ROLE" in
+    actor|observer) ;;
+    *) e2e_fail "pre18-xvfb.sh: unknown E2E_ROLE '$E2E_ROLE' (actor|observer)" ;;
+esac
+
+if [ "$E2E_ROLE" = observer ]; then
+    # The observer is a NON-ACTOR client: distinct username (no commands,
+    # no op needed) and the observer in-jar driver (E2EObserverDriver).
+    E2E_USERNAME="ObserverPlayer"
+    E2E_JVM_PROPERTY="-Deverlastingskins.e2e.observer=true"
+    RESULT_COPY="$RUNNER_TMP/e2e-result-observer.json"
+else
+    E2E_JVM_PROPERTY="-Deverlastingskins.e2e=true"
+    RESULT_COPY="$RUNNER_TMP/e2e-result.json"
+fi
 
 # ---------------------------------------------------------------------------
 # Pinned client artifacts per era/lane (lib-8 + slice-1 empirical pinning).
@@ -227,7 +255,6 @@ JAVA8_BIN="$E2E_JAVA8"
 
 export LIBGL_ALWAYS_SOFTWARE=1
 export GALLIUM_DRIVER=llvmpipe
-
 if [ "$E2E_ERA" = "1.6.4-tweaker" ]; then
     e2e_log "launching client (xvfb + Mesa llvmpipe, tweaker model)..."
     # shellcheck disable=SC2086
@@ -235,7 +262,7 @@ if [ "$E2E_ERA" = "1.6.4-tweaker" ]; then
         timeout --kill-after=10 "$E2E_CLIENT_TIMEOUT_S" \
         xvfb-run -a "$JAVA8_BIN" -Xmx1G -Xms512M \
         -Djava.library.path="$E2E_CLIENT_DIR/natives" \
-        -Deverlastingskins.e2e=true \
+        $E2E_JVM_PROPERTY \
         -Dfml.ignoreInvalidMinecraftCertificates=true \
         -Dfml.ignorePatchDiscrepancies=true \
         -cp "$CP" net.minecraft.launchwrapper.Launch \
@@ -299,8 +326,13 @@ if [ ! -f "$RESULT_FILE" ]; then
     exit 2
 fi
 
-cp "$RESULT_FILE" "$RUNNER_TMP/e2e-result.json"
-CODE=$(python3 -c "import json; print(json.load(open('$RESULT_FILE')).get('exit_code', 3))")
+cp "$RESULT_FILE" "$RESULT_COPY"
+if [ "$E2E_ROLE" = observer ]; then
+    CODE=$(python3 -c "import json; print(json.load(open('$RESULT_FILE')).get('observer_exit_code', 3))")
+else
+    CODE=$(python3 -c "import json; print(json.load(open('$RESULT_FILE')).get('exit_code', 3))")
+fi
+e2e_log "driver result ($E2E_ROLE): exit_code=$CODE"
 e2e_log "driver result: exit_code=$CODE"
 kill_tree "$CLIENT_PID" 2>/dev/null || true
 exit "$CODE"

--- a/scripts/e2e/e2e-common.sh
+++ b/scripts/e2e/e2e-common.sh
@@ -4,10 +4,16 @@
 #
 # Flow: prepare server dir (mods/, sentinel, server.properties) → boot the
 # real server (bg) → wait for the vanilla "For help, type \"help\"" boot
-# line → invoke the era client driver script → merge the driver's
-# gameDir result into ${RUNNER_TMP}/e2e-result.json → assert the contract
-# fields → map exit codes (0 all green | 1 assertion failed | 2 retryable
-# infra | 3 build/hard failure).
+# line → launch the OBSERVER client (no commands) and wait for its join
+# marker → launch the ACTOR client (era driver) → wait for BOTH result
+# files → merge actor + observer documents into
+# ${RUNNER_TMP}/e2e-result.json (observer_* fields additive) → assert the
+# contract fields → map exit codes (0 all green | 1 assertion failed | 2
+# retryable infra | 3 build/hard failure). The serialized launch (observer
+# FIRST) makes the fan-out delivery deterministic: the observer is in-world
+# before the actor joins, so the sentinel hook's post-connection
+# re-broadcast lands the PNG on the wire after the actor is spawned on the
+# observer (lib-23 gap (d) coverage).
 #
 # Era deltas (E2E_ERA, default "1.6.4-tweaker"):
 #   - 1.6.4-tweaker: server boots as cpw.mods.fml.relauncher.ServerLaunchWrapper
@@ -166,6 +172,11 @@ cleanup() {
     if [ -n "$SERVER_PID" ]; then
         kill_tree "$SERVER_PID" 2>/dev/null || true
     fi
+    # The observer script's own client is reaped by its 420s timeout if this
+    # run fails early (no pkill by project policy).
+    if [ -n "${OBSERVER_SCRIPT_PID:-}" ]; then
+        kill "$OBSERVER_SCRIPT_PID" 2>/dev/null || true
+    fi
 }
 trap cleanup EXIT
 
@@ -190,7 +201,41 @@ fi
 e2e_log "server booted (For help, type \"help\")"
 
 # ---------------------------------------------------------------------------
-# Client driver (era-specific)
+# Observer client FIRST (serialized launch, lib-23 gap (d)): the observer
+# must be in-world BEFORE the actor joins, so the sentinel hook's delayed
+# re-broadcast (10s after the actor's connection) lands the PNG on the wire
+# after the actor is spawned in the observer's world. The observer runs NO
+# commands; its join marker (ES_E2E_JOIN in its client log) gates the actor
+# launch.
+# ---------------------------------------------------------------------------
+OBSERVER_DIR="$RUNNER_TMP/client-$E2E_LANE-observer"
+OBSERVER_LOG="$OBSERVER_DIR/client.log"
+OBSERVER_RESULT="$RUNNER_TMP/e2e-result-observer.json"
+OBSERVER_SCRIPT_PID=""
+# The observer's process budget is longer than the actor's: its assert phase
+# polls the TDI until the actor's re-broadcast injection lands.
+set +e
+E2E_CLIENT_DIR="$OBSERVER_DIR" \
+E2E_ROLE=observer \
+E2E_CLIENT_TIMEOUT_S=420 \
+E2E_MOD_JAR="$E2E_MOD_JAR" \
+E2E_SENTINEL_PNG="$E2E_SENTINEL_PNG" \
+E2E_SERVER_HOST="127.0.0.1" \
+E2E_SERVER_PORT="$E2E_SERVER_PORT" \
+E2E_JAVA8="$JAVA8_BIN" \
+bash "$E2E_DRIVER_SCRIPT" &
+OBSERVER_SCRIPT_PID=$!
+set -e
+
+if ! wait_for_log "$OBSERVER_LOG" 'ES_E2E_JOIN' 240; then
+    e2e_warn "observer join timeout (tail of observer client.log follows)"
+    tail -n 40 "$OBSERVER_LOG" >&2 || true
+    exit 2
+fi
+e2e_log "observer joined (ES_E2E_JOIN)"
+
+# ---------------------------------------------------------------------------
+# Actor client (era-specific) — launched only after the observer is in-world.
 # ---------------------------------------------------------------------------
 # Drop any stale result doc from a previous run: a driver timeout must never
 # be masked by an old driver's result file (observed live: a failed 1.6.4
@@ -198,6 +243,7 @@ e2e_log "server booted (For help, type \"help\")"
 rm -f "$RESULT_JSON"
 set +e
 E2E_CLIENT_DIR="$RUNNER_TMP/client-$E2E_LANE" \
+E2E_ROLE=actor \
 E2E_MOD_JAR="$E2E_MOD_JAR" \
 E2E_SENTINEL_PNG="$E2E_SENTINEL_PNG" \
 E2E_SERVER_HOST="127.0.0.1" \
@@ -208,10 +254,29 @@ DRIVER_CODE=$?
 set -e
 
 # ---------------------------------------------------------------------------
+# Wait for the observer's result file (the observer script runs in the
+# background; its own wait loop caps at E2E_CLIENT_TIMEOUT_S).
+# ---------------------------------------------------------------------------
+i=0
+while [ "$i" -lt 240 ] && [ ! -f "$OBSERVER_RESULT" ]; do
+    if ! kill -0 "$OBSERVER_SCRIPT_PID" 2>/dev/null && [ ! -f "$OBSERVER_RESULT" ]; then
+        # Observer script exited without producing a result — boot failure.
+        break
+    fi
+    sleep 2
+    i=$((i + 2))
+done
+
+# ---------------------------------------------------------------------------
 # Assemble the final contract doc + assertions
 # ---------------------------------------------------------------------------
 if [ ! -f "$RESULT_JSON" ]; then
     e2e_warn "no driver result (driver exit $DRIVER_CODE)"
+    exit 2
+fi
+if [ ! -f "$OBSERVER_RESULT" ]; then
+    e2e_warn "no observer result (observer script exit $OBSERVER_SCRIPT_PID)"
+    tail -n 40 "$OBSERVER_LOG" >&2 || true
     exit 2
 fi
 
@@ -220,7 +285,7 @@ fi
 kill_tree "$SERVER_PID" 2>/dev/null || true
 SERVER_PID=""
 
-assemble_result "true" "$RESULT_JSON"
+assemble_result "true" "$RESULT_JSON" "$OBSERVER_RESULT"
 
 # Driver exit code FIRST (audit lib-20): the driver's exit_code is the
 # authoritative mid-flow outcome and must be interpreted BEFORE the hard
@@ -229,12 +294,13 @@ assemble_result "true" "$RESULT_JSON"
 # impossible. Contract (master plan): 0 all green | 1 assertion failed |
 # 2 retryable infra | 3 build failure (script-side, e2e_fail).
 DRIVER_FINAL_CODE=$(result_exit_code)
-if [ "$DRIVER_FINAL_CODE" -eq 2 ]; then
-    e2e_warn "RETRYABLE: driver reported infra failure (exit 2)"
+OBSERVER_FINAL_CODE=$(observer_exit_code)
+if [ "$DRIVER_FINAL_CODE" -eq 2 ] || [ "$OBSERVER_FINAL_CODE" -eq 2 ]; then
+    e2e_warn "RETRYABLE: driver/observer reported infra failure (exit 2)"
     exit 2
 fi
-if [ "$DRIVER_FINAL_CODE" -ne 0 ]; then
-    e2e_warn "FAIL: driver exit code $DRIVER_FINAL_CODE"
+if [ "$DRIVER_FINAL_CODE" -ne 0 ] || [ "$OBSERVER_FINAL_CODE" -ne 0 ]; then
+    e2e_warn "FAIL: driver exit code $DRIVER_FINAL_CODE, observer exit code $OBSERVER_FINAL_CODE"
     exit 1
 fi
 
@@ -245,6 +311,9 @@ assert_result "client_joined" "True"
 assert_result "command_executed" "True"
 assert_result "renderer_state" "sentinel"
 assert_result "renderer_verified" "True"
+assert_result "observer_joined" "True"
+assert_result "observer_renderer_state" "sentinel"
+assert_result "observer_renderer_verified" "True"
 
 e2e_log "e2e complete: exit_code=0 duration_ms=$(python3 -c "import json; print(json.load(open('$RESULT_JSON')).get('duration_ms'))")"
 e2e_log "PASS: real-client E2E ($E2E_LANE) all green"

--- a/scripts/e2e/lib.sh
+++ b/scripts/e2e/lib.sh
@@ -118,22 +118,31 @@ seed_fml_libdir() {
 # ---------------------------------------------------------------------------
 # Result contract helpers
 # ---------------------------------------------------------------------------
-# assemble_result <server_booted> — merges script-side facts into the final
-# ${RUNNER_TMP}/e2e-result.json. The in-jar driver writes its client-side
-# document (client_joined, command_executed, renderer_state,
-# renderer_verified, duration_ms, exit_code, artifacts) to the client
-# gameDir; this replaces the client's server_booted:false placeholder.
+# assemble_result <server_booted> [actor_json] [observer_json] — merges
+# script-side facts into the final ${RUNNER_TMP}/e2e-result.json. The in-jar
+# driver writes its client-side document (client_joined, command_executed,
+# renderer_state, renderer_verified, duration_ms, exit_code, artifacts) to
+# the client gameDir; the observer driver writes its own document
+# (observer_joined, observer_renderer_state, observer_renderer_verified,
+# observer_exit_code, ...). This replaces the client's server_booted:false
+# placeholder and appends every observer_* field (additive, backward-
+# compatible: actor fields are untouched).
 assemble_result() {
-    local server_booted="$1" client_json="${2:-}"
+    local server_booted="$1" client_json="${2:-}" observer_json="${3:-}"
     if [ -z "$client_json" ] || [ ! -f "$client_json" ]; then
         e2e_fail "assemble_result: client result file missing ($client_json)"
     fi
-    python3 - "$client_json" "$RESULT_JSON" "$server_booted" <<'PY'
+    python3 - "$client_json" "$RESULT_JSON" "$server_booted" "$observer_json" <<'PY'
 import json, sys
-client, out, booted = sys.argv[1], sys.argv[2], sys.argv[3] == "true"
+client, out, booted, obs = sys.argv[1], sys.argv[2], sys.argv[3] == "true", sys.argv[4]
 doc = json.load(open(client))
 doc["lane"] = doc.get("lane", "1.6.4")
 doc["server_booted"] = booted
+if obs:
+    observer = json.load(open(obs))
+    for k, v in observer.items():
+        if k.startswith("observer_"):
+            doc[k] = v
 with open(out, "w") as f:
     json.dump(doc, f, indent=2)
 PY
@@ -154,6 +163,11 @@ assert_result() {
 # result_exit_code — the driver's exit code from the final doc.
 result_exit_code() {
     python3 -c "import json; print(json.load(open('$RESULT_JSON')).get('exit_code', 3))"
+}
+
+# observer_exit_code — the observer driver's exit code from the final doc.
+observer_exit_code() {
+    python3 -c "import json; print(json.load(open('$RESULT_JSON')).get('observer_exit_code', 3))"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Design

Adds the SECOND-OBSERVER client to the pre-1.8 real-client E2E (lib-23 coverage gap (d), ranked #3): an actor client runs `/skin`; a NON-ACTOR observer client (NO commands) must receive the broadcast and render the sentinel. Built on forge-1.6.4 (reference lane); structured so 1.5.2/1.4.7 ports follow (per-lane copies of the driver + role-aware orchestration).

**Two clients, serialized orchestration** (`e2e-common.sh`): server → observer client first (wait for its `ES_E2E_JOIN` log marker) → actor client → wait for BOTH result files → merge actor + `observer_*` fields (additive, backward-compatible) → assert 8 gates → exit map (0/1/2/3 contract).

## Observer assertion semantics — REAL handler injection from the wire, NOT self-injection

`E2EObserverDriver` never writes the image field. The observer's real `ClientSkinHandler` (#426, the shipped handler) receives the broadcast (`SkinMessage` with the PNG bytes inline), decodes and injects into the TARGET player's `ThreadDownloadImageData`. The observer driver asserts the TARGET player's TDI **already holds** the sentinel pixels (`pixelsEqual` vs the sentinel file) + the wire PNG matches the sentinel file pixel-for-pixel (`wire_png_matches_sentinel` artifact) — proving the broadcast fanned out AND the real handler injected (vs the actor's self-injection, which is unchanged).

## Two bytecode-verified findings that shaped the design

1. **The login broadcast cannot deliver to the observer's handler.** 1.6.4 login ordering (verified in the FML-patched `ServerConfigurationManager`/`NetLoginHandler`): the broadcast is queued in the login flow; the actor's spawn packets to the observer go out on the NEXT `EntityTracker` tick — so the observer receives `[broadcast][spawn]` and `ClientSkinHandler` drops it (target not spawned). Additionally the actor's in-world window is only ~1s (it joins, proves the command surface, exits) — measured live.
2. **#426 regression (unnoticed — the 1.6.4 E2E is not in CI yet):** `EverlastingSkins.init()` moved `E2E.install()` behind the server-only guard, so the client-side E2E driver NEVER installed since #426. Fixed: `E2E.install()` now runs on both sides (it is side-gated internally).

**Delivery seam (E2E-only, property-gated):** `E2ESentinelHook` caches the seed bytes and fires a re-broadcast BURST (0.25s period × 40) after every connection — a burst element deterministically lands inside the actor's ~1s in-world window, the real handler injects, and the observer's RENDER_ASSERT polls the TDI (180s) until the injection is visible. The seeded property cannot carry the PNG (its value is base64 bytes, not a texture URL), so the burst broadcasts the cached seed bytes directly; immune to the actor's `/skin clear`.

## Result contract (backward-compatible)

Actor fields unchanged (`client_joined`, `command_executed`, `renderer_state`, `renderer_verified`, `exit_code`, `artifacts`); observer fields additive (`observer_joined`, `observer_renderer_state`, `observer_renderer_verified`, `observer_exit_code`, `observer_duration_ms`, `observer_artifacts`).

## Live trial (xvfb, real 1.6.4 client + server, port 25603)

**PASS — both clients exit 0, all 8 assert gates green** (two consecutive full runs; run 4 first green after the burst fix, run 5 confirms determinism):

```
observer_joined: True | observer_renderer_state: sentinel | observer_renderer_verified: True
wire_png_matches_sentinel: true
actor_exit: 0 | observer_exit: 0
ES_E2E_OBSERVER_RENDERER=wire-injection verified target=TestPlayer
ES_E2E_SENTINEL=rebroadcast player=TestPlayer pngBytes=134
```

Observer proved the wire-delivered sentinel: the wire carried the exact 134-byte sentinel PNG and the target player's TDI (observer's world view) held its pixels — injected by the real #426 handler.

## Validation

- Lane build (Corretto 8) + unit tests: E2EObserverDriverPhaseTest 5, E2EResultTest 9, E2ESentinelHookTest 8, E2EDriverPhaseTest 4 — all green; actor flow byte-identical (zero diff to E2EDriver.java)
- Root gates: `:common:build` + full root `build` (JDK 21) green; test-count 433; verifyNoMixin green; vendored-harness diff-guard PASS; aislop ci --changes 0 warnings; bash -n + shellcheck (only the pre-existing SC2034)
- Actor flow unregressed: actor result identical shape + exit 0 in both live runs