### PR TITLE
fix(e2e): 1.6.4 server launchwrapper classpath + 1.7.10 HeadlessMC handshake

### DIFF
--- a/scripts/e2e/drivers/headlessmc.sh
+++ b/scripts/e2e/drivers/headlessmc.sh
@@ -65,7 +65,7 @@ SERVER_LOG="$SERVER_DIR/server.log"
 # launcher.mojang.com object id for the server jars).
 # ---------------------------------------------------------------------------
 case "$E2E_LANE" in
-    1.7.10)
+        1.7.10)
         HMC_SPECIFICS_NAME="hmc-specifics-1.7.10-2.4.0-lexforge-release.jar"
         MC_VERSION="1.7.10"
         MC_VERSION_ID="1.7.10-Forge10.13.4.1614-1.7.10"
@@ -74,7 +74,11 @@ case "$E2E_LANE" in
         SERVER_SHA1="952438ac4e01b4d115c5fc38f891710c4941df29"
         FORGE_SHA1="25fd97f72beca728112256938e03e8105b1b78cc"
         SERVER_MAIN="cpw.mods.fml.relauncher.ServerLaunchWrapper"
-        SCENARIO_SKIN_CMD="/skin set Notch"
+        # Post-#423 grammar: the 1.7.10 lane's /skin is
+        # `set <mojang|web|random>` (bare `set Notch` hits the usage reply
+        # and never runs the skin action — the slice-2 trial jar predated
+        # the parity rework, so its bare-name command masked this).
+        SCENARIO_SKIN_CMD="/skin set mojang Notch"
         ;;
     1.8.9)
         HMC_SPECIFICS_NAME="hmc-specifics-1.8.9-2.4.0-lexforge-release.jar"
@@ -275,8 +279,16 @@ if [ -n "$HMC_SPECIFICS_NAME" ]; then
     cp "$E2E_HMC_SPECIFICS_JAR" "$CLIENT_DIR/mods/$HMC_SPECIFICS_NAME"
 fi
 
-# Scenario: bridge lanes drive /skin + the bridge ack + quit through the
-# console; the 1.10.2 in-jar driver emits its own markers.
+# Scenario: bridge lanes drive /skin + the bridge ack through the
+# console; the 1.10.2 in-jar driver emits its own markers. NOTE (no quit
+# SEND on bridge lanes): the server-side skin action (a blocking Mojang
+# profile fetch on the server thread) must COMPLETE before the client
+# disconnects — a mid-command disconnect aborts the completion path and
+# the ES_E2E_SKIN=ok sentinel never logs (observed on main's CI 2026-08-11
+# and reproduced locally: client quit ~1s after the /skin SEND, sentinel
+# never appeared despite a fast Mojang API). The steps therefore end in the
+# implicit WAIT_FOR_END (test timeout), keeping the client in-world until
+# the driver sees the sentinel and kills it.
 SCENARIO_FILE="$RUNNER_TMP/scenario-$E2E_LANE.json"
 if [ -n "$HMC_SPECIFICS_NAME" ]; then
     cat > "$SCENARIO_FILE" <<EOF
@@ -285,8 +297,7 @@ if [ -n "$HMC_SPECIFICS_NAME" ]; then
   "steps": [
     {"type": "CONTAINS", "message": "minecraft:music.game", "timeout": 240},
     {"type": "SEND", "message": "$SCENARIO_SKIN_CMD"},
-    {"type": "SEND", "message": ". hmc-e2e-bridge-ok"},
-    {"type": "SEND", "message": "quit"}
+    {"type": "SEND", "message": ". hmc-e2e-bridge-ok"}
   ],
   "timeout": 300
 }
@@ -367,7 +378,12 @@ set -e
 
 # ---------------------------------------------------------------------------
 # Assertions: server-side sentinel is primary; the launcher's CommandTest
-# outcome is secondary.
+# outcome is secondary (the driver header's contract). The bridge scenario
+# has no quit SEND, so the client stays in-world until the server-side skin
+# action completes and the sentinel logs; the driver then kills the client
+# (WAIT_FOR_END ends with the process). If the client dies early for any
+# reason, the sentinel can no longer appear (mid-command disconnect aborts
+# the completion path), so the poll just reports the miss.
 # ---------------------------------------------------------------------------
 SENTINEL_SEEN=0
 for i in $(seq 1 90); do
@@ -386,27 +402,30 @@ SERVER_PID=""
 
 if [ "$SENTINEL_SEEN" -eq 1 ]; then
     e2e_log "server sentinel seen (ES_E2E_SKIN=ok)"
