### PR TITLE
fix(e2e): 1.18.2/1.20.1 Java-17 discovery order + jdks cache + result-file hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -853,6 +853,7 @@ jobs:
           path: |
             ~/.gradle/wrapper/dists
             ~/.gradle/caches
+            ~/.gradle/jdks
           key: gradle-${{ runner.os }}-${{ matrix.lane }}-${{ hashFiles('**/gradle-wrapper.properties') }}
           restore-keys: |
             gradle-${{ runner.os }}-${{ matrix.lane }}-

--- a/forge-1.18.2/test-infrastructure/run-e2e.sh
+++ b/forge-1.18.2/test-infrastructure/run-e2e.sh
@@ -38,22 +38,6 @@ else
 fi
 echo "[e2e:1.18.2] Java 21: $E2E_JAVA21_HOME/bin/java"
 
-# Server java: the lane's Java 17 toolchain (production Forge 40 requires
-# 17). Prefer a foojay-resolved JDK 17; fall back to the daemon JDK if 17
-# is unavailable (the build still resolves the toolchain itself).
-E2E_JAVA=""
-for cand in "$HOME/.gradle/jdks"/eclipse_adoptium-17-amd64-linux*/bin/java; do
-    [ -x "$cand" ] && E2E_JAVA="$cand" && break
-done
-if [ -z "$E2E_JAVA" ] && [ -x /usr/lib/jvm/java-17-openjdk-amd64/bin/java ]; then
-    E2E_JAVA="/usr/lib/jvm/java-17-openjdk-amd64/bin/java"
-fi
-if [ -z "$E2E_JAVA" ]; then
-    echo "[e2e:1.18.2][fail] Java 17 not found for the production server" >&2
-    exit 3
-fi
-echo "[e2e:1.18.2] server Java 17: $E2E_JAVA"
-
 # ---------------------------------------------------------------------------
 # Build the lane (own wrapper: Gradle 8.14 on Java 21, FG 6.0.54)
 # ---------------------------------------------------------------------------
@@ -70,6 +54,24 @@ if [ -z "$MOD_JAR" ]; then
     exit 3
 fi
 echo "[e2e:1.18.2] mod jar: $MOD_JAR"
+
+# Server java: the lane's Java 17 toolchain (production Forge 40 requires
+# 17). Discovery runs AFTER the lane build: foojay resolves the 17 toolchain
+# into ~/.gradle/jdks during `./gradlew build`, so a fresh runner (or a
+# cache that carried no jdks) finds it here. Prefer the foojay-resolved JDK
+# 17; fall back to a system JDK 17 if present.
+E2E_JAVA=""
+for cand in "$HOME/.gradle/jdks"/eclipse_adoptium-17-amd64-linux*/bin/java; do
+    [ -x "$cand" ] && E2E_JAVA="$cand" && break
+done
+if [ -z "$E2E_JAVA" ] && [ -x /usr/lib/jvm/java-17-openjdk-amd64/bin/java ]; then
+    E2E_JAVA="/usr/lib/jvm/java-17-openjdk-amd64/bin/java"
+fi
+if [ -z "$E2E_JAVA" ]; then
+    echo "[e2e:1.18.2][fail] Java 17 not found for the production server" >&2
+    exit 3
+fi
+echo "[e2e:1.18.2] server Java 17: $E2E_JAVA"
 
 # ---------------------------------------------------------------------------
 # Invoke the shared orchestrator (modern-smoke era)

--- a/forge-1.20.1/test-infrastructure/run-e2e.sh
+++ b/forge-1.20.1/test-infrastructure/run-e2e.sh
@@ -39,22 +39,6 @@ else
 fi
 echo "[e2e:1.20.1] Java 21: $E2E_JAVA21_HOME/bin/java"
 
-# Server java: the lane's Java 17 toolchain (production Forge 47 requires
-# 17). Prefer a foojay-resolved JDK 17; fall back to the daemon JDK if 17
-# is unavailable (the build still resolves the toolchain itself).
-E2E_JAVA=""
-for cand in "$HOME/.gradle/jdks"/eclipse_adoptium-17-amd64-linux*/bin/java; do
-    [ -x "$cand" ] && E2E_JAVA="$cand" && break
-done
-if [ -z "$E2E_JAVA" ] && [ -x /usr/lib/jvm/java-17-openjdk-amd64/bin/java ]; then
-    E2E_JAVA="/usr/lib/jvm/java-17-openjdk-amd64/bin/java"
-fi
-if [ -z "$E2E_JAVA" ]; then
-    echo "[e2e:1.20.1][fail] Java 17 not found for the production server" >&2
-    exit 3
-fi
-echo "[e2e:1.20.1] server Java 17: $E2E_JAVA"
-
 # ---------------------------------------------------------------------------
 # Build the lane (own wrapper: Gradle 8.14 on Java 21, FG 6.0.54)
 # ---------------------------------------------------------------------------
@@ -71,6 +55,24 @@ if [ -z "$MOD_JAR" ]; then
     exit 3
 fi
 echo "[e2e:1.20.1] mod jar: $MOD_JAR"
