### PR TITLE
fix(ci): auto-update workflow behind_prs GITHUB_OUTPUT format

### DIFF
--- a/.github/workflows/auto-update-pr-branches.yml
+++ b/.github/workflows/auto-update-pr-branches.yml
@@ -73,14 +73,38 @@ jobs:
           numbers="$(gh pr list --repo ${{ github.repository }} --base main --state open \
             --limit 100 --json number,isDraft,autoMergeRequest,mergeStateStatus \
             --jq '.[] | select(.isDraft == false and .autoMergeRequest != null and .mergeStateStatus == "BEHIND") | .number')"
+          # Format guard (regression prevention): jq emits one PR number per
+          # line, so every emitted line must be a bare integer. If the query
+          # shape ever changes, the GITHUB_OUTPUT write below would fail the
+          # step and deadlock every BEHIND auto-merge PR again — a loud
+          # failure right here beats a silent deadlock.
+          if grep -vE '^[0-9]+$' <<<"$numbers" | grep -q .; then
+            echo "::error::behind_prs format guard tripped: expected only PR numbers, got: $(printf '%s' "$numbers" | tr '\n' ' ')" >&2
+            exit 1
+          fi
           echo "found $(wc -w <<<"$numbers") BEHIND auto-merge PR(s)"
-          echo "behind_prs=$numbers" >> "$GITHUB_OUTPUT"
+          # GITHUB_OUTPUT multiline syntax: jq emits one number per line and
+          # a single-line `key=value` write would split across GITHUB_OUTPUT
+          # lines — the parser rejects the orphan lines ("Invalid format
+          # '451'", runs 31585576691/31591453568) and the step fails. The
+          # heredoc form carries the newline-delimited list natively; any
+          # consumer splitting on whitespace (the Update step's `for n in
+          # $numbers`, or `while read`) handles it unchanged.
+          {
+            echo "behind_prs<<EOF"
+            printf '%s\n' "$numbers"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Update BEHIND branches (PAT-gated)
         if: env.PAT_AVAILABLE == 'true'
         env:
           GH_TOKEN: ${{ secrets.EVERLASTINGSKINS_PAT }}
         run: |
+          # Deliberately re-list at update time (fresh state; avoids the
+          # list-vs-update 422 race) rather than consuming the List step's
+          # behind_prs output — the output exists for observability and
+          # future consumers, and is valid either way.
           numbers="$(gh pr list --repo ${{ github.repository }} --base main --state open \
             --limit 100 --json number,isDraft,autoMergeRequest,mergeStateStatus \
             --jq '.[] | select(.isDraft == false and .autoMergeRequest != null and .mergeStateStatus == "BEHIND") | .number')"


### PR DESCRIPTION
## Root cause

The standing `Auto-update PR branches` workflow deadlocks every BEHIND auto-merge PR. The List step wrote the BEHIND PR list with a bare single-line echo into `$GITHUB_OUTPUT`:

```bash
echo "behind_prs=$numbers" >> "$GITHUB_OUTPUT"
```

`gh pr list --jq '.[] | ... | .number'` emits **one PR number per line**, so the write split across GITHUB_OUTPUT lines. The runner parsed `behind_prs=451` and then rejected the orphan lines:

```
##[error]Unable to process file command 'output' successfully.
##[error]Invalid format '451'
```

(runs [31585576691](https://github.com/Levosilimo/Everlasting-Skins/actions/runs/31585576691) + [31591453568](https://github.com/Levosilimo/Everlasting-Skins/actions/runs/31591453568), both 2026-08-12). The List step fails → the PAT-gated Update step never runs → BEHIND PRs (currently **#451 #447 #448 #453**) never get `gh pr update-branch` → deadlock under strict "require branches to be up to date" protection.

## Fix

Switch the output write to GITHUB_OUTPUT **multiline syntax** (`key<<EOF ... EOF`), which carries the newline-delimited list natively. Downstream consumption is unaffected: the Update step splits on whitespace (`for n in $numbers`), which handles the newline form unchanged (it also deliberately re-lists at update time for fresh state / 422-race avoidance — documented in a comment).

## Hardening (regression prevention)

Added a **format guard** before the write: every emitted line must match `^[0-9]+$`; otherwise the step fails loudly with a `::error` annotation and a readable dump of the offending value. A caught failure beats a silent deadlock — a shape change in the query can never again corrupt GITHUB_OUTPUT and freeze BEHIND PRs without anyone noticing.

## Verification (local)

- actionlint 1.7.12: clean (this is the tool that would have caught the bad `run:` block)
- yamllint 1.38.0: clean
- List-step core simulated against the live repo: 4 BEHIND PRs emitted, GITHUB_OUTPUT file parsed back (awk block extraction + `while read`/for-loop consumer round-trip) — count matches exactly
- Edge cases: empty list passes (writes valid empty block); non-numeric line trips the guard; valid multiline passes
- Pre-commit gates: aislop / compile / test-count (446) / verify-no-mixin all green

## Exercise path

The standing workflow fires on its own schedule (`*/30 * * * *`) and on every push to `main` — the next scheduled run (or next merge to main) exercises the fix with no manual dispatch needed. Not run live here per policy (no workflow_dispatch without approval).