### PR TITLE
fix(e2e): 1.6.4 client GL context under CI xvfb (llvmpipe depth/env)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -583,7 +583,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgl1-mesa-dri libglx-mesa0 mesa-utils \
             libxrandr2 libxxf86vm1 libxcursor1 libxi6 libxinerama1 \
-            libasound2t64 libopenal1
+            libasound2t64 libopenal1 x11-xserver-utils
       - name: Cache Gradle wrapper and caches
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:

--- a/scripts/e2e/drivers/pre18-xvfb.sh
+++ b/scripts/e2e/drivers/pre18-xvfb.sh
@@ -255,12 +255,29 @@ JAVA8_BIN="$E2E_JAVA8"
 
 export LIBGL_ALWAYS_SOFTWARE=1
 export GALLIUM_DRIVER=llvmpipe
+
+# LWJGL 2.x Display.<clinit> shells out to the external `xrandr -q` binary to
+# enumerate screens (XRandR.populate()); when the binary is missing the exec
+# fails, the screen map stays empty and getScreenNames()[0] throws
+# ArrayIndexOutOfBoundsException: 0 -> Display init dies with "No OpenGL
+# context found in the current thread" (seen live on the ubuntu-24.04 CI
+# runner, which ships xvfb but NOT x11-xserver-utils/xrandr). Fail fast with
+# an actionable message instead of the cryptic LWJGL crash.
+if ! command -v xrandr >/dev/null 2>&1; then
+    e2e_fail "xrandr (package x11-xserver-utils) is required for the LWJGL 2 client GL boot"
+fi
+
+# Run Xvfb with an explicit 24-bit screen: xvfb-run's default screen config
+# differs across hosts/images, and an 8-bit root breaks LWJGL 2 GL context
+# creation (the classic headless-CI GL failure). 1280x1024x24 matches the
+# slice-1 locally-proven-green configuration.
+XVFB_SERVER_ARGS="-screen 0 1280x1024x24"
 if [ "$E2E_ERA" = "1.6.4-tweaker" ]; then
     e2e_log "launching client (xvfb + Mesa llvmpipe, tweaker model)..."
     # shellcheck disable=SC2086
     CLIENT_PID=$(start_guarded "$CLIENT_LOG" \
         timeout --kill-after=10 "$E2E_CLIENT_TIMEOUT_S" \
-        xvfb-run -a "$JAVA8_BIN" -Xmx1G -Xms512M \
+        xvfb-run -a -s "$XVFB_SERVER_ARGS" "$JAVA8_BIN" -Xmx1G -Xms512M \
         -Djava.library.path="$E2E_CLIENT_DIR/natives" \
         $E2E_JVM_PROPERTY \
         -Dfml.ignoreInvalidMinecraftCertificates=true \
@@ -282,7 +299,7 @@ else
     # shellcheck disable=SC2016
     CLIENT_PID=$(start_guarded "$CLIENT_LOG" bash -c '
         cd "$1" || exit 3
-        exec timeout --kill-after=10 "$8" xvfb-run -a "$2" -Xmx1G -Xms512M \
+        exec timeout --kill-after=10 "$8" xvfb-run -a -s "$9" "$2" -Xmx1G -Xms512M \
             -Djava.library.path="$3" \
             -Dminecraft.applet.TargetDirectory="$1" \
             -Deverlastingskins.e2e=true \
@@ -290,7 +307,7 @@ else
             -Deverlastingskins.e2e.port="$5" \
             -cp "$6" net.minecraft.client.Minecraft "$7" "e2e-session-token"
     ' _ "$E2E_CLIENT_DIR" "$JAVA8_BIN" "$E2E_CLIENT_DIR/natives" \
-        "$E2E_SERVER_HOST" "$E2E_SERVER_PORT" "$CP" "$E2E_USERNAME" "$E2E_CLIENT_TIMEOUT_S")
+        "$E2E_SERVER_HOST" "$E2E_SERVER_PORT" "$CP" "$E2E_USERNAME" "$E2E_CLIENT_TIMEOUT_S" "$XVFB_SERVER_ARGS")
 fi
 
 RESULT_FILE="$E2E_CLIENT_DIR/e2e-result.json"


### PR DESCRIPTION
## Problem

The informational `E2E (forge-1.6.4)` job (ubuntu-24.04) crashes the real 1.6.4 client under xvfb:

```
java.lang.ExceptionInInitializerError
	at net.minecraft.client.Minecraft.func_71384_a(Minecraft.java:408)
Caused by: java.lang.ArrayIndexOutOfBoundsException: 0
	at org.lwjgl.opengl.LinuxDisplay.getAvailableDisplayModes(LinuxDisplay.java:951)
	at org.lwjgl.opengl.LinuxDisplay.init(LinuxDisplay.java:738)
	at org.lwjgl.opengl.Display.<clinit>(Display.java:138)
...
	OpenGL: ~~ERROR~~ RuntimeException: No OpenGL context found in the current thread.
```

Locally the same driver is green — the crash is CI-env-specific.

## Root cause (evidenced)

LWJGL 2.9.4's `Display.<clinit>` → `LinuxDisplay.init` → `getAvailableDisplayModes`
(`LinuxDisplay.java:951`) calls `XRandR.getScreenNames()[0]`. `XRandR.populate()`
shells out to the **external `xrandr -q` binary** and, when the exec fails, the
`catch (Throwable)` clears the screen map — `getScreenNames()` returns `[]` and
`[0]` throws `ArrayIndexOutOfBoundsException: 0`. The downstream
"No OpenGL context found in the current thread" is the crash-report symptom of
the failed Display init.

The ubuntu-24.04 runner image ships `xvfb 2:21.1.12-1ubuntu1.6` (same package as
the local host — its `xvfb-run` default screen is already 24-bit `1280x1024x24`)
but **NOT `x11-xserver-utils`** (the `xrandr` CLI). The job's apt list installed
`libxrandr2` (the XRandR *library*) but never the CLI binary. Locally `xrandr`
is present → `xrandr -q` parses fine → green. That is the CI/local delta.

## Fix

- `scripts/e2e/drivers/pre18-xvfb.sh`:
  - fail fast with an actionable message when `xrandr` is missing (instead of the cryptic LWJGL AIOOBE crash),
  - run Xvfb with an explicit 24-bit screen (`xvfb-run -s "-screen 0 1280x1024x24"`, the slice-1 locally-proven config) so an 8-bit root can never break LWJGL 2 GL context creation on any host.
- `.github/workflows/ci.yml`: add `x11-xserver-utils` to the `e2e-pre18` apt install (provides `/usr/bin/xrandr`).

## Verification

- Local full 1.6.4 E2E (`bash forge-1.6.4/test-infrastructure/run-e2e.sh`, JDK 8): **exit 0** — server boot + observer join + actor join, all 8 contract asserts pass (`server_booted`, `client_joined`, `command_executed`, `renderer_state=sentinel`, `renderer_verified`, observer twins).
- `bash -n` + shellcheck: no new findings (2 pre-existing SC1091/SC2012).
- `scripts/ci-vendored-harness-diff-guard.sh`: PASS (no harness/build.gradle touched).
- Pre-commit gates: aislop 0 issues, offline compile BUILD SUCCESSFUL, test-count 435, verify-no-mixin pass.