### PR TITLE
tooling: decompile.sh (Vineflower 1.12) + bytecode.sh (ASM Textifier) + AGENTS.md bytecode/decompile policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,17 @@ hardening, not scope creep: jitpack uptime is a real CI risk. Mitigations:
   legacy MCP artifacts (`de.oceanlabs.mcp:RetroGuard:3.6.6`) from
   `maven.minecraftforge.net` — keep that repo in the buildscript block.
 
+### Reading vendored-lane bytecode (1.4.7 / 1.5.2 / 1.6.4)
+
+Read the PRE-DECOMPILED tree at `~/.gradle/everlastingskins-vendored/<era>/decompiled/`
+(one `<name>.src/` per jar: client/merged/server/universal deobf + raw vendored)
+FIRST; `scripts/decompile.sh` (Vineflower 1.12.0, sha1-pinned) is only for uncached
+jars. `scripts/bytecode.sh` (ASM 9.10.1 Textifier; `--offsets` prints numeric byte
+offsets) is the bytecode-precision tool — offsets/owners/flags/descriptors; `javap -c -p`
+for quick checks; `javap -v` only for raw constant-pool dumps. Resolve obf names via
+`<lane>/build/deobf/{obf-to-deobf,deobf-to-obf}.srg` + `<lane>/build/mcp*/{methods,fields}.csv`.
+Never decompile raw obf jars for reading — use the deobf jars' decompiled output.
+
 ## Rules
 
 1. **`:common` owns version-independent code.** Every forge module is a thin