-    # Grace window for the client-side outcome: the 1.10.2 in-jar driver
-    # writes e2e-result.json 20s after join; the bridge CommandTest
-    # completes on the quit SEND. Poll while the client is still alive.
-    for _ in $(seq 1 30); do
-        if [ "$E2E_LANE" = "1.10.2" ] && [ -f "$CLIENT_DIR/e2e-result.json" ]; then
-            break
-        fi
-        if [ "$E2E_LANE" != "1.10.2" ] && grep -q "CommandTest was successful" "$CLIENT_LOG" 2>/dev/null; then
-            break
-        fi
-        if ! kill -0 "$CLIENT_PID" 2>/dev/null; then
-            break
-        fi
-        sleep 2
-    done
+    if [ "$E2E_LANE" = "1.10.2" ]; then
+        # Grace window for the client-side outcome: the 1.10.2 in-jar driver
+        # writes e2e-result.json ~20s after join. Poll while it is alive.
+        for _ in $(seq 1 30); do
+            if [ -f "$CLIENT_DIR/e2e-result.json" ]; then
+                break
+            fi
+            if ! kill -0 "$CLIENT_PID" 2>/dev/null; then
+                break
+            fi
+            sleep 2
+        done
+    fi
+    # Bridge lanes: the scenario ended in WAIT_FOR_END (no quit SEND); the
+    # sentinel is the authoritative outcome, so end the client here. The
+    # launcher may or may not print "CommandTest was successful" before the
+    # group kill lands — the driver outcome is derived from the sentinel.
     kill_tree "$CLIENT_PID" 2>/dev/null || true
 else
     e2e_warn "server sentinel NOT seen (server log tail follows)"
     tail -n 20 "$SERVER_LOG" >&2 || true
     e2e_warn "client log tail follows"
     tail -n 20 "$CLIENT_LOG" >&2 || true
+    kill_tree "$CLIENT_PID" 2>/dev/null || true
 fi
 
 # ---------------------------------------------------------------------------
@@ -422,9 +441,18 @@ if [ "$E2E_LANE" = "1.10.2" ]; then
         DRIVER_CODE=$(python3 -c "import json; print(int(json.load(open('$CLIENT_DIR/e2e-result.json')).get('exit_code', 3)))")
     fi
 else
-    if grep -q "CommandTest was successful" "$CLIENT_LOG" 2>/dev/null; then
+    # Bridge lanes: with the no-quit scenario the client is killed by the
+    # driver after the sentinel, so "CommandTest was successful" is not a
+    # reliable signal (the group kill races the launcher's final print).
+    # Derive the contract fields from the SERVER log instead: the join line,
+    # the bridge-ack chat, and the sentinel (primary).
+    if grep -q "$E2E_USERNAME joined the game" "$SERVER_LOG" 2>/dev/null; then
         CLIENT_JOINED="True"
+    fi
+    if grep -q "<$E2E_USERNAME> hmc-e2e-bridge-ok" "$SERVER_LOG" 2>/dev/null; then
         COMMAND_EXECUTED="True"
+    fi
+    if [ "$SENTINEL_SEEN" -eq 1 ] || grep -q "CommandTest was successful" "$CLIENT_LOG" 2>/dev/null; then
         DRIVER_CODE=0
     fi
 fi

--- a/scripts/e2e/e2e-common.sh
+++ b/scripts/e2e/e2e-common.sh
@@ -120,8 +120,16 @@ fetch_artifact "$UNIVERSAL_NAME" "$UNIVERSAL_URL" "$UNIVERSAL_SHA1"
 # ---------------------------------------------------------------------------
 # Server library fetch (both eras; cached+verified is a no-op). The legacy
 # FML relauncher pre-seed below additionally needs asm-all on the cache.
+# launchwrapper-1.8.jar + jopt-simple-4.5.jar are the tweaker-model boot
+# libs (SERVER_CP references both); they were missing from this fetch loop
+# (only the client driver pre18-xvfb.sh fetched them), so a fresh cache
+# silently dropped the classpath entries and the 1.6.4 server died with
+# ClassNotFoundException: net.minecraft.launchwrapper.Launch on main's CI.
+# sha1s match the client driver's pins (same artifacts).
 # ---------------------------------------------------------------------------
 for spec in \
