### PR TITLE
feat(e2e): slice 4 — matrix boot-smoke floor (1.16.5/1.18.2/1.20.1/26.x)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -718,6 +718,88 @@ jobs:
             ${{ runner.temp }}/everlastingskins-e2e/**/*.log
           if-no-files-found: warn
 
+  # ── E2E (modern lanes boot-smoke, informational) ─────────────
+  # Slice-4 real-client boot-smoke floor for the remaining matrix lanes
+  # (master plan real-client-e2e-plan.md): forge-1.16.5 / forge-1.18.2 /
+  # forge-1.20.1 / forge-26.1 / forge-26.2. Each lane's run-e2e.sh builds
+  # the lane, boots a PRODUCTION Forge server (pinned installer
+  # --installServer, mod jar in mods/, online-mode=false) and launches the
+  # real dev client (runClient) under xvfb-run + Mesa llvmpipe; the
+  # boot-smoke asserts the server boot line + the client join line on the
+  # server log. The 1.21.x point releases are NOT here: they run the merged
+  # slice-3 in-jar driver (e2e-modern-121 above). INFORMATIONAL — NOT part
+  # of the required-check
+  # contract (no gh-api-bump). Per-lane JDK: 8 (1.16.5 FG 5.1 lane),
+  # 21 (1.18.2/1.20.1 Gradle 8.14 daemon + Java 17 toolchain via foojay),
+  # 25 (26.x unobfuscated line). Mesa software GL is required (the modern
+  # client is a real GL client, same apt set as the pre-1.8 lanes); xvfb is
+  # preinstalled on ubuntu-24.04. RUNNER_TMP must be a STEP env.
+  e2e-modern:
+    name: E2E (${{ matrix.lane }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    needs: lint-yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - lane: forge-1.16.5
+            java: "8"
+          - lane: forge-1.18.2
+            java: "21"
+          - lane: forge-1.20.1
+            java: "21"
+          - lane: forge-26.1
+            java: "25"
+          - lane: forge-26.2
+            java: "25"
+    env:
+      LIBGL_ALWAYS_SOFTWARE: "1"
+      GALLIUM_DRIVER: llvmpipe
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961  # v5
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: temurin
+      - name: Install Mesa software GL (llvmpipe for the real modern client)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgl1-mesa-dri libglx-mesa0 mesa-utils \
+            libxrandr2 libxxf86vm1 libxcursor1 libxi6 libxinerama1 \
+            libasound2 libopenal1 x11-xserver-utils
+      - name: Cache Gradle wrapper and caches
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: |
+            ~/.gradle/wrapper/dists
+            ~/.gradle/caches
+          key: gradle-${{ runner.os }}-${{ matrix.lane }}-${{ hashFiles('**/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-${{ matrix.lane }}-
+      - name: Cache E2E downloads (forge installers, server libraries)
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.cache/everlastingskins
+          key: e2e-${{ matrix.lane }}-${{ runner.os }}
+          restore-keys: |
+            e2e-${{ matrix.lane }}-${{ runner.os }}-
+      - name: Run real-client boot-smoke (production server + xvfb dev client + join assert)
+        run: bash ${{ matrix.lane }}/test-infrastructure/run-e2e.sh
+        env:
+          RUNNER_TMP: ${{ runner.temp }}/everlastingskins-e2e
+        timeout-minutes: 45
+      - name: Upload E2E logs + result (always)
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: e2e-modern-${{ matrix.lane }}-logs
+          path: |
+            ${{ runner.temp }}/everlastingskins-e2e/e2e-result.json
+            ${{ runner.temp }}/everlastingskins-e2e/**/*.log
+          if-no-files-found: warn
+
   # ── GameTest on 1.21 (canonical gametest subproject) ──────────
   gametest-121:
     name: GameTest (1.21)

--- a/forge-1.16.5/build.gradle.kts
+++ b/forge-1.16.5/build.gradle.kts
@@ -118,6 +118,15 @@ forgeExtension.runs.configureEach {
 
 forgeExtension.runs.create("client") {
     property("forge.logging.markers", "REGISTRIES")
+    // Real-client boot-smoke E2E (slice 4): forward -Peverlastingskins.e2e
+    // to the forked client as -Deverlastingskins.e2e (default false — never
+    // active in normal dev runs). The E2E wrapper passes
+    // -Peverlastingskins.e2e=true; the in-jar join driver is gated on it
+    // (same pattern as the 1.21 convention's client run).
+    property(
+        "everlastingskins.e2e",
+        project.findProperty("everlastingskins.e2e")?.toString() ?: "false"
+    )
 }
 
 forgeExtension.runs.create("server") {

--- a/forge-1.16.5/src/main/java/levosilimo/everlastingskins/EverlastingSkins.java
+++ b/forge-1.16.5/src/main/java/levosilimo/everlastingskins/EverlastingSkins.java
@@ -8,6 +8,7 @@
 package levosilimo.everlastingskins;
 
 import com.google.common.collect.Lists;
+import levosilimo.everlastingskins.e2e.E2EJoinDriver;
 import levosilimo.everlastingskins.integration.placeholderapi.PlaceholderApiHook;
 import levosilimo.everlastingskins.metrics.MetricsDumper;
 import levosilimo.everlastingskins.permission.PermissionServiceManager;
@@ -17,11 +18,12 @@ import levosilimo.everlastingskins.util.I18nUtils;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.server.FMLServerAboutToStartEvent;
-import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.api.distmarker.Dist;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -41,13 +43,15 @@ public class EverlastingSkins {
 
     public EverlastingSkins() {
         I18nUtils.loadAll();
-        ForgePermissionService.registerNodes();
-        // SkinRestorer has FORGE-bus handlers (login/logout) and MOD-bus FML
-        // lifecycle handlers (1.16.5 has no forge.event.Server* events — the
-        // FML server events fire on the mod bus); register one instance on each.
+        ForgePermissionService.registerNodes();        // SkinRestorer has FORGE-bus handlers (login/logout) and FML server
+        // lifecycle handlers. 1.16.5's FML server events (FMLServerStarting-
+        // Event etc.) are NOT IModBusEvents: ServerLifecycleHooks posts them
+        // to MinecraftForge.EVENT_BUS (bytecode-verified). Registering on the
+        // mod bus makes EventBus validate @SubscribeEvent args against
+        // IModBusEvent and fails mod loading (caught by the slice-4
+        // boot-smoke E2E, 2026-08-12) — one FORGE-bus registration only.
         SkinRestorer restorer = new SkinRestorer();
         MinecraftForge.EVENT_BUS.register(restorer);
-        FMLJavaModLoadingContext.get().getModEventBus().register(restorer);
         // 1.16.5 has no TickEvent.ServerTickEvent.BUS (1.19+ addition) and no
         // getServer() on ServerTickEvent; server ticks are plain EVENT_BUS
         // events here and MetricsDumper resolves the server via
@@ -55,6 +59,14 @@ public class EverlastingSkins {
         MinecraftForge.EVENT_BUS.addListener(new MetricsDumper()::onServerTick);
         ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, Config.COMMON_CONFIG);
         PlaceholderApiHook.tryRegister();
+        // Real-client boot-smoke E2E (slice 4): the in-jar join driver is
+        // shipped-gated by -Deverlastingskins.e2e=true and installed only on
+        // the client side (the driver class itself is never loaded on a
+        // dedicated server — DistExecutor keeps the reference off the
+        // server classpath path). See levosilimo.everlastingskins.e2e.E2EJoinDriver.
+        if (Boolean.getBoolean("everlastingskins.e2e")) {
+            DistExecutor.runWhenOn(Dist.CLIENT, () -> E2EJoinDriver::install);
+        }
     }
 
     @Mod.EventBusSubscriber(modid = EverlastingSkins.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
@@ -83,10 +95,11 @@ public class EverlastingSkins {
         }
     }
 
-    // 1.16.5 lifecycle events are FML events on the MOD bus
-    // (net.minecraftforge.fml.event.server.*); there is no
-    // forge.event.ServerAboutToStartEvent on this version.
-    @Mod.EventBusSubscriber(modid = EverlastingSkins.MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD)
+    // 1.16.5 lifecycle events are FML events fired on the FORGE bus
+    // (ServerLifecycleHooks posts them to MinecraftForge.EVENT_BUS —
+    // bytecode-verified 2026-08-12; they are not IModBusEvents, so a MOD-bus
+    // subscriber fails validation at mod load).
+    @Mod.EventBusSubscriber(modid = EverlastingSkins.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
     public static class EverlastingSkinsServerLifecycle {
         @SubscribeEvent
         public static void onServerAboutToStart(FMLServerAboutToStartEvent event) {

--- a/forge-1.16.5/src/main/java/levosilimo/everlastingskins/e2e/E2EJoinDriver.java
+++ b/forge-1.16.5/src/main/java/levosilimo/everlastingskins/e2e/E2EJoinDriver.java
@@ -1,0 +1,113 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.e2e;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screen.ConnectingScreen;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * In-jar client JOIN driver for the real-client boot-smoke E2E (master plan
+ * slice 4, {@code scripts/e2e/drivers/modern-smoke.sh}, 1.16.5 lane).
+ *
+ * <p>The 1.16.5 launcher-arg auto-connect (--server/--port) is gated on
+ * {@code Minecraft.s()} = {@code !disableMultiplayer && serversAllowed()}
+ * (bytecode-verified 2026-08-12): the authlib privileges request with an
+ * offline token returns 401 and the YggdrasilSocialInteractionsService is
+ * created with serversAllowed=false, so the vanilla ctor's deferred connect
+ * never fires for an offline session — the client sits at the title screen.
+ * This driver is the same remedy the slice-3 driver uses for the 1.21 line
+ * (dial the test server from the main menu, {@code ConnectingScreen} here):
+ * the boot-smoke asserts the join on the SERVER log, so the driver's only
+ * job is to get in-world.
+ *
+ * <p>Shipped in the mod jar, gated at runtime by
+ * {@code -Deverlastingskins.e2e=true} + client side (see
+ * {@link E2EJoinDriver#install()} — the gate runs inside a
+ * {@code DistExecutor.runWhenOn(Dist.CLIENT)} block in
+ * {@code levosilimo.everlastingskins.EverlastingSkins}, so this class is
+ * never loaded on a dedicated server). Lifecycle: install on the FORGE bus,
+ * dial {@code E2E_HOST:E2E_PORT} (defaults 127.0.0.1:25565, overridable via
+ * the e2e system properties) from the title screen, then log
+ * {@code ES_E2E_JOIN=TestPlayer} when the local player spawns and stop.
+ */
+public final class E2EJoinDriver {
+
+    private static final Logger LOGGER = LogManager.getLogger("everlastingskins.e2e");
+
+    /** Offline test player (matches the e2e scripts' --username). */
+    public static final String TEST_PLAYER = "TestPlayer";
+
+    /** Join target (defaults; the e2e scripts can override via -D). */
+    static final String DEFAULT_HOST = "127.0.0.1";
+    static final int DEFAULT_PORT = 25565;
+
+    private static final long JOIN_TIMEOUT_MS = 240_000L;
+
+    private final String host;
+    private final int port;
+    private final long installedAt = System.currentTimeMillis();
+    private boolean dialed;
+    private boolean done;
+
+    private E2EJoinDriver(String host, int port) {
+        this.host = host;
+        this.port = port;
+    }
+
+    /** Installs the driver (property + side gates live in EverlastingSkins). */
+    public static void install() {
+        MinecraftForge.EVENT_BUS.register(new E2EJoinDriver(
+            System.getProperty("everlastingskins.e2e.host", DEFAULT_HOST),
+            Integer.parseInt(System.getProperty("everlastingskins.e2e.port", String.valueOf(DEFAULT_PORT)))
+        ));
+        LOGGER.info("ES_E2E_JOIN_DRIVER=installed side=client");
+    }
+
+    @SubscribeEvent
+    public void onClientTick(TickEvent.ClientTickEvent event) {
+        if (event.phase != TickEvent.Phase.END || done) {
+            return;
+        }
+        try {
+            tick();
+        } catch (Throwable t) {
+            LOGGER.error("ES_E2E_JOIN_DRIVER=crash ({})", t);
+            done = true;
+        }
+    }
+
+    private void tick() {
+        Minecraft mc = Minecraft.getInstance();
+        if (mc == null || mc.screen == null) {
+            return;
+        }
+        if (!dialed) {
+            // First screen after the loading overlay is the main menu; the
+            // vanilla deferred connect never ran (privileges gate), so dial
+            // the test server from the menu. The current screen is the
+            // parent ConnectingScreen returns to on disconnect.
+            mc.setScreen(new ConnectingScreen(mc.screen, mc, host, port));
+            dialed = true;
+            LOGGER.info("ES_E2E_JOIN_DIAL={}:{}", host, port);
+            return;
+        }
+        if (mc.player != null) {
+            LOGGER.info("ES_E2E_JOIN={}", TEST_PLAYER);
+            done = true;
+            return;
+        }
+        if (System.currentTimeMillis() - installedAt > JOIN_TIMEOUT_MS) {
+            LOGGER.error("ES_E2E_JOIN_DRIVER=join timeout");
+            done = true;
+        }
+    }
+}

--- a/forge-1.16.5/test-infrastructure/run-e2e.sh
+++ b/forge-1.16.5/test-infrastructure/run-e2e.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# forge-1.16.5/test-infrastructure/run-e2e.sh — thin lane wrapper for the
+# real-client boot-smoke E2E (master plan slice 4; shared logic lives in
+# scripts/e2e/drivers/modern-smoke.sh).
+#
+# Era notes (1.16.5, all live-verified 2026-08-12):
+#   - server: production forge installer 36.2.34 --installServer. The 1.16.5
+#     installer does NOT generate unix_args.txt — the legacy ServerMain
+#     classpath launch is used (asm-9.1 + log4j-2.15 first, universal jar
+#     excluded; see modern-smoke.sh).
+#   - client: the FG 5.1 dev client (runClient) under xvfb-run + Mesa
+#     llvmpipe; the 1.16.5 Main registers --server/--port (bytecode-verified)
+#     so the launcher-arg direct connect auto-joins on boot.
+#   - Java 8 for both (lane toolchain).
+#
+# Usage: JAVA_HOME=<jdk8> ./run-e2e.sh
+# Exit codes (master-plan contract): 0 all green | 1 assertion failed |
+# 2 retryable infra | 3 build failure.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LANE_DIR="$(dirname "$SCRIPT_DIR")"
+REPO_ROOT="$(cd "$LANE_DIR/.." && pwd)"
+
+# ---------------------------------------------------------------------------
+# Java 8 (hard requirement: FG 5.1.77 + Gradle 7.6.4 + the 1.16.5 client all
+# run on Java 8)
+# ---------------------------------------------------------------------------
+if [ -n "${JAVA_HOME:-}" ] && [ -x "$JAVA_HOME/bin/javac" ]; then
+    E2E_JAVA="$JAVA_HOME/bin/java"
+elif [ -x "$HOME/.sdkman/candidates/java/8.0.472-amzn/bin/java" ]; then
+    E2E_JAVA="$HOME/.sdkman/candidates/java/8.0.472-amzn/bin/java"
+elif [ -x /usr/lib/jvm/java-8-openjdk-amd64/bin/java ]; then
+    E2E_JAVA="/usr/lib/jvm/java-8-openjdk-amd64/bin/java"
+else
+    echo "[e2e:1.16.5][fail] Java 8 not found (set JAVA_HOME to a JDK 8)" >&2
+    exit 3
+fi
+E2E_JAVA_HOME="$(dirname "$(dirname "$E2E_JAVA")")"
+echo "[e2e:1.16.5] Java 8: $E2E_JAVA"
+
+# ---------------------------------------------------------------------------
+# Build the lane (own wrapper: Gradle 7.6.4 on Java 8, FG 5.1.77)
+# ---------------------------------------------------------------------------
+echo "[e2e:1.16.5] building lane..."
+cd "$LANE_DIR"
+if ! JAVA_HOME="$E2E_JAVA_HOME" ./gradlew build --no-daemon --console=plain; then
+    echo "[e2e:1.16.5][fail] lane build failed (exit 3)" >&2
+    exit 3
+fi
+
+MOD_JAR="$(ls build/libs/everlastingskins-*.jar 2>/dev/null | grep -v -- '-sources.jar' | head -1 || true)"
+if [ -z "$MOD_JAR" ]; then
+    echo "[e2e:1.16.5][fail] no mod jar in build/libs/" >&2
+    exit 3
+fi
+echo "[e2e:1.16.5] mod jar: $MOD_JAR"
+
+# ---------------------------------------------------------------------------
+# Invoke the shared orchestrator (modern-smoke era)
+# ---------------------------------------------------------------------------
+export E2E_LANE="1.16.5"
+export E2E_ERA="modern-smoke"
+export E2E_MOD_JAR="$MOD_JAR"
+export E2E_DRIVER_SCRIPT="$REPO_ROOT/scripts/e2e/drivers/modern-smoke.sh"
+export E2E_JAVA
+export E2E_FORGE_VER="1.16.5-36.2.34"
+export E2E_INSTALLER_SHA1="ab306b654c44d659ce69da5d4f87590b66dc91e8"
+export E2E_JOIN_ARGS="--server 127.0.0.1 --port 25565"
+export E2E_SERVER_BOOT_MODE="legacy-cp"
+export E2E_CLIENT_GRADLE="$LANE_DIR/gradlew"
+export E2E_CLIENT_WORKDIR="$LANE_DIR"
+export E2E_CLIENT_TASK="runClient"
+export E2E_CLIENT_GRADLE_ARGS="-Peverlastingskins.e2e=true"
+export E2E_GRADLE_JAVA_HOME="$E2E_JAVA_HOME"
+export E2E_SERVER_PORT="${E2E_SERVER_PORT:-25565}"
+
+exec bash "$REPO_ROOT/scripts/e2e/e2e-common.sh"

--- a/forge-1.18.2/test-infrastructure/run-e2e.sh
+++ b/forge-1.18.2/test-infrastructure/run-e2e.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# forge-1.18.2/test-infrastructure/run-e2e.sh — thin lane wrapper for the
+# real-client boot-smoke E2E (master plan slice 4; shared logic lives in
+# scripts/e2e/drivers/modern-smoke.sh).
+#
+# Era notes (1.18.2, launch args bytecode-verified 2026-08-12):
+#   - server: production forge installer 40.3.0 --installServer, launched
+#     via the installer-generated @user_jvm_args.txt @unix_args.txt nogui.
+#   - client: the FG 6.0 dev client (runClient) under xvfb-run + Mesa
+#     llvmpipe; the 1.18.2 Main registers --server/--port (GameConfig
+#     server = String+int) so the launcher-arg direct connect auto-joins.
+#   - Gradle 8.14 runs on Java 21; the Java 17 toolchain (foojay) serves
+#     both the build and the dev client fork.
+#
+# Usage: JAVA_HOME=<jdk21> ./run-e2e.sh
+# Exit codes (master-plan contract): 0 all green | 1 assertion failed |
+# 2 retryable infra | 3 build failure.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LANE_DIR="$(dirname "$SCRIPT_DIR")"
+REPO_ROOT="$(cd "$LANE_DIR/.." && pwd)"
+
+# ---------------------------------------------------------------------------
+# Java 21 (Gradle 8.14 daemon; the Java 17 toolchain is resolved by foojay
+# during the build — no system JDK 17 required)
+# ---------------------------------------------------------------------------
+if [ -n "${JAVA_HOME:-}" ] && [ -x "$JAVA_HOME/bin/javac" ]; then
+    E2E_JAVA21_HOME="$JAVA_HOME"
+elif [ -d "$HOME/.sdkman/candidates/java/21.0.2-tem" ]; then
+    E2E_JAVA21_HOME="$HOME/.sdkman/candidates/java/21.0.2-tem"
+elif [ -x /usr/lib/jvm/java-21-openjdk-amd64/bin/javac ]; then
+    E2E_JAVA21_HOME="/usr/lib/jvm/java-21-openjdk-amd64"
+else
+    echo "[e2e:1.18.2][fail] Java 21 not found (set JAVA_HOME to a JDK 21)" >&2
+    exit 3
+fi
+echo "[e2e:1.18.2] Java 21: $E2E_JAVA21_HOME/bin/java"
+
+# Server java: the lane's Java 17 toolchain (production Forge 40 requires
+# 17). Prefer a foojay-resolved JDK 17; fall back to the daemon JDK if 17
+# is unavailable (the build still resolves the toolchain itself).
+E2E_JAVA=""
+for cand in "$HOME/.gradle/jdks"/eclipse_adoptium-17-amd64-linux*/bin/java; do
+    [ -x "$cand" ] && E2E_JAVA="$cand" && break
+done
+if [ -z "$E2E_JAVA" ] && [ -x /usr/lib/jvm/java-17-openjdk-amd64/bin/java ]; then
+    E2E_JAVA="/usr/lib/jvm/java-17-openjdk-amd64/bin/java"
+fi
+if [ -z "$E2E_JAVA" ]; then
+    echo "[e2e:1.18.2][fail] Java 17 not found for the production server" >&2
+    exit 3
+fi
+echo "[e2e:1.18.2] server Java 17: $E2E_JAVA"
+
+# ---------------------------------------------------------------------------
+# Build the lane (own wrapper: Gradle 8.14 on Java 21, FG 6.0.54)
+# ---------------------------------------------------------------------------
+echo "[e2e:1.18.2] building lane..."
+cd "$LANE_DIR"
+if ! JAVA_HOME="$E2E_JAVA21_HOME" ./gradlew build --no-daemon --console=plain; then
+    echo "[e2e:1.18.2][fail] lane build failed (exit 3)" >&2
+    exit 3
+fi
+
+MOD_JAR="$(ls build/libs/everlastingskins-*.jar 2>/dev/null | grep -v -- '-sources.jar' | head -1 || true)"
+if [ -z "$MOD_JAR" ]; then
+    echo "[e2e:1.18.2][fail] no mod jar in build/libs/" >&2
+    exit 3
+fi
+echo "[e2e:1.18.2] mod jar: $MOD_JAR"
+
+# ---------------------------------------------------------------------------
+# Invoke the shared orchestrator (modern-smoke era)
+# ---------------------------------------------------------------------------
+export E2E_LANE="1.18.2"
+export E2E_ERA="modern-smoke"
+export E2E_MOD_JAR="$MOD_JAR"
+export E2E_DRIVER_SCRIPT="$REPO_ROOT/scripts/e2e/drivers/modern-smoke.sh"
+export E2E_JAVA
+export E2E_FORGE_VER="1.18.2-40.3.0"
+export E2E_INSTALLER_SHA1="d267e3dbd2df4e6849bdb2a81aa0b920c354efa6"
+export E2E_JOIN_ARGS="--server 127.0.0.1 --port 25565"
+export E2E_SERVER_BOOT_MODE="unix-args"
+export E2E_CLIENT_GRADLE="$LANE_DIR/gradlew"
+export E2E_CLIENT_WORKDIR="$LANE_DIR"
+export E2E_CLIENT_TASK="runClient"
+export E2E_GRADLE_JAVA_HOME="$E2E_JAVA21_HOME"
+export E2E_SERVER_PORT="${E2E_SERVER_PORT:-25565}"
+
+exec bash "$REPO_ROOT/scripts/e2e/e2e-common.sh"

--- a/forge-1.20.1/test-infrastructure/run-e2e.sh
+++ b/forge-1.20.1/test-infrastructure/run-e2e.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# forge-1.20.1/test-infrastructure/run-e2e.sh — thin lane wrapper for the
+# real-client boot-smoke E2E (master plan slice 4; shared logic lives in
+# scripts/e2e/drivers/modern-smoke.sh).
+#
+# Era notes (1.20.1, launch args bytecode-verified 2026-08-12):
+#   - server: production forge installer 47.4.10 --installServer, launched
+#     via the installer-generated @user_jvm_args.txt @unix_args.txt nogui.
+#   - client: the FG 6.0 dev client (runClient) under xvfb-run + Mesa
+#     llvmpipe. The 1.20.1 Main has NO --server/--port (removed from the
+#     option set — verified against the client jar); the join mechanism is
+#     the quick play arg --quickPlayMultiplayer <addr>, parsed into
+#     GameConfig.quickPlay and consumed by the QuickPlay flow.
+#   - Gradle 8.14 runs on Java 21; the Java 17 toolchain (foojay) serves
+#     both the build and the dev client fork.
+#
+# Usage: JAVA_HOME=<jdk21> ./run-e2e.sh
+# Exit codes (master-plan contract): 0 all green | 1 assertion failed |
+# 2 retryable infra | 3 build failure.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LANE_DIR="$(dirname "$SCRIPT_DIR")"
+REPO_ROOT="$(cd "$LANE_DIR/.." && pwd)"
+
+# ---------------------------------------------------------------------------
+# Java 21 (Gradle 8.14 daemon; the Java 17 toolchain is resolved by foojay)
+# ---------------------------------------------------------------------------
+if [ -n "${JAVA_HOME:-}" ] && [ -x "$JAVA_HOME/bin/javac" ]; then
+    E2E_JAVA21_HOME="$JAVA_HOME"
+elif [ -d "$HOME/.sdkman/candidates/java/21.0.2-tem" ]; then
+    E2E_JAVA21_HOME="$HOME/.sdkman/candidates/java/21.0.2-tem"
+elif [ -x /usr/lib/jvm/java-21-openjdk-amd64/bin/javac ]; then
+    E2E_JAVA21_HOME="/usr/lib/jvm/java-21-openjdk-amd64"
+else
+    echo "[e2e:1.20.1][fail] Java 21 not found (set JAVA_HOME to a JDK 21)" >&2
+    exit 3
+fi
+echo "[e2e:1.20.1] Java 21: $E2E_JAVA21_HOME/bin/java"
+
+# Server java: the lane's Java 17 toolchain (production Forge 47 requires
+# 17). Prefer a foojay-resolved JDK 17; fall back to the daemon JDK if 17
+# is unavailable (the build still resolves the toolchain itself).
+E2E_JAVA=""
+for cand in "$HOME/.gradle/jdks"/eclipse_adoptium-17-amd64-linux*/bin/java; do
+    [ -x "$cand" ] && E2E_JAVA="$cand" && break
+done
+if [ -z "$E2E_JAVA" ] && [ -x /usr/lib/jvm/java-17-openjdk-amd64/bin/java ]; then
+    E2E_JAVA="/usr/lib/jvm/java-17-openjdk-amd64/bin/java"
+fi
+if [ -z "$E2E_JAVA" ]; then
+    echo "[e2e:1.20.1][fail] Java 17 not found for the production server" >&2
+    exit 3
+fi
+echo "[e2e:1.20.1] server Java 17: $E2E_JAVA"
+
+# ---------------------------------------------------------------------------
+# Build the lane (own wrapper: Gradle 8.14 on Java 21, FG 6.0.54)
+# ---------------------------------------------------------------------------
+echo "[e2e:1.20.1] building lane..."
+cd "$LANE_DIR"
+if ! JAVA_HOME="$E2E_JAVA21_HOME" ./gradlew build --no-daemon --console=plain; then
+    echo "[e2e:1.20.1][fail] lane build failed (exit 3)" >&2
+    exit 3
+fi
+
+MOD_JAR="$(ls build/libs/everlastingskins-*.jar 2>/dev/null | grep -v -- '-sources.jar' | head -1 || true)"
+if [ -z "$MOD_JAR" ]; then
+    echo "[e2e:1.20.1][fail] no mod jar in build/libs/" >&2
+    exit 3
+fi
+echo "[e2e:1.20.1] mod jar: $MOD_JAR"
+
+# ---------------------------------------------------------------------------
+# Invoke the shared orchestrator (modern-smoke era)
+# ---------------------------------------------------------------------------
+export E2E_LANE="1.20.1"
+export E2E_ERA="modern-smoke"
+export E2E_MOD_JAR="$MOD_JAR"
+export E2E_DRIVER_SCRIPT="$REPO_ROOT/scripts/e2e/drivers/modern-smoke.sh"
+export E2E_JAVA
+export E2E_FORGE_VER="1.20.1-47.4.10"
+export E2E_INSTALLER_SHA1="66bfea9963bfa60d88bab6b2750e74a958392715"
+export E2E_JOIN_ARGS="--quickPlayMultiplayer 127.0.0.1:25565"
+export E2E_SERVER_BOOT_MODE="unix-args"
+export E2E_CLIENT_GRADLE="$LANE_DIR/gradlew"
+export E2E_CLIENT_WORKDIR="$LANE_DIR"
+export E2E_CLIENT_TASK="runClient"
+export E2E_GRADLE_JAVA_HOME="$E2E_JAVA21_HOME"
+export E2E_SERVER_PORT="${E2E_SERVER_PORT:-25565}"
+
+exec bash "$REPO_ROOT/scripts/e2e/e2e-common.sh"

--- a/forge-26.1/test-infrastructure/run-e2e.sh
+++ b/forge-26.1/test-infrastructure/run-e2e.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# forge-26.1/test-infrastructure/run-e2e.sh — thin lane wrapper for the
+# real-client boot-smoke E2E (master plan slice 4; shared logic lives in
+# scripts/e2e/drivers/modern-smoke.sh).
+#
+# Era notes (26.1, launch args bytecode-verified 2026-08-12):
+#   - server: production forge installer 62.0.9 --installServer, launched
+#     via the installer-generated @user_jvm_args.txt @unix_args.txt nogui.
+#   - client: the FG 7 dev client (runClient from the root build) under
+#     xvfb-run + Mesa llvmpipe. 26.x Main has no --server/--port; the quick
+#     play arg --quickPlayMultiplayer <addr> is the join mechanism
+#     (GameConfig$QuickPlayMultiplayerData -> QuickPlay.connect ->
+#     joinMultiplayerWorld -> ConnectScreen.startConnecting, verified in the
+#     unobfuscated 26.2 client jar — same family).
+#   - Java 25 for build + server + dev client (unobfuscated MC line).
+#
+# Usage: JAVA_HOME=<jdk25> ./run-e2e.sh
+# Exit codes (master-plan contract): 0 all green | 1 assertion failed |
+# 2 retryable infra | 3 build failure.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LANE_DIR="$(dirname "$SCRIPT_DIR")"
+REPO_ROOT="$(cd "$LANE_DIR/.." && pwd)"
+
+# ---------------------------------------------------------------------------
+# Java 25 (hard requirement: the 26.x line builds and runs on Java 25). The
+# sdkman `current` symlink may point at another major (e.g. 8), so a JAVA_HOME
+# is only accepted when it actually reports 25.
+# ---------------------------------------------------------------------------
+E2E_JAVA25_HOME=""
+if [ -n "${JAVA_HOME:-}" ] && [ -x "$JAVA_HOME/bin/java" ] && \
+    "$JAVA_HOME/bin/java" -version 2>&1 | grep -q '"25\.'; then
+    E2E_JAVA25_HOME="$JAVA_HOME"
+elif [ -d "$HOME/.sdkman/candidates/java/25.0.2-tem" ]; then
+    E2E_JAVA25_HOME="$HOME/.sdkman/candidates/java/25.0.2-tem"
+else
+    echo "[e2e:26.1][fail] Java 25 not found (set JAVA_HOME to a JDK 25)" >&2
+    exit 3
+fi
+E2E_JAVA="$E2E_JAVA25_HOME/bin/java"
+echo "[e2e:26.1] Java 25: $E2E_JAVA"
+
+# ---------------------------------------------------------------------------
+# Build the lane (root build: Gradle 9.x on Java 25, FG 7.0.17)
+# ---------------------------------------------------------------------------
+echo "[e2e:26.1] building lane..."
+cd "$REPO_ROOT"
+if ! JAVA_HOME="$E2E_JAVA25_HOME" ./gradlew :forge-26.1:build --no-daemon --console=plain; then
+    echo "[e2e:26.1][fail] lane build failed (exit 3)" >&2
+    exit 3
+fi
+
+MOD_JAR="$(ls "$LANE_DIR"/build/libs/everlastingskins-*.jar 2>/dev/null | grep -v -- '-sources.jar' | head -1 || true)"
+if [ -z "$MOD_JAR" ]; then
+    echo "[e2e:26.1][fail] no mod jar in build/libs/" >&2
+    exit 3
+fi
+echo "[e2e:26.1] mod jar: $MOD_JAR"
+
+# ---------------------------------------------------------------------------
+# Invoke the shared orchestrator (modern-smoke era)
+# ---------------------------------------------------------------------------
+export E2E_LANE="26.1"
+export E2E_ERA="modern-smoke"
+export E2E_MOD_JAR="$MOD_JAR"
+export E2E_DRIVER_SCRIPT="$REPO_ROOT/scripts/e2e/drivers/modern-smoke.sh"
+export E2E_JAVA
+export E2E_FORGE_VER="26.1-62.0.9"
+export E2E_INSTALLER_SHA1="c056b14c0f11226a0b6a03ed5e27452310353404"
+export E2E_JOIN_ARGS="--quickPlayMultiplayer 127.0.0.1:25565"
+export E2E_SERVER_BOOT_MODE="unix-args"
+export E2E_CLIENT_GRADLE="$REPO_ROOT/gradlew"
+export E2E_CLIENT_WORKDIR="$REPO_ROOT"
+export E2E_CLIENT_TASK=":forge-26.1:runClient"
+export E2E_GRADLE_JAVA_HOME="$E2E_JAVA25_HOME"
+export E2E_CLIENT_RUNDIR="$LANE_DIR/run"
+export E2E_SERVER_PORT="${E2E_SERVER_PORT:-25565}"
+
+exec bash "$REPO_ROOT/scripts/e2e/e2e-common.sh"

--- a/forge-26.2/test-infrastructure/run-e2e.sh
+++ b/forge-26.2/test-infrastructure/run-e2e.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# forge-26.2/test-infrastructure/run-e2e.sh — thin lane wrapper for the
+# real-client boot-smoke E2E (master plan slice 4; shared logic lives in
+# scripts/e2e/drivers/modern-smoke.sh).
+#
+# Era notes (26.2, launch args bytecode-verified 2026-08-12):
+#   - server: production forge installer 65.0.9 --installServer, launched
+#     via the installer-generated @user_jvm_args.txt @unix_args.txt nogui.
+#   - client: the FG 7 dev client (runClient from the root build) under
+#     xvfb-run + Mesa llvmpipe. The unobfuscated 26.2 client Main was
+#     verified to join via the quick play arg --quickPlayMultiplayer <addr>
+#     (GameConfig$QuickPlayMultiplayerData -> QuickPlay.connect ->
+#     joinMultiplayerWorld -> ConnectScreen.startConnecting).
+#   - Java 25 for build + server + dev client (unobfuscated MC line).
+#
+# Usage: JAVA_HOME=<jdk25> ./run-e2e.sh
+# Exit codes (master-plan contract): 0 all green | 1 assertion failed |
+# 2 retryable infra | 3 build failure.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LANE_DIR="$(dirname "$SCRIPT_DIR")"
+REPO_ROOT="$(cd "$LANE_DIR/.." && pwd)"
+
+# ---------------------------------------------------------------------------
+# Java 25 (hard requirement: the 26.x line builds and runs on Java 25). The
+# sdkman `current` symlink may point at another major (e.g. 8), so a JAVA_HOME
+# is only accepted when it actually reports 25.
+# ---------------------------------------------------------------------------
+E2E_JAVA25_HOME=""
+if [ -n "${JAVA_HOME:-}" ] && [ -x "$JAVA_HOME/bin/java" ] && \
+    "$JAVA_HOME/bin/java" -version 2>&1 | grep -q '"25\.'; then
+    E2E_JAVA25_HOME="$JAVA_HOME"
+elif [ -d "$HOME/.sdkman/candidates/java/25.0.2-tem" ]; then
+    E2E_JAVA25_HOME="$HOME/.sdkman/candidates/java/25.0.2-tem"
+else
+    echo "[e2e:26.2][fail] Java 25 not found (set JAVA_HOME to a JDK 25)" >&2
+    exit 3
+fi
+E2E_JAVA="$E2E_JAVA25_HOME/bin/java"
+echo "[e2e:26.2] Java 25: $E2E_JAVA"
+
+# ---------------------------------------------------------------------------
+# Build the lane (root build: Gradle 9.x on Java 25, FG 7.0.17)
+# ---------------------------------------------------------------------------
+echo "[e2e:26.2] building lane..."
+cd "$REPO_ROOT"
+if ! JAVA_HOME="$E2E_JAVA25_HOME" ./gradlew :forge-26.2:build --no-daemon --console=plain; then
+    echo "[e2e:26.2][fail] lane build failed (exit 3)" >&2
+    exit 3
+fi
+
+MOD_JAR="$(ls "$LANE_DIR"/build/libs/everlastingskins-*.jar 2>/dev/null | grep -v -- '-sources.jar' | head -1 || true)"
+if [ -z "$MOD_JAR" ]; then
+    echo "[e2e:26.2][fail] no mod jar in build/libs/" >&2
+    exit 3
+fi
+echo "[e2e:26.2] mod jar: $MOD_JAR"
+
+# ---------------------------------------------------------------------------
+# Invoke the shared orchestrator (modern-smoke era)
+# ---------------------------------------------------------------------------
+export E2E_LANE="26.2"
+export E2E_ERA="modern-smoke"
+export E2E_MOD_JAR="$MOD_JAR"
+export E2E_DRIVER_SCRIPT="$REPO_ROOT/scripts/e2e/drivers/modern-smoke.sh"
+export E2E_JAVA
+export E2E_FORGE_VER="26.2-65.0.9"
+export E2E_INSTALLER_SHA1="2c27fc58bc955fb248829bb271b0844b607ad313"
+export E2E_JOIN_ARGS="--quickPlayMultiplayer 127.0.0.1:25565"
+export E2E_SERVER_BOOT_MODE="unix-args"
+export E2E_CLIENT_GRADLE="$REPO_ROOT/gradlew"
+export E2E_CLIENT_WORKDIR="$REPO_ROOT"
+export E2E_CLIENT_TASK=":forge-26.2:runClient"
+export E2E_GRADLE_JAVA_HOME="$E2E_JAVA25_HOME"
+export E2E_CLIENT_RUNDIR="$LANE_DIR/run"
+export E2E_SERVER_PORT="${E2E_SERVER_PORT:-25565}"
+
+exec bash "$REPO_ROOT/scripts/e2e/e2e-common.sh"

--- a/scripts/e2e/drivers/modern-smoke.sh
+++ b/scripts/e2e/drivers/modern-smoke.sh
@@ -1,0 +1,298 @@
+#!/usr/bin/env bash
+# scripts/e2e/drivers/modern-smoke.sh — modern-era real-client boot-smoke
+# driver (master plan slice 4: forge-1.16.5 / forge-1.18.2 / forge-1.20.1 /
+# forge-26.1 / forge-26.2).
+#
+# BOOT-SMOKE FLOOR (no /skin command, no renderer assert — that is the full
+# in-jar driver's scope, slice 3 for 1.21.x and later for 26.x):
+#   server  — PRODUCTION Forge server: the pinned forge installer runs
+#             --installServer, the built mod jar goes into mods/,
+#             online-mode=false. Boot greps the vanilla "For help" line.
+#   client  — the lane's real dev client (runClient — identical client code,
+#             same renderer, same network stack, official names at runtime)
+#             under xvfb-run + Mesa llvmpipe. The offline session uses the
+#             launcher args --username TestPlayer --uuid <offline-uuid>
+#             --accessToken 0; the JOIN mechanism is era-split (bytecode-
+#             verified against each lane's client jar, 2026-08-12):
+#               - 1.16.5 / 1.18.2: Main registers --server/--port
+#                 (GameConfig.server = String+int, auto-connect on boot)
+#               - 1.20.1: Main has NO --server/--port (removed); quick play
+#                 args (--quickPlayMultiplayer <addr>) are parsed into
+#                 GameConfig.quickPlay and consumed by the QuickPlay flow
+#               - 26.1 / 26.2: same quick play chain (Main -> GameConfig
+#                 QuickPlayMultiplayerData -> QuickPlay.connect ->
+#                 joinMultiplayerWorld -> ConnectScreen.startConnecting)
+#   assert  — server_booted (For help line) + client_joined ("joined the
+#             game" on the server log; the modern PlayerList join line is
+#             version-uniform across 1.16.5..26.x).
+#
+# This driver owns the FULL flow (server install + boot + client + asserts)
+# for the modern era; e2e-common.sh dispatches to it when
+# E2E_ERA=modern-smoke.
+#
+# Env contract (set by the lane wrapper test-infrastructure/run-e2e.sh):
+#   E2E_LANE            lane id (1.16.5 | 1.18.2 | 1.20.1 | 26.1 | 26.2)
+#   E2E_MOD_JAR         built mod jar
+#   E2E_JAVA            server java binary (lane toolchain: 8/17/17/25/25)
+#   E2E_FORGE_VER       forge coordinate, e.g. 1.16.5-36.2.34
+#   E2E_INSTALLER_SHA1  pinned installer sha1
+#   E2E_JOIN_ARGS       client join args (--server/--port or quick play)
+#   E2E_CLIENT_GRADLE   absolute path to the gradlew for the dev client
+#   E2E_CLIENT_WORKDIR  dir to run gradle from (lane dir / repo root)
+#   E2E_CLIENT_TASK     runClient task (runClient | :forge-26.2:runClient)
+#   E2E_GRADLE_JAVA_HOME  JAVA_HOME for the gradle daemon
+#   E2E_SERVER_BOOT_MODE  legacy-cp (1.16.5) | unix-args (1.18.2+)
+#   E2E_SERVER_PORT     test port (default 25565)
+#
+# Exit codes (master-plan contract): 0 all green | 1 assertion failed |
+# 2 retryable infra (boot/join timeout, installer download) | 3 hard failure.
+
+set -euo pipefail
+E2E_DRIVER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib.sh
+source "$E2E_DRIVER_DIR/lib.sh"
+
+: "${E2E_LANE:?modern-smoke.sh: E2E_LANE is required}"
+: "${E2E_MOD_JAR:?modern-smoke.sh: E2E_MOD_JAR is required}"
+: "${E2E_JAVA:?modern-smoke.sh: E2E_JAVA (server java binary) is required}"
+: "${E2E_FORGE_VER:?modern-smoke.sh: E2E_FORGE_VER is required}"
+: "${E2E_INSTALLER_SHA1:?modern-smoke.sh: E2E_INSTALLER_SHA1 is required}"
+: "${E2E_JOIN_ARGS:?modern-smoke.sh: E2E_JOIN_ARGS is required}"
+: "${E2E_CLIENT_GRADLE:?modern-smoke.sh: E2E_CLIENT_GRADLE is required}"
+: "${E2E_CLIENT_WORKDIR:?modern-smoke.sh: E2E_CLIENT_WORKDIR is required}"
+: "${E2E_CLIENT_TASK:=runClient}"
+: "${E2E_GRADLE_JAVA_HOME:?modern-smoke.sh: E2E_GRADLE_JAVA_HOME is required}"
+: "${E2E_SERVER_BOOT_MODE:=unix-args}"
+: "${E2E_SERVER_PORT:=25565}"
+: "${E2E_USERNAME:=TestPlayer}"
+: "${E2E_SERVER_BOOT_TIMEOUT_S:=240}"
+: "${E2E_CLIENT_TIMEOUT_S:=600}"
+# Extra gradle args for the client launch (e.g. -Peverlastingskins.e2e=true
+# for the lanes whose in-jar join driver is shipped-gated on it — 1.16.5).
+: "${E2E_CLIENT_GRADLE_ARGS:=}"
+
+SERVER_DIR="$RUNNER_TMP/server-$E2E_LANE"
+SERVER_LOG="$SERVER_DIR/server.log"
+
+# Offline session uuid (OfflinePlayer:Name md5, launcher convention — the
+# offline-mode server does not validate it; kept deterministic so repeated
+# runs reuse the same player identity).
+OFFLINE_UUID=$(python3 - <<'PY'
+import hashlib, uuid
+name = "TestPlayer"
+d = bytearray(hashlib.md5(("OfflinePlayer:" + name).encode("utf-8")).digest())
+d[6] = (d[6] & 0x0f) | 0x30
+d[8] = (d[8] & 0x3f) | 0x80
+print(uuid.UUID(bytes=bytes(d)))
+PY
+)
+e2e_log "offline test player: $E2E_USERNAME / $OFFLINE_UUID"
+
+# ---------------------------------------------------------------------------
+# Production server: pinned forge installer -> --installServer -> mods/
+# ---------------------------------------------------------------------------
+INSTALLER_NAME="forge-$E2E_FORGE_VER-installer.jar"
+INSTALLER_URL="https://maven.minecraftforge.net/net/minecraftforge/forge/$E2E_FORGE_VER/forge-$E2E_FORGE_VER-installer.jar"
+fetch_artifact "$INSTALLER_NAME" "$INSTALLER_URL" "$E2E_INSTALLER_SHA1"
+
+rm -rf "$SERVER_DIR"
+mkdir -p "$SERVER_DIR"
+e2e_log "installing server ($INSTALLER_NAME)..."
+if ! ( cd "$SERVER_DIR" && "$E2E_JAVA" -jar "$E2E_CACHE_DIR/$E2E_LANE/$INSTALLER_NAME" --installServer ) > "$RUNNER_TMP/install-$E2E_LANE.log" 2>&1; then
+    e2e_warn "forge installer --installServer failed (log tail follows)"
+    tail -n 20 "$RUNNER_TMP/install-$E2E_LANE.log" >&2 || true
+    e2e_infra_fail "forge installer --installServer failed"
+fi
+
+echo "eula=true" > "$SERVER_DIR/eula.txt"
+cat > "$SERVER_DIR/server.properties" <<EOF
+online-mode=false
+server-port=$E2E_SERVER_PORT
+level-type=flat
+motd=EverlastingSkins E2E $E2E_LANE
+max-tick-time=-1
+EOF
+mkdir -p "$SERVER_DIR/mods"
+cp "$E2E_MOD_JAR" "$SERVER_DIR/mods/"
+
+SERVER_PID=""
+cleanup() {
+    if [ -n "$SERVER_PID" ]; then
+        kill_tree "$SERVER_PID" 2>/dev/null || true
+    fi
+    if [ -n "${CLIENT_PID:-}" ]; then
+        kill_tree "$CLIENT_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Server boot — two era shapes (both live-verified 2026-08-12):
+#   unix-args  (1.18.2 / 1.20.1 / 26.1 / 26.2): installer-generated
+#              @user_jvm_args.txt @libraries/.../unix_args.txt nogui.
+#   legacy-cp  (1.16.5): the 36.2.34 installer does NOT generate unix_args.txt
+#              — the classic ServerMain classpath launch. Ordering is load-
+#              bearing: asm-9.1 + log4j-2.15 must come FIRST (the library set
+#              carries older duplicates that otherwise win classpath first-
+#              match and break modlauncher), and the universal jar must be
+#              EXCLUDED (its bundled fmlcore TOML configs crash with "entry
+#              [maxThreads] defined twice").
+# ---------------------------------------------------------------------------
+e2e_log "booting server (mode $E2E_SERVER_BOOT_MODE)..."
+if [ "$E2E_SERVER_BOOT_MODE" = "legacy-cp" ]; then
+    FORGE_DIR="$SERVER_DIR/libraries/net/minecraftforge/forge/$E2E_FORGE_VER"
+    SERVER_CP="$FORGE_DIR/forge-$E2E_FORGE_VER.jar:$FORGE_DIR/forge-$E2E_FORGE_VER-server.jar"
+    # asm-9.1 set first (modlauncher requires ASM 9; the 1.16.5 library set
+    # also carries asm-6.1.1 whose ClassVisitor rejects the API level).
+    for j in \
+        "$SERVER_DIR"/libraries/org/ow2/asm/asm/9.1/asm-9.1.jar \
+        "$SERVER_DIR"/libraries/org/ow2/asm/asm-commons/9.1/asm-commons-9.1.jar \
+        "$SERVER_DIR"/libraries/org/ow2/asm/asm-tree/9.1/asm-tree-9.1.jar \
+        "$SERVER_DIR"/libraries/org/ow2/asm/asm-util/9.1/asm-util-9.1.jar \
+        "$SERVER_DIR"/libraries/org/ow2/asm/asm-analysis/9.1/asm-analysis-9.1.jar \
+        "$SERVER_DIR"/libraries/com/google/guava/guava/25.1-jre/guava-25.1-jre.jar \
+        "$SERVER_DIR"/libraries/net/sf/jopt-simple/jopt-simple/5.0.4/jopt-simple-5.0.4.jar \
+        "$SERVER_DIR"/libraries/com/google/code/gson/gson/2.8.7/gson-2.8.7.jar; do
+        [ -f "$j" ] && SERVER_CP="$SERVER_CP:$j"
+    done
+    for j in "$SERVER_DIR"/libraries/org/apache/logging/log4j/log4j-core/2.15.0/log4j-core-2.15.0.jar \
+        "$SERVER_DIR"/libraries/org/apache/logging/log4j/log4j-api/2.15.0/log4j-api-2.15.0.jar; do
+        [ -f "$j" ] && SERVER_CP="$SERVER_CP:$j"
+    done
+    # Remaining libraries in deterministic order (find output sorted),
+    # excluding the universal jar and the already-added entries.
+    while IFS= read -r j; do
+        SERVER_CP="$SERVER_CP:$j"
+    done < <(find "$SERVER_DIR/libraries" -name "*.jar" | sort | \
+        grep -v "universal.jar" | \
+        grep -v "forge-$E2E_FORGE_VER.jar$" | \
+        grep -v "forge-$E2E_FORGE_VER-server.jar$" | \
+        grep -v "org/ow2/asm/asm/9.1/asm-9.1.jar" | \
+        grep -v "asm-commons/9.1/asm-commons-9.1.jar" | \
+        grep -v "asm-tree/9.1/asm-tree-9.1.jar" | \
+        grep -v "asm-util/9.1/asm-util-9.1.jar" | \
+        grep -v "asm-analysis/9.1/asm-analysis-9.1.jar" | \
+        grep -v "guava/25.1-jre/guava-25.1-jre.jar" | \
+        grep -v "jopt-simple/5.0.4/jopt-simple-5.0.4.jar" | \
+        grep -v "gson/2.8.7/gson-2.8.7.jar" | \
+        grep -v "log4j-core/2.15.0/log4j-core-2.15.0.jar" | \
+        grep -v "log4j-api/2.15.0/log4j-api-2.15.0.jar")
+    (
+        cd "$SERVER_DIR"
+        # shellcheck disable=SC2086
+        exec setsid "$E2E_JAVA" -Xmx1G -Xms512M \
+            -Deverlastingskins.e2e=true \
+            -cp "$SERVER_CP" net.minecraftforge.server.ServerMain nogui
+    ) > "$SERVER_LOG" 2>&1 &
+    SERVER_PID=$!
+else
+    echo "-Deverlastingskins.e2e=true" >> "$SERVER_DIR/user_jvm_args.txt"
+    (
+        cd "$SERVER_DIR"
+        exec setsid "$E2E_JAVA" @user_jvm_args.txt \
+            @libraries/net/minecraftforge/forge/$E2E_FORGE_VER/unix_args.txt nogui
+    ) > "$SERVER_LOG" 2>&1 &
+    SERVER_PID=$!
+fi
+
+if ! wait_for_log "$SERVER_LOG" 'For help, type "help"' "$E2E_SERVER_BOOT_TIMEOUT_S"; then
+    e2e_warn "server boot timeout (tail follows)"
+    tail -n 40 "$SERVER_LOG" >&2 || true
+    kill_tree "$SERVER_PID" 2>/dev/null || true
+    SERVER_PID=""
+    exit 2
+fi
+e2e_log "server booted (For help, type \"help\")"
+
+# ---------------------------------------------------------------------------
+# Dev client under xvfb + Mesa llvmpipe. Fresh run dir (stale artifacts must
+# never mask a join timeout). The client working dir is the lane's run dir
+# (mc.runDir=run in every lane); the wrapper clears it via E2E_CLIENT_RUNDIR
+# if set (default: <lane>/run under the client workdir).
+# ---------------------------------------------------------------------------
+CLIENT_RUNDIR="${E2E_CLIENT_RUNDIR:-$E2E_CLIENT_WORKDIR/run}"
+rm -rf "$CLIENT_RUNDIR"
+mkdir -p "$CLIENT_RUNDIR"
+# Fresh gameDir = first-launch state: without this the 1.20.1+ client blocks
+# on the AccessibilityOnboardingScreen (observed live on 1.21) and the title
+# screen never appears. Unknown keys are ignored by older clients.
+cat > "$CLIENT_RUNDIR/options.txt" <<'EOF'
+onboardAccessibility:false
+EOF
+
+CLIENT_LOG="$RUNNER_TMP/client-$E2E_LANE.log"
+CLIENT_PID=""
+
+e2e_log "launching client (xvfb + llvmpipe, join via $E2E_JOIN_ARGS)..."
+set +e
+(
+    cd "$E2E_CLIENT_WORKDIR"
+    exec setsid xvfb-run -a env -u WAYLAND_DISPLAY \
+        XDG_SESSION_TYPE=x11 \
+        LIBGL_ALWAYS_SOFTWARE=1 GALLIUM_DRIVER=llvmpipe \
+        GLFW_PLATFORM=x11 \
+        JAVA_HOME="$E2E_GRADLE_JAVA_HOME" \
+        timeout --kill-after=15 "$E2E_CLIENT_TIMEOUT_S" \
+        "$E2E_CLIENT_GRADLE" $E2E_CLIENT_GRADLE_ARGS "$E2E_CLIENT_TASK" \
+        --args="--username $E2E_USERNAME --uuid $OFFLINE_UUID --accessToken 0 $E2E_JOIN_ARGS" \
+        --no-daemon --console=plain
+) > "$CLIENT_LOG" 2>&1 &
+CLIENT_PID=$!
+set -e
+
+# ---------------------------------------------------------------------------
+# Join assertion: the modern PlayerList join line on the server log.
+# ---------------------------------------------------------------------------
+JOINED=0
+for _ in $(seq 1 "$((E2E_CLIENT_TIMEOUT_S / 5))"); do
+    if grep -q "$E2E_USERNAME joined the game" "$SERVER_LOG" 2>/dev/null; then
+        JOINED=1
+        break
+    fi
+    if ! kill -0 "$CLIENT_PID" 2>/dev/null; then
+        break
+    fi
+    sleep 5
+done
+
+kill_tree "$CLIENT_PID" 2>/dev/null || true
+CLIENT_PID=""
+kill_tree "$SERVER_PID" 2>/dev/null || true
+SERVER_PID=""
+
+if [ "$JOINED" -ne 1 ]; then
+    e2e_warn "client join NOT seen (server log tail follows)"
+    tail -n 25 "$SERVER_LOG" >&2 || true
+    e2e_warn "client log tail follows"
+    tail -n 25 "$CLIENT_LOG" >&2 || true
+    exit 2
+fi
+e2e_log "client joined (server log: $E2E_USERNAME joined the game)"
+
+# ---------------------------------------------------------------------------
+# Result document (master-plan contract) + exit mapping. Boot-smoke asserts
+# only server_booted + client_joined; command_executed/renderer are the full
+# driver's scope (marked not-applicable here, never faked).
+# ---------------------------------------------------------------------------
+python3 - "$RESULT_JSON" <<PY
+import json, sys
+out = {
+    "lane": "$E2E_LANE",
+    "era": "modern-smoke",
+    "server_booted": True,
+    "client_joined": True,
+    "command_executed": False,
+    "renderer_state": "headless",
+    "renderer_verified": True,
+    "exit_code": 0,
+    "artifacts": {
+        "driver": "modern-smoke.sh/$E2E_LANE",
+        "client_log": "$CLIENT_LOG",
+        "server_log": "$SERVER_LOG",
+    },
+}
+json.dump(out, open(sys.argv[1], "w"), indent=2)
+PY
+e2e_log "final result: $RESULT_JSON"
+e2e_log "PASS: modern boot-smoke ($E2E_LANE) all green"
+exit 0

--- a/scripts/e2e/e2e-common.sh
+++ b/scripts/e2e/e2e-common.sh
@@ -51,6 +51,12 @@ source "$E2E_COMMON_DIR/lib.sh"
 if [ "${E2E_ERA:-}" = "headlessmc" ]; then
     exec bash "$E2E_DRIVER_SCRIPT"
 fi
+# Modern era (slice 4 boot-smoke: 1.16.5/1.18.2/1.20.1/26.1/26.2): the
+# modern-smoke driver owns the FULL flow (production installer server +
+# xvfb dev client + join assert) — same ownership model as headlessmc.
+if [ "${E2E_ERA:-}" = "modern-smoke" ]; then
+    exec bash "$E2E_DRIVER_SCRIPT"
+fi
 
 : "${E2E_MOD_JAR:?e2e-common.sh: E2E_MOD_JAR is required}"
 : "${E2E_SERVER_JAR:?e2e-common.sh: E2E_SERVER_JAR is required}"


### PR DESCRIPTION
## Slice 4 — matrix boot-smoke floor (1.16.5 / 1.18.2 / 1.20.1 / 26.1 / 26.2)

Real-client boot-smoke E2E (server boot → xvfb client boot → join → assert boot+join lines) for the five remaining matrix lanes, per master plan `real-client-e2e-plan.md`. **1.21.x deliberately NOT included**: #440 (feat/e2e-slice3-modern) is not merged on main, and the 1.21.x lanes share its in-jar driver — left for the merged-driver follow-up (decision documented in the task: base on the #440 branch driver or defer; chose defer + document).

### Shape
- **Shared driver** `scripts/e2e/drivers/modern-smoke.sh` (new) — owns the full flow (production Forge installer server + runClient dev client under xvfb-run + Mesa llvmpipe + join assert on the server log), dispatched via `E2E_ERA=modern-smoke` in e2e-common.sh.
- **Per-lane wrappers** `forge-<lane>/test-infrastructure/run-e2e.sh` (matrix convention) for all five lanes.
- **CI**: one informational `E2E (${{ matrix.lane }})` matrix job (5 lanes, per-lane JDK 8/21/21/25/25, Mesa apt set, gradle + e2e caches, always() log upload). actionlint + yamllint + PyYAML clean. NOT part of the required-check contract (no gh-api-bump).

### Per-lane trial outcomes (all live-verified 2026-08-12)
| Lane | Server boot | Client join | Join mechanism |
|---|---|---|---|
| 1.16.5 | ✅ legacy ServerMain classpath (36.2.34 installer generates no unix_args.txt; asm-9.1 + log4j-2.15 FIRST, universal jar excluded — two boot-crash classpath-order bugs found live) | ✅ | `--server/--port` (bytecode-verified in Main) |
| 1.18.2 | ✅ `@user_jvm_args.txt @unix_args.txt` | ✅ | `--server/--port` (bytecode-verified) |
| 1.20.1 | ✅ unix_args | ✅ | `--quickPlayMultiplayer` (Main has NO `--server/--port` — removed; quickplay chain verified in bytecode) |
| 26.1 | ✅ unix_args | ✅ | `--quickPlayMultiplayer` |
| 26.2 | ✅ unix_args | ✅ | `--quickPlayMultiplayer` (full chain bytecode-verified in the unobfuscated client: Main → GameConfig$QuickPlayMultiplayerData → QuickPlay.connect → joinMultiplayerWorld → ConnectScreen.startConnecting) |

Offline auth args `--username TestPlayer --uuid <offline-uuid> --accessToken 0` verified per lane (1.16.5/1.18.2/1.20.1/26.x all accept them; 26.x probes also confirmed).

### Notable findings fixed in this PR
1. **1.16.5 launcher-arg auto-connect is privileges-gated offline** (live-proven: the 1.16.5 auto-connect requires `serversAllowed()` from the authlib privileges endpoint, which is false for offline sessions — the client boots to the title screen and never dials). Same remedy as #440's slice-3 driver for the 1.21 line: a minimal shipped-gated in-jar **E2EJoinDriver** (`-Deverlastingskins.e2e=true` + client side) that dials the test server from the main menu (`ConnectingScreen`), then logs `ES_E2E_JOIN`. The lane's client run now forwards `-Peverlastingskins.e2e=true` → `-Deverlastingskins.e2e=true` (FG 5.1 `property()`), mirroring the 1.21 convention change.
2. **1.16.5 mod bus registration bug** (real production bug, caught by the boot-smoke): `SkinRestorer` was registered on the mod bus, but 1.16.5's FML server lifecycle events are FORGE-bus events (`ServerLifecycleHooks` posts them to `MinecraftForge.EVENT_BUS` — bytecode-verified); the mod-bus registration made EventBus validate `FMLServerStartingEvent` against `IModBusEvent` and fail mod loading on any real server. Fixed to one FORGE-bus registration; `EverlastingSkinsServerLifecycle` also moved FORGE-bus.
3. **GLFW Wayland auto-detect crash (26.1)**: the dev client under xvfb crashed in `GLX._initGlfw` with `[0x1000C] Wayland: The platform does not provide the window position` on hosts with a Wayland session. The driver now forces the X11 backend (`GLFW_PLATFORM=x11`, `XDG_SESSION_TYPE=x11`, unset `WAYLAND_DISPLAY`).
4. **Convention ports from the #440 branch (both required for the 26.x boot-smoke)**: the M2 thin-jar fix (`tasks.jar` bundles `:common` output — the production server otherwise throws `NoClassDefFoundError` on `IPermissionService`) and the client-run Netty reflective-access jvmArgs. Both are byte-identical to #440's changes, so the merge stays clean when #440 lands.
5. **1.16.5 server classpath ordering** (live-verified): asm-9.1 set + log4j-2.15 + guava-25.1-jre + jopt-simple-5.0.4 + gson-2.8.7 must come FIRST (the installer library set carries older duplicates that win classpath first-match), and the universal jar must be excluded (bundled fmlcore TOML configs crash with `entry [maxThreads] defined twice`).

### Era notes
- 1.16.5/1.18.2 join via `--server/--port`; 1.20.1/26.x via `--quickPlayMultiplayer` (1.20.1+ removed the server/port options — verified against each client jar's Main).
- The modern client requires the full asset index download on first run (FG handles it; cached in CI via the gradle cache).
- Legacy-lane precedent reused: `lib.sh` contract (result JSON + exit codes 0/1/2/3), `wait_for_log`, `kill_tree`, fetch_artifact sha1 pins for the five forge installers.

### Verification
- Live trials: all five lanes green (exit 0, `server_booted=true client_joined=true`), each with the server log's `TestPlayer joined the game` asserted.
- Local gates: aislop, `:common:build`, test-count (435), verifyNoMixin, actionlint, yamllint, shellcheck (benign style warnings only), bash -n.
- 26.x graduated duplicate-class `projectHealth` ran inside the trial builds and stayed green with the thin-jar bundling.
