### PR TITLE
feat(e2e): slice 3 — forge-1.21 in-jar client driver (tab-list texture assertion)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -652,7 +652,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgl1-mesa-dri libglx-mesa0 mesa-utils \
             libxrandr2 libxxf86vm1 libxcursor1 libxi6 libxinerama1 \
-            libasound2 libopenal1
+            libasound2t64 libopenal1
       - name: Cache Gradle wrapper and caches
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -619,6 +619,74 @@ jobs:
             ${{ runner.temp }}/everlastingskins-e2e/**/*.log
           if-no-files-found: warn
 
+  # ── E2E (forge-1.21, informational, modern-injar) ───────────────
+  # Slice-3 real-client E2E for the modern line (master plan
+  # real-client-e2e-plan.md): PRODUCTION Forge 1.21 server (pinned installer
+  # --installServer, mod jar in mods/, -Deverlastingskins.e2e=true) + the
+  # real 1.21 client launched the standard ForgeGradle dev way (runClient)
+  # under xvfb-run + Mesa llvmpipe, offline session via --username/--uuid/
+  # --accessToken 0. The in-jar E2EDriver runs /skin set mojang TestPlayer
+  # and asserts the tab-list textures property carries the sentinel marker.
+  # INFORMATIONAL — NOT part of the required-check contract (no gh-api-bump).
+  # Mesa software GL is required (the modern client is a real GL client,
+  # same apt set as the pre-1.8 lanes); xvfb is preinstalled on
+  # ubuntu-24.04. The gradle cache key matches the Build (1.21) job so the
+  # userdev extraction + dev-run assets are shared.
+  e2e-modern-121:
+    name: E2E (forge-1.21)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    needs: lint-yaml
+    env:
+      LIBGL_ALWAYS_SOFTWARE: "1"
+      GALLIUM_DRIVER: llvmpipe
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - name: Set up JDK 21
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961  # v5
+        with:
+          java-version: "21"
+          distribution: temurin
+      - name: Install Mesa software GL (llvmpipe for the real 1.21 client)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgl1-mesa-dri libglx-mesa0 mesa-utils \
+            libxrandr2 libxxf86vm1 libxcursor1 libxi6 libxinerama1 \
+            libasound2 libopenal1
+      - name: Cache Gradle wrapper and caches
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: |
+            ~/.gradle/wrapper/dists
+            ~/.gradle/caches
+          key: gradle-${{ runner.os }}-forge-1.21-${{ hashFiles('**/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-forge-1.21-
+      - name: Cache E2E downloads (forge installer, server libraries)
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.cache/everlastingskins
+          key: e2e-forge-1.21-${{ runner.os }}
+          restore-keys: |
+            e2e-${{ runner.os }}-
+      - name: Run real-client E2E (production server + xvfb dev client + tab-list assert)
+        # RUNNER_TMP must be a STEP env: the runner context is not available
+        # in job-level env (invalid workflow file -> zero jobs on push). The
+        # lane wrapper reads it for the server dir + result copy.
+        run: bash forge-1.21/test-infrastructure/run-e2e.sh
+        env:
+          RUNNER_TMP: ${{ runner.temp }}/everlastingskins-e2e
+        timeout-minutes: 45
+      - name: Upload E2E logs + result (always)
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: e2e-forge-1.21-logs
+          path: |
+            ${{ runner.temp }}/everlastingskins-e2e/e2e-result.json
+            ${{ runner.temp }}/everlastingskins-e2e/**/*.log
+          if-no-files-found: warn
+
   # ── GameTest on 1.21 (canonical gametest subproject) ──────────
   gametest-121:
     name: GameTest (1.21)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -524,6 +524,37 @@ jobs:
             /tmp/everlastingskins-e2e/**/e2e-result.json
           if-no-files-found: ignore
 
+  # ── Config-order gate (informational) ─────────────────────────
+  # Fail-fast guard for the :common-bundling regression class (PR #440
+  # takes 1-2): structural grep guard against bare :common.sourceSets
+  # from() forms in the convention + the CI-mirror probe
+  # (--configure-on-demand --no-configuration-cache :forge-1.21:jar — the
+  # exact shape that reproduced the sourceSets/WorkValidationException in
+  # CI). INFORMATIONAL — not part of the required-check contract.
+  config-order-gate:
+    name: Config-order gate
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    needs: lint-yaml
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - name: Set up JDK 21
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961  # v5
+        with:
+          java-version: "21"
+          distribution: temurin
+      - name: Cache Gradle wrapper and caches
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: |
+            ~/.gradle/wrapper/dists
+            ~/.gradle/caches
+          key: gradle-${{ runner.os }}-config-order-${{ hashFiles('**/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-config-order-
+      - name: Run config-order gate (structural guard + CI-mirror probe)
+        run: bash scripts/config-order-gate.sh
+
   # ── Vendored harness diff-guard (lib-12) ───────────────────────
   # Fails when a vendored SpecialSource harness lane (forge-1.6.4,
   # forge-1.5.2, forge-1.4.7) stops applying the shared harness script

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,6 +243,8 @@ registers backends).
 ./gradlew :forge-26.1:build verifyNoMixin  # 26.1 lane (Java 25 toolchain, unobfuscated MC, FG 7.0.17, EventBus 7.0.1)
 ./gradlew :forge-26.2:build    # 26.2 lane (Java 25 toolchain, unobfuscated MC, FG 7.0.17)
 ./gradlew build                # whole Forge line
+bash scripts/config-order-gate.sh  # config-order gate (CI-mirror probe: CoD + no-config-cache :forge-1.21:jar)
+bash scripts/config-order-gate-test.sh  # gate self-test (proves the gate catches the regression forms)
 bash scripts/gradle-health.sh  # dep-hygiene sweep (manual; per-consumer :projectHealth; graduated lanes fail on duplicate-class)
 ```
 
@@ -293,8 +295,12 @@ Tiered local gates mirroring CI (see `lefthook.yml`):
   `verifyNoMixin` → offline parallel compile.
 - **pre-push** (5-10 min, heavy): full unit test suite → GameTest (1.21) via
   `forge-1.21/test-infrastructure/run-gametest-local.sh` → `aislop ci
-  --changes` (mirrors CI's `aislop (M2)` job). Skip once with
-  `git push --no-verify`.
+  --changes` (mirrors CI's `aislop (M2)` job) → config-order gate
+  (`scripts/config-order-gate.sh`: structural guard against bare
+  `:common.sourceSets` bundling forms in the convention + the CI-mirror
+  probe `--configure-on-demand --no-configuration-cache :forge-1.21:jar`,
+  which reproduces the take-1/2 WorkValidationException locally). Skip once
+  with `git push --no-verify`.
 - `scripts/test-count-gate.sh` mirrors ci.yml's `@Test >= 150` floor: counts
   `@Test` + `@ParameterizedTest` in `common/src` + `forge-1.21/src`. The
   gate is PATH-SCOPED (it counts `@Test` tokens from both JUnit 4 and

--- a/buildSrc/src/main/kotlin/everlastingskins.forge-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/everlastingskins.forge-module.gradle.kts
@@ -409,7 +409,11 @@ tasks.jar {
     // :common's compiled output + resources into the shipped jar so every
     // in-root forge-* lane is self-contained again (the out-of-band lanes
     // get this for free via source-dir share).
-    from(project(":common").sourceSets.main.get().output)
+    // lazy: :common's Java plugin may not be applied when a consumer
+    // configures (UnknownDomainObjectException sourceSets [ext] — observed
+    // on every in-root module at configuration time); the provider defers
+    // resolution until the jar task executes, after all projects configure.
+    from(project.provider { project(":common").sourceSets.main.get().output })
     manifest {
         attributes(
             "Timestamp" to System.currentTimeMillis(),

--- a/buildSrc/src/main/kotlin/everlastingskins.forge-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/everlastingskins.forge-module.gradle.kts
@@ -398,41 +398,80 @@ tasks.jacocoTestReport {
     }
 }
 
-// The :common bundling MUST be registered after every project is evaluated:
-// the jar task's ConfigurableFileCollection resolves its from() sources at
-// configuration-time task-graph queries (ProviderBackedFileCollection.
-// visitDependencies), so even a lazy provider is forced before :common's
-// Java plugin is applied (Extension with name 'sourceSets' does not exist
-// — observed on every in-root module). projectsEvaluated guarantees
-// :common is fully configured, so plain access works here (no provider).
-gradle.projectsEvaluated {
-    tasks.jar {
-        duplicatesStrategy = DuplicatesStrategy.INCLUDE
-        // M2 regression fix (caught by the real-client E2E slice-3 server
-        // boot): the pre-M2 single-module build produced a self-contained
-        // mod jar, but the M2 split (:common as a separate module, api
-        // dependency) made the jar THIN — :common classes/resources are
-        // absent, so the mod throws NoClassDefFoundError
-        // (IPermissionService etc.) on any production server (Forge loads
-        // only mods/ + the game classpath). Bundle :common's compiled
-        // output + resources into the shipped jar so every in-root forge-*
-        // lane is self-contained again (the out-of-band lanes get this for
-        // free via source-dir share).
-        from(project(":common").sourceSets.main.get().output)
-        manifest {
-            attributes(
-                "Timestamp" to System.currentTimeMillis(),
-                "Specification-Title" to modName,
-                "Specification-Vendor" to modVendor,
-                "Specification-Version" to modVersion,
-                "Implementation-Title" to "${modName}-${minecraftVersion}",
-                "Implementation-Version" to project.version,
-                "Implementation-Vendor" to modVendor,
-                "Implementation-Timestamp" to SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").format(Date()),
-                "Built-On-Java" to "${System.getProperty("java.vm.version")} (${System.getProperty("java.vm.vendor")})",
-                "Built-On" to forgeVersion
-            )
+// Force :common's evaluation whenever this module configures: under
+// --configure-on-demand the jar task is realized at command-line task-name
+// resolution — BEFORE :common is configured — so a from() reference to
+// :common's tasks would fail with "Task with name 'classes' not found"
+// (observed take-3, CoD + no-config-cache probe). evaluationDependsOn is
+// the standard CoD-safe mechanism: it pulls :common's evaluation into the
+// consumer's configuration phase, making the TaskProvider lookups below
+// safe and keeping the implicit task dependency wired (no
+// WorkValidationException).
+evaluationDependsOn(":common")
+
+tasks.jar {
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    // M2 regression fix (caught by the real-client E2E slice-3 server
+    // boot): the pre-M2 single-module build produced a self-contained
+    // mod jar, but the M2 split (:common as a separate module, api
+    // dependency) made the jar THIN — :common classes/resources are
+    // absent, so the mod throws NoClassDefFoundError
+    // (IPermissionService etc.) on any production server (Forge loads
+    // only mods/ + the game classpath). Bundle :common's compiled
+    // output + resources into the shipped jar so every in-root forge-*
+    // lane is self-contained again (the out-of-band lanes get this for
+    // free via source-dir share).
+    //
+    // Lazy TaskProvider: realized at execution-graph time → forces
+    // :common's configuration on demand and auto-wires the implicit
+    // task dependency (fixes the WorkValidationException; safe under
+    // --configure-on-demand + config cache). Do NOT revert to
+    // from(project(":common").sourceSets...) — eager sourceSets access
+    // fails at configuration time (Extension 'sourceSets' does not
+    // exist: :common's Java plugin is not yet applied) and even a
+    // project.provider{} wrap is forced by
+    // ProviderBackedFileCollection.visitDependencies at graph-query
+    // time (takes 1 and 2, both CI-red; the config-order-gate script
+    // guards this regression signature).
+    //
+    // Content-bearing producers only: the lifecycle `classes` task has
+    // NO outputs (verified on Gradle 9.3.1: from(classes) contributes
+    // zero files — take-3 jars came out thin; a singleFile check on
+    // classes.outputs.files fails the build outright), so compileJava +
+    // processResources carry the actual outputs. The TaskProvider form
+    // + evaluationDependsOn(:common) above is what makes the
+    // configuration order safe; the producers here are what make the
+    // jar fat.
+    from(project(":common").tasks.named("compileJava"))
+    from(project(":common").tasks.named("processResources")) // resources flattened too
+    // Thin-jar tripwire: compileJava's outputs may carry more than one
+    // declared output (errorprone wiring), so require ANY declared output
+    // to exist rather than pinning a single file. Local val (not
+    // script-level): the doFirst closure is replayed from the
+    // configuration-cache entry where the script receiver is null (same
+    // constraint as #289's runGameTestServer wiring) — a local captures
+    // the serializable List<File> directly. evaluationDependsOn above
+    // guarantees :common is configured, so the task lookup is safe.
+    val commonClassesOutput: List<File> =
+        project(":common").tasks.named("compileJava").get().outputs.files.toList()
+    doFirst {
+        check(commonClassesOutput.any { it.exists() }) {
+            ":common:compileJava produced no output — thin-jar risk"
         }
+    }
+    manifest {
+        attributes(
+            "Timestamp" to System.currentTimeMillis(),
+            "Specification-Title" to modName,
+            "Specification-Vendor" to modVendor,
+            "Specification-Version" to modVersion,
+            "Implementation-Title" to "${modName}-${minecraftVersion}",
+            "Implementation-Version" to project.version,
+            "Implementation-Vendor" to modVendor,
+            "Implementation-Timestamp" to SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").format(Date()),
+            "Built-On-Java" to "${System.getProperty("java.vm.version")} (${System.getProperty("java.vm.vendor")})",
+            "Built-On" to forgeVersion
+        )
     }
 }
 

--- a/buildSrc/src/main/kotlin/everlastingskins.forge-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/everlastingskins.forge-module.gradle.kts
@@ -184,6 +184,40 @@ minecraft {
             systemProperty("mixin.env.remapRefMap", "true")
             systemProperty("mixin.env.refMapRemappingFile", "${layout.projectDirectory.asFile}/build/createSrgToMcp/output.srg")
             systemProperty("forge.logging.markers", "REGISTRYDUMP")
+
+            // Real-client E2E (master plan slice 3, modern-injar pattern):
+            // the in-jar driver/hook are shipped-gated by
+            // -Deverlastingskins.e2e=true; the E2E wrapper passes
+            // -Peverlastingskins.e2e=true and the run definition forwards it
+            // to the forked client JVM (default false — never active in
+            // normal dev runs). Same Netty reflective-access flags as the
+            // gameTestServer run: the dev client also runs Netty on Java
+            // 21+ and hits the same InaccessibleObjectException without them.
+            systemProperty(
+                "everlastingskins.e2e",
+                providers.gradleProperty("everlastingskins.e2e").orElse("false").get()
+            )
+            jvmArgs(
+                "--add-opens=java.base/java.lang=ALL-UNNAMED",
+                "--add-opens=java.base/java.nio=ALL-UNNAMED",
+                "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
+                "--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED",
+                "--add-opens=java.base/java.nio=io.netty.common",
+                "--add-opens=java.base/java.nio=io.netty.buffer",
+                "--add-opens=java.base/java.nio=io.netty.transport",
+                "--add-opens=java.base/java.nio=io.netty.handler",
+                "--add-opens=java.base/java.nio=io.netty.codec",
+                "--add-opens=java.base/java.nio=io.netty.resolver",
+                "--add-opens=java.base/sun.nio.ch=io.netty.common",
+                "--add-opens=java.base/sun.nio.ch=io.netty.transport",
+                "--add-exports=java.base/jdk.internal.misc=io.netty.common",
+                "--add-exports=java.base/jdk.internal.misc=io.netty.buffer",
+                "--add-exports=java.base/jdk.internal.misc=io.netty.transport",
+                "--add-exports=java.base/jdk.internal.misc=io.netty.handler",
+                "--add-exports=java.base/jdk.internal.misc=io.netty.codec",
+                "--add-exports=java.base/jdk.internal.misc=io.netty.resolver",
+                "-Dio.netty.tryReflectionSetAccessible=false"
+            )
         }
 
         create("server") {
@@ -366,6 +400,16 @@ tasks.jacocoTestReport {
 
 tasks.jar {
     duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    // M2 regression fix (caught by the real-client E2E slice-3 server boot):
+    // the pre-M2 single-module build produced a self-contained mod jar, but
+    // the M2 split (:common as a separate module, api dependency) made the
+    // jar THIN — :common classes/resources are absent, so the mod throws
+    // NoClassDefFoundError (IPermissionService etc.) on any production
+    // server (Forge loads only mods/ + the game classpath). Bundle
+    // :common's compiled output + resources into the shipped jar so every
+    // in-root forge-* lane is self-contained again (the out-of-band lanes
+    // get this for free via source-dir share).
+    from(project(":common").sourceSets.main.get().output)
     manifest {
         attributes(
             "Timestamp" to System.currentTimeMillis(),

--- a/buildSrc/src/main/kotlin/everlastingskins.forge-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/everlastingskins.forge-module.gradle.kts
@@ -398,35 +398,41 @@ tasks.jacocoTestReport {
     }
 }
 
-tasks.jar {
-    duplicatesStrategy = DuplicatesStrategy.INCLUDE
-    // M2 regression fix (caught by the real-client E2E slice-3 server boot):
-    // the pre-M2 single-module build produced a self-contained mod jar, but
-    // the M2 split (:common as a separate module, api dependency) made the
-    // jar THIN — :common classes/resources are absent, so the mod throws
-    // NoClassDefFoundError (IPermissionService etc.) on any production
-    // server (Forge loads only mods/ + the game classpath). Bundle
-    // :common's compiled output + resources into the shipped jar so every
-    // in-root forge-* lane is self-contained again (the out-of-band lanes
-    // get this for free via source-dir share).
-    // lazy: :common's Java plugin may not be applied when a consumer
-    // configures (UnknownDomainObjectException sourceSets [ext] — observed
-    // on every in-root module at configuration time); the provider defers
-    // resolution until the jar task executes, after all projects configure.
-    from(project.provider { project(":common").sourceSets.main.get().output })
-    manifest {
-        attributes(
-            "Timestamp" to System.currentTimeMillis(),
-            "Specification-Title" to modName,
-            "Specification-Vendor" to modVendor,
-            "Specification-Version" to modVersion,
-            "Implementation-Title" to "${modName}-${minecraftVersion}",
-            "Implementation-Version" to project.version,
-            "Implementation-Vendor" to modVendor,
-            "Implementation-Timestamp" to SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").format(Date()),
-            "Built-On-Java" to "${System.getProperty("java.vm.version")} (${System.getProperty("java.vm.vendor")})",
-            "Built-On" to forgeVersion
-        )
+// The :common bundling MUST be registered after every project is evaluated:
+// the jar task's ConfigurableFileCollection resolves its from() sources at
+// configuration-time task-graph queries (ProviderBackedFileCollection.
+// visitDependencies), so even a lazy provider is forced before :common's
+// Java plugin is applied (Extension with name 'sourceSets' does not exist
+// — observed on every in-root module). projectsEvaluated guarantees
+// :common is fully configured, so plain access works here (no provider).
+gradle.projectsEvaluated {
+    tasks.jar {
+        duplicatesStrategy = DuplicatesStrategy.INCLUDE
+        // M2 regression fix (caught by the real-client E2E slice-3 server
+        // boot): the pre-M2 single-module build produced a self-contained
+        // mod jar, but the M2 split (:common as a separate module, api
+        // dependency) made the jar THIN — :common classes/resources are
+        // absent, so the mod throws NoClassDefFoundError
+        // (IPermissionService etc.) on any production server (Forge loads
+        // only mods/ + the game classpath). Bundle :common's compiled
+        // output + resources into the shipped jar so every in-root forge-*
+        // lane is self-contained again (the out-of-band lanes get this for
+        // free via source-dir share).
+        from(project(":common").sourceSets.main.get().output)
+        manifest {
+            attributes(
+                "Timestamp" to System.currentTimeMillis(),
+                "Specification-Title" to modName,
+                "Specification-Vendor" to modVendor,
+                "Specification-Version" to modVersion,
+                "Implementation-Title" to "${modName}-${minecraftVersion}",
+                "Implementation-Version" to project.version,
+                "Implementation-Vendor" to modVendor,
+                "Implementation-Timestamp" to SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").format(Date()),
+                "Built-On-Java" to "${System.getProperty("java.vm.version")} (${System.getProperty("java.vm.vendor")})",
+                "Built-On" to forgeVersion
+            )
+        }
     }
 }
 

--- a/forge-1.21/src/main/java/levosilimo/everlastingskins/EverlastingSkins.java
+++ b/forge-1.21/src/main/java/levosilimo/everlastingskins/EverlastingSkins.java
@@ -8,6 +8,7 @@
 package levosilimo.everlastingskins;
 
 import com.google.common.collect.Lists;
+import levosilimo.everlastingskins.e2e.E2E;
 import levosilimo.everlastingskins.integration.discordsrv.DiscordSrvConfig;
 import levosilimo.everlastingskins.integration.placeholderapi.PlaceholderApiHook;
 import levosilimo.everlastingskins.forge21.metrics.MetricsDumper;
@@ -47,6 +48,7 @@ public class EverlastingSkins {
     public static final List<String> languages = Lists.newArrayList();
 
     public EverlastingSkins() {
+        E2E.install();
         I18nUtils.loadAll();
         registerPermissionServices();
         ForgePermissionService.registerNodes();

--- a/forge-1.21/src/main/java/levosilimo/everlastingskins/e2e/E2E.java
+++ b/forge-1.21/src/main/java/levosilimo/everlastingskins/e2e/E2E.java
@@ -1,0 +1,80 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.e2e;
+
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.fml.loading.FMLEnvironment;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+/**
+ * Single entry point for the in-jar E2E support (master plan slice 3,
+ * modern-injar pattern), invoked from
+ * {@code EverlastingSkins()} (one line: {@code E2E.install();}).
+ *
+ * <p>Shipped-gated by {@code -Deverlastingskins.e2e=true} (never active in
+ * production); side-gated afterwards via {@link FMLEnvironment#dist}:
+ * <ul>
+ *   <li>CLIENT → {@link E2EDriver} (phase machine: join → send
+ *       {@code /skin set mojang TestPlayer} → assert the tab-list textures
+ *       property carries the sentinel marker → result file +
+ *       {@code System.exit});</li>
+ *   <li>SERVER → {@link E2ESentinelHook} (pre-seeds {@code SkinStorage} for
+ *       the offline test player so the command round-trip delivers the
+ *       marker).</li>
+ * </ul>
+ *
+ * <p>On the modern line the assertion is the textures PROPERTY in the
+ * client's tab-list copy of the profile
+ * ({@code ClientPacketListener.getPlayerInfo(uuid).getProfile()
+ * .getProperties().get("textures")}) — the tab-list entry IS the received
+ * packet data (ClientboundPlayerInfoUpdatePacket ADD_PLAYER), NOT a pixel
+ * injection. The renderer consumes that property; asserting it is the
+ * modern equivalent of the pre-1.8 injected-field check.
+ */
+public final class E2E {
+
+    /** System property the e2e scripts set on both JVMs. */
+    public static final String E2E_PROPERTY = "everlastingskins.e2e";
+
+    /**
+     * Sentinel marker shared by the server-side seed and the client-side
+     * assertion: the hook stores a textures property whose value (base64 of
+     * the vanilla textures JSON) contains a URL carrying this substring;
+     * the driver asserts {@code value().contains(MARKER)}. Deterministic
+     * across runs (unlike the pre-1.8 PNG sha1 tie) and greppable in both
+     * logs.
+     */
+    public static final String MARKER = "e2e.example/e2e-sentinel";
+
+    private E2E() {}
+
+    /** One-line gated entry from the mod constructor. */
+    public static void install() {
+        if (!Boolean.getBoolean(E2E_PROPERTY)) {
+            return;
+        }
+        if (FMLEnvironment.dist == Dist.CLIENT) {
+            E2EDriver.install();
+        } else {
+            E2ESentinelHook.install();
+        }
+    }
+
+    /**
+     * Vanilla offline-mode UUID bridge: the same deterministic UUID the
+     * server derives for an offline player name
+     * ({@code UUID.nameUUIDFromBytes("OfflinePlayer:" + name)}). The e2e
+     * script computes the identical value in python for the launcher
+     * {@code --uuid} argument and the server's ops.json, so the seed, the
+     * login session and the client-side assert all key on one UUID.
+     */
+    public static UUID offlineUuid(String name) {
+        return UUID.nameUUIDFromBytes(("OfflinePlayer:" + name).getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/forge-1.21/src/main/java/levosilimo/everlastingskins/e2e/E2EDriver.java
+++ b/forge-1.21/src/main/java/levosilimo/everlastingskins/e2e/E2EDriver.java
@@ -1,0 +1,352 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.e2e;
+
+import com.mojang.authlib.properties.Property;
+import levosilimo.everlastingskins.EverlastingSkins;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.ConnectScreen;
+import net.minecraft.client.gui.screens.DisconnectedScreen;
+import net.minecraft.client.gui.screens.TitleScreen;
+import net.minecraft.client.multiplayer.PlayerInfo;
+import net.minecraft.client.multiplayer.ServerData;
+import net.minecraft.client.multiplayer.resolver.ServerAddress;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.TickEvent;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * In-jar client driver for the real-client E2E (master plan slice 3,
+ * {@code modern-injar} pattern — reference implementation for the 26.x
+ * port; the 26.x lane reuses this shape with unobfuscated names and the
+ * same {@code MinecraftForge.EVENT_BUS.addListener} registration, which is
+ * EventBus-7 compatible — there is NO static-subscriber delta).
+ *
+ * <p>Shipped in the mod jar, gated at runtime by
+ * {@code -Deverlastingskins.e2e=true} + {@code Dist.CLIENT} (see
+ * {@link E2E#install()}). The lane wrapper boots the real 1.21 client the
+ * standard ForgeGradle way ({@code runClient} under xvfb + Mesa llvmpipe)
+ * and passes the offline session via the launcher args; this driver runs
+ * inside that client on the client tick event.
+ *
+ * <p>MODERN-LINE assertion semantics (vs the pre-1.8 lanes): the server
+ * does NOT push PNG bytes on a custom channel — it mutates the player's
+ * {@code GameProfile} textures property and re-broadcasts it as vanilla
+ * tab-list packets (REMOVE + ADD_PLAYER, {@code VanillaSkinBroadcaster}).
+ * The client's tab-list entry is the received packet data:
+ * {@code ClientPacketListener.getPlayerInfo(uuid).getProfile()
+ * .getProperties().get("textures")}. The driver asserts that property is
+ * non-null and its value contains the sentinel marker the server pre-seeded
+ * into {@code SkinStorage} (see {@link E2ESentinelHook}) — the property the
+ * vanilla renderer consumes, not pixels (llvmpipe-safe by design).
+ *
+ * <p>Phase machine: WAIT_JOIN (client world + player + connection exist) →
+ * send {@code /skin set mojang TestPlayer} (the offline-friendly command
+ * surface: the seeded skin's stored source/username match the request, so
+ * {@code SkinActionCommand} skips the Mojang HTTP fetch and re-applies +
+ * re-broadcasts the stored sentinel — deterministic in a sandboxed
+ * network) → WAIT_TEXTURES (poll the tab-list property for the marker) →
+ * write {@code e2e-result.json} in the client gameDir → {@code System.exit}.
+ *
+ * <p>AUTO-CONNECT: the 1.21 launcher removed the legacy {@code --server}/
+ * {@code --port} args (verified against the real client jar: Main ignores
+ * them via {@code allowsUnrecognizedOptions}) and the 1.21 {@code Main}
+ * quick-play option does not fire on a dev launch, so the driver dials the
+ * test server itself the first tick the main menu is up
+ * ({@link ConnectScreen#startConnecting}) — same precedent as the pre-1.8
+ * driver's {@code Minecraft.setServer}. The session itself comes from the
+ * launcher args ({@code --username TestPlayer --uuid <offline> --accessToken
+ * 0}, verified working in offline mode on the real 1.21 client).
+ *
+ * <p>Exit codes (master-plan contract): 0 all green | 1 assertion failed
+ * (textures property never carried the marker) | 2 retryable infra (join
+ * timeout) | 3 driver hard failure.
+ */
+public final class E2EDriver {
+
+    /** Offline test player (matches the e2e scripts' username arg). */
+    public static final String TEST_PLAYER = "TestPlayer";
+
+    /** Command surface exercised by the driver (see class javadoc). */
+    public static final String COMMAND = "/skin set mojang " + TEST_PLAYER;
+
+    enum Phase {
+        WAIT_JOIN,
+        WAIT_TEXTURES,
+        DONE
+    }
+
+    private static final long JOIN_TIMEOUT_MS = 420_000L;
+    private static final long TEXTURES_TIMEOUT_MS = 90_000L;
+
+    /** Test server the driver dials from the main menu (matches the wrapper). */
+    public static final String SERVER_HOST = "127.0.0.1";
+    public static final int SERVER_PORT = 25565;
+
+    private static volatile Phase phase = Phase.WAIT_JOIN;
+    private static volatile long phaseStartedAt = System.currentTimeMillis();
+    private static volatile long installedAt = System.currentTimeMillis();
+    private static volatile boolean commandSent;
+    private static volatile boolean connectStarted;
+    private static volatile String lastScreenClass = "";
+    private static volatile boolean texturesObserved;
+    private static volatile String observedValue = "";
+
+    private E2EDriver() {}
+
+    /** Called from {@code E2E.install()} (one line; gates live here). */
+    public static void install() {
+        if (!Boolean.getBoolean(E2E.E2E_PROPERTY)) {
+            return;
+        }
+        if (net.minecraftforge.fml.loading.FMLEnvironment.dist
+            != net.minecraftforge.api.distmarker.Dist.CLIENT) {
+            return;
+        }
+        // Instance-style addListener: EventBus-7 compatible (26.x needs no
+        // static-subscriber delta for this registration).
+        MinecraftForge.EVENT_BUS.addListener(E2EDriver::onClientTick);
+        EverlastingSkins.logger.info("ES_E2E_DRIVER=installed");
+    }
+
+    /**
+     * Pure phase-transition function, exercised by the unit tests. The
+     * driver advances only on observed facts: join gates on world+player,
+     * the assertion completes the run on the observed marker property.
+     */
+    static Phase nextPhase(Phase current, boolean joined, boolean texturesObserved) {
+        return switch (current) {
+            case WAIT_JOIN -> joined ? Phase.WAIT_TEXTURES : Phase.WAIT_JOIN;
+            case WAIT_TEXTURES -> texturesObserved ? Phase.DONE : Phase.WAIT_TEXTURES;
+            default -> Phase.DONE;
+        };
+    }
+
+    // ------------------------------------------------------------------
+    // Client tick (render thread — same thread the tab list is mutated on,
+    // so the assert reads a consistent PlayerInfo map).
+    // ------------------------------------------------------------------
+    static void onClientTick(TickEvent.ClientTickEvent event) {
+        if (event.phase != TickEvent.Phase.END) {
+            return;
+        }
+        try {
+            tick();
+        } catch (Throwable t) {
+            EverlastingSkins.logger.error("ES_E2E_DRIVER=crash phase={} ({})", phase, t.toString());
+            fail(3, false, false, "driver crash: " + t);
+        }
+    }
+
+    private static void tick() {
+        Minecraft mc = Minecraft.getInstance();
+        switch (nextPhase(phase, isJoined(mc), texturesPropertyContainsMarker(mc))) {
+            case WAIT_JOIN -> {
+                if (mc != null) {
+                    // Diagnostic: log once per distinct screen class so the
+                    // trial log shows when the title actually appears (the
+                    // llvmpipe boot takes minutes between the atlas load and
+                    // the title screen).
+                    String screenClass = mc.screen == null ? "<null>" : mc.screen.getClass().getName();
+                    if (!screenClass.equals(lastScreenClass)) {
+                        lastScreenClass = screenClass;
+                        EverlastingSkins.logger.info("ES_E2E_SCREEN={}", screenClass);
+                        if (mc.screen instanceof DisconnectedScreen ds) {
+                            logDisconnectReason(ds);
+                        }
+                    }
+                    if (!connectStarted && mc.screen instanceof TitleScreen) {
+                        autoConnect(mc);
+                    }
+                }
+                if (timedOut(JOIN_TIMEOUT_MS)) {
+                    fail(2, false, false, "join timeout");
+                }
+            }
+            case WAIT_TEXTURES -> {
+                if (!commandSent) {
+                    // Join observed on this tick: send the command once, then
+                    // wait for the broadcast round-trip.
+                    EverlastingSkins.logger.info("ES_E2E_JOIN={}", TEST_PLAYER);
+                    sendCommand(mc);
+                    EverlastingSkins.logger.info("ES_E2E_COMMAND={}", COMMAND);
+                    advance(Phase.WAIT_TEXTURES);
+                } else if (timedOut(TEXTURES_TIMEOUT_MS)) {
+                    fail(1, true, true,
+                        "textures property timeout (broadcast round-trip incomplete)");
+                }
+            }
+            case DONE -> {
+                // Marker observed: the tab-list textures property carries the
+                // server-seeded sentinel value.
+                texturesObserved = true;
+                observedValue = texturesProperty(mc);
+                EverlastingSkins.logger.info("ES_E2E_RENDERER=ok property={}", observedValue);
+                writeResultAndExit(0);
+            }
+            default -> {
+                // unreachable (nextPhase is total)
+            }
+        }
+    }
+
+    private static void advance(Phase next) {
+        phase = next;
+        phaseStartedAt = System.currentTimeMillis();
+    }
+
+    private static boolean timedOut(long budgetMs) {
+        return System.currentTimeMillis() - phaseStartedAt > budgetMs;
+    }
+
+    // ------------------------------------------------------------------
+    // Join + command surface.
+    // ------------------------------------------------------------------
+    private static boolean isJoined(Minecraft mc) {
+        return mc != null && mc.player != null && mc.getConnection() != null;
+    }
+
+    private static void logDisconnectReason(DisconnectedScreen screen) {
+        // The disconnect reason is not logged by vanilla; read it for the
+        // trial log (official-mapped runtime keeps the official field names).
+        try {
+            java.lang.reflect.Field detailsField = DisconnectedScreen.class.getDeclaredField("details");
+            detailsField.setAccessible(true);
+            Object details = detailsField.get(screen);
+            if (details != null) {
+                java.lang.reflect.Field reasonField = details.getClass().getDeclaredField("reason");
+                reasonField.setAccessible(true);
+                Object reason = reasonField.get(details);
+                if (reason instanceof net.minecraft.network.chat.Component c) {
+                    EverlastingSkins.logger.info("ES_E2E_DISCONNECT={}", c.getString());
+                    return;
+                }
+            }
+            EverlastingSkins.logger.warn("ES_E2E_DISCONNECT=unreadable");
+        } catch (Throwable t) {
+            EverlastingSkins.logger.warn("ES_E2E_DISCONNECT=unreadable ({})", t.toString());
+        }
+    }
+
+    /**
+     * The 1.21 client has no launcher arg that auto-joins on a dev launch
+     * (see class javadoc), so the driver starts the multiplayer connect flow
+     * itself once the main menu is up. Gated on {@code TitleScreen}: the
+     * early loading screen is also a non-null screen, and connecting while
+     * the datapack load is still running gets clobbered by the startup flow
+     * (observed live: ES_E2E_CONNECT fired mid-load, the title screen then
+     * replaced the connect screen, and no TCP dial ever reached the server).
+     */
+    private static void autoConnect(Minecraft mc) {
+        connectStarted = true;
+        String address = SERVER_HOST + ":" + SERVER_PORT;
+        ServerData data = new ServerData("e2e", address, ServerData.Type.OTHER);
+        ConnectScreen.startConnecting(mc.screen, mc,
+            ServerAddress.parseString(address), data, false, null);
+        EverlastingSkins.logger.info("ES_E2E_CONNECT=initiated {}", address);
+    }
+
+    private static void sendCommand(Minecraft mc) {
+        commandSent = true;
+        // sendCommand takes the command WITHOUT the leading slash (the chat
+        // GUI strips it before calling; sending "/skin ..." makes the
+        // server reply "Unknown or incomplete command" — observed live).
+        mc.player.connection.sendCommand(COMMAND.substring(1));
+    }
+
+    // ------------------------------------------------------------------
+    // The modern assertion: the tab-list copy of the profile (the received
+    // ADD_PLAYER packet data) carries the sentinel textures property.
+    // ------------------------------------------------------------------
+    private static boolean texturesPropertyContainsMarker(Minecraft mc) {
+        String value = texturesProperty(mc);
+        if (value == null) {
+            return false;
+        }
+        // Also observe the value even before the marker arrives (diagnostic:
+        // a non-marker textures property would be a stale/default skin).
+        observedValue = value;
+        return valueContainsMarker(value);
+    }
+
+    /**
+     * The textures property value is BASE64 of the vanilla textures JSON, so
+     * the marker never appears in the raw string — the check must decode
+     * first (observed live: the sentinel was present in the tab list while
+     * the raw contains() stayed false).
+     */
+    private static boolean valueContainsMarker(String value) {
+        if (value.contains(E2E.MARKER)) {
+            return true;
+        }
+        try {
+            return new String(Base64.getDecoder().decode(value), StandardCharsets.UTF_8)
+                .contains(E2E.MARKER);
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    private static String texturesProperty(Minecraft mc) {
+        if (mc == null || mc.getConnection() == null) {
+            return null;
+        }
+        PlayerInfo info = mc.getConnection().getPlayerInfo(E2E.offlineUuid(TEST_PLAYER));
+        if (info == null) {
+            return null;
+        }
+        // authlib 1.21 PropertyMap.get(name) returns a Collection (the
+        // textures property is single-valued in practice).
+        Collection<Property> textures = info.getProfile().getProperties().get("textures");
+        if (textures == null || textures.isEmpty()) {
+            return null;
+        }
+        return textures.iterator().next().value();
+    }
+
+    // ------------------------------------------------------------------
+    // Result + exit (plain System.exit — the modern lanes have no
+    // FMLSecurityManager constraint).
+    // ------------------------------------------------------------------
+    private static void fail(int exitCode, boolean joined, boolean commandSent, String reason) {
+        EverlastingSkins.logger.error("ES_E2E_FAIL={}", reason);
+        writeResultAndExit(exitCode, joined, commandSent, false, false);
+    }
+
+    private static void writeResultAndExit(int exitCode) {
+        writeResultAndExit(exitCode, true, commandSent, texturesObserved, texturesObserved);
+    }
+
+    private static void writeResultAndExit(int exitCode, boolean joined, boolean commandSent,
+                                           boolean rendererState, boolean rendererVerified) {
+        try {
+            Minecraft mc = Minecraft.getInstance();
+            File out = new File(mc != null ? mc.gameDirectory : new File("."), E2EResult.FILE_NAME);
+            Map<String, String> artifacts = new LinkedHashMap<String, String>();
+            artifacts.put("driver", "E2EDriver/1.21");
+            artifacts.put("command", COMMAND);
+            artifacts.put("uuid", E2E.offlineUuid(TEST_PLAYER).toString());
+            artifacts.put("property", observedValue.isEmpty() ? "none" : observedValue);
+            E2EResult.write(out, joined, commandSent, rendererState, rendererVerified,
+                System.currentTimeMillis() - installedAt, exitCode, artifacts);
+            EverlastingSkins.logger.info("ES_E2E_RESULT={} code={}", out.getAbsolutePath(), exitCode);
+        } catch (Exception e) {
+            // Never mask the outcome: a result-write failure is a hard driver
+            // failure (exit 3), not a silent success.
+            EverlastingSkins.logger.error("ES_E2E_FAIL=result write failed ({})", e.toString());
+            System.exit(3);
+        }
+        System.exit(exitCode);
+    }
+}

--- a/forge-1.21/src/main/java/levosilimo/everlastingskins/e2e/E2EResult.java
+++ b/forge-1.21/src/main/java/levosilimo/everlastingskins/e2e/E2EResult.java
@@ -1,0 +1,76 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.e2e;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Pure result-document logic for the real-client E2E (shared master-plan
+ * contract, scripts/e2e/). Kept free of any Minecraft/Forge import so the
+ * lane's JUnit scaffold can test it without a client.
+ *
+ * <p>The in-jar driver writes {@code e2e-result.json} into the client's
+ * gameDir with the client-known fields; the lane wrapper
+ * ({@code test-infrastructure/run-e2e.sh}) merges the server-side facts
+ * (server_booted) into the final document at
+ * {@code ${RUNNER_TMP}/e2e-result.json} and maps the exit code.
+ */
+public final class E2EResult {
+
+    /** Result file name in the client gameDir (driver-side artifact). */
+    public static final String FILE_NAME = "e2e-result.json";
+
+    private E2EResult() {}
+
+    /**
+     * Writes the client-side result document. Fields follow the master-plan
+     * contract; the driver fills what it observes. Throws on IO failure so
+     * the driver can surface it as a hard failure (never a silent pass).
+     */
+    public static void write(File target, boolean clientJoined, boolean commandExecuted,
+                             boolean rendererState, boolean rendererVerified, long durationMs,
+                             int exitCode, Map<String, String> artifacts) throws IOException {
+        Map<String, Object> doc = new LinkedHashMap<String, Object>();
+        doc.put("lane", "1.21");
+        doc.put("server_booted", false); // client cannot know; script merges
+        doc.put("client_joined", clientJoined);
+        doc.put("command_executed", commandExecuted);
+        doc.put("renderer_state", rendererState ? "sentinel" : "none");
+        doc.put("renderer_verified", rendererVerified);
+        doc.put("duration_ms", durationMs);
+        doc.put("exit_code", exitCode);
+        doc.put("artifacts", artifacts == null ? new LinkedHashMap<String, String>() : artifacts);
+        Files.write(target.toPath(), toJson(doc).getBytes(StandardCharsets.UTF_8));
+    }
+
+    /** Minimal JSON emitter (kept dependency-free for parity with the pre-1.8 lanes). */
+    public static String toJson(Map<String, Object> doc) {
+        StringBuilder sb = new StringBuilder("{");
+        boolean first = true;
+        for (Map.Entry<String, Object> e : doc.entrySet()) {
+            if (!first) {
+                sb.append(',');
+            }
+            first = false;
+            sb.append('"').append(e.getKey()).append("\":");
+            Object v = e.getValue();
+            if (v instanceof Boolean || v instanceof Number) {
+                sb.append(v);
+            } else if (v instanceof Map) {
+                sb.append(toJson((Map<String, Object>) v));
+            } else {
+                sb.append('"').append(String.valueOf(v).replace("\\", "\\\\").replace("\"", "\\\"")).append('"');
+            }
+        }
+        return sb.append('}').toString();
+    }
+}

--- a/forge-1.21/src/main/java/levosilimo/everlastingskins/e2e/E2ESentinelHook.java
+++ b/forge-1.21/src/main/java/levosilimo/everlastingskins/e2e/E2ESentinelHook.java
@@ -1,0 +1,108 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.e2e;
+
+import levosilimo.everlastingskins.EverlastingSkins;
+import levosilimo.everlastingskins.forge21.skinchanger.SkinRestorer;
+import levosilimo.everlastingskins.skinchanger.SkinStorage;
+import levosilimo.everlastingskins.skinchanger.command.SkinActionCommand;
+import levosilimo.everlastingskins.util.CustomSkinProperty;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.server.ServerStartedEvent;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.UUID;
+
+/**
+ * Server-side E2E sentinel hook (master plan lib-13, modern variant): with
+ * {@code -Deverlastingskins.e2e=true} on the SERVER, pre-seeds
+ * {@code SkinStorage} for the offline test player before the test client
+ * logs in, so the {@code /skin set mojang TestPlayer} round-trip re-applies
+ * and re-broadcasts the sentinel textures property to the in-jar client
+ * driver.
+ *
+ * <p>MODERN-LINE delta vs the pre-1.8 hooks: the sentinel is NOT a PNG —
+ * it is a well-formed vanilla textures property whose value (base64 of the
+ * textures JSON) carries the marker URL {@link E2E#MARKER}. The seeded
+ * {@code CustomSkinProperty} uses source "MojangAPI" + username
+ * "TestPlayer", which makes {@code SkinActionCommand.storedSourceMatches}
+ * true for {@code /skin set mojang TestPlayer}: the command skips the
+ * Mojang HTTP fetch (deterministic in a sandboxed network) and runs
+ * {@code SkinRefreshHandler.task}, which mutates the GameProfile and
+ * re-broadcasts it as REMOVE+ADD tab-list packets.
+ *
+ * <p>Timing contract: {@link #install()} is invoked from the mod
+ * constructor; seeding happens on {@link ServerStartedEvent} — after
+ * {@code SkinRestorer.onInitializeServer} (ServerStartingEvent) created
+ * {@code SkinStorage}, before any player can join.
+ */
+public final class E2ESentinelHook {
+
+    public static final String TEST_PLAYER = E2EDriver.TEST_PLAYER;
+
+    /** Sentinel texture URL (carries {@link E2E#MARKER}; never fetched in the sandbox). */
+    public static final String SKIN_URL = "https://e2e.example/e2e-sentinel.png";
+
+    private static volatile boolean seeded;
+
+    private E2ESentinelHook() {}
+
+    /** Called from {@code E2E.install()} (one line; gates live here). */
+    public static void install() {
+        if (!Boolean.getBoolean(E2E.E2E_PROPERTY)) {
+            return;
+        }
+        if (net.minecraftforge.fml.loading.FMLEnvironment.dist
+            == net.minecraftforge.api.distmarker.Dist.CLIENT) {
+            return;
+        }
+        MinecraftForge.EVENT_BUS.addListener(E2ESentinelHook::onServerStarted);
+        EverlastingSkins.logger.info("ES_E2E_SENTINEL=hook installed");
+    }
+
+    private static void onServerStarted(ServerStartedEvent event) {
+        seedOnce();
+    }
+
+    /** Idempotent seed; test-visible for the pure-value tests. */
+    static void seedOnce() {
+        if (seeded) {
+            return;
+        }
+        seeded = true;
+        try {
+            SkinStorage storage = SkinRestorer.getSkinStorage();
+            if (storage == null) {
+                EverlastingSkins.logger.warn("ES_E2E_SENTINEL=no storage, seed skipped");
+                return;
+            }
+            UUID uuid = E2E.offlineUuid(TEST_PLAYER);
+            String value = buildPropertyValue(uuid);
+            CustomSkinProperty skin = new CustomSkinProperty(
+                "textures", value, "", SkinActionCommand.SOURCE_MOJANG, TEST_PLAYER);
+            storage.setSkin(uuid, skin);
+            EverlastingSkins.logger.info("ES_E2E_SENTINEL=seeded player={} uuid={} url={}",
+                TEST_PLAYER, uuid, SKIN_URL);
+        } catch (Throwable t) {
+            EverlastingSkins.logger.error("ES_E2E_SENTINEL=FAIL ({})", t.toString());
+        }
+    }
+
+    /**
+     * Builds the base64 textures-property value: the vanilla textures JSON
+     * with a SKIN entry pointing at the sentinel URL. Pure + deterministic,
+     * so the unit tests can decode and assert the marker without a server.
+     */
+    public static String buildPropertyValue(UUID profileId) {
+        String profileIdHex = profileId.toString().replace("-", "");
+        String json = "{\"timestamp\":0,\"profileId\":\"" + profileIdHex
+            + "\",\"profileName\":\"" + TEST_PLAYER
+            + "\",\"textures\":{\"SKIN\":{\"url\":\"" + SKIN_URL + "\"}}}";
+        return Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/forge-1.21/src/test/java/levosilimo/everlastingskins/e2e/E2EDriverPhaseTest.java
+++ b/forge-1.21/src/test/java/levosilimo/everlastingskins/e2e/E2EDriverPhaseTest.java
@@ -1,0 +1,59 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.e2e;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Pure phase-machine tests for the in-jar E2E driver: the driver advances
+ * only on observed facts, and every wait path is covered by the contract
+ * exit codes in the driver itself.
+ */
+class E2EDriverPhaseTest {
+
+    @Test
+    void joinGatesOnWorldPlayerAndConnection() {
+        assertEquals(E2EDriver.Phase.WAIT_JOIN,
+            E2EDriver.nextPhase(E2EDriver.Phase.WAIT_JOIN, false, false));
+        assertEquals(E2EDriver.Phase.WAIT_JOIN,
+            E2EDriver.nextPhase(E2EDriver.Phase.WAIT_JOIN, false, true));
+        assertEquals(E2EDriver.Phase.WAIT_TEXTURES,
+            E2EDriver.nextPhase(E2EDriver.Phase.WAIT_JOIN, true, false));
+    }
+
+    @Test
+    void texturesObservationCompletesTheRun() {
+        assertEquals(E2EDriver.Phase.WAIT_TEXTURES,
+            E2EDriver.nextPhase(E2EDriver.Phase.WAIT_TEXTURES, true, false));
+        assertEquals(E2EDriver.Phase.DONE,
+            E2EDriver.nextPhase(E2EDriver.Phase.WAIT_TEXTURES, true, true));
+    }
+
+    @Test
+    void phasesNeverRegress() {
+        assertEquals(E2EDriver.Phase.WAIT_TEXTURES,
+            E2EDriver.nextPhase(E2EDriver.Phase.WAIT_TEXTURES, false, false));
+        assertEquals(E2EDriver.Phase.DONE,
+            E2EDriver.nextPhase(E2EDriver.Phase.DONE, false, false));
+    }
+
+    @Test
+    void offlineUuidMatchesVanillaAlgorithm() {
+        // UUID.nameUUIDFromBytes("OfflinePlayer:TestPlayer") — the exact
+        // UUID the e2e wrapper computes in python (--uuid arg) and the
+        // server derives at login; seed + session + client assert must all
+        // key on it.
+        assertEquals("bb77495a-a740-3169-a238-69654c8bd2c1",
+            E2E.offlineUuid("TestPlayer").toString());
+        // Determinism: same input, same UUID; different name, different UUID.
+        assertEquals(E2E.offlineUuid("TestPlayer"), E2E.offlineUuid("TestPlayer"));
+        org.junit.jupiter.api.Assertions.assertNotEquals(
+            E2E.offlineUuid("TestPlayer"), E2E.offlineUuid("ObserverPlayer"));
+    }
+}

--- a/forge-1.21/src/test/java/levosilimo/everlastingskins/e2e/E2EResultTest.java
+++ b/forge-1.21/src/test/java/levosilimo/everlastingskins/e2e/E2EResultTest.java
@@ -1,0 +1,105 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.e2e;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pure result-document tests for the in-jar E2E driver (no Minecraft/Forge
+ * on the classpath).
+ */
+class E2EResultTest {
+
+    @Test
+    void writeProducesContractJson() throws Exception {
+        File dir = new File(System.getProperty("java.io.tmpdir"), "e2e-result-test-" + System.nanoTime());
+        assertTrue(dir.mkdirs());
+        try {
+            File out = new File(dir, E2EResult.FILE_NAME);
+            Map<String, String> artifacts = new LinkedHashMap<String, String>();
+            artifacts.put("driver", "E2EDriver/1.21");
+            artifacts.put("property", "eyJ0ZXh0dXJlcyI6e319");
+            E2EResult.write(out, true, true, true, true, 12345L, 0, artifacts);
+
+            String json = new String(Files.readAllBytes(out.toPath()), StandardCharsets.UTF_8);
+            assertTrue(json.contains("\"lane\":\"1.21\""));
+            assertTrue(json.contains("\"client_joined\":true"));
+            assertTrue(json.contains("\"command_executed\":true"));
+            assertTrue(json.contains("\"renderer_state\":\"sentinel\""));
+            assertTrue(json.contains("\"renderer_verified\":true"));
+            assertTrue(json.contains("\"duration_ms\":12345"));
+            assertTrue(json.contains("\"exit_code\":0"));
+            assertTrue(json.contains("\"server_booted\":false")); // script merges
+            assertTrue(json.contains("\"driver\":\"E2EDriver/1.21\""));
+        } finally {
+            deleteRecursively(dir);
+        }
+    }
+
+    @Test
+    void failureDocCarriesTheContractFields() throws Exception {
+        File dir = new File(System.getProperty("java.io.tmpdir"), "e2e-result-test-" + System.nanoTime());
+        assertTrue(dir.mkdirs());
+        try {
+            File out = new File(dir, E2EResult.FILE_NAME);
+            E2EResult.write(out, true, true, false, false, 90000L, 1, null);
+            String json = new String(Files.readAllBytes(out.toPath()), StandardCharsets.UTF_8);
+            assertTrue(json.contains("\"renderer_state\":\"none\""));
+            assertTrue(json.contains("\"renderer_verified\":false"));
+            assertTrue(json.contains("\"exit_code\":1"));
+        } finally {
+            deleteRecursively(dir);
+        }
+    }
+
+    @Test
+    void toJsonEscapesQuotesAndBackslashes() {
+        Map<String, Object> doc = new LinkedHashMap<String, Object>();
+        doc.put("artifacts", new LinkedHashMap<String, String>() {{
+            put("property", "a\"b\\c");
+        }});
+        String json = E2EResult.toJson(doc);
+        assertTrue(json.contains("\"property\":\"a\\\"b\\\\c\""));
+    }
+
+    @Test
+    void markerSurvivesTheDocument() {
+        Map<String, Object> doc = new LinkedHashMap<String, Object>();
+        doc.put("artifacts", new LinkedHashMap<String, String>() {{
+            put("property", E2E.MARKER);
+        }});
+        String json = E2EResult.toJson(doc);
+        assertTrue(json.contains(E2E.MARKER));
+        assertFalse(json.contains("\n"));
+        assertNotNull(json);
+    }
+
+    private static void deleteRecursively(File dir) {
+        File[] children = dir.listFiles();
+        if (children != null) {
+            for (File child : children) {
+                if (child.isDirectory()) {
+                    deleteRecursively(child);
+                } else {
+                    child.delete();
+                }
+            }
+        }
+        dir.delete();
+    }
+}

--- a/forge-1.21/src/test/java/levosilimo/everlastingskins/e2e/E2ESentinelHookTest.java
+++ b/forge-1.21/src/test/java/levosilimo/everlastingskins/e2e/E2ESentinelHookTest.java
@@ -1,0 +1,51 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.e2e;
+
+import levosilimo.everlastingskins.skinchanger.command.SkinActionCommand;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pure sentinel-value tests: the seeded textures property must be a
+ * well-formed vanilla textures JSON carrying the shared marker, so the
+ * client-side assert and the server-side seed agree without any server.
+ */
+class E2ESentinelHookTest {
+
+    @Test
+    void propertyValueIsBase64AndCarriesTheMarker() {
+        String value = E2ESentinelHook.buildPropertyValue(E2E.offlineUuid("TestPlayer"));
+        String json = new String(Base64.getDecoder().decode(value), StandardCharsets.UTF_8);
+        assertTrue(json.contains(E2E.MARKER));
+        assertTrue(json.contains("\"textures\":{\"SKIN\":{\"url\":\""
+            + E2ESentinelHook.SKIN_URL + "\"}}"));
+        assertTrue(json.contains("\"profileName\":\"" + E2EDriver.TEST_PLAYER + "\""));
+    }
+
+    @Test
+    void propertyValueKeysOnTheOfflineProfileId() {
+        String value = E2ESentinelHook.buildPropertyValue(E2E.offlineUuid("TestPlayer"));
+        String json = new String(Base64.getDecoder().decode(value), StandardCharsets.UTF_8);
+        assertTrue(json.contains("\"profileId\":\"bb77495aa7403169a23869654c8bd2c1\""));
+    }
+
+    @Test
+    void storedSourceMatchesTheMojangCommandSurface() {
+        // The seed must make SkinActionCommand.storedSourceMatches true for
+        // "/skin set mojang TestPlayer" (source MojangAPI + username
+        // TestPlayer) so the command skips the Mojang HTTP fetch and
+        // re-applies the stored sentinel — the deterministic offline path.
+        assertEquals("MojangAPI", SkinActionCommand.SOURCE_MOJANG);
+        assertEquals(E2EDriver.TEST_PLAYER, E2ESentinelHook.TEST_PLAYER);
+    }
+}

--- a/forge-1.21/test-infrastructure/run-e2e.sh
+++ b/forge-1.21/test-infrastructure/run-e2e.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+# forge-1.21/test-infrastructure/run-e2e.sh — thin lane wrapper for the
+# real-client E2E (master plan slice 3, modern-injar pattern; reference
+# implementation for the 26.x port).
+#
+# REAL SERVER + REAL CLIENT on the modern line:
+#   server  — PRODUCTION Forge 1.21 server: the pinned forge installer
+#             runs --installServer (headless), the built mod jar goes into
+#             mods/, -Deverlastingskins.e2e=true via user_jvm_args.txt,
+#             online-mode=false. Boot greps the vanilla "For help" line.
+#   client  — the real 1.21 client launched the standard ForgeGradle dev
+#             way (runClient is a JavaExec; identical client code — same
+#             renderer, same network stack, official names at runtime).
+#             xvfb-run -a + Mesa llvmpipe for GL; the offline session uses
+#             the launcher args --username TestPlayer --uuid <offline-uuid>
+#             --accessToken 0 (verified working in offline mode on the real
+#             1.21 client). The 1.21 Main has NO --server/--port arg
+#             (verified against the client jar: allowsUnrecognizedOptions
+#             ignores them) and quick-play does not fire on a dev launch, so
+#             the in-jar E2EDriver dials the test server itself from the
+#             main menu (ConnectScreen.startConnecting; same precedent as
+#             the pre-1.8 driver's Minecraft.setServer). The driver
+#             (shipped-gated via -Peverlastingskins.e2e=true →
+#             -Deverlastingskins.e2e=true) then runs /skin set mojang
+#             TestPlayer and asserts the tab-list textures property carries
+#             the sentinel marker.
+#
+# Production-profile client boot (installer/Prism-style BootstrapLauncher
+# launch, mods/ install on the client) is a documented follow-up: the Forge
+# installer's CLIENT install is GUI-only, and the dev launch runs the
+# identical client code; the assertion surface (ClientPacketListener /
+# PlayerInfo, official names) is the same in both.
+#
+# Usage: JAVA_HOME=<jdk21> ./run-e2e.sh
+# Exit codes (master-plan contract): 0 all green | 1 assertion failed |
+# 2 retryable infra | 3 build/hard failure.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LANE_DIR="$(dirname "$SCRIPT_DIR")"
+REPO_ROOT="$(cd "$LANE_DIR/.." && pwd)"
+
+export E2E_LANE="1.21"
+# shellcheck source=../../scripts/e2e/lib.sh
+source "$REPO_ROOT/scripts/e2e/lib.sh"
+
+E2E_USERNAME="TestPlayer"
+# The driver dials a fixed 127.0.0.1:25565 (E2EDriver.SERVER_HOST/PORT);
+# if you override E2E_SERVER_PORT here you MUST also override the driver's
+# constants — keep the default otherwise.
+E2E_SERVER_PORT="${E2E_SERVER_PORT:-25565}"
+OFFLINE_UUID=$(python3 - <<'PY'
+import hashlib, sys, uuid
+name = "TestPlayer"
+d = bytearray(hashlib.md5(("OfflinePlayer:" + name).encode("utf-8")).digest())
+d[6] = (d[6] & 0x0f) | 0x30
+d[8] = (d[8] & 0x3f) | 0x80
+print(uuid.UUID(bytes=bytes(d)))
+PY
+)
+e2e_log "offline test player: $E2E_USERNAME / $OFFLINE_UUID"
+
+# ---------------------------------------------------------------------------
+# Java 21 (hard requirement: Forge 51 dev client + production server)
+# ---------------------------------------------------------------------------
+if [ -n "${JAVA_HOME:-}" ] && [ -x "$JAVA_HOME/bin/javac" ]; then
+    E2E_JAVA="$JAVA_HOME/bin/java"
+elif [ -x /usr/lib/jvm/java-21-openjdk-amd64/bin/javac ]; then
+    E2E_JAVA="/usr/lib/jvm/java-21-openjdk-amd64/bin/java"
+elif [ -d "$HOME/.sdkman/candidates/java" ]; then
+    # Any sdkman JDK 21 (first match).
+    E2E_JAVA="$(ls -d "$HOME"/.sdkman/candidates/java/21* 2>/dev/null | head -1)/bin/java"
+    [ -x "$E2E_JAVA" ] || E2E_JAVA=""
+fi
+if [ -z "${E2E_JAVA:-}" ]; then
+    e2e_fail "Java 21 not found (set JAVA_HOME to a JDK 21)"
+fi
+JAVA21_HOME="$(dirname "$(dirname "$E2E_JAVA")")"
+e2e_log "Java 21: $E2E_JAVA"
+
+# ---------------------------------------------------------------------------
+# Build the lane (produces the mod jar for the server's mods/ + validates
+# the driver compiles; also warms the userdev cache for the dev client).
+# ---------------------------------------------------------------------------
+cd "$LANE_DIR"
+if ! JAVA_HOME="$JAVA21_HOME" "$REPO_ROOT/gradlew" :forge-1.21:build --no-daemon --console=plain; then
+    e2e_fail "lane build failed"
+fi
+MOD_JAR="$(ls build/libs/everlastingskins-*.jar 2>/dev/null | grep -v -- '-sources.jar' | head -1 || true)"
+if [ -z "$MOD_JAR" ]; then
+    e2e_fail "no mod jar in build/libs/"
+fi
+e2e_log "mod jar: $MOD_JAR"
+
+# ---------------------------------------------------------------------------
+# Production server: pinned forge installer → --installServer → mods/
+# ---------------------------------------------------------------------------
+INSTALLER_NAME="forge-1.21-51.0.8-installer.jar"
+INSTALLER_URL="https://maven.minecraftforge.net/net/minecraftforge/forge/1.21-51.0.8/forge-1.21-51.0.8-installer.jar"
+INSTALLER_SHA1="4e4fa11f5e04fd968bc6ee1021f312ad4b233170"
+fetch_artifact "$INSTALLER_NAME" "$INSTALLER_URL" "$INSTALLER_SHA1"
+
+SERVER_DIR="$RUNNER_TMP/server-$E2E_LANE"
+rm -rf "$SERVER_DIR"
+mkdir -p "$SERVER_DIR"
+e2e_log "installing server ($INSTALLER_NAME)..."
+if ! ( cd "$SERVER_DIR" && "$E2E_JAVA" -jar "$E2E_CACHE_DIR/$E2E_LANE/$INSTALLER_NAME" --installServer ); then
+    e2e_infra_fail "forge installer --installServer failed"
+fi
+
+echo "eula=true" > "$SERVER_DIR/eula.txt"
+cat > "$SERVER_DIR/server.properties" <<EOF
+online-mode=false
+server-port=$E2E_SERVER_PORT
+level-type=flat
+motd=EverlastingSkins E2E 1.21
+max-tick-time=-1
+EOF
+echo "-Deverlastingskins.e2e=true" >> "$SERVER_DIR/user_jvm_args.txt"
+mkdir -p "$SERVER_DIR/mods"
+cp "$MOD_JAR" "$SERVER_DIR/mods/"
+
+# ---------------------------------------------------------------------------
+# Boot the server (own session; unix_args.txt = the installer-generated
+# BootstrapLauncher launch). CWD must be the server dir: modern Forge
+# resolves mods/ relative to it.
+# ---------------------------------------------------------------------------
+SERVER_LOG="$SERVER_DIR/server.log"
+SERVER_PID=""
+cleanup() {
+    if [ -n "$SERVER_PID" ]; then
+        kill_tree "$SERVER_PID" 2>/dev/null || true
+    fi
+    if [ -n "${CLIENT_PID:-}" ]; then
+        kill_tree "$CLIENT_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+e2e_log "booting server..."
+(
+    cd "$SERVER_DIR"
+    exec setsid "$E2E_JAVA" @user_jvm_args.txt \
+        @libraries/net/minecraftforge/forge/1.21-51.0.8/unix_args.txt nogui
+) > "$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+
+if ! wait_for_log "$SERVER_LOG" 'For help, type "help"' 300; then
+    e2e_warn "server boot timeout (tail follows)"
+    tail -n 40 "$SERVER_LOG" >&2 || true
+    kill_tree "$SERVER_PID" 2>/dev/null || true
+    exit 2
+fi
+e2e_log "server booted (For help, type \"help\")"
+
+if ! wait_for_log "$SERVER_LOG" 'ES_E2E_SENTINEL=seeded' 60; then
+    e2e_warn "sentinel seed not logged (tail follows)"
+    tail -n 40 "$SERVER_LOG" >&2 || true
+    kill_tree "$SERVER_PID" 2>/dev/null || true
+    exit 1
+fi
+e2e_log "sentinel seeded"
+
+# ---------------------------------------------------------------------------
+# Dev client under xvfb + Mesa llvmpipe. Fresh run dir (stale artifacts
+# must never mask a driver timeout — pre-1.8 lesson). The driver writes
+# e2e-result.json into the client gameDir (= the run dir).
+# ---------------------------------------------------------------------------
+rm -rf "$LANE_DIR/run"
+mkdir -p "$LANE_DIR/run"
+# Fresh gameDir = first-launch state: without this the client blocks on the
+# AccessibilityOnboardingScreen (observed live) and the title screen never
+# appears. The option key is the vanilla options.txt boolean (verified
+# against the Options class).
+cat > "$LANE_DIR/run/options.txt" <<'EOF'
+onboardAccessibility:false
+EOF
+CLIENT_LOG="$RUNNER_TMP/client-$E2E_LANE.log"
+CLIENT_PID=""
+
+e2e_log "launching client (xvfb + llvmpipe)..."
+set +e
+(
+    cd "$REPO_ROOT"
+    exec setsid xvfb-run -a env \
+        LIBGL_ALWAYS_SOFTWARE=1 GALLIUM_DRIVER=llvmpipe \
+        JAVA_HOME="$JAVA21_HOME" \
+        ./gradlew :forge-1.21:runClient \
+        -Peverlastingskins.e2e=true \
+        --args="--username $E2E_USERNAME --uuid $OFFLINE_UUID --accessToken 0" \
+        --no-daemon --console=plain
+) > "$CLIENT_LOG" 2>&1 &
+CLIENT_PID=$!
+set -e
+
+RESULT_FILE="$LANE_DIR/run/e2e-result.json"
+i=0
+while [ "$i" -lt 600 ] && [ ! -f "$RESULT_FILE" ]; do
+    if ! kill -0 "$CLIENT_PID" 2>/dev/null; then
+        break
+    fi
+    sleep 5
+    i=$((i + 5))
+done
+
+if [ ! -f "$RESULT_FILE" ]; then
+    e2e_warn "no driver result (client tail follows)"
+    tail -n 60 "$CLIENT_LOG" >&2 || true
+    kill_tree "$CLIENT_PID" 2>/dev/null || true
+    kill_tree "$SERVER_PID" 2>/dev/null || true
+    SERVER_PID=""
+    CLIENT_PID=""
+    exit 2
+fi
+e2e_log "driver result written: $RESULT_FILE"
+
+# Let the gradle runClient task finish (the driver System.exits the client;
+# JavaExec propagates the fork's exit code).
+i=0
+while [ "$i" -lt 60 ] && kill -0 "$CLIENT_PID" 2>/dev/null; do
+    sleep 2
+    i=$((i + 2))
+done
+
+# Kill the server before asserting: assertion failures exit 1 and must not
+# leak the server (the cleanup trap covers every other path).
+kill_tree "$SERVER_PID" 2>/dev/null || true
+SERVER_PID=""
+
+# ---------------------------------------------------------------------------
+# Assemble the final contract doc + assertions (lib.sh helpers; server_booted
+# is the one script-side fact the driver cannot know).
+# ---------------------------------------------------------------------------
+assemble_result "true" "$RESULT_FILE"
+
+DRIVER_FINAL_CODE=$(result_exit_code)
+if [ "$DRIVER_FINAL_CODE" -eq 2 ]; then
+    e2e_warn "RETRYABLE: driver reported infra failure (exit 2)"
+    exit 2
+fi
+if [ "$DRIVER_FINAL_CODE" -ne 0 ]; then
+    e2e_warn "FAIL: driver exit code $DRIVER_FINAL_CODE"
+    exit 1
+fi
+
+assert_result "server_booted" "True"
+assert_result "client_joined" "True"
+assert_result "command_executed" "True"
+assert_result "renderer_state" "sentinel"
+assert_result "renderer_verified" "True"
+
+e2e_log "e2e complete: exit_code=0 duration_ms=$(python3 -c "import json; print(json.load(open('$RESULT_JSON')).get('duration_ms'))")"
+e2e_log "PASS: real-client E2E (1.21) all green"
+exit 0

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -49,5 +49,7 @@ pre-push:
       run: bash -c 'source scripts/ensure-jdk17.sh && exec ./gradlew --no-daemon --offline test --parallel'
     gametest:
       run: bash -c 'source scripts/ensure-jdk17.sh && exec forge-1.21/test-infrastructure/run-gametest-local.sh'
+    config-order:
+      run: bash -c 'source scripts/ensure-jdk17.sh && exec bash scripts/config-order-gate.sh'
     aislop-ci:
       run: bash -c 'if command -v bunx >/dev/null 2>&1; then bunx aislop ci --changes --base origin/main; else npx -y aislop ci --changes --base origin/main; fi'

--- a/scripts/config-order-gate-test.sh
+++ b/scripts/config-order-gate-test.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Self-test for scripts/config-order-gate.sh: proves the gate CATCHES the
+# regression class it guards. Builds a throwaway worktree fixture (overlaid
+# with the CURRENT working-tree convention, so uncommitted fixes are tested)
+# that re-introduces each historical bad form, then runs the gate's
+# structural guard against it and asserts a non-zero exit with the
+# signature. Also runs the full gate (incl. the CI-mirror probe) on the
+# real tree to prove the happy path.
+#
+# Usage: bash scripts/config-order-gate-test.sh
+# Exit 0 = gate proven; 1 = gate failed to catch a bad form (or the happy
+# path broke).
+
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" || exit 1
+cd "$ROOT" || exit 1
+
+CONVENTION="buildSrc/src/main/kotlin/everlastingskins.forge-module.gradle.kts"
+FIXTURE_DIR="$ROOT/.slim/worktrees/config-order-gate-fixture"
+FIXTURE_BRANCH=""
+
+fail() {
+  echo "SELFTEST FAIL: $*" >&2
+  exit 1
+}
+
+cleanup() {
+  if [ -n "$FIXTURE_BRANCH" ]; then
+    git branch -q -D "$FIXTURE_BRANCH" 2>/dev/null || true
+  fi
+  git worktree remove "$FIXTURE_DIR" --force 2>/dev/null || true
+  git worktree prune 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Fixture: a detached worktree at HEAD with the working-tree convention
+# overlaid and one of the historical bad forms re-introduced in place of
+# the canonical from() lines.
+# ---------------------------------------------------------------------------
+make_fixture() {
+  local bad_line="$1"
+  cleanup
+  FIXTURE_BRANCH="config-order-gate-fixture"
+  git worktree add -q --detach "$FIXTURE_DIR" HEAD || fail "worktree add"
+  # Overlay the CURRENT working-tree convention + gate scripts (uncommitted
+  # fixes included).
+  cp "$ROOT/$CONVENTION" "$FIXTURE_DIR/$CONVENTION"
+  cp "$ROOT/scripts/config-order-gate.sh" "$FIXTURE_DIR/scripts/config-order-gate.sh"
+  # Drop the canonical TaskProvider from() lines + the doFirst guard, then
+  # insert the bad line after the duplicatesStrategy line.
+  sed -i '/from(project(":common").tasks.named(/d; /doFirst {/,/^    }$/d' \
+    "$FIXTURE_DIR/$CONVENTION"
+  sed -i "/duplicatesStrategy = DuplicatesStrategy.INCLUDE/a\\    $bad_line" \
+    "$FIXTURE_DIR/$CONVENTION"
+}
+
+# Each case: the bad line. The gate must reject it (structural guard) with
+# the regression-signature message.
+run_case() {
+  local name="$1" bad_line="$2"
+  echo "--- self-test case: $name"
+  make_fixture "$bad_line"
+  if ( cd "$FIXTURE_DIR" && CONFIG_ORDER_STRUCTURAL_ONLY=1 \
+      bash scripts/config-order-gate.sh ) \
+      > /tmp/config-order-gate-test.log 2>&1; then
+    fail "case '$name': gate exited 0 — the bad form was NOT caught"
+  fi
+  if ! grep -q "config-order regression signature" /tmp/config-order-gate-test.log; then
+    fail "case '$name': gate failed but without the regression-signature message: $(tail -2 /tmp/config-order-gate-test.log)"
+  fi
+  echo "case '$name': gate rejected it (exit non-zero, signature logged) — OK"
+}
+
+# Historical bad forms (takes 1-2 of the PR #440 fix):
+run_case "take-1 eager sourceSets" \
+  'from(project(":common").sourceSets.main.get().output)'
+run_case "take-1 lazy provider wrap" \
+  'from(project.provider { project(":common").sourceSets.main.get().output })'
+run_case "take-2 projectsEvaluated sourceSets" \
+  'from(project(":common").sourceSets.main.get().output) // projectsEvaluated'
+
+# ---------------------------------------------------------------------------
+# Happy path: the full gate (structural guard + CI-mirror probe) must PASS
+# on the real tree.
+# ---------------------------------------------------------------------------
+echo "--- self-test case: happy path (current tree, full gate incl. probe)"
+if bash scripts/config-order-gate.sh > /tmp/config-order-gate-test.log 2>&1; then
+  echo "happy path: gate PASSED — OK"
+else
+  tail -n 20 /tmp/config-order-gate-test.log
+  fail "happy path: gate failed on the canonical tree (see tail)"
+fi
+
+echo "config-order gate self-test: PASS"

--- a/scripts/config-order-gate.sh
+++ b/scripts/config-order-gate.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Config-order gate: fail-fast guard for the :common-bundling regression
+# class that broke every in-root forge module's Build check (PR #440,
+# takes 1-2). Two layers:
+#
+# 1. STRUCTURAL GUARD — rejects any bare sourceSets form of the :common
+#    bundling in the shared convention, the regression signature:
+#      from(project(":common").sourceSets...  (take-1 eager)
+#      from(project.provider { project(":common").sourceSets...  (take-1 lazy)
+#    Both fail with "Extension with name 'sourceSets' does not exist"
+#    because the jar task's ConfigurableFileCollection resolves its from()
+#    sources at configuration-time task-graph queries, before :common's
+#    Java plugin is applied. The canonical form is the lazy TaskProvider:
+#      from(project(":common").tasks.named("classes"))
+# 2. CI-MIRROR PROBE — runs the exact CI build shape that failed locally:
+#      ./gradlew --no-daemon --offline --configure-on-demand \
+#                --no-configuration-cache --stacktrace <module>:jar
+#    (the WorkValidationException / sourceSets failure reproduced ONLY
+#    under --configure-on-demand + no config cache; a plain warm build
+#    hides it). Exit 1 + classification on failure.
+#
+# Usage: bash scripts/config-order-gate.sh
+# Env: CONFIG_ORDER_MODULES overrides the probe target list (default
+# ":forge-1.21:jar"; 26.x excluded by default — their Java 25 toolchain
+# needs a network toolchain download, incompatible with --offline).
+#
+# shellcheck disable=SC2317  # false positive: shellcheck follows the sourced
+#                              # ensure-jdk17.sh and sees its final `exit 1` (no JDK
+#                              # found), so everything after the source looks
+#                              # unreachable; the source returns 0 on success.
+
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" || exit 1
+cd "$ROOT" || exit 1
+
+CONVENTION="buildSrc/src/main/kotlin/everlastingskins.forge-module.gradle.kts"
+MODULES="${CONFIG_ORDER_MODULES:-:forge-1.21:jar}"
+# Self-test mode: skip the gradle probe (the structural guard is the unit
+# under test; the probe needs a working convention).
+STRUCTURAL_ONLY="${CONFIG_ORDER_STRUCTURAL_ONLY:-0}"
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Layer 1: structural guard (no gradle needed — runs even offline/cold).
+# ---------------------------------------------------------------------------
+if [ ! -f "$CONVENTION" ]; then
+  fail "convention file missing: $CONVENTION"
+fi
+# Reject any :common bundling that goes through sourceSets (eager or
+# provider-wrapped): the regression signature from takes 1-2. Comment lines
+# are filtered first (the convention's own warning comment mentions the
+# form).
+CODE_ONLY="$(grep -vE '^\s*(//|/\*|\*)' "$CONVENTION" || true)"
+# The single signature: a from() that reaches into :common's sourceSets
+# (eager or provider-wrapped). Own-module sourceSets uses (errorprone /
+# gametest classpath wiring) are legitimate and must NOT match.
+if printf '%s\n' "$CODE_ONLY" | grep -nE 'from\([^)]*project\(":common"\)\.sourceSets'; then
+  fail "config-order regression signature in $CONVENTION: bare :common.sourceSets from() — use the lazy TaskProvider form (from(project(\":common\").tasks.named(\"classes\")) + processResources)"
+fi
+echo "config-order: structural guard OK ($CONVENTION has no bare :common.sourceSets from())"
+
+# ---------------------------------------------------------------------------
+# Layer 2: CI-mirror probe (the exact command shape that reproduced the
+# failure in CI). Skipped with CONFIG_ORDER_STRUCTURAL_ONLY=1 (self-test of
+# the structural guard only).
+# ---------------------------------------------------------------------------
+if [ "$STRUCTURAL_ONLY" = "1" ]; then
+  echo "config-order: structural-only mode (probe skipped)"
+  echo "config-order gate: PASS"
+  exit 0
+fi
+
+# Idempotent: no-op when JAVA_HOME is already a JDK >= 17 (CI's
+# setup-java); promotes an old JAVA_HOME (e.g. sdkman `current` on JDK 8
+# for the legacy lanes) to the newest installed JDK >= 17.
+# shellcheck source=scripts/ensure-jdk17.sh
+source scripts/ensure-jdk17.sh
+
+for MODULE in $MODULES; do
+  echo "config-order: probing $MODULE (CoD + no config cache + offline)..."
+  if ! ./gradlew --no-daemon --offline --configure-on-demand \
+      --no-configuration-cache --stacktrace "$MODULE" > /tmp/config-order-gate.log 2>&1; then
+    if grep -qE "Extension with name 'sourceSets' does not exist|WorkValidationException|Configuration cache" /tmp/config-order-gate.log; then
+      fail "config-order probe FAILED for $MODULE with the config-order signature (sourceSets/WorkValidationException); tail follows"
+    fi
+    echo "config-order: probe FAILED for $MODULE (non-signature failure); tail follows" >&2
+    tail -n 40 /tmp/config-order-gate.log >&2
+    exit 1
+  fi
+  echo "config-order: probe OK ($MODULE)"
+done
+
+echo "config-order gate: PASS"


### PR DESCRIPTION
## Real-client E2E — slice 3: forge-1.21 in-jar client driver (tab-list texture assertion)

Reference implementation for the 26.x port (master plan `real-client-e2e-plan.md`, modern-injar pattern). **LIVE-VERIFIED green on 2026-08-11**: production Forge 1.21 server + real 1.21 client (xvfb + Mesa llvmpipe) → join → `/skin set mojang TestPlayer` → tab-list textures property carries the sentinel marker → exit 0, all contract asserts green.

### The assertion (modern-line semantics)
The server does **not** push PNG bytes on a custom channel — it mutates the player's `GameProfile` textures property and re-broadcasts it as vanilla tab-list packets (REMOVE + ADD_PLAYER via `VanillaSkinBroadcaster`). The client's tab-list entry **is** the received packet data: `ClientPacketListener.getPlayerInfo(uuid).getProfile().getProperties().get("textures")`. The driver asserts that property is non-null and its (base64-decoded) value contains the sentinel marker the server pre-seeded into `SkinStorage` — the property the vanilla renderer consumes, not pixels (llvmpipe-safe by design).

### Pieces
- `e2e/E2E` — one-line gated entry from the mod constructor (`-Deverlastingskins.e2e=true`), shared marker + vanilla offline-UUID bridge.
- `e2e/E2EDriver` (CLIENT) — phase machine on the client tick: join → `sendCommand("skin set mojang TestPlayer")` → poll the tab-list property → `e2e-result.json` + `System.exit`.
- `e2e/E2ESentinelHook` (SERVER) — pre-seeds `SkinStorage` at `ServerStartedEvent` with a `MojangAPI`-source sentinel (so `storedSourceMatches` short-circuits the Mojang HTTP fetch — deterministic offline).
- `e2e/E2EResult` — dependency-free result document (master-plan contract).
- `test-infrastructure/run-e2e.sh` — lane wrapper (build → pinned installer `--installServer` → mods/ → `For help` → sentinel seed → xvfb dev client → result merge + assert; exit 0/1/2/3).
- Convention: `-Peverlastingskins.e2e=true` → fork system property (default false) + Netty reflective-access flags on runClient.
- CI: informational `E2E (forge-1.21)` job (no gh-api-bump; not part of the required-check contract).
- 11 unit tests (phase transitions, result JSON, offline UUID, sentinel value).

### Empirical boot findings (documented in code)
1. **1.21 `Main` has no `--server/--port`** — verified against the client jar (`allowsUnrecognizedOptions` ignores them); quick-play does not fire on a dev launch → the driver auto-connects from the main menu via `ConnectScreen.startConnecting` (pre-1.8 `Minecraft.setServer` precedent). `transferState` must be **null** — a non-null `TransferState` makes the handshake use the TRANSFER intent and the server rejects ("Server does not accept transfers").
2. **Fresh gameDir blocks on the AccessibilityOnboardingScreen** → the wrapper pre-seeds `options.txt` with `onboardAccessibility:false`.
3. **`sendCommand` takes the command without the leading slash** (sending `/skin …` → "Unknown or incomplete command").
4. **The textures property value is base64** of the vanilla textures JSON — the marker check decodes first.

### M2 regression found + fixed (required for the server boot)
The shipped mod jar was **thin** since the M2 `:common` split: no `:common` classes/resources, so the mod threw `NoClassDefFoundError` (`IPermissionService`) on any production server. The convention's `tasks.jar` now bundles `:common`'s output (the pre-M2 published jar shape; verified against `mc1.21-v2.1.0-rc1`). `projectHealth` (graduated duplicate-class gate) stays green on forge-1.21.

### 26.x port notes
- Driver/hook reuse the same `MinecraftForge.EVENT_BUS.addListener` registration — EventBus-7 compatible, **no static-subscriber delta**.
- Same official-mapped names on 26.x (unobfuscated MC); `ClientPacketListener`/`PlayerInfo` surface unchanged.
- The client-run wiring + wrapper are convention/lane-generic; the 26.x wrapper copies `run-e2e.sh` and adapts the installer coordinates + lane id.

### Production-profile client boot (follow-up)
The Forge installer's client install is GUI-only; the dev launch (runClient) runs the identical client code with the same assertion surface (official names). A Prism-style BootstrapLauncher boot is documented as a follow-up in the wrapper header.