+    "launchwrapper-1.8.jar|https://libraries.minecraft.net/net/minecraft/launchwrapper/1.8/launchwrapper-1.8.jar|d4c0895977dd7f0b3f56281cee53a64d4c0c0322" \
+    "jopt-simple-4.5.jar|https://libraries.minecraft.net/net/sf/jopt-simple/jopt-simple/4.5/jopt-simple-4.5.jar|6065cc95c661255349c1d0756657be17c29a4fd3" \
     "guava-14.0.jar|https://libraries.minecraft.net/com/google/guava/guava/14.0/guava-14.0.jar|67b7be4ee7ba48e4828a42d6d5069761186d4a53" \
     "gson-2.2.2.jar|https://libraries.minecraft.net/com/google/code/gson/gson/2.2.2/gson-2.2.2.jar|1f96456ca233dec780aa224bff076d8e8bca3908" \
     "commons-lang3-3.1.jar|https://libraries.minecraft.net/org/apache/commons/commons-lang3/3.1/commons-lang3-3.1.jar|905075e6c80f206bbe6cf1e809d2caa69f420c76" \


### PR DESCRIPTION
## What

Two pre-existing E2E reds on `main` (both **informational** jobs, not required checks), root-caused from CI artifacts (run 31523691202) plus local reproduction. Script-side only — no harness/build.gradle changes (vendored-harness diff-guard clean).

### 1. E2E (forge-1.6.4): server boot timeout — `ClassNotFoundException: net.minecraft.launchwrapper.Launch`

**Root cause:** `scripts/e2e/e2e-common.sh`'s server library fetch loop was missing `launchwrapper-1.8.jar` and `jopt-simple-4.5.jar`, even though both are referenced by the assembled `SERVER_CP`. Only the client driver (`pre18-xvfb.sh`) fetched them, so on a fresh runner the classpath entries pointed at nonexistent cache files — Java silently drops those, and the 1.6.4 tweaker-model server died before boot.

**Fix:** added both artifacts to the server fetch loop with the same sha1 pins the client driver already uses (`d4c089…` / `6065cc…`). `fetch_artifact` is cache-idempotent, so warm caches are unaffected.

**Verified locally:** removed both libs from the e2e cache (fresh-runner simulation) → fixed loop re-fetched them → server booted (`Done (2.858s)! For help, type "help"`). Full 1.6.4 E2E (server + observer + actor clients under xvfb) green, exit 0.

### 2. E2E (forge-1.7.10) [and forge-1.8.9, same shared driver]: `sentinel=0`, `TestPlayer lost connection … Connection reset by peer`

**Root cause (two layers, both proven from CI + local logs):**

- **Command grammar mismatch:** the 1.7.10 scenario sent `/skin set Notch`, which does not match the lane's current post-#423 grammar (`/skin set <mojang|web|random>`). The command hit the usage-reply path and never ran the skin action — `ES_E2E_SKIN=ok` could never appear. The slice-2 trial validated against a pre-parity jar (confirmed: the trial server's mod jar contains the old `setSkin(GameProfile, UUID, String)` SkinCommand, not the current one). CI's "connection reset" was a red herring — the client quit 1s later either way.
- **Quit-vs-fetch race:** even with a valid command, the scenario's immediate `quit` SEND raced the server-side Mojang skin fetch. A mid-command disconnect **aborts the completion path** — neither `ES_E2E_SKIN=ok` nor the `fail` marker ever logs (reproduced locally: 30s of post-disconnect polling produced nothing; the 1.8.9 lane failed the same way despite having the correct grammar).

**Fix (in `scripts/e2e/drivers/headlessmc.sh`):**
- 1.7.10 scenario command → `/skin set mojang Notch` (matches the lane grammar; `source=Notch` sentinel as before).
- Bridge-lane scenario no longer SENDs `quit`: steps end in the implicit `WAIT_FOR_END`, keeping the client in-world until the server-side action completes; the driver kills the client after the sentinel (sentinel stays the primary assertion, per the driver header's contract). The 1.10.2 in-jar-driver path is unchanged (its scenario already has no quit; the result-doc grace poll is preserved).
- Bridge-lane result fields (`client_joined` / `command_executed` / driver outcome) are now derived from server-side markers (join line, bridge-ack chat, sentinel) since the launcher's `CommandTest was successful` print races the driver's group kill.

**Verified locally:** full 1.7.10 E2E green, exit 0 (`ES_E2E_SKIN=cmd … args=[set, mojang, Notch]` → `ES_E2E_SKIN=ok player=TestPlayer source=Notch` 1s later). 1.8.9 re-verification in progress (first attempt collided with the 1.6.4 run on port 25565 — test-harness artifact of parallel local runs, not a code issue).

## Notes / follow-ups

- The 1.7.10 `applyMojangLookup` catch-block for `RuntimeException` logs **no** E2E marker (only the empty-result path logs `ES_E2E_SKIN=fail`). A silent HTTP failure is therefore invisible in the E2E logs. Not part of this script-side fix; a 3-line mod-side marker is the follow-up if E2E reds recur with `sentinel=0` + no `fail` marker.
- Both jobs are informational; expected to go green on this PR's CI.