--- a/scripts/asm-offsets/OffsetsDriver.java
+++ b/scripts/asm-offsets/OffsetsDriver.java
@@ -1,0 +1,136 @@
+// scripts/asm-offsets/OffsetsDriver.java
+// Bytecode-offset driver for scripts/bytecode.sh --offsets.
+//
+// Textifies a class file with ASM's TraceClassVisitor(Textifier) and names
+// every label by its NUMERIC bytecode offset instead of Textifier's
+// visit-order "L0/L1..." names, so instructions and jumps can be reasoned
+// about at byte offset precision (the same precision javap -v uses for its
+// "offset:" column).
+//
+// Modern ASM no longer stores the offset on Label.info (the field is
+// writer-reserved), so the driver subclasses ClassReader and overrides the
+// protected readLabel(int, Label[]) hook — every label the reader creates
+// (label table, jump targets, try-catch, frames, debug) funnels through it —
+// to record label -> bytecodeOffset. Textifier spawns a per-method printer
+// via its protected createTextifier() factory, so the offset-naming
+// Textifier subclass overrides both visitLabel and createTextifier.
+//
+// Compile once into the tools cache (scripts/bytecode.sh does this on
+// demand); needs asm-9.10.1.jar + asm-util-9.10.1.jar on the classpath:
+//   javac -cp asm.jar:asm-util.jar -d <tools-cache> OffsetsDriver.java
+//
+// Usage: java -cp <tools-cache>:asm.jar:asm-util.jar OffsetsDriver [-nodebug] <classfile>
+
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.util.Textifier;
+import org.objectweb.asm.util.TraceClassVisitor;
+
+public class OffsetsDriver {
+
+    /** ClassReader that records the bytecode offset of every label it creates. */
+    static final class OffsetReader extends ClassReader {
+        final Map<Label, Integer> labelOffsets = new HashMap<>();
+
+        OffsetReader(byte[] classFile) {
+            super(classFile);
+        }
+
+        @Override
+        protected Label readLabel(final int bytecodeOffset, final Label[] labels) {
+            Label label = super.readLabel(bytecodeOffset, labels);
+            labelOffsets.put(label, bytecodeOffset);
+            return label;
+        }
+    }
+
+    /** Textifier that names every label L%04X by its bytecode offset. */
+    static final class OffsetTextifier extends Textifier {
+        private final OffsetReader reader;
+
+        OffsetTextifier(OffsetReader reader) {
+            super(Opcodes.ASM9);
+            this.reader = reader;
+        }
+
+        @Override
+        protected Textifier createTextifier() {
+            // Per-method printers (spawned by visitMethod) must share the naming.
+            return new OffsetTextifier(reader);
+        }
+
+        @Override
+        public void visitLabel(Label label) {
+            nameIfKnown(label);
+            super.visitLabel(label);
+        }
+
+        @Override
+        public void visitTryCatchBlock(Label start, Label end, Label handler, String type) {
+            // Exception-table labels are emitted before their visitLabel, so
+            // pre-register the names or getLabelName falls back to visit-order.
+            nameIfKnown(start);
+            nameIfKnown(end);
+            nameIfKnown(handler);
+            super.visitTryCatchBlock(start, end, handler, type);
+        }
+
+        @Override
+        public void visitFrame(int type, int nLocal, Object[] local, int nStack, Object[] stack) {
+            if (local != null) {
+                for (Object o : local) {
+                    if (o instanceof Label) {
+                        nameIfKnown((Label) o);
+                    }
+                }
+            }
+            if (stack != null) {
+                for (Object o : stack) {
+                    if (o instanceof Label) {
+                        nameIfKnown((Label) o);
+                    }
+                }
+            }
+            super.visitFrame(type, nLocal, local, nStack, stack);
+        }
+
+        private void nameIfKnown(Label label) {
+            if (labelNames == null) {
+                // Textifier 9.10.1 lazily creates labelNames in getLabelName;
+                // our pre-registration runs before that on fresh method printers.
+                labelNames = new HashMap<>();
+            }
+            Integer offset = reader.labelOffsets.get(label);
+            if (offset != null) {
+                labelNames.put(label, String.format("L%04X", offset));
+            }
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        boolean nodebug = false;
+        String file = null;
+        for (String a : args) {
+            if (a.equals("-nodebug")) {
+                nodebug = true;
+            } else {
+                file = a;
+            }
+        }
+        if (file == null) {
+            System.err.println("usage: OffsetsDriver [-nodebug] <classfile>");
+            System.exit(1);
+        }
+        byte[] bytes = Files.readAllBytes(Paths.get(file));
+        OffsetReader reader = new OffsetReader(bytes);
+        OffsetTextifier textifier = new OffsetTextifier(reader);
+        int flags = nodebug ? ClassReader.SKIP_DEBUG : 0;
+        reader.accept(new TraceClassVisitor(null, textifier, new PrintWriter(System.out, true)), flags);
+    }
+}

--- a/scripts/bytecode.sh
+++ b/scripts/bytecode.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# scripts/bytecode.sh
+# Bytecode-precision reading for the vendored-harness lanes
+# (1.4.7 / 1.5.2 / 1.6.4). See the AGENTS.md "Reading vendored-lane
+# bytecode" section for when to use this vs. decompile.sh.
+#
+# Pinned tools (sha1-verified at every run; fetched once from Maven Central
+# into ~/.cache/everlastingskins/tools/):
+#   asm-9.10.1.jar       sha1 ada2141c0cc52ee8f5c48cd5fa4ce0e794f22236
+#   asm-util-9.10.1.jar  sha1 7bb9d450e8d4cbf9f9e04096c44bbfe7fba80b15
+#   (org.ow2.asm:asm:9.10.1, org.ow2.asm:asm-util:9.10.1)
+#
+# Usage:
+#   scripts/bytecode.sh <classfile>                 ASM Textifier -nodebug
+#   scripts/bytecode.sh --offsets <classfile>       Textifier, numeric label offsets
+#   scripts/bytecode.sh --cp <era>:<class>          javap -v (raw constant-pool dump)
+#   scripts/bytecode.sh <era>:<class> [--offsets]   unzip -p from the vendored
+#                                                   client/server jar, then Textifier
+#
+# <class> is a slash-separated binary name (e.g.
+# net/minecraft/src/ThreadDownloadImageData). <era> is 1.4.7 / 1.5.2 / 1.6.4;
+# the jar is looked up under ~/.gradle/everlastingskins-vendored/<era>/
+# (client jar first, then server jar). A direct .class path also works.
+
+set -euo pipefail
+
+TOOLS_DIR="${HOME}/.cache/everlastingskins/tools"
+ASM_JAR="${TOOLS_DIR}/asm-9.10.1.jar"
+ASM_UTIL_JAR="${TOOLS_DIR}/asm-util-9.10.1.jar"
+ASM_SHA1="ada2141c0cc52ee8f5c48cd5fa4ce0e794f22236"
+ASM_UTIL_SHA1="7bb9d450e8d4cbf9f9e04096c44bbfe7fba80b15"
+ASM_URL="https://repo1.maven.org/maven2/org/ow2/asm/asm/9.10.1/asm-9.10.1.jar"
+ASM_UTIL_URL="https://repo1.maven.org/maven2/org/ow2/asm/asm-util/9.10.1/asm-util-9.10.1.jar"
+VENDORED_ROOT="${HOME}/.gradle/everlastingskins-vendored"
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+fetch_sha1_verified() { # <url> <out> <want>
+  local url="$1" out="$2" want="$3" actual
+  if [[ ! -f "${out}" ]]; then
+    mkdir -p "${TOOLS_DIR}"
+    echo "Fetching $(basename "${out}") from Maven Central..."
+    curl -fsSL -o "${out}" "${url}"
+  fi
+  actual="$(sha1sum "${out}" | awk '{print $1}')"
+  [[ "${actual}" == "${want}" ]] \
+    || die "$(basename "${out}") sha1 mismatch: got ${actual}, want ${want} (delete ${out} to re-fetch)"
+}
+
+ensure_tools() {
+  fetch_sha1_verified "${ASM_URL}" "${ASM_JAR}" "${ASM_SHA1}"
+  fetch_sha1_verified "${ASM_UTIL_URL}" "${ASM_UTIL_JAR}" "${ASM_UTIL_SHA1}"
+}
+
+ensure_driver() {
+  ensure_tools
+  if [[ ! -f "${TOOLS_DIR}/OffsetsDriver.class" ]]; then
+    local src="${REPO_ROOT}/scripts/asm-offsets/OffsetsDriver.java"
+    [[ -f "${src}" ]] || die "offset driver source not found: ${src}"
+    echo "Compiling offset driver into ${TOOLS_DIR}..."
+    javac -cp "${ASM_JAR}:${ASM_UTIL_JAR}" -d "${TOOLS_DIR}" "${src}"
+  fi
+}
+
+classfile_from_era() { # <era:class> -> echoes extracted temp class file
+  local arg="$1" era class jar
+  era="${arg%%:*}"
+  class="${arg#*:}"
+  [[ "${class}" == "${arg}" ]] && die "expected <era>:<class>, got: ${arg}"
+  local found=""
+  for jar in "${VENDORED_ROOT}/${era}"/minecraft_client.*.jar "${VENDORED_ROOT}/${era}"/minecraft_server.*.jar; do
+    [[ -f "${jar}" ]] || continue
+    if unzip -l "${jar}" "${class}.class" >/dev/null 2>&1; then
+      found="${jar}"
+      break
+    fi
+  done
+  [[ -n "${found}" ]] || die "class ${class} not found in ${VENDORED_ROOT}/${era}/ client/server jars"
+  mkdir -p "${TOOLS_DIR}/tmp"
+  local tmp
+  tmp="${TOOLS_DIR}/tmp/$(basename "${found}" .jar)-${class//\//_}.class"
+  unzip -p "${found}" "${class}.class" > "${tmp}"
+  echo "${tmp}"
+}
+
+# --- mode / argument parsing ---
+MODE="textifier"
+ARGS=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --offsets) MODE="offsets" ;;
+    --cp) MODE="javap-v" ;;
+    *) ARGS+=("$1") ;;
+  esac
+  shift
+done
+[[ ${#ARGS[@]} -eq 1 ]] || die "usage: scripts/bytecode.sh [--offsets|--cp] <classfile | <era>:<class>>"
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+TARGET="${ARGS[0]}"
+
+if [[ "${TARGET}" == *:* ]]; then
+  TARGET="$(classfile_from_era "${TARGET}")"
+fi
+[[ -f "${TARGET}" ]] || die "class file not found: ${TARGET}"
+
+case "${MODE}" in
+  textifier)
+    ensure_tools
+    java -cp "${ASM_JAR}:${ASM_UTIL_JAR}" org.objectweb.asm.util.Textifier -nodebug "${TARGET}"
+    ;;
+  offsets)
+    ensure_driver
+    java -cp "${TOOLS_DIR}:${ASM_JAR}:${ASM_UTIL_JAR}" OffsetsDriver -nodebug "${TARGET}"
+    ;;
+  javap-v)
+    javap -v "${TARGET}"
+    ;;
+esac

