### PR TITLE
fix(forge-1.7.10): E2E fail marker on SkinCommand RuntimeException path

### DIFF
--- a/forge-1.7.10/src/main/java/levosilimo/everlastingskins/skinchanger/SkinCommand.java
+++ b/forge-1.7.10/src/main/java/levosilimo/everlastingskins/skinchanger/SkinCommand.java
@@ -287,6 +287,11 @@ public class SkinCommand implements ICommand {
         } catch (RuntimeException e) {
             recordRefreshFailed(targets);
             sender.addChatMessage(new ChatComponentText("Could not resolve a skin for '" + username + "'."));
+            if (Boolean.getBoolean("everlastingskins.e2e")) {
+                String player = targets.isEmpty() ? "unknown" : targets.get(0).getGameProfile().getName();
+                EverlastingSkins.logger.info("ES_E2E_SKIN=fail player={} source={} reason=exception msg={}",
+                    player, username, e.getMessage());
+            }
             return;
         }
         long fetchNanos = System.nanoTime() - fetchStart;

--- a/forge-1.7.10/src/test/java/levosilimo/everlastingskins/skinchanger/SkinRestorerCommandTest.java
+++ b/forge-1.7.10/src/test/java/levosilimo/everlastingskins/skinchanger/SkinRestorerCommandTest.java
@@ -180,6 +180,22 @@ public class SkinRestorerCommandTest {
     }
 
     @Test
+    public void setDispatchMojangExceptionReportsFailure() throws Exception {
+        // Resolver throws (silent Mojang fetch failure): the command must not
+        // crash and must store nothing — the same failure shape as the
+        // empty-result path. The ES_E2E_SKIN=fail marker this path logs is
+        // not assertable here (no log-capture/appender infra in this lane's
+        // tests), so the marker-adjacent behavior is what's under test.
+        SkinCommand.setMojangApiForTest(new ThrowingMojangApi(new RuntimeException("connection refused")));
+
+        EntityPlayerMP player = mockPlayer(TEST_UUID, "Notch");
+        SkinCommand.setServerOverrideForTest(mockServer(player));
+
+        command.processCommand(player, new String[]{"set", "mojang", "ghost"});
+        assertEquals(null, provider.getSkin(TEST_UUID));
+    }
+
+    @Test
     public void targetResolutionByName() throws Exception {
         EntityPlayerMP self = mockPlayer(TEST_UUID, "Notch");
         EntityPlayerMP other = mockPlayer(UUID.randomUUID(), "Steve");
@@ -538,6 +554,30 @@ public class SkinRestorerCommandTest {
         @Override
         public Optional<MojangSkinDataResult> getSkin(String nameOrUniqueId) {
             return result;
+        }
+
+        @Override
+        public Optional<UUID> getUUID(String playerName) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<CustomSkinProperty> getProfile(ProfileLookup lookup) {
+            return Optional.empty();
+        }
+    }
+
+    /** Deterministic throwing Mojang lookup fake (memory #1115; no live HTTP). */
+    private static final class ThrowingMojangApi implements MojangAPI {
+        private final RuntimeException failure;
+
+        ThrowingMojangApi(RuntimeException failure) {
+            this.failure = failure;
+        }
+
+        @Override
+        public Optional<MojangSkinDataResult> getSkin(String nameOrUniqueId) {
+            throw failure;
         }
 
         @Override


### PR DESCRIPTION
## What

Logs the E2E fail marker on SkinCommand's Mojang-fetch RuntimeException catch path, completing the marker coverage for the 1.7.10 lane:

- `ES_E2E_SKIN=fail player={} source={} reason=exception msg={}` — same gate (`-Deverlastingskins.e2e=true`), same logger level (`EverlastingSkins.logger.info`), and same `player/source` key prefix as the existing committed `reason=no-skin` fail marker (SkinCommand.java:303), plus the exception message for E2E triage.
- New `setDispatchMojangExceptionReportsFailure` test: `ThrowingMojangApi` fake (mirrors `FakeMojangApi`; memory #1115 — no live HTTP) asserts the marker-adjacent behavior — no crash, nothing stored on the exception path, same failure shape as the empty-result path. The marker itself is not assertable in-lane (no log-capture/appender infra in the 1.7.10 tests).

## Verification

- forge-1.7.10 lane build (Corretto 8, Gradle 4.4.1): BUILD SUCCESSFUL — 48 unit tests incl. the new one, `:verifyNoMixin` passed
- Root gates: aislop (0 errors), :common:build, test-count (446), verifyNoMixin — all green (pre-commit + pre-push hooks)
- No harness/build.gradle changes (diff-guard unaffected): 2 files only