### PR TITLE
fix(ci): libasound2t64 for the e2e-modern Mesa step + mesa-apt guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -753,7 +753,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgl1-mesa-dri libglx-mesa0 mesa-utils \
             libxrandr2 libxxf86vm1 libxcursor1 libxi6 libxinerama1 \
-            libasound2 libopenal1 x11-xserver-utils
+            libasound2t64 libopenal1 x11-xserver-utils
       - name: Cache Gradle wrapper and caches
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -842,7 +842,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgl1-mesa-dri libglx-mesa0 mesa-utils \
             libxrandr2 libxxf86vm1 libxcursor1 libxi6 libxinerama1 \
-            libasound2 libopenal1 x11-xserver-utils
+            libasound2t64 libopenal1 x11-xserver-utils
       - name: Cache Gradle wrapper and caches
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
         with:
           config_file: .yamllint.yml
           strict: true
+      - name: Check CI Mesa apt packages (t64 ALSA only)
+        run: bash scripts/check-ci-mesa.sh
 
   # ── Build matrix over the M2 modules (JDK 21) ──────────────────
   build:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -37,6 +37,8 @@ pre-commit:
         exit 0; fi; $RUNNER aislop scan --staged'
     test-count:
       run: bash scripts/test-count-gate.sh
+    mesa-apt:
+      run: bash scripts/check-ci-mesa.sh
     verify-no-mixin:
       run: bash -c 'source scripts/ensure-jdk17.sh && exec ./gradlew --no-daemon --offline :common:verifyNoMixin :forge-1.21:verifyNoMixin'
     compile:

--- a/scripts/check-ci-mesa.sh
+++ b/scripts/check-ci-mesa.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Mesa software-GL apt guard (S1 systemic breakage).
+#
+# Ubuntu 24.04 (noble) renamed libasound2 -> libasound2t64 (the 64-bit-time
+# transition); the plain libasound2 package no longer exists on the
+# ubuntu-24.04 runner image, so any bare reference in the E2E apt lists
+# makes `apt-get install` fail for every job sharing the step. This guard
+# fails when ci.yml contains a bare `libasound2` token (i.e. not followed
+# by `t64`), so the regression cannot land again via copy-paste of an old
+# step or a new lane reusing the pre-fix install list.
+#
+# Usage: bash scripts/check-ci-mesa.sh
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CI_YML="$ROOT/.github/workflows/ci.yml"
+
+if [[ ! -f "$CI_YML" ]]; then
+  echo "check-ci-mesa: $CI_YML not found" >&2
+  exit 1
+fi
+
+# Bare libasound2 (not libasound2t64). -P is fine here: CI runners are
+# GNU grep on ubuntu images, and the guard itself runs in CI's lint-yaml
+# job (and optionally in pre-commit on the dev host).
+if grep -nP 'libasound2(?!t64)' "$CI_YML"; then
+  echo "check-ci-mesa: FAIL — bare 'libasound2' found in .github/workflows/ci.yml" >&2
+  echo "  Ubuntu 24.04 renamed libasound2 -> libasound2t64; use libasound2t64" >&2
+  echo "  in every E2E apt list (e2e-modern Mesa step et al)." >&2
+  exit 1
+fi
+
+echo "check-ci-mesa: OK — no bare libasound2 references in ci.yml"
+exit 0


### PR DESCRIPTION
## One-token fix (S1)

Ubuntu 24.04 (noble) renamed `libasound2` → `libasound2t64` (64-bit-time transition). The plain package no longer resolves on the `ubuntu-24.04` runner, so the e2e-modern job's shared Mesa install step fails `apt-get install` for **all five** E2E lanes (forge-1.16.5 / 1.18.2 / 1.20.1 / 26.1 / 26.2).

- `.github/workflows/ci.yml`: `libasound2` → `libasound2t64` in the Mesa step. Audited: only `libasound2` is t64-renamed in the step's package list — no other package changes.

## Regression guard

- `scripts/check-ci-mesa.sh`: greps ci.yml for a bare `libasound2` token (`grep -P 'libasound2(?!t64)'`), exits 1 with a t64-rename message on match.
- Wired into `lefthook.yml` pre-commit (`mesa-apt`) **and** a step in the existing `lint-yaml` CI job — enforced in CI regardless of local hooks (mirrors the vendored-harness diff-guard precedent).

Regression origin: copy-pasted pre-#438 install lists (the #444 E2E set re-used the old step).

## Verified locally (host = ubuntu-24.04)

- `apt-cache policy libasound2t64` → candidate present; `apt-cache policy libasound2` → (none)
- guard: positive (fixed tree) exit 0, negative (bare injected) exit 1
- `bash -n` + shellcheck clean; PyYAML + yamllint clean; pre-commit hook suite green (incl. mesa-apt)