### PR TITLE
fix(gametest): 1.21.8 mod version requirement accepts 2.1.0-rc1

### DIFF
--- a/forge-1.21.1/src/gametest/resources/META-INF/mods.toml
+++ b/forge-1.21.1/src/gametest/resources/META-INF/mods.toml
@@ -12,6 +12,6 @@ Development-only mod carrying the EverlastingSkins game test classes and structu
 [[dependencies.everlastingskins_gametest]]
 modId = "everlastingskins"
 mandatory = true
-versionRange = "[2.1.0,)"
+versionRange = "[2.1.0-rc1,)"
 ordering = "AFTER"
 side = "SERVER"

--- a/forge-1.21.4/src/gametest/resources/META-INF/mods.toml
+++ b/forge-1.21.4/src/gametest/resources/META-INF/mods.toml
@@ -12,6 +12,6 @@ Development-only mod carrying the EverlastingSkins game test classes and structu
 [[dependencies.everlastingskins_gametest]]
 modId = "everlastingskins"
 mandatory = true
-versionRange = "[2.1.0,)"
+versionRange = "[2.1.0-rc1,)"
 ordering = "AFTER"
 side = "SERVER"

--- a/forge-1.21.8/src/gametest/resources/META-INF/mods.toml
+++ b/forge-1.21.8/src/gametest/resources/META-INF/mods.toml
@@ -12,6 +12,6 @@ Development-only mod carrying the EverlastingSkins game test classes and structu
 [[dependencies.everlastingskins_gametest]]
 modId = "everlastingskins"
 mandatory = true
-versionRange = "[2.1.0,)"
+versionRange = "[2.1.0-rc1,)"
 ordering = "AFTER"
 side = "SERVER"

--- a/forge-1.21/src/gametest/resources/META-INF/mods.toml
+++ b/forge-1.21/src/gametest/resources/META-INF/mods.toml
@@ -12,6 +12,6 @@ Development-only mod carrying the EverlastingSkins game test classes and structu
 [[dependencies.everlastingskins_gametest]]
 modId = "everlastingskins"
 mandatory = true
-versionRange = "[2.1.0,)"
+versionRange = "[2.1.0-rc1,)"
 ordering = "AFTER"
 side = "SERVER"


### PR DESCRIPTION
## Problem

forge-1.21.8 gametest mod requires `everlastingskins >= 2.1.0` but `mod_version=2.1.0-rc1` (prerelease sorts below 2.1.0 in Forge version semantics) → deterministic GameTest failure: `Mod everlastingskins_gametest requires everlastingskins 2.1.0 or above`.

## Fix

Lower the gametest dependency range bound to `[2.1.0-rc1,)` in all four 1.21.x lanes (1.21/1.21.1/1.21.4 carry the same latent bug). 26.1/26.2 already use `[2.1.0-beta.1,)` matching their mod_version — no change needed.

Local compile gate: `:forge-1.21.8:compileGametestJava` BUILD SUCCESSFUL (through gradle-locked.sh, configure-on-demand).