+
+# Server java: the lane's Java 17 toolchain (production Forge 47 requires
+# 17). Discovery runs AFTER the lane build: foojay resolves the 17 toolchain
+# into ~/.gradle/jdks during `./gradlew build`, so a fresh runner (or a
+# cache that carried no jdks) finds it here. Prefer the foojay-resolved JDK
+# 17; fall back to a system JDK 17 if present.
+E2E_JAVA=""
+for cand in "$HOME/.gradle/jdks"/eclipse_adoptium-17-amd64-linux*/bin/java; do
+    [ -x "$cand" ] && E2E_JAVA="$cand" && break
+done
+if [ -z "$E2E_JAVA" ] && [ -x /usr/lib/jvm/java-17-openjdk-amd64/bin/java ]; then
+    E2E_JAVA="/usr/lib/jvm/java-17-openjdk-amd64/bin/java"
+fi
+if [ -z "$E2E_JAVA" ]; then
+    echo "[e2e:1.20.1][fail] Java 17 not found for the production server" >&2
+    exit 3
+fi
+echo "[e2e:1.20.1] server Java 17: $E2E_JAVA"
 
 # ---------------------------------------------------------------------------
 # Invoke the shared orchestrator (modern-smoke era)

--- a/scripts/e2e/drivers/modern-smoke.sh
+++ b/scripts/e2e/drivers/modern-smoke.sh
@@ -71,6 +71,30 @@ source "$E2E_DRIVER_DIR/lib.sh"
 # for the lanes whose in-jar join driver is shipped-gated on it — 1.16.5).
 : "${E2E_CLIENT_GRADLE_ARGS:=}"
 
+# ---------------------------------------------------------------------------
+# Result-doc guard: the CI artifact upload publishes ${RUNNER_TMP}/e2e-result.json
+# and warns when it is missing (e.g. a wrapper-side early exit or a driver
+# failure before the PASS-path write). Any non-zero exit without a written
+# doc emits a minimal failure doc (exit_code + server_booted:false) so the
+# driver contract always lands a result. The PASS path below writes the full
+# doc and exits 0, which this trap leaves untouched.
+# ---------------------------------------------------------------------------
+write_failure_result() {
+    local code="$1"
+    [ -f "$RESULT_JSON" ] && return 0
+    python3 - "$RESULT_JSON" "$code" <<PY
+import json, sys
+out = {
+    "lane": "$E2E_LANE",
+    "era": "modern-smoke",
+    "server_booted": False,
+    "exit_code": int(sys.argv[2]),
+}
+json.dump(out, open(sys.argv[1], "w"), indent=2)
+PY
+}
+trap 'write_failure_result "$?"' EXIT
+
 SERVER_DIR="$RUNNER_TMP/server-$E2E_LANE"
 SERVER_LOG="$SERVER_DIR/server.log"
 


### PR DESCRIPTION
## What

Fixes the `E2E (forge-1.18.2)` + `E2E (forge-1.20.1)` CI failures (wrapper Java-17 guard exit 3) from run 31573727090 (deep-dive provenance).

**Root cause:** both wrappers' Java-17 discovery loop (foojay `~/.gradle/jdks` glob, then `/usr/lib/jvm/java-17-openjdk-amd64`) runs BEFORE the `./gradlew build` step that foojay-resolves 17 into `~/.gradle/jdks`; and the `e2e-modern` job caches only `~/.gradle/wrapper/dists` + `~/.gradle/caches` — never `~/.gradle/jdks`. On a fresh runner there is no 17 binary at discovery time → `exit 3` before build/installer/server/client ever run. Masked until #453 let the jobs reach the wrapper.

## Three-layer fix

1. **Reorder (both wrappers)** — `forge-1.18.2/` + `forge-1.20.1/` `test-infrastructure/run-e2e.sh`: the Java-17 discovery block moves AFTER the lane build, so the build's foojay resolution has populated `~/.gradle/jdks` on the cold path. Candidates + the explicit `/usr/lib/jvm` fallback unchanged.
2. **Cache path** — `.github/workflows/ci.yml` `e2e-modern` job: `~/.gradle/jdks` added to the Gradle cache path list, so a warm cache carries the foojay-resolved 17 to the E2E job (same key shape as the Build jobs, so the jdks also warm those lanes).
3. **Result-file hardening** — `scripts/e2e/drivers/modern-smoke.sh`: an EXIT trap emits a minimal `e2e-result.json` (`exit_code` + `server_booted: false`) on ANY non-zero exit without a written doc (installer failure, boot/join timeout, `set -e` abort) — the artifact upload no longer silently warns on failure runs. PASS path unchanged.

## Why only these two lanes

- `forge-1.16.5` runs the server on the setup-java 8 JDK (no foojay 17 needed).
- `forge-26.1`/`forge-26.2` use `E2E_JAVA25_HOME` (Java 25 server toolchain).
- Only 1.18.2/1.20.1 (Gradle 8.14 daemon on Java 21, production Forge 40/47 requiring 17) hit the pre-build 17 discovery.

## Verification

- `bash -n` + shellcheck: both wrappers zero-delta vs baseline; modern-smoke only adds the already-tolerated SC2317 class (trap-referenced fn, same as `cleanup()`).
- actionlint + yamllint strict (repo `.yamllint.yml`): clean.
- Mocked discovery-order test (fresh `$HOME` with fake `eclipse_adoptium-17-amd64-linux*` trees): old pre-build ordering reproduces the exit-3 bug; post-build ordering finds the foojay JDK (both suffix shapes); runs on BOTH wrappers.
- Mocked result-doc guard test: exit-2, `set -e` abort, and PASS paths all behave as specified.
- Pre-commit hooks green on all three commits (aislop, compile, test-count 446, verify-no-mixin).

Honest note: a full local E2E run was NOT performed — the local `~/.gradle/jdks` already has a 17, so the ordering fix is only observable via the fresh-`GRADLE_USER_HOME` path; the mocked repro above is the local evidence. The CI E2E jobs themselves are the live verification.