### PR TITLE
fix(gametest): skinStorage init guard for debounceAfter100ms (6 lanes)

### DIFF
--- a/forge-1.21.1/src/gametest/java/levosilimo/everlastingskins/gametest/SkinVisibilityTest.java
+++ b/forge-1.21.1/src/gametest/java/levosilimo/everlastingskins/gametest/SkinVisibilityTest.java
@@ -927,6 +927,7 @@ public class SkinVisibilityTest {
 
     @GameTest(template = "everlastingskins:empty", batch = "debounceAfter100ms", timeoutTicks = 200)
     public void debounceAfter100ms(GameTestHelper helper) {
+        ensureStorage(helper);
         FakeMojangAPI fake = installFakeMojangAPI(true);
         MinecraftServer server = helper.getLevel().getServer();
         ServerPlayer playerA = mockPlayer(helper, "DebounceA");

--- a/forge-1.21.4/src/gametest/java/levosilimo/everlastingskins/gametest/SkinVisibilityTest.java
+++ b/forge-1.21.4/src/gametest/java/levosilimo/everlastingskins/gametest/SkinVisibilityTest.java
@@ -927,6 +927,7 @@ public class SkinVisibilityTest {
 
     @GameTest(template = "everlastingskins:empty", batch = "debounceAfter100ms", timeoutTicks = 200)
     public void debounceAfter100ms(GameTestHelper helper) {
+        ensureStorage(helper);
         FakeMojangAPI fake = installFakeMojangAPI(true);
         MinecraftServer server = helper.getLevel().getServer();
         ServerPlayer playerA = mockPlayer(helper, "DebounceA");

--- a/forge-1.21.8/src/gametest/java/levosilimo/everlastingskins/gametest/SkinVisibilityTest.java
+++ b/forge-1.21.8/src/gametest/java/levosilimo/everlastingskins/gametest/SkinVisibilityTest.java
@@ -927,6 +927,7 @@ public class SkinVisibilityTest {
 
     @GameTest(structure = "everlastingskins:empty", environment = "everlastingskins_gametest:debounce_after100ms", maxTicks = 200)
     public void debounceAfter100ms(GameTestHelper helper) {
+        ensureStorage(helper);
         FakeMojangAPI fake = installFakeMojangAPI(true);
         MinecraftServer server = helper.getLevel().getServer();
         ServerPlayer playerA = mockPlayer(helper, "DebounceA");

--- a/forge-1.21/src/gametest/java/levosilimo/everlastingskins/gametest/SkinVisibilityTest.java
+++ b/forge-1.21/src/gametest/java/levosilimo/everlastingskins/gametest/SkinVisibilityTest.java
@@ -875,6 +875,7 @@ public class SkinVisibilityTest {
 
     @GameTest(template = "everlastingskins:empty", batch = "debounceAfter100ms", timeoutTicks = 200)
     public void debounceAfter100ms(GameTestHelper helper) {
+        ensureStorage(helper);
         FakeMojangAPI fake = installFakeMojangAPI(true);
         MinecraftServer server = helper.getLevel().getServer();
         ServerPlayer playerA = mockPlayer(helper, "DebounceA");

--- a/forge-26.1/src/gametest/java/levosilimo/everlastingskins/gametest/SkinVisibilityTest.java
+++ b/forge-26.1/src/gametest/java/levosilimo/everlastingskins/gametest/SkinVisibilityTest.java
@@ -925,6 +925,7 @@ public class SkinVisibilityTest {
 
     @GameTest(structure = "everlastingskins:empty", environment = "everlastingskins_gametest:debounce_after100ms", maxTicks = 200)
     public void debounceAfter100ms(GameTestHelper helper) {
+        ensureStorage(helper);
         FakeMojangAPI fake = installFakeMojangAPI(true);
         MinecraftServer server = helper.getLevel().getServer();
         ServerPlayer playerA = mockPlayer(helper, "DebounceA");

--- a/forge-26.2/src/gametest/java/levosilimo/everlastingskins/gametest/SkinVisibilityTest.java
+++ b/forge-26.2/src/gametest/java/levosilimo/everlastingskins/gametest/SkinVisibilityTest.java
@@ -925,6 +925,7 @@ public class SkinVisibilityTest {
 
     @GameTest(structure = "everlastingskins:empty", environment = "everlastingskins_gametest:debounce_after100ms", maxTicks = 200)
     public void debounceAfter100ms(GameTestHelper helper) {
+        ensureStorage(helper);
         FakeMojangAPI fake = installFakeMojangAPI(true);
         MinecraftServer server = helper.getLevel().getServer();
         ServerPlayer playerA = mockPlayer(helper, "DebounceA");


### PR DESCRIPTION
## Fix S3 — GameTest skinStorage NPE order-race family

### Root cause
`SkinRestorer.skinStorage` (static) is initialized **only** in `onInitializeServer(ServerStartingEvent)`. The Forge GameTestServer never fires ServerStartingEvent (it never calls `DedicatedServer.initServer` — documented in SkinVisibilityTest L94-96). The suite works around this per-test via `ensureStorage(helper)` (manually posts ServerStartingEvent; fails loudly if init fails) — but `debounceAfter100ms` (forge-26.1 ~L926-935) did **not** call `ensureStorage`; its `placePlayer()` → `PlayerLoggedInEvent` → `SkinRestorer.onPlayerLoggedIn` → `skinStorage.hasDefaultSkin(uuid)` NPE'd whenever the test ran before any sibling test initialized the static. Order-race flake.

### Exposure
Six lanes, structurally identical missing guard: forge-26.1 (failing lane, run 31571634822), forge-26.2 (byte-identical), forge-1.21 / 1.21.1 / 1.21.4 / 1.21.8. The run's 26.1-fail/26.2-pass split was ordering luck. NOT a #451 regression — documented pre-existing family #330/#332/#334/#346.

### Fix
1. **Per-test guards (all 6 lanes):** `ensureStorage(helper);` as the first line of `debounceAfter100ms`, before `placePlayer` — matching the exact sibling idiom per lane (`ServerStartingEvent.BUS.post` + `Component.literal` on 26.1/26.2/1.21.8; `MinecraftForge.EVENT_BUS.post` + String on 1.21/1.21.1/1.21.4).
2. **Systemic bootstrap init — evaluated, NOT implemented (documented follow-up):** a single construction-time post of ServerStartingEvent is impossible: the GameTest entry (`EverlastingSkinsGameTest` @Mod constructor + test registration) runs at mod-load, **before any `MinecraftServer` exists**, and `onInitializeServer` requires a server handle. A class-load static init has the same problem. `ensureStorage` is already the idempotent single point (static `skinStorage` + null check), so with the guards its coverage is complete and the suite is order-independent. A genuine systemic init would need a Forge-side GameTestServer bootstrap hook (structural churn, out of scope) — follow-up tracked in the issue family.

### Verification
- forge-26.1 `runGameTestServer` ×3: `All 35 required tests passed :)` ×3 (incl. `debounce_after100ms` environment)
- forge-1.21 `runGameTestServer` ×3: `All 34 required tests passed :)` ×3 (incl. `everlastingskins.debounceafter100ms` batch; DebounceA login + SKIN_REFRESH = the previously-NPE path)
- Pre-commit gates: aislop clean, compile green, test-count 446 (≥150), verifyNoMixin pass