### PR TITLE
feat(e2e): forge-1.16.5 full in-jar driver (slice 3 port)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -718,20 +718,94 @@ jobs:
             ${{ runner.temp }}/everlastingskins-e2e/**/*.log
           if-no-files-found: warn
 
+  # ── E2E (forge-1.16.5, informational, modern-injar) ────────────
+  # Slice-3 full in-jar E2E for the 1.16.5 lane (master plan
+  # real-client-e2e-plan.md): the lane wrapper points at
+  # scripts/e2e/drivers/modern-injar.sh (E2E_ERA=modern-injar) — a
+  # PRODUCTION Forge 1.16.5 server (pinned installer --installServer, mod
+  # jar in mods/, legacy-cp ServerMain boot with -Deverlastingskins.e2e=true
+  # on the JVM line — the 36.2.34 installer generates no unix_args.txt)
+  # + the real 1.16.5 dev client (runClient) under xvfb-run + Mesa
+  # llvmpipe, offline session via --username/--uuid/--accessToken 0. The
+  # in-jar E2EDriver dials the test server from the title screen (the
+  # --server/--port deferred connect 401s for an offline token), runs
+  # /skin set mojang TestPlayer and asserts the tab-list textures property
+  # carries the sentinel marker. The E2E (forge-1.16.5) matrix entry below
+  # runs the same wrapper; this dedicated job mirrors e2e-modern-121 (the
+  # Build (forge-1.16.5) gradle cache key, corretto 8) for the lane's full
+  # driver signal.
+  # INFORMATIONAL — NOT part of the required-check contract (no gh-api-bump).
+  e2e-modern-1165-injar:
+    name: E2E (forge-1.16.5 full in-jar)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    needs: lint-yaml
+    env:
+      LIBGL_ALWAYS_SOFTWARE: "1"
+      GALLIUM_DRIVER: llvmpipe
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - name: Set up JDK 8
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961  # v5
+        with:
+          java-version: "8"
+          distribution: corretto
+      - name: Install Mesa software GL (llvmpipe for the real 1.16.5 client)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgl1-mesa-dri libglx-mesa0 mesa-utils \
+            libxrandr2 libxxf86vm1 libxcursor1 libxi6 libxinerama1 \
+            libasound2 libopenal1 x11-xserver-utils
+      - name: Cache Gradle wrapper and caches
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: |
+            ~/.gradle/wrapper/dists
+            ~/.gradle/caches
+          key: gradle-${{ runner.os }}-forge-1.16.5-${{ hashFiles('**/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-forge-1.16.5-
+      - name: Cache E2E downloads (forge installer, server libraries)
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.cache/everlastingskins
+          key: e2e-forge-1.16.5-${{ runner.os }}
+          restore-keys: |
+            e2e-${{ runner.os }}-
+      - name: Run real-client E2E (production server + xvfb dev client + tab-list assert)
+        # RUNNER_TMP must be a STEP env: the runner context is not available
+        # in job-level env (invalid workflow file -> zero jobs on push). The
+        # lane wrapper reads it for the server dir + result copy.
+        run: bash forge-1.16.5/test-infrastructure/run-e2e.sh
+        env:
+          RUNNER_TMP: ${{ runner.temp }}/everlastingskins-e2e
+        timeout-minutes: 45
+      - name: Upload E2E logs + result (always)
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: e2e-forge-1.16.5-logs
+          path: |
+            ${{ runner.temp }}/everlastingskins-e2e/e2e-result.json
+            ${{ runner.temp }}/everlastingskins-e2e/**/*.log
+          if-no-files-found: warn
+
   # ── E2E (modern lanes, informational) ─────────────────────────
   # Real-client E2E for the remaining matrix lanes (master plan
-  # real-client-e2e-plan.md): forge-1.16.5 / forge-1.18.2 / forge-1.20.1
-  # run the slice-4 boot-smoke floor (each lane's run-e2e.sh builds the
-  # lane, boots a PRODUCTION Forge server (pinned installer
-  # --installServer, mod jar in mods/, online-mode=false) and launches the
-  # real dev client (runClient) under xvfb-run + Mesa llvmpipe; the
-  # boot-smoke asserts the server boot line + the client join line on the
-  # server log). forge-26.1 / forge-26.2 run the FULL slice-3 in-jar driver
-  # (modern-injar era): the same production server + xvfb client, plus the
-  # in-jar E2EDriver round-trip — /skin set mojang TestPlayer, tab-list
-  # textures sentinel-marker assert, result JSON + exit-code mapping
-  # (26.x port of the 1.21 flow). The 1.21.x point releases are NOT here:
-  # they run the slice-3 in-jar driver (e2e-modern-121 above).
+  # real-client-e2e-plan.md): forge-1.18.2 / forge-1.20.1 run the slice-4
+  # boot-smoke floor (each lane's run-e2e.sh builds the lane, boots a
+  # PRODUCTION Forge server (pinned installer --installServer, mod jar in
+  # mods/, online-mode=false) and launches the real dev client (runClient)
+  # under xvfb-run + Mesa llvmpipe; the boot-smoke asserts the server boot
+  # line + the client join line on the server log). forge-1.16.5 runs the
+  # FULL slice-3 in-jar driver too (its wrapper points at modern-injar.sh;
+  # see the dedicated E2E (forge-1.16.5 full in-jar) job). forge-26.1 /
+  # forge-26.2 run the FULL slice-3 in-jar driver (modern-injar era): the
+  # same production server + xvfb client, plus the in-jar E2EDriver
+  # round-trip — /skin set mojang TestPlayer, tab-list textures
+  # sentinel-marker assert, result JSON + exit-code mapping (26.x port of
+  # the 1.21 flow). The 1.21.x point releases are NOT here: they run the
+  # slice-3 in-jar driver (e2e-modern-121 above).
   # INFORMATIONAL — NOT part of the required-check
   # contract (no gh-api-bump). Per-lane JDK: 8 (1.16.5 FG 5.1 lane),
   # 21 (1.18.2/1.20.1 Gradle 8.14 daemon + Java 17 toolchain via foojay),

--- a/forge-1.16.5/src/main/java/levosilimo/everlastingskins/EverlastingSkins.java
+++ b/forge-1.16.5/src/main/java/levosilimo/everlastingskins/EverlastingSkins.java
@@ -8,7 +8,7 @@
 package levosilimo.everlastingskins;
 
 import com.google.common.collect.Lists;
-import levosilimo.everlastingskins.e2e.E2EJoinDriver;
+import levosilimo.everlastingskins.e2e.E2E;
 import levosilimo.everlastingskins.integration.placeholderapi.PlaceholderApiHook;
 import levosilimo.everlastingskins.metrics.MetricsDumper;
 import levosilimo.everlastingskins.permission.PermissionServiceManager;
@@ -18,12 +18,10 @@ import levosilimo.everlastingskins.util.I18nUtils;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.server.FMLServerAboutToStartEvent;
-import net.minecraftforge.api.distmarker.Dist;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -59,14 +57,13 @@ public class EverlastingSkins {
         MinecraftForge.EVENT_BUS.addListener(new MetricsDumper()::onServerTick);
         ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, Config.COMMON_CONFIG);
         PlaceholderApiHook.tryRegister();
-        // Real-client boot-smoke E2E (slice 4): the in-jar join driver is
-        // shipped-gated by -Deverlastingskins.e2e=true and installed only on
-        // the client side (the driver class itself is never loaded on a
-        // dedicated server — DistExecutor keeps the reference off the
-        // server classpath path). See levosilimo.everlastingskins.e2e.E2EJoinDriver.
-        if (Boolean.getBoolean("everlastingskins.e2e")) {
-            DistExecutor.runWhenOn(Dist.CLIENT, () -> E2EJoinDriver::install);
-        }
+        // Real-client full in-jar E2E (slice 3): E2E.install() is
+        // shipped-gated by -Deverlastingskins.e2e=true and side-gated via
+        // DistExecutor.safeRunWhenOn (client → E2EDriver phase machine,
+        // dedicated server → E2ESentinelHook seed). The slice-4 boot-smoke
+        // E2EJoinDriver stays in the tree (dormant) as the reference for
+        // the launcher-arg privileges gate this driver replaces.
+        E2E.install();
     }
 
     @Mod.EventBusSubscriber(modid = EverlastingSkins.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)

--- a/forge-1.16.5/src/main/java/levosilimo/everlastingskins/e2e/E2E.java
+++ b/forge-1.16.5/src/main/java/levosilimo/everlastingskins/e2e/E2E.java
@@ -1,0 +1,78 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.e2e;
+
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.fml.DistExecutor;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+/**
+ * Single entry point for the in-jar E2E support (master plan slice 3,
+ * modern-injar pattern), invoked from
+ * {@code EverlastingSkins()} (one line: {@code E2E.install();}).
+ *
+ * <p>Shipped-gated by {@code -Deverlastingskins.e2e=true} (never active in
+ * production); side-gated afterwards via
+ * {@link DistExecutor#safeRunWhenOn}:
+ * <ul>
+ *   <li>CLIENT → {@link E2EDriver} (phase machine: join → send
+ *       {@code /skin set mojang TestPlayer} → assert the tab-list textures
+ *       property carries the sentinel marker → result file +
+ *       {@code System.exit});</li>
+ *   <li>DEDICATED_SERVER → {@link E2ESentinelHook} (pre-seeds
+ *       {@code SkinStorage} for the offline test player so the command
+ *       round-trip delivers the marker).</li>
+ * </ul>
+ *
+ * <p>On the modern line the assertion is the textures PROPERTY in the
+ * client's tab-list copy of the profile
+ * ({@code ClientPlayNetHandler.getPlayerInfo(uuid).getProfile()
+ * .getProperties().get("textures")}) — the tab-list entry IS the received
+ * packet data (SPlayerListItemPacket ADD_PLAYER), NOT a pixel injection.
+ * The renderer consumes that property; asserting it is the modern
+ * equivalent of the pre-1.8 injected-field check.
+ */
+public final class E2E {
+
+    /** System property the e2e scripts set on both JVMs. */
+    public static final String E2E_PROPERTY = "everlastingskins.e2e";
+
+    /**
+     * Sentinel marker shared by the server-side seed and the client-side
+     * assertion: the hook stores a textures property whose value (base64 of
+     * the vanilla textures JSON) contains a URL carrying this substring;
+     * the driver asserts {@code value().contains(MARKER)}. Deterministic
+     * across runs (unlike the pre-1.8 PNG sha1 tie) and greppable in both
+     * logs.
+     */
+    public static final String MARKER = "e2e.example/e2e-sentinel";
+
+    private E2E() {}
+
+    /** One-line gated entry from the mod constructor. */
+    public static void install() {
+        if (!Boolean.getBoolean(E2E_PROPERTY)) {
+            return;
+        }
+        DistExecutor.safeRunWhenOn(Dist.CLIENT, () -> E2EDriver::install);
+        DistExecutor.safeRunWhenOn(Dist.DEDICATED_SERVER, () -> E2ESentinelHook::install);
+    }
+
+    /**
+     * Vanilla offline-mode UUID bridge: the same deterministic UUID the
+     * server derives for an offline player name
+     * ({@code UUID.nameUUIDFromBytes("OfflinePlayer:" + name)}). The e2e
+     * script computes the identical value in python for the launcher
+     * {@code --uuid} argument and the server's ops.json, so the seed, the
+     * login session and the client-side assert all key on one UUID.
+     */
+    public static UUID offlineUuid(String name) {
+        return UUID.nameUUIDFromBytes(("OfflinePlayer:" + name).getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/forge-1.16.5/src/main/java/levosilimo/everlastingskins/e2e/E2EDriver.java
+++ b/forge-1.16.5/src/main/java/levosilimo/everlastingskins/e2e/E2EDriver.java
@@ -1,0 +1,357 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.e2e;
+
+import com.mojang.authlib.properties.Property;
+import levosilimo.everlastingskins.EverlastingSkins;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screen.ConnectingScreen;
+import net.minecraft.client.gui.screen.DisconnectedScreen;
+import net.minecraft.client.gui.screen.MainMenuScreen;
+import net.minecraft.client.network.play.NetworkPlayerInfo;
+import net.minecraft.network.play.client.CChatMessagePacket;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.TickEvent;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * In-jar client driver for the real-client E2E (master plan slice 3,
+ * {@code modern-injar} pattern — the 1.16.5 port of the 1.21 driver,
+ * adapted to the 1.16.5 API surface, all names bytecode-verified against
+ * the FG 5.1 deobf client jar 2026-08-12).
+ *
+ * <p>Shipped in the mod jar, gated at runtime by
+ * {@code -Deverlastingskins.e2e=true} + {@code Dist.CLIENT} (see
+ * {@link E2E#install()}). The lane wrapper boots the real 1.16.5 client
+ * the standard ForgeGradle way ({@code runClient} under xvfb + Mesa
+ * llvmpipe) and passes the offline session via the launcher args; this
+ * driver runs inside that client on the client tick event.
+ *
+ * <p>MODERN-LINE assertion semantics (vs the pre-1.8 lanes): the server
+ * does NOT push PNG bytes on a custom channel — it mutates the player's
+ * {@code GameProfile} textures property and re-broadcasts it as vanilla
+ * tab-list packets (REMOVE + ADD_PLAYER, {@code VanillaSkinBroadcaster}).
+ * The client's tab-list entry is the received packet data:
+ * {@code ClientPlayNetHandler.getPlayerInfo(uuid).getProfile()
+ * .getProperties().get("textures")}. The driver asserts that property is
+ * non-null and its value contains the sentinel marker the server pre-seeded
+ * into {@code SkinStorage} (see {@link E2ESentinelHook}) — the property the
+ * vanilla renderer consumes, not pixels (llvmpipe-safe by design).
+ *
+ * <p>Phase machine: WAIT_JOIN (client world + player + connection exist) →
+ * send {@code /skin set mojang TestPlayer} (the offline-friendly command
+ * surface: the seeded skin's stored source/username match the request, so
+ * {@code SkinActionCommand} skips the Mojang HTTP fetch and re-applies +
+ * re-broadcasts the stored sentinel — deterministic in a sandboxed
+ * network) → WAIT_TEXTURES (poll the tab-list property for the marker) →
+ * write {@code e2e-result.json} in the client gameDir → {@code System.exit}.
+ *
+ * <p>1.16.5 deltas vs the 1.21 driver (all bytecode-verified):
+ * <ul>
+ *   <li>Java 8 surface: no switch-expressions / pattern instanceof /
+ *       records (phase machine as if/else chains, casts after
+ *       {@code instanceof});</li>
+ *   <li>the 1.16.5 Main registers {@code --server/--port}, but the vanilla
+ *       deferred connect is gated on the authlib privileges request, which
+ *       401s for an offline token — the client sits at the main menu
+ *       (observed live on the boot-smoke lane, E2EJoinDriver), so the
+ *       driver dials the test server itself from the main menu via
+ *       {@code ConnectingScreen(Screen, Minecraft, String, int)} (the
+ *       1.16.5 menu screen is {@code MainMenuScreen} — {@code TitleScreen}
+ *       is 1.17+ naming);</li>
+ *   <li>{@code ClientPlayNetHandler} has no {@code sendCommand} (1.18+
+ *       addition) and no {@code sendPacket} — packets go out via
+ *       {@code send(IPacket)}; commands are {@code CChatMessagePacket}s
+ *       with the LEADING slash (the server's
+ *       {@code ServerPlayNetHandler.handleChat} routes {@code "/"}-prefixed
+ *       messages to the command dispatcher); this is the opposite of 1.21's
+ *       {@code sendCommand(COMMAND.substring(1))};</li>
+ *   <li>{@code DisconnectedScreen} carries the reason in a private final
+ *       {@code ITextComponent reason} field (reflect-read for the trial
+ *       log — the {@code details}/{@code reason} pair is 1.19+);</li>
+ *   <li>the game dir field is {@code Minecraft.gameDirectory};</li>
+ *   <li>the {@code getPlayerInfo} surface is
+ *       {@code net.minecraft.client.network.play.ClientPlayNetHandler} +
+ *       {@code NetworkPlayerInfo} (the 1.16.5 play-net package).</li>
+ * </ul>
+ *
+ * <p>Exit codes (master-plan contract): 0 all green | 1 assertion failed
+ * (textures property never carried the marker) | 2 retryable infra (join
+ * timeout) | 3 driver hard failure.
+ */
+public final class E2EDriver {
+
+    /** Offline test player (matches the e2e scripts' username arg). */
+    public static final String TEST_PLAYER = "TestPlayer";
+
+    /** Command surface exercised by the driver (see class javadoc). */
+    public static final String COMMAND = "/skin set mojang " + TEST_PLAYER;
+
+    enum Phase {
+        WAIT_JOIN,
+        WAIT_TEXTURES,
+        DONE
+    }
+
+    private static final long JOIN_TIMEOUT_MS = 420_000L;
+    private static final long TEXTURES_TIMEOUT_MS = 90_000L;
+
+    /** Test server the driver dials from the main menu (matches the wrapper). */
+    public static final String SERVER_HOST = "127.0.0.1";
+    public static final int SERVER_PORT = 25565;
+
+    private static volatile Phase phase = Phase.WAIT_JOIN;
+    private static volatile long phaseStartedAt = System.currentTimeMillis();
+    private static volatile long installedAt = System.currentTimeMillis();
+    private static volatile boolean commandSent;
+    private static volatile boolean connectStarted;
+    private static volatile String lastScreenClass = "";
+    private static volatile boolean texturesObserved;
+    private static volatile String observedValue = "";
+
+    private E2EDriver() {}
+
+    /** Called from {@code E2E.install()} (one line; gates live here). */
+    public static void install() {
+        if (!Boolean.getBoolean(E2E.E2E_PROPERTY)) {
+            return;
+        }
+        MinecraftForge.EVENT_BUS.addListener(E2EDriver::onClientTick);
+        EverlastingSkins.logger.info("ES_E2E_DRIVER=installed");
+    }
+
+    /**
+     * Pure phase-transition function, exercised by the unit tests. The
+     * driver advances only on observed facts: join gates on world+player,
+     * the assertion completes the run on the observed marker property.
+     */
+    static Phase nextPhase(Phase current, boolean joined, boolean texturesObserved) {
+        if (current == Phase.WAIT_JOIN) {
+            return joined ? Phase.WAIT_TEXTURES : Phase.WAIT_JOIN;
+        }
+        if (current == Phase.WAIT_TEXTURES) {
+            return texturesObserved ? Phase.DONE : Phase.WAIT_TEXTURES;
+        }
+        return Phase.DONE;
+    }
+
+    // ------------------------------------------------------------------
+    // Client tick (render thread — same thread the tab list is mutated on,
+    // so the assert reads a consistent PlayerInfo map).
+    // ------------------------------------------------------------------
+    static void onClientTick(TickEvent.ClientTickEvent event) {
+        if (event.phase != TickEvent.Phase.END) {
+            return;
+        }
+        try {
+            tick();
+        } catch (Throwable t) {
+            EverlastingSkins.logger.error("ES_E2E_DRIVER=crash phase={} ({})", phase, t.toString());
+            fail(3, false, false, "driver crash: " + t);
+        }
+    }
+
+    private static void tick() {
+        Minecraft mc = Minecraft.getInstance();
+        Phase next = nextPhase(phase, isJoined(mc), texturesPropertyContainsMarker(mc));
+        if (next == Phase.WAIT_JOIN) {
+            if (mc != null) {
+                // Diagnostic: log once per distinct screen class so the
+                // trial log shows when the title actually appears (the
+                // llvmpipe boot takes minutes between the atlas load and
+                // the title screen).
+                String screenClass = mc.screen == null ? "<null>" : mc.screen.getClass().getName();
+                if (!screenClass.equals(lastScreenClass)) {
+                    lastScreenClass = screenClass;
+                    EverlastingSkins.logger.info("ES_E2E_SCREEN={}", screenClass);
+                    if (mc.screen instanceof DisconnectedScreen) {
+                        logDisconnectReason((DisconnectedScreen) mc.screen);
+                    }
+                }
+                if (!connectStarted && mc.screen instanceof MainMenuScreen) {
+                    autoConnect(mc);
+                }
+            }
+            if (timedOut(JOIN_TIMEOUT_MS)) {
+                fail(2, false, false, "join timeout");
+            }
+        } else if (next == Phase.WAIT_TEXTURES) {
+            if (!commandSent) {
+                // Join observed on this tick: send the command once, then
+                // wait for the broadcast round-trip.
+                EverlastingSkins.logger.info("ES_E2E_JOIN={}", TEST_PLAYER);
+                sendCommand(mc);
+                EverlastingSkins.logger.info("ES_E2E_COMMAND={}", COMMAND);
+                advance(Phase.WAIT_TEXTURES);
+            } else if (timedOut(TEXTURES_TIMEOUT_MS)) {
+                fail(1, true, true,
+                    "textures property timeout (broadcast round-trip incomplete)");
+            }
+        } else {
+            // DONE: marker observed — the tab-list textures property
+            // carries the server-seeded sentinel value.
+            texturesObserved = true;
+            observedValue = texturesProperty(mc);
+            EverlastingSkins.logger.info("ES_E2E_RENDERER=ok property={}", observedValue);
+            writeResultAndExit(0);
+        }
+    }
+
+    private static void advance(Phase next) {
+        phase = next;
+        phaseStartedAt = System.currentTimeMillis();
+    }
+
+    private static boolean timedOut(long budgetMs) {
+        return System.currentTimeMillis() - phaseStartedAt > budgetMs;
+    }
+
+    // ------------------------------------------------------------------
+    // Join + command surface.
+    // ------------------------------------------------------------------
+    private static boolean isJoined(Minecraft mc) {
+        return mc != null && mc.player != null && mc.getConnection() != null;
+    }
+
+    private static void logDisconnectReason(DisconnectedScreen screen) {
+        // The disconnect reason is not logged by vanilla; read it for the
+        // trial log. 1.16.5 keeps it in a private final ITextComponent
+        // "reason" field (the details/reason pair is 1.19+).
+        try {
+            java.lang.reflect.Field reasonField = DisconnectedScreen.class.getDeclaredField("reason");
+            reasonField.setAccessible(true);
+            Object reason = reasonField.get(screen);
+            if (reason instanceof ITextComponent) {
+                EverlastingSkins.logger.info("ES_E2E_DISCONNECT={}",
+                    ((ITextComponent) reason).getString());
+                return;
+            }
+            EverlastingSkins.logger.warn("ES_E2E_DISCONNECT=unreadable");
+        } catch (Throwable t) {
+            EverlastingSkins.logger.warn("ES_E2E_DISCONNECT=unreadable ({})", t.toString());
+        }
+    }
+
+    /**
+     * The vanilla deferred connect from {@code --server/--port} never fires
+     * for an offline session (the authlib privileges request 401s —
+     * bytecode-verified on this lane), so the driver starts the multiplayer
+     * connect flow itself once the main menu is up. Gated on
+     * {@code MainMenuScreen}: the early loading screen is also a non-null
+     * screen, and connecting while the datapack load is still running gets
+     * clobbered by the startup flow (observed live on 1.21: ES_E2E_CONNECT
+     * fired mid-load, the title screen then replaced the connect screen,
+     * and no TCP dial ever reached the server).
+     */
+    private static void autoConnect(Minecraft mc) {
+        connectStarted = true;
+        mc.setScreen(new ConnectingScreen(mc.screen, mc, SERVER_HOST, SERVER_PORT));
+        EverlastingSkins.logger.info("ES_E2E_CONNECT=initiated {}:{}", SERVER_HOST, SERVER_PORT);
+    }
+
+    private static void sendCommand(Minecraft mc) {
+        commandSent = true;
+        // 1.16.5 has no sendCommand on ClientPlayNetHandler (1.18+): the
+        // client sends commands as chat packets WITH the leading slash via
+        // connection.send(...) (sendPacket is also 1.18+ naming) and
+        // ServerPlayNetHandler.handleChat routes them to the dispatcher.
+        mc.player.connection.send(new CChatMessagePacket(COMMAND));
+    }
+
+    // ------------------------------------------------------------------
+    // The modern assertion: the tab-list copy of the profile (the received
+    // ADD_PLAYER packet data) carries the sentinel textures property.
+    // ------------------------------------------------------------------
+    private static boolean texturesPropertyContainsMarker(Minecraft mc) {
+        String value = texturesProperty(mc);
+        if (value == null) {
+            return false;
+        }
+        // Also observe the value even before the marker arrives (diagnostic:
+        // a non-marker textures property would be a stale/default skin).
+        observedValue = value;
+        return valueContainsMarker(value);
+    }
+
+    /**
+     * The textures property value is BASE64 of the vanilla textures JSON, so
+     * the marker never appears in the raw string — the check must decode
+     * first (observed live on 1.21: the sentinel was present in the tab
+     * list while the raw contains() stayed false).
+     */
+    private static boolean valueContainsMarker(String value) {
+        if (value.contains(E2E.MARKER)) {
+            return true;
+        }
+        try {
+            return new String(Base64.getDecoder().decode(value), StandardCharsets.UTF_8)
+                .contains(E2E.MARKER);
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    private static String texturesProperty(Minecraft mc) {
+        if (mc == null || mc.getConnection() == null) {
+            return null;
+        }
+        NetworkPlayerInfo info = mc.getConnection().getPlayerInfo(E2E.offlineUuid(TEST_PLAYER));
+        if (info == null) {
+            return null;
+        }
+        // authlib 1.5.25 PropertyMap extends a String->Property multimap, so
+        // get("textures") returns a Collection (single-valued in practice).
+        Collection<Property> textures = info.getProfile().getProperties().get("textures");
+        if (textures == null || textures.isEmpty()) {
+            return null;
+        }
+        return textures.iterator().next().getValue();
+    }
+
+    // ------------------------------------------------------------------
+    // Result + exit (plain System.exit — the modern lanes have no
+    // FMLSecurityManager constraint).
+    // ------------------------------------------------------------------
+    private static void fail(int exitCode, boolean joined, boolean commandSent, String reason) {
+        EverlastingSkins.logger.error("ES_E2E_FAIL={}", reason);
+        writeResultAndExit(exitCode, joined, commandSent, false, false);
+    }
+
+    private static void writeResultAndExit(int exitCode) {
+        writeResultAndExit(exitCode, true, commandSent, texturesObserved, texturesObserved);
+    }
+
+    private static void writeResultAndExit(int exitCode, boolean joined, boolean commandSent,
+                                           boolean rendererState, boolean rendererVerified) {
+        try {
+            Minecraft mc = Minecraft.getInstance();
+            File out = new File(mc != null ? mc.gameDirectory : new File("."), E2EResult.FILE_NAME);
+            Map<String, String> artifacts = new LinkedHashMap<String, String>();
+            artifacts.put("driver", "E2EDriver/1.16.5");
+            artifacts.put("command", COMMAND);
+            artifacts.put("uuid", E2E.offlineUuid(TEST_PLAYER).toString());
+            artifacts.put("property", observedValue.isEmpty() ? "none" : observedValue);
+            E2EResult.write(out, joined, commandSent, rendererState, rendererVerified,
+                System.currentTimeMillis() - installedAt, exitCode, artifacts);
+            EverlastingSkins.logger.info("ES_E2E_RESULT={} code={}", out.getAbsolutePath(), exitCode);
+        } catch (Exception e) {
+            // Never mask the outcome: a result-write failure is a hard driver
+            // failure (exit 3), not a silent success.
+            EverlastingSkins.logger.error("ES_E2E_FAIL=result write failed ({})", e.toString());
+            System.exit(3);
+        }
+        System.exit(exitCode);
+    }
+}

--- a/forge-1.16.5/src/main/java/levosilimo/everlastingskins/e2e/E2EResult.java
+++ b/forge-1.16.5/src/main/java/levosilimo/everlastingskins/e2e/E2EResult.java
@@ -1,0 +1,76 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.e2e;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Pure result-document logic for the real-client E2E (shared master-plan
+ * contract, scripts/e2e/). Kept free of any Minecraft/Forge import so the
+ * lane's JUnit scaffold can test it without a client.
+ *
+ * <p>The in-jar driver writes {@code e2e-result.json} into the client's
+ * gameDir with the client-known fields; the lane wrapper
+ * ({@code test-infrastructure/run-e2e.sh}) merges the server-side facts
+ * (server_booted) into the final document at
+ * {@code ${RUNNER_TMP}/e2e-result.json} and maps the exit code.
+ */
+public final class E2EResult {
+
+    /** Result file name in the client gameDir (driver-side artifact). */
+    public static final String FILE_NAME = "e2e-result.json";
+
+    private E2EResult() {}
+
+    /**
+     * Writes the client-side result document. Fields follow the master-plan
+     * contract; the driver fills what it observes. Throws on IO failure so
+     * the driver can surface it as a hard failure (never a silent pass).
+     */
+    public static void write(File target, boolean clientJoined, boolean commandExecuted,
+                             boolean rendererState, boolean rendererVerified, long durationMs,
+                             int exitCode, Map<String, String> artifacts) throws IOException {
+        Map<String, Object> doc = new LinkedHashMap<String, Object>();
+        doc.put("lane", "1.16.5");
+        doc.put("server_booted", false); // client cannot know; script merges
+        doc.put("client_joined", clientJoined);
+        doc.put("command_executed", commandExecuted);
+        doc.put("renderer_state", rendererState ? "sentinel" : "none");
+        doc.put("renderer_verified", rendererVerified);
+        doc.put("duration_ms", durationMs);
+        doc.put("exit_code", exitCode);
+        doc.put("artifacts", artifacts == null ? new LinkedHashMap<String, String>() : artifacts);
+        Files.write(target.toPath(), toJson(doc).getBytes(StandardCharsets.UTF_8));
+    }
+
+    /** Minimal JSON emitter (kept dependency-free for parity with the pre-1.8 lanes). */
+    public static String toJson(Map<String, Object> doc) {
+        StringBuilder sb = new StringBuilder("{");
+        boolean first = true;
+        for (Map.Entry<String, Object> e : doc.entrySet()) {
+            if (!first) {
+                sb.append(',');
+            }
+            first = false;
+            sb.append('"').append(e.getKey()).append("\":");
+            Object v = e.getValue();
+            if (v instanceof Boolean || v instanceof Number) {
+                sb.append(v);
+            } else if (v instanceof Map) {
+                sb.append(toJson((Map<String, Object>) v));
+            } else {
+                sb.append('"').append(String.valueOf(v).replace("\\", "\\\\").replace("\"", "\\\"")).append('"');
+            }
+        }
+        return sb.append('}').toString();
+    }
+}

--- a/forge-1.16.5/src/main/java/levosilimo/everlastingskins/e2e/E2ESentinelHook.java
+++ b/forge-1.16.5/src/main/java/levosilimo/everlastingskins/e2e/E2ESentinelHook.java
@@ -1,0 +1,111 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.e2e;
+
+import levosilimo.everlastingskins.EverlastingSkins;
+import levosilimo.everlastingskins.skinchanger.SkinRestorer;
+import levosilimo.everlastingskins.skinchanger.SkinStorage;
+import levosilimo.everlastingskins.skinchanger.command.SkinActionCommand;
+import levosilimo.everlastingskins.util.CustomSkinProperty;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.event.server.FMLServerStartedEvent;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.UUID;
+
+/**
+ * Server-side E2E sentinel hook (master plan lib-13, modern variant): with
+ * {@code -Deverlastingskins.e2e=true} on the SERVER, pre-seeds
+ * {@code SkinStorage} for the offline test player before the test client
+ * logs in, so the {@code /skin set mojang TestPlayer} round-trip re-applies
+ * and re-broadcasts the sentinel textures property to the in-jar client
+ * driver.
+ *
+ * <p>MODERN-LINE delta vs the pre-1.8 hooks: the sentinel is NOT a PNG —
+ * it is a well-formed vanilla textures property whose value (base64 of the
+ * textures JSON) carries the marker URL {@link E2E#MARKER}. The seeded
+ * {@code CustomSkinProperty} uses source "MojangAPI" + username
+ * "TestPlayer", which makes {@code SkinActionCommand.storedSourceMatches}
+ * true for {@code /skin set mojang TestPlayer}: the command skips the
+ * Mojang HTTP fetch (deterministic in a sandboxed network) and re-applies
+ * the stored skin, which re-broadcasts it as REMOVE+ADD tab-list packets.
+ *
+ * <p>1.16.5 delta vs the 1.21 hook: {@code net.minecraftforge.event
+ * .ServerStartedEvent} does not exist on 1.16.5 — the FML server lifecycle
+ * events live in {@code net.minecraftforge.fml.event.server} and
+ * {@code ServerLifecycleHooks.handleServerStarted} posts
+ * {@link FMLServerStartedEvent} to {@code MinecraftForge.EVENT_BUS}
+ * (bytecode-verified 2026-08-12; same posting path as the lane's proven
+ * {@code FMLServerStartingEvent} handler in {@link SkinRestorer}).
+ *
+ * <p>Timing contract: {@link #install()} is invoked from the mod
+ * constructor; seeding happens on {@link FMLServerStartedEvent} — after
+ * {@code SkinRestorer.onInitializeServer} (FMLServerStartingEvent) created
+ * {@code SkinStorage}, before any player can join.
+ */
+public final class E2ESentinelHook {
+
+    public static final String TEST_PLAYER = E2EDriver.TEST_PLAYER;
+
+    /** Sentinel texture URL (carries {@link E2E#MARKER}; never fetched in the sandbox). */
+    public static final String SKIN_URL = "https://e2e.example/e2e-sentinel.png";
+
+    private static volatile boolean seeded;
+
+    private E2ESentinelHook() {}
+
+    /** Called from {@code E2E.install()} (one line; gates live here). */
+    public static void install() {
+        if (!Boolean.getBoolean(E2E.E2E_PROPERTY)) {
+            return;
+        }
+        MinecraftForge.EVENT_BUS.addListener(E2ESentinelHook::onServerStarted);
+        EverlastingSkins.logger.info("ES_E2E_SENTINEL=hook installed");
+    }
+
+    private static void onServerStarted(FMLServerStartedEvent event) {
+        seedOnce();
+    }
+
+    /** Idempotent seed; test-visible for the pure-value tests. */
+    static void seedOnce() {
+        if (seeded) {
+            return;
+        }
+        seeded = true;
+        try {
+            SkinStorage storage = SkinRestorer.getSkinStorage();
+            if (storage == null) {
+                EverlastingSkins.logger.warn("ES_E2E_SENTINEL=no storage, seed skipped");
+                return;
+            }
+            UUID uuid = E2E.offlineUuid(TEST_PLAYER);
+            String value = buildPropertyValue(uuid);
+            CustomSkinProperty skin = new CustomSkinProperty(
+                "textures", value, "", SkinActionCommand.SOURCE_MOJANG, TEST_PLAYER);
+            storage.setSkin(uuid, skin);
+            EverlastingSkins.logger.info("ES_E2E_SENTINEL=seeded player={} uuid={} url={}",
+                TEST_PLAYER, uuid, SKIN_URL);
+        } catch (Throwable t) {
+            EverlastingSkins.logger.error("ES_E2E_SENTINEL=FAIL ({})", t.toString());
+        }
+    }
+
+    /**
+     * Builds the base64 textures-property value: the vanilla textures JSON
+     * with a SKIN entry pointing at the sentinel URL. Pure + deterministic,
+     * so the unit tests can decode and assert the marker without a server.
+     */
+    public static String buildPropertyValue(UUID profileId) {
+        String profileIdHex = profileId.toString().replace("-", "");
+        String json = "{\"timestamp\":0,\"profileId\":\"" + profileIdHex
+            + "\",\"profileName\":\"" + TEST_PLAYER
+            + "\",\"textures\":{\"SKIN\":{\"url\":\"" + SKIN_URL + "\"}}}";
+        return Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/forge-1.16.5/src/test/java/levosilimo/everlastingskins/e2e/E2EDriverPhaseTest.java
+++ b/forge-1.16.5/src/test/java/levosilimo/everlastingskins/e2e/E2EDriverPhaseTest.java
@@ -1,0 +1,59 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.e2e;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Pure phase-machine tests for the in-jar E2E driver: the driver advances
+ * only on observed facts, and every wait path is covered by the contract
+ * exit codes in the driver itself.
+ */
+class E2EDriverPhaseTest {
+
+    @Test
+    void joinGatesOnWorldPlayerAndConnection() {
+        assertEquals(E2EDriver.Phase.WAIT_JOIN,
+            E2EDriver.nextPhase(E2EDriver.Phase.WAIT_JOIN, false, false));
+        assertEquals(E2EDriver.Phase.WAIT_JOIN,
+            E2EDriver.nextPhase(E2EDriver.Phase.WAIT_JOIN, false, true));
+        assertEquals(E2EDriver.Phase.WAIT_TEXTURES,
+            E2EDriver.nextPhase(E2EDriver.Phase.WAIT_JOIN, true, false));
+    }
+
+    @Test
+    void texturesObservationCompletesTheRun() {
+        assertEquals(E2EDriver.Phase.WAIT_TEXTURES,
+            E2EDriver.nextPhase(E2EDriver.Phase.WAIT_TEXTURES, true, false));
+        assertEquals(E2EDriver.Phase.DONE,
+            E2EDriver.nextPhase(E2EDriver.Phase.WAIT_TEXTURES, true, true));
+    }
+
+    @Test
+    void phasesNeverRegress() {
+        assertEquals(E2EDriver.Phase.WAIT_TEXTURES,
+            E2EDriver.nextPhase(E2EDriver.Phase.WAIT_TEXTURES, false, false));
+        assertEquals(E2EDriver.Phase.DONE,
+            E2EDriver.nextPhase(E2EDriver.Phase.DONE, false, false));
+    }
+
+    @Test
+    void offlineUuidMatchesVanillaAlgorithm() {
+        // UUID.nameUUIDFromBytes("OfflinePlayer:TestPlayer") — the exact
+        // UUID the e2e wrapper computes in python (--uuid arg) and the
+        // server derives at login; seed + session + client assert must all
+        // key on it.
+        assertEquals("bb77495a-a740-3169-a238-69654c8bd2c1",
+            E2E.offlineUuid("TestPlayer").toString());
+        // Determinism: same input, same UUID; different name, different UUID.
+        assertEquals(E2E.offlineUuid("TestPlayer"), E2E.offlineUuid("TestPlayer"));
+        org.junit.jupiter.api.Assertions.assertNotEquals(
+            E2E.offlineUuid("TestPlayer"), E2E.offlineUuid("ObserverPlayer"));
+    }
+}

--- a/forge-1.16.5/src/test/java/levosilimo/everlastingskins/e2e/E2EResultTest.java
+++ b/forge-1.16.5/src/test/java/levosilimo/everlastingskins/e2e/E2EResultTest.java
@@ -1,0 +1,105 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.e2e;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pure result-document tests for the in-jar E2E driver (no Minecraft/Forge
+ * on the classpath).
+ */
+class E2EResultTest {
+
+    @Test
+    void writeProducesContractJson() throws Exception {
+        File dir = new File(System.getProperty("java.io.tmpdir"), "e2e-result-test-" + System.nanoTime());
+        assertTrue(dir.mkdirs());
+        try {
+            File out = new File(dir, E2EResult.FILE_NAME);
+            Map<String, String> artifacts = new LinkedHashMap<String, String>();
+            artifacts.put("driver", "E2EDriver/1.16.5");
+            artifacts.put("property", "eyJ0ZXh0dXJlcyI6e319");
+            E2EResult.write(out, true, true, true, true, 12345L, 0, artifacts);
+
+            String json = new String(Files.readAllBytes(out.toPath()), StandardCharsets.UTF_8);
+            assertTrue(json.contains("\"lane\":\"1.16.5\""));
+            assertTrue(json.contains("\"client_joined\":true"));
+            assertTrue(json.contains("\"command_executed\":true"));
+            assertTrue(json.contains("\"renderer_state\":\"sentinel\""));
+            assertTrue(json.contains("\"renderer_verified\":true"));
+            assertTrue(json.contains("\"duration_ms\":12345"));
+            assertTrue(json.contains("\"exit_code\":0"));
+            assertTrue(json.contains("\"server_booted\":false")); // script merges
+            assertTrue(json.contains("\"driver\":\"E2EDriver/1.16.5\""));
+        } finally {
+            deleteRecursively(dir);
+        }
+    }
+
+    @Test
+    void failureDocCarriesTheContractFields() throws Exception {
+        File dir = new File(System.getProperty("java.io.tmpdir"), "e2e-result-test-" + System.nanoTime());
+        assertTrue(dir.mkdirs());
+        try {
+            File out = new File(dir, E2EResult.FILE_NAME);
+            E2EResult.write(out, true, true, false, false, 90000L, 1, null);
+            String json = new String(Files.readAllBytes(out.toPath()), StandardCharsets.UTF_8);
+            assertTrue(json.contains("\"renderer_state\":\"none\""));
+            assertTrue(json.contains("\"renderer_verified\":false"));
+            assertTrue(json.contains("\"exit_code\":1"));
+        } finally {
+            deleteRecursively(dir);
+        }
+    }
+
+    @Test
+    void toJsonEscapesQuotesAndBackslashes() {
+        Map<String, Object> doc = new LinkedHashMap<String, Object>();
+        doc.put("artifacts", new LinkedHashMap<String, String>() {{
+            put("property", "a\"b\\c");
+        }});
+        String json = E2EResult.toJson(doc);
+        assertTrue(json.contains("\"property\":\"a\\\"b\\\\c\""));
+    }
+
+    @Test
+    void markerSurvivesTheDocument() {
+        Map<String, Object> doc = new LinkedHashMap<String, Object>();
+        doc.put("artifacts", new LinkedHashMap<String, String>() {{
+            put("property", E2E.MARKER);
+        }});
+        String json = E2EResult.toJson(doc);
+        assertTrue(json.contains(E2E.MARKER));
+        assertFalse(json.contains("\n"));
+        assertNotNull(json);
+    }
+
+    private static void deleteRecursively(File dir) {
+        File[] children = dir.listFiles();
+        if (children != null) {
+            for (File child : children) {
+                if (child.isDirectory()) {
+                    deleteRecursively(child);
+                } else {
+                    child.delete();
+                }
+            }
+        }
+        dir.delete();
+    }
+}

--- a/forge-1.16.5/src/test/java/levosilimo/everlastingskins/e2e/E2ESentinelHookTest.java
+++ b/forge-1.16.5/src/test/java/levosilimo/everlastingskins/e2e/E2ESentinelHookTest.java
@@ -1,0 +1,51 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2026 Levosilimo
+ * https://github.com/Levosilimo/Everlasting-Skins
+ */
+
+package levosilimo.everlastingskins.e2e;
+
+import levosilimo.everlastingskins.skinchanger.command.SkinActionCommand;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pure sentinel-value tests: the seeded textures property must be a
+ * well-formed vanilla textures JSON carrying the shared marker, so the
+ * client-side assert and the server-side seed agree without any server.
+ */
+class E2ESentinelHookTest {
+
+    @Test
+    void propertyValueIsBase64AndCarriesTheMarker() {
+        String value = E2ESentinelHook.buildPropertyValue(E2E.offlineUuid("TestPlayer"));
+        String json = new String(Base64.getDecoder().decode(value), StandardCharsets.UTF_8);
+        assertTrue(json.contains(E2E.MARKER));
+        assertTrue(json.contains("\"textures\":{\"SKIN\":{\"url\":\""
+            + E2ESentinelHook.SKIN_URL + "\"}}"));
+        assertTrue(json.contains("\"profileName\":\"" + E2EDriver.TEST_PLAYER + "\""));
+    }
+
+    @Test
+    void propertyValueKeysOnTheOfflineProfileId() {
+        String value = E2ESentinelHook.buildPropertyValue(E2E.offlineUuid("TestPlayer"));
+        String json = new String(Base64.getDecoder().decode(value), StandardCharsets.UTF_8);
+        assertTrue(json.contains("\"profileId\":\"bb77495aa7403169a23869654c8bd2c1\""));
+    }
+
+    @Test
+    void storedSourceMatchesTheMojangCommandSurface() {
+        // The seed must make SkinActionCommand.storedSourceMatches true for
+        // "/skin set mojang TestPlayer" (source MojangAPI + username
+        // TestPlayer) so the command skips the Mojang HTTP fetch and
+        // re-applies the stored sentinel — the deterministic offline path.
+        assertEquals("MojangAPI", SkinActionCommand.SOURCE_MOJANG);
+        assertEquals(E2EDriver.TEST_PLAYER, E2ESentinelHook.TEST_PLAYER);
+    }
+}

--- a/forge-1.16.5/test-infrastructure/run-e2e.sh
+++ b/forge-1.16.5/test-infrastructure/run-e2e.sh
@@ -1,16 +1,20 @@
 #!/usr/bin/env bash
 # forge-1.16.5/test-infrastructure/run-e2e.sh — thin lane wrapper for the
-# real-client boot-smoke E2E (master plan slice 4; shared logic lives in
-# scripts/e2e/drivers/modern-smoke.sh).
+# real-client FULL in-jar E2E (master plan slice 3, modern-injar era;
+# shared logic lives in scripts/e2e/drivers/modern-injar.sh).
 #
 # Era notes (1.16.5, all live-verified 2026-08-12):
 #   - server: production forge installer 36.2.34 --installServer. The 1.16.5
 #     installer does NOT generate unix_args.txt — the legacy ServerMain
 #     classpath launch is used (asm-9.1 + log4j-2.15 first, universal jar
-#     excluded; see modern-smoke.sh).
+#     excluded; see modern-injar.sh), with -Deverlastingskins.e2e=true on
+#     the JVM command line (no user_jvm_args.txt on this era).
 #   - client: the FG 5.1 dev client (runClient) under xvfb-run + Mesa
-#     llvmpipe; the 1.16.5 Main registers --server/--port (bytecode-verified)
-#     so the launcher-arg direct connect auto-joins on boot.
+#     llvmpipe; the in-jar E2EDriver dials the test server from the title
+#     screen (the 1.16.5 Main registers --server/--port, but the vanilla
+#     deferred connect is gated on the authlib privileges request, which
+#     401s for an offline token — the client sits at the title screen
+#     otherwise) and runs the /skin set mojang TestPlayer round-trip.
 #   - Java 8 for both (lane toolchain).
 #
 # Usage: JAVA_HOME=<jdk8> ./run-e2e.sh
@@ -58,12 +62,12 @@ fi
 echo "[e2e:1.16.5] mod jar: $MOD_JAR"
 
 # ---------------------------------------------------------------------------
-# Invoke the shared orchestrator (modern-smoke era)
+# Invoke the shared orchestrator (modern-injar era)
 # ---------------------------------------------------------------------------
 export E2E_LANE="1.16.5"
-export E2E_ERA="modern-smoke"
+export E2E_ERA="modern-injar"
 export E2E_MOD_JAR="$MOD_JAR"
-export E2E_DRIVER_SCRIPT="$REPO_ROOT/scripts/e2e/drivers/modern-smoke.sh"
+export E2E_DRIVER_SCRIPT="$REPO_ROOT/scripts/e2e/drivers/modern-injar.sh"
 export E2E_JAVA
 export E2E_FORGE_VER="1.16.5-36.2.34"
 export E2E_INSTALLER_SHA1="ab306b654c44d659ce69da5d4f87590b66dc91e8"

--- a/scripts/e2e/drivers/modern-injar.sh
+++ b/scripts/e2e/drivers/modern-injar.sh
@@ -6,17 +6,23 @@
 # FULL-DRIVER FLOW (vs the slice-4 boot-smoke floor in modern-smoke.sh):
 #   server  — PRODUCTION Forge server: the pinned forge installer runs
 #             --installServer, the built mod jar goes into mods/,
-#             online-mode=false, -Deverlastingskins.e2e=true via
-#             user_jvm_args.txt. Boot greps the vanilla "For help" line,
-#             then the sentinel-seed line (ES_E2E_SENTINEL=seeded).
+#             online-mode=false. The -Deverlastingskins.e2e=true flag is
+#             era-split: user_jvm_args.txt on the unix-args eras, the JVM
+#             command line on legacy-cp (1.16.5 — no unix_args.txt). Boot
+#             greps the vanilla "For help" line, then the sentinel-seed
+#             line (ES_E2E_SENTINEL=seeded).
 #   client  — the lane's real dev client (runClient — identical client code,
 #             same renderer, same network stack, official names at runtime)
 #             under xvfb-run + Mesa llvmpipe, shipped-gated via
 #             -Peverlastingskins.e2e=true → -Deverlastingskins.e2e=true.
 #             The offline session uses the launcher args --username TestPlayer
-#             --uuid <offline-uuid> --accessToken 0; the JOIN mechanism is the
-#             quick-play arg (--quickPlayMultiplayer 127.0.0.1:25565,
-#             bytecode-verified on the unobfuscated 26.x client jars).
+#             --uuid <offline-uuid> --accessToken 0; the JOIN mechanism is
+#             era-split (bytecode-verified 2026-08-12): the 26.x quick-play
+#             arg (--quickPlayMultiplayer 127.0.0.1:25565), while the 1.16.5
+#             driver dials the server itself from the title screen
+#             (ConnectingScreen — the --server/--port deferred connect is
+#             gated on the authlib privileges request, which 401s for an
+#             offline token).
 #   assert  — the in-jar E2EDriver (shipped in the mod jar, gated) runs
 #             /skin set mojang TestPlayer and asserts the tab-list textures
 #             property carries the server-seeded sentinel marker (base64-
@@ -25,8 +31,9 @@
 #             file, merges server_booted, maps the exit code and runs the
 #             contract assert gates.
 #
-# This driver owns the FULL flow for the modern in-jar lanes (26.1/26.2);
-# e2e-common.sh dispatches to it when E2E_ERA=modern-injar.
+# This driver owns the FULL flow for the modern in-jar lanes
+# (1.16.5 / 26.1 / 26.2); e2e-common.sh dispatches to it when
+# E2E_ERA=modern-injar.
 #
 # Env contract (set by the lane wrapper test-infrastructure/run-e2e.sh):
 #   E2E_LANE            lane id (26.1 | 26.2)
@@ -39,7 +46,7 @@
 #   E2E_CLIENT_WORKDIR  dir to run gradle from (repo root)
 #   E2E_CLIENT_TASK     runClient task (:forge-26.2:runClient)
 #   E2E_GRADLE_JAVA_HOME  JAVA_HOME for the gradle daemon
-#   E2E_SERVER_BOOT_MODE  unix-args (26.x)
+#   E2E_SERVER_BOOT_MODE  legacy-cp (1.16.5) | unix-args (26.x)
 #   E2E_SERVER_PORT     test port (default 25565)
 #   E2E_CLIENT_GRADLE_ARGS  extra gradle args, e.g. -Peverlastingskins.e2e=true
 #
@@ -113,7 +120,6 @@ level-type=flat
 motd=EverlastingSkins E2E $E2E_LANE
 max-tick-time=-1
 EOF
-echo "-Deverlastingskins.e2e=true" >> "$SERVER_DIR/user_jvm_args.txt"
 mkdir -p "$SERVER_DIR/mods"
 cp "$E2E_MOD_JAR" "$SERVER_DIR/mods/"
 
@@ -129,16 +135,75 @@ cleanup() {
 trap cleanup EXIT
 
 # ---------------------------------------------------------------------------
-# Server boot (unix-args era: installer-generated @user_jvm_args.txt
-# @libraries/.../unix_args.txt nogui — live-verified on the 26.x lanes).
+# Server boot — two era shapes (both live-verified 2026-08-12):
+#   unix-args  (26.x): installer-generated @user_jvm_args.txt
+#              @libraries/.../unix_args.txt nogui; the e2e JVM flag goes
+#              into user_jvm_args.txt.
+#   legacy-cp  (1.16.5): the 36.2.34 installer does NOT generate unix_args.txt
+#              — the classic ServerMain classpath launch. Ordering is load-
+#              bearing: asm-9.1 + log4j-2.15 must come FIRST (the library set
+#              carries older duplicates that otherwise win classpath first-
+#              match and break modlauncher), and the universal jar must be
+#              EXCLUDED (its bundled fmlcore TOML configs crash with "entry
+#              [maxThreads] defined twice"). The e2e JVM flag is on the java
+#              command line (no user_jvm_args.txt on this era).
 # ---------------------------------------------------------------------------
 e2e_log "booting server (mode $E2E_SERVER_BOOT_MODE)..."
-(
-    cd "$SERVER_DIR"
-    exec setsid "$E2E_JAVA" @user_jvm_args.txt \
-        @libraries/net/minecraftforge/forge/$E2E_FORGE_VER/unix_args.txt nogui
-) > "$SERVER_LOG" 2>&1 &
-SERVER_PID=$!
+if [ "$E2E_SERVER_BOOT_MODE" = "legacy-cp" ]; then
+    FORGE_DIR="$SERVER_DIR/libraries/net/minecraftforge/forge/$E2E_FORGE_VER"
+    SERVER_CP="$FORGE_DIR/forge-$E2E_FORGE_VER.jar:$FORGE_DIR/forge-$E2E_FORGE_VER-server.jar"
+    # asm-9.1 set first (modlauncher requires ASM 9; the 1.16.5 library set
+    # also carries asm-6.1.1 whose ClassVisitor rejects the API level).
+    for j in \
+        "$SERVER_DIR"/libraries/org/ow2/asm/asm/9.1/asm-9.1.jar \
+        "$SERVER_DIR"/libraries/org/ow2/asm/asm-commons/9.1/asm-commons-9.1.jar \
+        "$SERVER_DIR"/libraries/org/ow2/asm/asm-tree/9.1/asm-tree-9.1.jar \
+        "$SERVER_DIR"/libraries/org/ow2/asm/asm-util/9.1/asm-util-9.1.jar \
+        "$SERVER_DIR"/libraries/org/ow2/asm/asm-analysis/9.1/asm-analysis-9.1.jar \
+        "$SERVER_DIR"/libraries/com/google/guava/guava/25.1-jre/guava-25.1-jre.jar \
+        "$SERVER_DIR"/libraries/net/sf/jopt-simple/jopt-simple/5.0.4/jopt-simple-5.0.4.jar \
+        "$SERVER_DIR"/libraries/com/google/code/gson/gson/2.8.7/gson-2.8.7.jar; do
+        [ -f "$j" ] && SERVER_CP="$SERVER_CP:$j"
+    done
+    for j in "$SERVER_DIR"/libraries/org/apache/logging/log4j/log4j-core/2.15.0/log4j-core-2.15.0.jar \
+        "$SERVER_DIR"/libraries/org/apache/logging/log4j/log4j-api/2.15.0/log4j-api-2.15.0.jar; do
+        [ -f "$j" ] && SERVER_CP="$SERVER_CP:$j"
+    done
+    # Remaining libraries in deterministic order (find output sorted),
+    # excluding the universal jar and the already-added entries.
+    while IFS= read -r j; do
+        SERVER_CP="$SERVER_CP:$j"
+    done < <(find "$SERVER_DIR/libraries" -name "*.jar" | sort | \
+        grep -v "universal.jar" | \
+        grep -v "forge-$E2E_FORGE_VER.jar$" | \
+        grep -v "forge-$E2E_FORGE_VER-server.jar$" | \
+        grep -v "org/ow2/asm/asm/9.1/asm-9.1.jar" | \
+        grep -v "asm-commons/9.1/asm-commons-9.1.jar" | \
+        grep -v "asm-tree/9.1/asm-tree-9.1.jar" | \
+        grep -v "asm-util/9.1/asm-util-9.1.jar" | \
+        grep -v "asm-analysis/9.1/asm-analysis-9.1.jar" | \
+        grep -v "guava/25.1-jre/guava-25.1-jre.jar" | \
+        grep -v "jopt-simple/5.0.4/jopt-simple-5.0.4.jar" | \
+        grep -v "gson/2.8.7/gson-2.8.7.jar" | \
+        grep -v "log4j-core/2.15.0/log4j-core-2.15.0.jar" | \
+        grep -v "log4j-api/2.15.0/log4j-api-2.15.0.jar")
+    (
+        cd "$SERVER_DIR"
+        # shellcheck disable=SC2086
+        exec setsid "$E2E_JAVA" -Xmx1G -Xms512M \
+            -Deverlastingskins.e2e=true \
+            -cp "$SERVER_CP" net.minecraftforge.server.ServerMain nogui
+    ) > "$SERVER_LOG" 2>&1 &
+    SERVER_PID=$!
+else
+    echo "-Deverlastingskins.e2e=true" >> "$SERVER_DIR/user_jvm_args.txt"
+    (
+        cd "$SERVER_DIR"
+        exec setsid "$E2E_JAVA" @user_jvm_args.txt \
+            @libraries/net/minecraftforge/forge/$E2E_FORGE_VER/unix_args.txt nogui
+    ) > "$SERVER_LOG" 2>&1 &
+    SERVER_PID=$!
+fi
 
 if ! wait_for_log "$SERVER_LOG" 'For help, type "help"' "$E2E_SERVER_BOOT_TIMEOUT_S"; then
     e2e_warn "server boot timeout (tail follows)"


### PR DESCRIPTION
## What

Upgrades the forge-1.16.5 real-client E2E from the slice-4 boot-smoke floor to the FULL slice-3 in-jar driver (modern-injar pattern), per the librarian design spec (1.16.5 slice-3 port, authoritative; this worktree branch reuses the pre-existing clean lane).

**New files** — `forge-1.16.5/src/main/java/levosilimo/everlastingskins/e2e/`:
- `E2E.java` — gated entry (`-Deverlastingskins.e2e=true` → `DistExecutor.safeRunWhenOn(Dist.CLIENT/DEDICATED_SERVER)`), offline-UUID bridge.
- `E2EDriver.java` — phase machine (WAIT_JOIN → WAIT_TEXTURES → DONE): dials the test server from `MainMenuScreen` via `ConnectingScreen`, runs `/skin set mojang TestPlayer`, asserts the tab-list textures property carries the sentinel marker (base64-decoded), writes `e2e-result.json` into `Minecraft.gameDirectory`, `System.exit` 0/1/2/3.
- `E2ESentinelHook.java` — pre-seeds `SkinStorage` on the FORGE bus (see API note below).
- `E2EResult.java` — result doc, `lane` = `"1.16.5"`.

**Wiring**: `EverlastingSkins` constructor now calls `E2E.install()` (E2EJoinDriver stays dormant); `run-e2e.sh` moves to `E2E_ERA=modern-injar` (all pins kept); `modern-injar.sh` gains the **legacy-cp** server-boot branch (ported verbatim from modern-smoke.sh: asm-9.1-first classpath, universal excluded, deterministic find|sort, `-Deverlastingskins.e2e=true` JVM flag, `net.minecraftforge.server.ServerMain nogui`).

**CI**: new informational `E2E (forge-1.16.5 full in-jar)` job mirroring e2e-modern-121 (corretto 8, Mesa llvmpipe apt set, gradle cache key matching Build (forge-1.16.5), e2e-forge-1.16.5 download cache, step-level RUNNER_TMP, always() log upload). The e2e-modern matrix entry for the lane runs the same (now full-driver) wrapper.

**Tests** (JUnit 5.10.3, 11 new): `E2EDriverPhaseTest` (4), `E2EResultTest` (4, lane 1.16.5), `E2ESentinelHookTest` (3).

## Trial outcome

`bash forge-1.16.5/test-infrastructure/run-e2e.sh` — **exit 0 on the FIRST run**, zero iterations:

```
server_booted=True client_joined=True command_executed=True
renderer_state=sentinel renderer_verified=True exit_code=0 duration_ms=10800
```

Client log: `ES_E2E_DRIVER=installed` → `MainMenuScreen` → `ES_E2E_CONNECT=initiated 127.0.0.1:25565` → `ES_E2E_JOIN=TestPlayer` → `ES_E2E_COMMAND=/skin set mojang TestPlayer` → **`ES_E2E_RENDERER=ok`** (property decodes to the sentinel URL) → `ES_E2E_RESULT=... code=0`.
Server log: `ES_E2E_SENTINEL=hook installed` → **`ES_E2E_SENTINEL=seeded player=TestPlayer uuid=bb77495a-...`** → **`SKIN_REFRESH`** profile=TestPlayer.

## API verification notes (bytecode-verified against the FG 5.1 deobf client jar, 2026-08-12)

Verified as spec'd: `ClientPlayNetHandler.getPlayerInfo(UUID)` → `NetworkPlayerInfo.getProfile()` → `GameProfile.getProperties()` (authlib 1.5.25 PropertyMap.get → Collection<Property>), `DistExecutor.safeRunWhenOn(Dist, Supplier<SafeRunnable>)`, `Minecraft.gameDirectory`, `ConnectingScreen(Screen, Minecraft, String, int)`, `CChatMessagePacket(String)`.

Spec-flagged names that FLIPPED on 1.16.5 (documented in code):
- **`net.minecraftforge.event.ServerStartedEvent` does NOT exist on 1.16.5** → `net.minecraftforge.fml.event.server.FMLServerStartedEvent` (posted to `MinecraftForge.EVENT_BUS` by `ServerLifecycleHooks.handleServerStarted` — bytecode-verified; same posting path as the lane's proven `FMLServerStartingEvent` handler).
- **No `sendCommand`/`sendPacket`** (1.18+ additions) → commands go out as `CChatMessagePacket` WITH the leading slash via `connection.send(...)` (1.16.5 ServerPlayNetHandler routes `/`-prefixed chat to the dispatcher — bytecode-verified).
- **No `TitleScreen`** (1.17+ naming) → `MainMenuScreen`; **field is `gameDirectory`** (not gameDir).

## Gates

- Lane build green: `cd forge-1.16.5 && JAVA_HOME=.../8.0.472-amzn ./gradlew build verifyNoMixin --no-daemon` (11 e2e tests pass).
- bash -n / shellcheck (info-level only, same class as modern-smoke.sh baseline) / yamllint strict (repo config) / aislop ci --changes 0-0 / test-count 446 / git diff --check — all clean.
- Pre-commit hooks green on all 4 commits; live trial exit 0 with all contract gates.