### PR TITLE
fix(gametest): 1.21.8 concurrent skin-set observer grace window

### DIFF
--- a/forge-1.21.8/src/gametest/java/levosilimo/everlastingskins/gametest/SkinVisibilityTest.java
+++ b/forge-1.21.8/src/gametest/java/levosilimo/everlastingskins/gametest/SkinVisibilityTest.java
@@ -1524,6 +1524,12 @@ public class SkinVisibilityTest {
         // budget alone raced the concurrent dispatches on loaded CI runners).
         long startedNanos = System.nanoTime();
         long deadlineNanos = startedNanos + ASYNC_PIPELINE_DEADLINE_NANOS;
+        // Observer-packet grace (see OBSERVER_GRACE_NANOS): the broadcast can
+        // land a tick later than the storage write under load, so the raw
+        // obsCount assert must not fire until the grace has elapsed. The
+        // terminal fail below routes at graceEndNanos, keeping the wall-clock
+        // deadline as the bound while absorbing late arrivals.
+        long graceEndNanos = deadlineNanos + OBSERVER_GRACE_NANOS;
         // Progress-log throttle: surface the stall once per ~5s of wall time
         // instead of spamming every poll (initialized to start so the first
         // poll does not log).
@@ -1573,8 +1579,8 @@ public class SkinVisibilityTest {
                 // failure, so route the expiry through runAfterDelay: the test
                 // then fails AT the deadline with a clear message instead of
                 // racing the tick budget.
-                if (System.nanoTime() > deadlineNanos) {
-                    helper.runAfterDelay(1, () -> helper.fail(Component.literal("timed out after 60s wall-clock waiting for "
+                if (System.nanoTime() > graceEndNanos) {
+                    helper.runAfterDelay(1, () -> helper.fail(Component.literal("timed out after 60s wall-clock (+1s observer-packet grace) waiting for "
                             + "concurrent skin set (ticks=" + helper.getTick() + ")")));
                 }
                 if (!futureA.isDone() || !futureB.isDone()) {
@@ -1601,10 +1607,23 @@ public class SkinVisibilityTest {
                             elapsedMs, helper.getTick(), obsCountA, obsCountB);
                 }
                 if (obsCountA != 1) {
-                    throw new GameTestAssertException(Component.literal("observerA expected 1 packet, got " + obsCountA), -1);
+                    // Inside the grace window, keep re-polling: the broadcast
+                    // can land a later tick under load, and throwing the raw
+                    // assert here lets the framework record the transient as
+                    // the failure before the wall-clock deadline routes a
+                    // clean timeout (#448). The raw form only fires past
+                    // graceEndNanos, where the runAfterDelay route above has
+                    // already scheduled the terminal fail.
+                    if (System.nanoTime() > graceEndNanos) {
+                        throw new GameTestAssertException(Component.literal("observerA expected 1 packet, got " + obsCountA), -1);
+                    }
+                    throw new GameTestAssertException(Component.literal("waiting for observerA ADD_PLAYER packet (got " + obsCountA + ")"), -1);
                 }
                 if (obsCountB != 1) {
-                    throw new GameTestAssertException(Component.literal("observerB expected 1 packet, got " + obsCountB), -1);
+                    if (System.nanoTime() > graceEndNanos) {
+                        throw new GameTestAssertException(Component.literal("observerB expected 1 packet, got " + obsCountB), -1);
+                    }
+                    throw new GameTestAssertException(Component.literal("waiting for observerB ADD_PLAYER packet (got " + obsCountB + ")"), -1);
                 }
                 removeQuietly(server, playerA);
                 removeQuietly(server, playerB);
@@ -1846,6 +1865,18 @@ public class SkinVisibilityTest {
      * 20002ms while futures+storage had completed in <5s).
      */
     private static final long ASYNC_PIPELINE_DEADLINE_NANOS = TimeUnit.SECONDS.toNanos(60);
+
+    /**
+     * Observer-packet grace window past {@link #ASYNC_PIPELINE_DEADLINE_NANOS}
+     * for concurrentSkinSet_twoPlayers. The refresh-task ADD_PLAYER broadcast
+     * can land a tick (or a few) later than the storage write under load; the
+     * raw obsCount assert firing on that transient tick surfaced as
+     * "observerA expected 1 packet, got 0" before the wall-clock deadline
+     * route could convert it to a clean timeout (run 31601213606, #448).
+     * Absorb late arrivals for up to 1s past the deadline before asserting
+     * failure; the deadline route remains the terminal bound.
+     */
+    private static final long OBSERVER_GRACE_NANOS = TimeUnit.SECONDS.toNanos(1);
 
 
     private static List<Packet<?>> drain(ServerPlayer player) {

--- a/forge-1.21/src/gametest/java/levosilimo/everlastingskins/gametest/SkinVisibilityTest.java
+++ b/forge-1.21/src/gametest/java/levosilimo/everlastingskins/gametest/SkinVisibilityTest.java
@@ -1472,6 +1472,12 @@ public class SkinVisibilityTest {
         // budget alone raced the concurrent dispatches on loaded CI runners).
         long startedNanos = System.nanoTime();
         long deadlineNanos = startedNanos + ASYNC_PIPELINE_DEADLINE_NANOS;
+        // Observer-packet grace (see OBSERVER_GRACE_NANOS): the broadcast can
+        // land a tick later than the storage write under load, so the raw
+        // obsCount assert must not fire until the grace has elapsed. The
+        // terminal fail below routes at graceEndNanos, keeping the wall-clock
+        // deadline as the bound while absorbing late arrivals.
+        long graceEndNanos = deadlineNanos + OBSERVER_GRACE_NANOS;
         // Progress-log throttle: surface the stall once per ~5s of wall time
         // instead of spamming every poll (initialized to start so the first
         // poll does not log).
@@ -1521,8 +1527,8 @@ public class SkinVisibilityTest {
                 // failure, so route the expiry through runAfterDelay: the test
                 // then fails AT the deadline with a clear message instead of
                 // racing the tick budget.
-                if (System.nanoTime() > deadlineNanos) {
-                    helper.runAfterDelay(1, () -> helper.fail("timed out after 60s wall-clock waiting for "
+                if (System.nanoTime() > graceEndNanos) {
+                    helper.runAfterDelay(1, () -> helper.fail("timed out after 60s wall-clock (+1s observer-packet grace) waiting for "
                             + "concurrent skin set (ticks=" + helper.getTick() + ")"));
                 }
                 if (!futureA.isDone() || !futureB.isDone()) {
@@ -1548,10 +1554,23 @@ public class SkinVisibilityTest {
                 long obsCountA = countAddPlayerUpdatesWithTextures(drain(observerA), uuidA);
                 long obsCountB = countAddPlayerUpdatesWithTextures(drain(observerB), uuidB);
                 if (obsCountA != 1) {
-                    throw new GameTestAssertException("observerA expected 1 packet, got " + obsCountA);
+                    // Inside the grace window, keep re-polling: the broadcast
+                    // can land a later tick under load, and throwing the raw
+                    // assert here lets the framework record the transient as
+                    // the failure before the wall-clock deadline routes a
+                    // clean timeout (#448). The raw form only fires past
+                    // graceEndNanos, where the runAfterDelay route above has
+                    // already scheduled the terminal fail.
+                    if (System.nanoTime() > graceEndNanos) {
+                        throw new GameTestAssertException("observerA expected 1 packet, got " + obsCountA);
+                    }
+                    throw new GameTestAssertException("waiting for observerA ADD_PLAYER packet (got " + obsCountA + ")");
                 }
                 if (obsCountB != 1) {
-                    throw new GameTestAssertException("observerB expected 1 packet, got " + obsCountB);
+                    if (System.nanoTime() > graceEndNanos) {
+                        throw new GameTestAssertException("observerB expected 1 packet, got " + obsCountB);
+                    }
+                    throw new GameTestAssertException("waiting for observerB ADD_PLAYER packet (got " + obsCountB + ")");
                 }
                 removeQuietly(server, playerA);
                 removeQuietly(server, playerB);
@@ -1801,6 +1820,19 @@ public class SkinVisibilityTest {
      * futures+storage had completed in <5s).
      */
     private static final long ASYNC_PIPELINE_DEADLINE_NANOS = TimeUnit.SECONDS.toNanos(60);
+
+    /**
+     * Observer-packet grace window past {@link #ASYNC_PIPELINE_DEADLINE_NANOS}
+     * for concurrentSkinSet_twoPlayers (family parity with forge-1.21.8: run
+     * 31601213606, #448). The refresh-task ADD_PLAYER broadcast can land a
+     * tick (or a few) later than the storage write under load; the raw
+     * obsCount assert firing on that transient tick surfaced as "observerA
+     * expected 1 packet, got 0" before the wall-clock deadline route could
+     * convert it to a clean timeout. Absorb late arrivals for up to 1s past
+     * the deadline before asserting failure; the deadline route remains the
+     * terminal bound.
+     */
+    private static final long OBSERVER_GRACE_NANOS = TimeUnit.SECONDS.toNanos(1);
 
     private static void throwIfPastDeadline(long deadlineNanos, String what) {
         if (System.nanoTime() > deadlineNanos) {


### PR DESCRIPTION
## Problem

GameTest (1.21.8) `concurrent_skin_set_two_players` flaked in run 31601213606 / job 94128849800 (#448): the raw transient `observerA expected 1 packet, got 0 on tick -1` surfaced as `1 required tests failed` BEFORE the 60s wall-clock deadline routing (#455) could convert it to a clean timeout. The refresh-task ADD_PLAYER broadcast can land a tick (or a few) later than the storage write under load; the raw obsCount assert fires on that transient tick and the framework can record it as the failure before the deadline route fires.

## Fix

Observer-packet grace window (1s) past the 60s wall-clock deadline in `concurrentSkinSet_twoPlayers`:

- Inside the grace window (`deadline + 1s`), an `obsCount != 1` poll keeps re-polling with a `waiting for observerA ADD_PLAYER packet (got N)` form instead of throwing the raw assert — late-arriving broadcasts are absorbed.
- The raw assert form only fires past `deadline + grace`, where the existing `runAfterDelay` terminal route (the #455 mechanism, unchanged) has already scheduled the clean timeout failure. The wall-clock deadline remains the terminal bound — no regression of #455.
- New `OBSERVER_GRACE_NANOS` constant with evidence comment; timeout message updated to include the grace.

Parity: identical raw assert existed in forge-1.21's copy (#455 widened both) — same grace-window restructure applied there (family parity).

## Verification

- `./gradlew :forge-1.21.8:runGameTestServer --no-daemon --configure-on-demand` ×5 (JDK 21): **5/5 green** — "All 35 required tests passed" each run; `concurrent_skin_set_two_players` + debounce envs present in all logs; zero stall/timed-out lines.
- `./gradlew :forge-1.21:runGameTestServer --no-daemon --configure-on-demand` ×1 (JDK 21): **green** — "All 34 required tests passed".
- Pre-commit gates: aislop clean, offline compile pass, test-count 446, verifyNoMixin pass.
