### PR TITLE
fix(e2e): provision Java 17 explicitly for 1.18.2/1.20.1 E2E (cold-cache-proof)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -842,6 +842,24 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: temurin
+      - name: Set up JDK 17 (production Forge server for the 1.18.2/1.20.1 E2E)
+        # Cold-cache-proof server JDK: the lane wrapper's ~/.gradle/jdks glob
+        # only hits a warm foojay cache and misses the inner-dir layout
+        # (jdk-*/), and ubuntu-24.04 has no /usr/lib/jvm/java-17-openjdk-amd64,
+        # so a cache-missed E2E run still died with "Java 17 not found" after
+        # #457's reorder (run 31599664358). setup-java overwrites JAVA_HOME
+        # with 17 — fine here: both lanes compile with the Java 17 toolchain
+        # (build.gradle.kts toolchain 17), so the Gradle daemon on 17 satisfies
+        # the build, and the exported E2E_JAVA17_HOME feeds the production
+        # server fork.
+        if: matrix.lane == 'forge-1.18.2' || matrix.lane == 'forge-1.20.1'
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961  # v5
+        with:
+          java-version: "17"
+          distribution: temurin
+      - name: Export E2E_JAVA17_HOME (server JDK for the 1.18.2/1.20.1 wrappers)
+        if: matrix.lane == 'forge-1.18.2' || matrix.lane == 'forge-1.20.1'
+        run: echo "E2E_JAVA17_HOME=$JAVA_HOME" >> "$GITHUB_ENV"
       - name: Install Mesa software GL (llvmpipe for the real modern client)
         run: |
           sudo apt-get update

--- a/forge-1.18.2/test-infrastructure/run-e2e.sh
+++ b/forge-1.18.2/test-infrastructure/run-e2e.sh
@@ -58,12 +58,16 @@ echo "[e2e:1.18.2] mod jar: $MOD_JAR"
 # Server java: the lane's Java 17 toolchain (production Forge 40 requires
 # 17). Discovery runs AFTER the lane build: foojay resolves the 17 toolchain
 # into ~/.gradle/jdks during `./gradlew build`, so a fresh runner (or a
-# cache that carried no jdks) finds it here. Prefer the foojay-resolved JDK
-# 17; fall back to a system JDK 17 if present.
+# cache that carried no jdks) finds it here. The job-provided E2E_JAVA17_HOME
+# (ci.yml setup-java, cache-independent) is the hard fallback — the jdks glob
+# is layout-fragile (inner jdk-*/ dirs) — then a system JDK 17.
 E2E_JAVA=""
 for cand in "$HOME/.gradle/jdks"/eclipse_adoptium-17-amd64-linux*/bin/java; do
     [ -x "$cand" ] && E2E_JAVA="$cand" && break
 done
+if [ -z "$E2E_JAVA" ] && [ -n "${E2E_JAVA17_HOME:-}" ] && [ -x "$E2E_JAVA17_HOME/bin/java" ]; then
+    E2E_JAVA="$E2E_JAVA17_HOME/bin/java"
+fi
 if [ -z "$E2E_JAVA" ] && [ -x /usr/lib/jvm/java-17-openjdk-amd64/bin/java ]; then
     E2E_JAVA="/usr/lib/jvm/java-17-openjdk-amd64/bin/java"
 fi

--- a/forge-1.20.1/test-infrastructure/run-e2e.sh
+++ b/forge-1.20.1/test-infrastructure/run-e2e.sh
@@ -59,12 +59,16 @@ echo "[e2e:1.20.1] mod jar: $MOD_JAR"
 # Server java: the lane's Java 17 toolchain (production Forge 47 requires
 # 17). Discovery runs AFTER the lane build: foojay resolves the 17 toolchain
 # into ~/.gradle/jdks during `./gradlew build`, so a fresh runner (or a