--- a/scripts/decompile.sh
+++ b/scripts/decompile.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# scripts/decompile.sh
+# Vineflower 1.12.0 wrapper for reading the vendored-harness lanes
+# (1.4.7 / 1.5.2 / 1.6.4). See the AGENTS.md "Reading vendored-lane
+# bytecode" section for when to use this vs. bytecode.sh.
+#
+# Pinned tool (sha1-verified at every run; fetched once from Maven Central
+# into ~/.cache/everlastingskins/tools/):
+#   vineflower-1.12.0.jar  sha1 85570609a0a5941a7d2918b6260b209de810f66f
+#   (org.vineflower:vineflower:1.12.0)
+#
+# Vineflower 1.12.0 requires a JVM 17+; the lanes themselves build on Java 8,
+# so the script resolves a modern java (JAVA_HOME, then sdkman candidates
+# 21/25/current, then PATH) instead of assuming `java` is new enough.
+#
+# Usage:
+#   scripts/decompile.sh <in.jar> <out-src-dir>
+#   scripts/decompile.sh --all-vendored
+#
+# Flags (fixed for MC-era reading): -din=1 -rbr=1 -dgs=1 -asc=1 -rsy=1
+#   -iec=1 -jvn=1 -isl=0 -iib=1 -bsm=1 -dcl=1 -lit=1 -nls=1 -log=ERROR
+#
+# --all-vendored batch: walks ONLY the path-bound roots (this project never
+# runs filesystem-wide searches — big slow HDDs): the raw jars in
+# ~/.gradle/everlastingskins-vendored/<era>/ and the deobf'd dev jars in
+# <repo>/forge-<era>/build/deobf/. Skips any output that already exists
+# under ~/.gradle/everlastingskins-vendored/<era>/decompiled/<name>.src/.
+
+set -euo pipefail
+
+TOOLS_DIR="${HOME}/.cache/everlastingskins/tools"
+VINEFLOWER_JAR="${TOOLS_DIR}/vineflower-1.12.0.jar"
+VINEFLOWER_SHA1="85570609a0a5941a7d2918b6260b209de810f66f"
+VINEFLOWER_URL="https://repo1.maven.org/maven2/org/vineflower/vineflower/1.12.0/vineflower-1.12.0.jar"
+VENDORED_ROOT="${HOME}/.gradle/everlastingskins-vendored"
+ERAS=(1.4.7 1.5.2 1.6.4)
+FLAGS=(-din=1 -rbr=1 -dgs=1 -asc=1 -rsy=1 -iec=1 -jvn=1 -isl=0 -iib=1 -bsm=1 -dcl=1 -lit=1 -nls=1 -log=ERROR)
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+# Resolve a JVM >= 17 (Vineflower requirement; the lanes' Java 8 is not enough).
+resolve_java() {
+  local candidates=()
+  [[ -n "${JAVA_HOME:-}" && -x "${JAVA_HOME}/bin/java" ]] && candidates+=("${JAVA_HOME}/bin/java")
+  candidates+=(
+    "${HOME}/.sdkman/candidates/java/current/bin/java"
+    "${HOME}/.sdkman/candidates/java/21.0.2-tem/bin/java"
+    "${HOME}/.sdkman/candidates/java/25.0.2-tem/bin/java"
+  )
+  command -v java >/dev/null 2>&1 && candidates+=("$(command -v java)")
+  local java major
+  for java in "${candidates[@]}"; do
+    [[ -x "${java}" ]] || continue
+    major="$("${java}" -version 2>&1 | head -1 | sed -E 's/.*version "([0-9]+).*/\1/')"
+    [[ "${major}" -ge 17 ]] 2>/dev/null && { echo "${java}"; return 0; }
+  done
+  die "no JVM >= 17 found (Vineflower 1.12.0 requirement); set JAVA_HOME"
+}
+
+ensure_tool() {
+  if [[ ! -f "${VINEFLOWER_JAR}" ]]; then
+    mkdir -p "${TOOLS_DIR}"
+    echo "Fetching Vineflower 1.12.0 from Maven Central..."
+    curl -fsSL -o "${VINEFLOWER_JAR}" "${VINEFLOWER_URL}"
+  fi
+  local actual
+  actual="$(sha1sum "${VINEFLOWER_JAR}" | awk '{print $1}')"
+  [[ "${actual}" == "${VINEFLOWER_SHA1}" ]] \
+    || die "vineflower sha1 mismatch: got ${actual}, want ${VINEFLOWER_SHA1} (delete ${VINEFLOWER_JAR} to re-fetch)"
+}
+
+decompile_one() { # <in.jar> <out-dir>
+  local in="$1" out="$2"
+  [[ -f "${in}" ]] || die "input jar not found: ${in}"
+  mkdir -p "$(dirname "${out}")"
+  echo "Decompiling $(basename "${in}") -> ${out}"
+  "$(resolve_java)" -Xmx4g -jar "${VINEFLOWER_JAR}" "${FLAGS[@]}" "${in}" "${out}"
+}
+
+if [[ "${1:-}" == "--all-vendored" ]]; then
+  ensure_tool
+  REPO_ROOT="$(git rev-parse --show-toplevel)"
+  for era in "${ERAS[@]}"; do
+    vendored="${VENDORED_ROOT}/${era}"
+    [[ -d "${vendored}" ]] || continue
+    out_root="${vendored}/decompiled"
+    # Raw vendored jars (single dir, no recursion).
+    for jar in "${vendored}"/*.jar; do
+      [[ -f "${jar}" ]] || continue
+      name="$(basename "${jar}" .jar)"
+      out="${out_root}/${name}.src"
+      if [[ -d "${out}" ]]; then
+        echo "skip (already decompiled): ${out}"
+      else
+        decompile_one "${jar}" "${out}"
+      fi
+    done
+    # Lane deobf'd dev jars.
+    lane="${REPO_ROOT}/forge-${era}/build/deobf"
+    [[ -d "${lane}" ]] || continue
+    for jar in "${lane}"/*deobf.jar; do
+      [[ -f "${jar}" ]] || continue
+      name="$(basename "${jar}" .jar)"
+      out="${out_root}/${name}.src"
+      if [[ -d "${out}" ]]; then
+        echo "skip (already decompiled): ${out}"
+      else
+        decompile_one "${jar}" "${out}"
+      fi
+    done
+  done
+  done_count=0
+  for era in "${ERAS[@]}"; do
+    [[ -d "${VENDORED_ROOT}/${era}/decompiled" ]] && done_count=$((done_count + 1))
+  done
+  echo "Batch complete: ${done_count} era(s) with output under ${VENDORED_ROOT}/<era>/decompiled/"
+else
+  [[ $# -eq 2 ]] || die "usage: scripts/decompile.sh <in.jar> <out-src-dir> | --all-vendored"
+  ensure_tool
+  decompile_one "$1" "$2"
+fi


### PR DESCRIPTION
## Tooling stabilization: decompile.sh + bytecode.sh + AGENTS.md policy

**Research verdict (lib-4 + lib-5):** the vendored-harness lanes (1.4.7 / 1.5.2 / 1.6.4) produce deobf'd dev jars (`build/deobf/{merged,client,server,universal}-deobf.jar`) but had no reading tooling. Decision rule: **read the pre-decompiled cache first; bytecode.sh when bytecode precision (offsets/owners/flags/descriptors) matters; javap for quick checks; never decompile raw obf jars for reading.**

**scripts/decompile.sh** — Vineflower 1.12.0 wrapper:
- Pin: `org.vineflower:vineflower:1.12.0`, sha1 `85570609a0a5941a7d2918b6260b209de810f66f` (Maven Central → `~/.cache/everlastingskins/tools/`, verified every run)
- Flags: `-din=1 -rbr=1 -dgs=1 -asc=1 -rsy=1 -iec=1 -jvn=1 -isl=0 -iib=1 -bsm=1 -dcl=1 -lit=1 -nls=1 -log=ERROR`, `-Xmx4g`
- Vineflower 1.12.0 needs JVM 17+; script resolves one (JAVA_HOME → sdkman 21/25/current → PATH) since the lanes themselves build on Java 8
- `--all-vendored` batch walks ONLY the path-bound roots: `~/.gradle/everlastingskins-vendored/<era>/` + `<repo>/forge-<era>/build/deobf/` — no filesystem-wide searches (host rule)

**scripts/bytecode.sh** — ASM 9.10.1 Textifier + offset driver:
- Pins: `asm-9.10.1.jar` sha1 `ada2141c0cc52ee8f5c48cd5fa4ce0e794f22236`, `asm-util-9.10.1.jar` sha1 `7bb9d450e8d4cbf9f9e04096c44bbfe7fba80b15`
- Default: Textifier `-nodebug`; `--offsets`: vendored driver (`scripts/asm-offsets/OffsetsDriver.java`, compiled once into the tools cache) — subclasses ClassReader's `readLabel` hook to name every label `L%04X` by its bytecode offset (modern ASM no longer sets `Label.info`); `--cp`: `javap -v`; accepts `<era>:<class>` (unzip -p from vendored client/server jar) or a direct `.class` path

**Local one-time pre-decompile (done, not committed):** all 3 eras × (deobf jars + raw vendored jars) → `~/.gradle/everlastingskins-vendored/<era>/decompiled/<name>.src/` (19 trees, 405–3414 java files each). Smoke: `ThreadDownloadImageData.java` present in 1.6.4 client-deobf output.

**AGENTS.md:** new "Reading vendored-lane bytecode" section — pre-decompiled tree first, decompile.sh only for uncached jars, bytecode.sh for precision, `javap -c -p` / `javap -v` guidance, mappings (`build/deobf/*.srg`, `build/mcp*/*.csv`) for obf-name resolution, never decompile raw obf jars for reading.

**Path-bound rule:** the only search roots are the vendored dir + lane build/deobf dirs (single `ls`/bounded `find`); `scripts/decompile.sh --all-vendored` implements exactly that.
