### PR TITLE
fix(test): mc1.12.2 E2ESentinelTest async verify race

### DIFF
--- a/mc1.12.2/src/test/java/levosilimo/everlastingskins/skinchanger/E2ESentinelTest.java
+++ b/mc1.12.2/src/test/java/levosilimo/everlastingskins/skinchanger/E2ESentinelTest.java
@@ -8,12 +8,10 @@ package levosilimo.everlastingskins.skinchanger;
 
 import levosilimo.everlastingskins.EverlastingSkins;
 import levosilimo.everlastingskins.harness.AsyncSupport;
-import levosilimo.everlastingskins.harness.PacketLog;
 import levosilimo.everlastingskins.harness.TestServerContext;
 import levosilimo.everlastingskins.integration.TestProperties;
 import levosilimo.everlastingskins.metrics.SkinMetrics;
 import net.minecraft.entity.player.EntityPlayerMP;
-import net.minecraft.network.play.server.SPacketChat;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,6 +28,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
 /**
@@ -42,8 +41,8 @@ import static org.mockito.Mockito.verify;
  *
  * The static-final logger is swapped for a Mockito mock for the duration of
  * each test (Java-8 modifiers surgery, same style as SkinActionTestAccess);
- * the sentinel fires on the async completion thread, so the await points
- * prove the pipeline reached (and passed) the marker.
+ * the sentinel fires on the async completion thread, so async sentinel
+ * assertions use Mockito timeout() to wait for the invocation itself.
  */
 class E2ESentinelTest {
 
@@ -113,7 +112,7 @@ class E2ESentinelTest {
                 () -> alice.getGameProfile().getProperties().get("textures").size() == 1),
             "skin must apply before the sentinel is asserted");
 
-        verify(logger).info(eq("ES_E2E_SKIN=ok player={} source={}"), eq("Alice"), eq("Notch"));
+        verify(logger, timeout(5000)).info(eq("ES_E2E_SKIN=ok player={} source={}"), eq("Alice"), eq("Notch"));
     }
 
     @Test
@@ -121,14 +120,19 @@ class E2ESentinelTest {
     void failureSentinel_loggedWhenProviderReturnsNoResult() {
         // No skin registered for "Ghost" -> provider empty -> no-skin branch.
         EntityPlayerMP alice = ctx.newPlayer("Alice");
-        PacketLog log = new PacketLog();
-        log.attachTo(alice.connection);
         ctx.commandManager.executeCommand(alice, "/skin set mojang Ghost");
 
-        assertTrue(AsyncSupport.await(5000, () -> log.ofType(SPacketChat.class).size() >= 1),
-            "no-result path must send the failure chat reply before the sentinel is asserted");
-
-        verify(logger).info(eq("ES_E2E_SKIN=fail player={} source={} reason=no-skin"),
+        // The sentinel fires on the async completion thread (SkinAction's
+        // EXECUTOR), so the assertion must wait for the invocation itself:
+        // awaiting the chat reply does NOT synchronize, because the
+        // synchronous "change" toast (Config.TOGGLE=true, sent in apply()
+        // before the fetch is submitted) is also an SPacketChat and satisfies
+        // a packet-count predicate before the completion thread has logged
+        // anything (observed as ArgumentsAreDifferent / TooFewActualInvocations
+        // flakes on CI). timeout() polls the mock until the fail sentinel
+        // appears or the window elapses, and still fails on a genuinely
+        // broken sentinel.
+        verify(logger, timeout(5000)).info(eq("ES_E2E_SKIN=fail player={} source={} reason=no-skin"),
             eq("Alice"), eq("Ghost"));
     }
 


### PR DESCRIPTION
## Root cause

The failure-sentinel test awaited `log.ofType(SPacketChat.class).size() >= 1` before verifying the logger mock. But `SkinAction.apply()` sends the synchronous "change" toast (`Config.TOGGLE=true`, default) via `p.sendMessage(...)` **before** submitting the async fetch to `EXECUTOR`. That toast is also an `SPacketChat`, so the packet-count predicate was satisfied immediately on the test thread and the `verify()` raced the completion thread.

Observed on CI: `ArgumentsAreDifferent` (earlier) and `TooFewActualInvocations` (run 31593682109 / job 94104246932, and main run 31593532890) — both are the same race: verify fired before the async `ES_E2E_SKIN=fail` sentinel logged. Product code is correct (the sentinel is a server-log diagnostic for the E2E driver; log-before-reply ordering is intentional) — this is a test-synchronization bug.

## Hardening

- `failureSentinel_loggedWhenProviderReturnsNoResult`: drop the racy chat-packet await; assert on the mock invocation itself with `Mockito.timeout(5000)` — polls until the fail sentinel fires or the window elapses. Still fails on a genuinely broken sentinel.
- `successSentinel_loggedAfterApply`: same `timeout(5000)` hardening (was already safe via the textures await; belt-and-suspenders, zero cost — timeout returns immediately when the invocation is present).
- cmd-marker test untouched (synchronous path); suppression test untouched (`never()` + sound textures await).

## Evidence

- Full lane build green: `cd mc1.12.2 && ./gradlew build --no-daemon` — BUILD SUCCESSFUL (522 tests, 1m 8s)
- 10× single-class reruns (`cleanTest test --tests levosilimo.everlastingskins.skinchanger.E2ESentinelTest`): 10/10 PASS

## Verification

- [x] Build (mc1.12.2) will re-run on this branch