### PR TITLE
test(mc1.12.2): harden SkinSyncAsyncOrderTest async-ordering (flake family #354/#334/#326)

### DIFF
--- a/common/src/test/java/levosilimo/everlastingskins/skinchanger/SkinSyncAsyncOrderTest.java
+++ b/common/src/test/java/levosilimo/everlastingskins/skinchanger/SkinSyncAsyncOrderTest.java
@@ -75,16 +75,33 @@ class SkinSyncAsyncOrderTest {
         UUID u = UUID.randomUUID();
         Path target = tempDir.resolve(u + ".json");
 
+        CustomSkinProperty stale = skin("YQ==");
         blockingStorage.setSkin(u, skin("Yg=="));
-        blockingStorage.saveSkinAsync(u, skin("YQ=="));
+        blockingStorage.saveSkinAsync(u, stale);
         // Settle barrier (mirrors the #354 terminal-metric pattern): the drain
         // runs on the lazily-created static writer thread after the 50ms
         // debounce, so on a loaded CI box it can take far longer than 5s to
         // reach the write. Await generously — once writeStarted fires the
         // drain is deterministically blocked holding the single writer thread
         // and every subsequent step is race-free.
-        assertTrue(blockingIO.writeStarted.await(GENEROUS_AWAIT_SECONDS, TimeUnit.SECONDS),
-                "drain must reach the file write before the sync save");
+        //
+        // The one-shot drainScheduled flag is suite-wide static while the
+        // pending map is per-instance, so a suite-mate's in-flight drain can
+        // consume the flag and strand this payload with no drain ever
+        // scheduled — the debounced write never starts (the lib-58
+        // lost-drain race, run 31508299301). Poll the real condition instead
+        // of racing the debounce: re-arm the drain with an idempotent
+        // saveSkinAsync (same payload — the merge is a no-op supersede; a
+        // no-op while the original drain is merely delayed, since the flag is
+        // still set) until writeStarted fires or the generous deadline passes.
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(GENEROUS_AWAIT_SECONDS);
+        while (!blockingIO.writeStarted.await(100, TimeUnit.MILLISECONDS)) {
+            if (System.nanoTime() > deadline) {
+                fail("drain must reach the file write before the sync save (writeStarted never fired within "
+                        + GENEROUS_AWAIT_SECONDS + "s; stillQueued=" + blockingStorage.hasPendingWrites() + ")");
+            }
+            blockingStorage.saveSkinAsync(u, stale); // re-arm: re-schedules the drain
+        }
 
         CountDownLatch syncDone = new CountDownLatch(1);
         ExecutorService saver = Executors.newSingleThreadExecutor();


### PR DESCRIPTION
## Failure evidence

`E2E (mc1.12.2)` run 31508299301 (1 of the last 20 runs): 518 tests / 1 failed.

```
SkinSyncAsyncOrderTest > syncSaveWaitsForInFlightDrainWrite() FAILED
    org.opentest4j.AssertionFailedError at SkinSyncAsyncOrderTest.java:86
```

Line 86 is the drain-start barrier: `assertTrue(blockingIO.writeStarted.await(GENEROUS_AWAIT_SECONDS, ...))`. The debounced drain never reached the file write within 30s.

## Root cause

Not a tight timeout — the drain was **never scheduled at all**. `SkinIO.scheduleDrain()` guards scheduling with a suite-wide **static one-shot** `drainScheduled` flag, while `pendingWrites` (and the drain's work-set) is **per-instance**:

1. A suite-mate's `saveSkinAsync` sets the static flag and schedules *its* drain (50ms debounce window).
2. This test's `saveSkinAsync` lands inside that window → `drainScheduled.getAndSet(true)` sees the flag already set → **silently skips scheduling**.
3. The suite-mate's `drainPending` iterates only *its own instance's* map; its `finally` reschedules only when *its own* map is non-empty.
4. This test's payload sits stranded in its own `pendingWrites`; no drain is ever scheduled for it → `writeStarted` never fires → 30s await times out → `AssertionFailedError` at line 86.

With 518 tests (several async saves each), the 50ms debounce window makes this a real ~1/20-run race. The sibling `SkinIODeleteRaceTest.deleteSerializedAgainstInFlightDrain` uses the same pattern with an even tighter 5s await and has the same latent exposure — left untouched to keep this change focused.

## Hardening choice: deterministic barrier (re-arm poll), not a timeout bump

The fix polls the real condition (`writeStarted`, counted down from *inside* the drain's blocked write — the #354 terminal-metric pattern) in bounded 100ms slices. If a slice elapses without the drain starting, it **re-arms the drain** with an idempotent `saveSkinAsync` (same payload — merge is a no-op supersede; a no-op while the original drain is merely delayed, since the flag is still set). Convergence is deterministic:

- Happy path: the debounced drain fires within the first slice → zero re-arms, behavior identical to before.
- Lost-drain case: the re-arm re-schedules a fresh drain → `writeStarted` fires → the test proceeds to the same race-free steps as before.

The actual FIFO assertion (2s negative probe: the sync save must NOT complete while the drain holds the single writer thread) and the final disk-state assert are **unchanged** — the test's intent (sync save waits for in-flight drain writes) is fully preserved, with the failure mode now a deterministic `fail()` carrying diagnostics (`stillQueued=` state).

## Local verification (Java 8 / Gradle 4.10.3, mc1.12.2 lane)

- `test --tests '*SkinSyncAsyncOrderTest*' --rerun-tasks` × 10 iterations: **10/10 PASS**
- Full lane suite (518 tests): **BUILD SUCCESSFUL**
- `:common:build` (root toolchain gate for the shared test file): **BUILD SUCCESSFUL**