-# cache that carried no jdks) finds it here. Prefer the foojay-resolved JDK
-# 17; fall back to a system JDK 17 if present.
+# cache that carried no jdks) finds it here. The job-provided E2E_JAVA17_HOME
+# (ci.yml setup-java, cache-independent) is the hard fallback — the jdks glob
+# is layout-fragile (inner jdk-*/ dirs) — then a system JDK 17.
 E2E_JAVA=""
 for cand in "$HOME/.gradle/jdks"/eclipse_adoptium-17-amd64-linux*/bin/java; do
     [ -x "$cand" ] && E2E_JAVA="$cand" && break
 done
+if [ -z "$E2E_JAVA" ] && [ -n "${E2E_JAVA17_HOME:-}" ] && [ -x "$E2E_JAVA17_HOME/bin/java" ]; then
+    E2E_JAVA="$E2E_JAVA17_HOME/bin/java"
+fi
 if [ -z "$E2E_JAVA" ] && [ -x /usr/lib/jvm/java-17-openjdk-amd64/bin/java ]; then
     E2E_JAVA="/usr/lib/jvm/java-17-openjdk-amd64/bin/java"
 fi


### PR DESCRIPTION
## Proven failure (why this re-fix)

Newest main run **31599664358** (head e82c2378 = #458 squash, includes #457): `E2E (forge-1.18.2)` + `E2E (forge-1.20.1)` FAIL at `Run real-client E2E` with `[e2e:1.18.2][fail] Java 17 not found for the production server` / exit 3. Both gradle caches MISSED (`Cache not found for input keys: gradle-Linux-forge-1.18.2-64d6…`, `e2e-forge-1.20.1-Linux`).

## Why #457's fix doesn't cover the cold cache

#457 landed two things (both **verified present on main** — the reorder was NOT lost):
1. `~/.gradle/jdks` added to the e2e-modern gradle cache key — warm-cache only.
2. Server-Java-17 discovery moved AFTER `./gradlew build` (foojay populates `~/.gradle/jdks`).

Both still fail cold: on a cache-missed runner the build-populated jdks glob **misses the actual foojay layout** — `~/.gradle/jdks/eclipse_adoptium-17-amd64-linux/jdk-17.0.20+8/bin/java` (inner `jdk-*/` dir) while the wrapper globs `eclipse_adoptium-17-amd64-linux*/bin/java` (bin/java directly). Verified locally: the glob only hits the flat-layout variant. And ubuntu-24.04 has no `/usr/lib/jvm/java-17-openjdk-amd64`. So even post-build, cold-cache discovery fails identically.

## The fix (cache-independent, three layers)

1. **ci.yml `e2e-modern`**: explicit `setup-java` step (`java-version: '17'`, temurin) for `forge-1.18.2`/`forge-1.20.1` before the run-e2e step, mirroring the 26.x per-lane JDK treatment; `E2E_JAVA17_HOME` exported from its `JAVA_HOME`. setup-java overwriting `JAVA_HOME` to 17 is safe: both lanes compile with the **Java 17 toolchain** (`build.gradle.kts` toolchain 17), so the Gradle daemon on 17 satisfies the build.
2. **Both `run-e2e.sh`**: `E2E_JAVA17_HOME` hard fallback between the jdks glob and the `/usr/lib/jvm` check — glob first, env second, system third, so standalone local use (`JAVA_HOME=<jdk21> ./run-e2e.sh`) is unchanged.
3. #457's discovery-after-build reorder verified present on main — kept as-is (belt and suspenders with the explicit provisioning).

## Verification

- `bash -n` + yamllint strict: pass
- Mocked cold-env (empty `HOME`, no `~/.gradle/jdks`, no system 17): env fallback resolves 17 → exit 0; no-env control still exits 3 (fail-fast contract intact)
- `forge-1.18.2` build sanity: `JAVA_HOME=<jdk21> ./gradlew build --no-daemon` → BUILD SUCCESSFUL
- Pre-commit gates (lefthook): aislop / compile / mesa-apt / test-count (446) / verify-no-mixin — all green