### PR TITLE
docs: fix stale E2E docs (mc1.12.2 README + master-plan status)

### DIFF
--- a/.slim/deepwork/real-client-e2e-plan.md
+++ b/.slim/deepwork/real-client-e2e-plan.md
@@ -1,0 +1,128 @@
+# Real-Client E2E Master Plan — EverlastingSkins (16 lanes) — 2026-08-10
+
+Synthesis of the 8-librarian E2E wave (lib-8..lib-15). User directive: full real-client
+coverage — boot real server + real client, run /skin from client, verify packet flow
+down to the renderer layer, per lane.
+
+## Shared contract (scripts/e2e/, every era implements verbatim)
+
+- Result file: fixed JSON at `${RUNNER_TMP}/e2e-result.json`:
+  {"lane":"1.6.4","server_booted":true,"client_joined":true,"command_executed":true,
+   "renderer_state":"sentinel","renderer_verified":true,"duration_ms":12345,"artifacts":{...}}
+- Exit codes: 0 all green | 1 assertion failed (result file has which) | 2 retryable infra
+  (client boot timeout, artifact fetch — CI retries with backoff) | 3 build failure.
+- Log markers (greppable): ES_E2E_COMMAND=ok, ES_E2E_RENDERER=ok|FAIL, ES_E2E_JOIN=<uuid>.
+- Artifact fetch: shared layer, `~/.cache/everlastingskins` (precedent ci.yml); pin URLs + sha.
+- Renderer assertion = INJECTED-FIELD state read, NEVER pixel checks (llvmpipe).
+
+## Era drivers (scripts/e2e/drivers/)
+
+- pre18-xvfb.sh — 1.4.7/1.5.2/1.6.4: xvfb-run + Mesa software GL real client + in-jar
+  driver (no stdin console pre-1.7.10). Driver auto-connects, receives channel byte-push,
+  injects sentinel skin, asserts injected renderer-layer field state.
+- headlessmc.sh — 1.7.10/1.8.9/1.10.2/1.12.2/1.16.5+: HeadlessMC wrapper (-lwjgl -offline);
+  hmc-specifics console bridge enables command-driven /skin on 1.12.2 (upgrade).
+- modern-injar.sh — 1.21.x/26.x: in-jar client driver (Fabric client-GameTest model):
+  join -> connection.sendCommand("/skin ...") -> wait ticks -> assert
+  connection.getPlayerInfo(uuid).getProfile().getProperties().get("textures") changed
+  (ClientPlayNetHandler 1.16.5 / ClientPacketListener 1.18.2+; PlayerInfo.getProfile()
+  version-uniform). 26.x: explicit EventBus-7 listener registration (no static
+  @EventBusSubscriber), unobfuscated names, Java 25.
+
+## Phasing
+
+- Slice 1 (HIGHEST value, hardest): pre-1.8 real-client E2E 1.6.4 -> 1.5.2 -> 1.4.7. **DONE** (#451/#474).
+  Co-designed with the in-flight joint client mod (branch feat/client-side-pre-1-8).
+  Driver must OWN the render/refresh thread to defeat the default-download overwrite race.
+  3 informational CI jobs (E2E (forge-1.6.4) etc.).
+- Slice 2 (highest ROI/hour): enable hmc-specifics console bridge on mc1.12.2 ->
+  boot-smoke -> command-driven /skin (E2E (mc1.12.2) already required). Then
+  1.7.10/1.8.9/1.10.2 first real-client coverage (HeadlessMC floor 1.7.10).
+  Spike first: bridge stability on 1.12.2 (JLine ClassNotFound observed on 1.21).
+  **DONE** (mc1.12.2 command-driven #449/#460; 1.7.10/1.8.9/1.10.2 HeadlessMC
+  E2E #438). Remaining: promote the informational e2e jobs to required via
+  gh-api-bump (separate lane).
+- Slice 3: 1.21.x in-jar client driver = modern template; replicate 1.21.1/4/8. **DONE** (#440).
+- Slice 4: rest of matrix boot-smoke at minimum: 1.16.5/1.18.2/1.20.1 (1.20.1 =
+  HMC gap 1.20.1-1.20.4 -> pre-1.8-style xvfb path); 26.1/26.2 full driver (cheap:
+  unobfuscated+modern). Batch-promote informational -> gh-api-bump after green.
+  **PARTIAL** — boot-smoke live (1.16.5/1.18.2/1.20.1); full driver (26.1/26.2)
+  + batch-promote pending.
+
+## CI (from lib-12)
+
+- ubuntu-24.04: xvfb preinstalled; Mesa llvmpipe NOT -> pre-1.8 real-GL lanes need:
+  sudo apt-get install -y libgl1-mesa-dri libglx-mesa0 mesa-utils libxrandr2 libxxf86vm1
+  libxcursor1 libxi6 libxinerama1 libasound2 libopenal1 + LIBGL_ALWAYS_SOFTWARE=1
+  GALLIUM_DRIVER=llvmpipe. HeadlessMC -lwjgl lanes need no Mesa.
+- Matrix job `E2E (${{ matrix.lane }})` with per-lane needs-mesa flag; 45-min timeout;
+  always() upload logs; cache keys e2e-<lane>.
+- Push-only for real-client E2E (mc1.12.2 precedent); retryable exit-code 2.
+- Client jars sourced SCRIPT-SIDE (run-e2e.sh curl+sha1), never build.gradle
+  (vendored-harness diff-guard constraint). 147-client.jar at repo root proves URLs resolve.
+- Java per era preinstalled (8/17/21/25 on 24.04); keep JAVA_HOME in script (sudo
+  does not inherit setup-java env).
+
+## Coverage matrix (final)
+
+- Full renderer E2E: 1.4.7/1.5.2/1.6.4 (in-jar joint mod sentinel), 1.7.10/1.8.9/1.10.2
+  (HeadlessMC command-driven), 1.12.2 (bridge upgrade), 1.21/1.21.1/1.21.4/1.21.8,
+  26.1/26.2 (in-jar driver).
+- Boot-smoke floor: 1.16.5, 1.18.2, 1.20.1.
+- Modern lanes: server GameTest kept (packet emission); real-client E2E adds the
+  missing client-side half.
+
+## Open items to resolve in Slice 1
+
+- Pin pre-1.8 CLIENT jar URLs (server jars pinned in build.gradle; client jars not yet).
+- Freeze the joint mod's injected-field name as the driver's assertion read.
+- Injection-race handling (driver owns render thread) is a first-class requirement
+  on the in-flight joint client mod.
+
+## Race-hardening spec (forward-looking, 2026-08-11 — lib-24 + lib-25)
+
+Verdict: NO hardening needed today. skins.minecraft.net is NXDOMAIN (probed) — the
+vanilla download thread writes the TDI image field ONLY on a successful 2xx
+(1.4.7/1.5.2 putfield bar.a/bfu.a @70/96; 1.6.4 setBufferedImage -> bic.d); on any
+failure it writes nothing, and the Steve default is a separate render path, never
+written into the field. Race is latent; becomes REAL only under a restored
+legacy-skin host (Option A / hosts redirect / LAN proxy) combined with client
+injection.
+
+Forward spec (when a client injection + restored host coexist):
+- Race-removing: URL-rewrite ASM per Ears' discipline — readable class name + SRG
+  method names ONLY (1.6+ LaunchWrapper runtime-deobfs notch->srg; production runs
+  net.minecraft.client.renderer.ThreadDownloadImageData + func_110554_a, NOT obf
+  bic/a). Never target obf constants (COMPUTE_FRAMES hazard, forum 19621). CSL's
+  reflection-by-type is the obf-agnostic alternative.
+- Window backstops: (a) server-side re-broadcast (only option consistent with the
+  server-only architecture, trivially E2E-testable on the server log); (b) client
+  re-injection guard via IScheduledTickHandler (FML 4.7/5.2/7.x ship it).
+- Crux risk: the vendored harness builds/reobfs the SERVER domain only; a client
+  coremod (manifest FMLCorePlugin + IFMLLoadingPlugin) needs a net-new client
+  subsystem + its own E2E fixture + harness/pipeline extension (assertNameDomain
+  verification exemption or client-domain build). Not a hardening of existing code.
+
+## Race-hardening spec (forward-looking, 2026-08-11 — lib-24 + lib-25)
+
+Verdict: NO hardening needed today. skins.minecraft.net is NXDOMAIN (probed) — the
+vanilla download thread writes the TDI image field ONLY on a successful 2xx
+(1.4.7/1.5.2 putfield bar.a/bfu.a @70/96; 1.6.4 setBufferedImage -> bic.d); on any
+failure it writes nothing, and the Steve default is a separate render path, never
+written into the field. Race is latent; becomes REAL only under a restored
+legacy-skin host (Option A / hosts redirect / LAN proxy) combined with client
+injection.
+
+Forward spec (when a client injection + restored host coexist):
+- Race-removing: URL-rewrite ASM per Ears' discipline — readable class name + SRG
+  method names ONLY (1.6+ LaunchWrapper runtime-deobfs notch->srg; production runs
+  net.minecraft.client.renderer.ThreadDownloadImageData + func_110554_a, NOT obf
+  bic/a). Never target obf constants (COMPUTE_FRAMES hazard, forum 19621). CSL's
+  reflection-by-type is the obf-agnostic alternative.
+- Window backstops: (a) server-side re-broadcast (only option consistent with the
+  server-only architecture, trivially E2E-testable on the server log); (b) client
+  re-injection guard via IScheduledTickHandler (FML 4.7/5.2/7.x ship it).
+- Crux risk: the vendored harness builds/reobfs the SERVER domain only; a client
+  coremod (manifest FMLCorePlugin + IFMLLoadingPlugin) needs a net-new client
+  subsystem + its own E2E fixture + harness/pipeline extension (assertNameDomain
+  verification exemption or client-domain build). Not a hardening of existing code.

--- a/mc1.12.2/test-infrastructure/README.md
+++ b/mc1.12.2/test-infrastructure/README.md
@@ -1,65 +1,84 @@
-# EverlastingSkins — E2E Test Infrastructure
+# EverlastingSkins — E2E Test Infrastructure (mc1.12.2)
 
-Server-log smoke test for the mc1.12.2 port. The vanilla 1.12.2 client has
-no console (stdin/stdout), so HeadlessMC `SEND`/`ENDS_WITH`/`CONTAINS`
-scenario steps cannot drive it. The runner instead starts a real Forge
-server with the mod, launches a headless client that auto-connects, and
-asserts on the server log:
+Command-driven real-client E2E for the mc1.12.2 port (headlessmc era, since
+#449/#460). A real Forge 14.23.5.2847 server runs the mod, a real 1.12.2
+client (TestPlayer) joins under the HeadlessMC launcher, and the vendored
+hmc-specifics console bridge sends `/skin set mojang Notch` through the
+client's chat surface. The server-side `ES_E2E_SKIN` sentinel is the primary
+assertion.
 
-1. Server booted (`For help, type "help"`)
-2. Client connected (the TestPlayer client joins)
-3. Mod presence from the FML handshake mod-list line (`everlastingskins` in the mod-list line Forge writes when the client joins — asserted after the join attempt, since Forge 1.12.2 names the mod id only at that handshake)
+`E2E (mc1.12.2)` is a REQUIRED check on `main` (part of the 22-context
+branch-protection contract), so it runs on every PR and push.
 
-Functional coverage (command cascade, persistence, permissions, packets)
-lives in the JUnit integration tests; this E2E is a boot smoke test.
+## Flow
+
+1. **Boot** — `run-e2e.sh` builds the lane (Gradle 4.10.3 / ForgeGradle 2.3.4,
+   Java 8) and hands off to the shared orchestrator:
+   `scripts/e2e/e2e-common.sh` dispatches to
+   `scripts/e2e/drivers/headlessmc.sh` (`E2E_ERA=headlessmc`), which owns the
+   full flow (server boot + client + assertions). The server runs with
+   `-Deverlastingskins.e2e=true` (offline; TestPlayer op'd via ops.json,
+   level 4) and must reach `For help, type "help"` (240s, exit 2 on timeout).
+2. **Join** — the client launches the forge-1.12.2-14.23.5.2860 profile
+   (`-lwjgl -offline`, dummy assets, jline disabled). The vanilla 1.12.2
+   client has no stdin console, so the scenario runs through the vendored
+   hmc-specifics bridge (`hmc-specifics-1.12.2-2.4.0-lexforge-release.jar`):
+   its HeadlessMcMcTweaker + mixins pipe stdin through the game's chat.
+   A hard join gate waits for `<user> joined the game` on the server log
+   (240s; exit 2 retryable, with a distinct fail-fast on the
+   parent-version-resolution signature).
+3. **SEND** — the scenario gates on the mod's own client-side
+   `ES_E2E_CLIENT_JOINED` marker (first in-world client tick), then SENDs
+   `/skin set mojang Notch` and the bridge ack `. hmc-e2e-bridge-ok`.
+   There is no quit SEND: the client stays in-world until the server-side
+   skin action completes (a mid-command disconnect aborts the sentinel
+   path).
+4. **Assert** — server-log assertions, all under
+   `-Deverlastingskins.e2e=true`:
+   - `ES_E2E_SKIN=cmd player=...` — SkinCommand entry marker: the /skin
+     reached the server. Absent after a successful join is a distinct
+     assertion failure (pre-join-race signature).
+   - `ES_E2E_SKIN=ok player=...` — SkinAction success sentinel (primary).
+   - `<TestPlayer> hmc-e2e-bridge-ok` — bridge ack (command_executed).
+5. **Report** — the driver writes the master-plan contract JSON
+   (`${RUNNER_TMP}/e2e-result.json`: lane, era=headlessmc, server_booted,
+   client_joined, command_executed, command_reached_server, renderer_state,
+   server_sentinel, exit_code) and exits per the contract below.
+
+## Exit-code contract
+
+- `0` all green (sentinel seen, result doc green)
+- `1` assertion failed (sentinel miss / command never reached the server)
+- `2` retryable infra (boot/join timeout, artifact or client-profile fetch
+  failure)
+- `3` build failure (lane build or missing Java 8)
 
 ## Quick start
 
 ```bash
-# Ensure Java 8 is on PATH, then run the 1.12.2 E2E
-bash test-infrastructure/run-e2e.sh mc1.12.2
+cd mc1.12.2 && JAVA_HOME=<jdk8> bash test-infrastructure/run-e2e.sh mc1.12.2
 ```
 
-`run-e2e.sh` builds the mod, installs Forge 14.23.5.2847 server with a
-client profile pre-installed via the 14.23.5.2860 installer (the 2847
-installer has no `--installClient` CLI), launches the server, and drives
-the client through the HeadlessMC wrapper (`-lwjgl -offline
---uid 14.23.5.2860`).
+`run-e2e.sh` finds Java 8 via `JAVA_HOME` or known install paths; the
+positional lane arg is accepted and ignored.
 
-## Why no scenario files
+## Materials
 
-HeadlessMC scenario steps match against the client process's stdin/stdout.
-A vanilla 1.12.2 client has neither, so `SEND`/`ENDS_WITH`/`CONTAINS` steps
-cannot drive it. The `hmc-specifics` module ships an official Forge 1.12.2
-build that can install a console bridge, but this repo deliberately disables
-it in CI (`hmc.auto.download.specifics=false` in `ci.yml` and `run-e2e.sh`):
-without the bridge the client cannot be command-driven, so the job stays a
-boot smoke rather than a scenario run. A JLine `ClassNotFoundException` was
-observed on a 1.21 client; that is not evidence for 1.12.2 and is not why
-specifics are disabled. Scenario JSON files were removed in favor of bash
-assertions on the server log, which is where all command and join activity
-is visible.
-
-## Install HeadlessMC
-
-The launcher wrapper JAR is v2.10.0. `run-e2e.sh` downloads it on demand
-into `test-infrastructure/headlessmc/`:
-
-```bash
-mkdir -p test-infrastructure/headlessmc
-curl -L -o test-infrastructure/headlessmc/headlessmc-launcher-wrapper.jar \
-  "https://github.com/headlesshq/headlessmc/releases/download/2.10.0/headlessmc-launcher-wrapper-2.10.0.jar"
-```
+All artifacts are sha1-pinned and cached under
+`~/.cache/everlastingskins/e2e/<lane>`: the HeadlessMC launcher wrapper
+(2.10.0), the server jar (launcher.mojang.com), the Forge 14.23.5.2847
+universal, and its manifest Class-Path libs. The hmc-specifics bridge jar
+has no live upstream URL and is vendored (sha1-pinned seed) at
+`mc1.12.2/test-infrastructure/hmc-specifics/`. The client profile is
+installed by the 14.23.5.2860 installer's `--installClient` (the canonical
+2847 installer has no such CLI, and HMCLite's forgecli crashes on 1.12.2
+installers); the vanilla parent version is provisioned deterministically
+from the Mojang version manifest before launch (fresh client homes, exit 2
+on failure).
 
 ## CI integration
 
-`.github/workflows/ci.yml` (job `e2e-test-1122`, displayed as "E2E
-(mc1.12.2)" — the exact check name branch protection requires on the
-`mc1.12.2` branch — boot smoke, not command E2E) inlines the same flow
-instead of calling `run-e2e.sh`: start the Forge server, launch the
-headless client (TestPlayer), assert the client joined
-on `$SERVER_DIR/logs/latest.log`, then assert mod presence from the FML
-handshake mod-list line. No `/skin` command can be sent without a console
-bridge, so the skin API endpoints are never exercised: the job uses no
-WireMock service and no endpoint overrides. Client crashes are visible
-because launch steps run under `set -euo pipefail`.
+`.github/workflows/ci.yml` job `e2e-mc1_12_2` (displayed as
+`E2E (mc1.12.2)`, the exact required-check name) runs
+`bash mc1.12.2/test-infrastructure/run-e2e.sh mc1.12.2` on ubuntu-24.04
+with JDK 8 and a 45-minute timeout.


### PR DESCRIPTION
Docs-only fix for two stale E2E documents:

1. `mc1.12.2/test-infrastructure/README.md` still documented the pre-#449 boot-smoke shape (no console, boot-only). Rewritten to the command-driven headlessmc era: boot, join, hmc-specifics bridge SEND of `/skin set mojang Notch` + ack, `ES_E2E_SKIN` sentinel asserts, exit-code contract 0/1/2/3, and the required-check status of `E2E (mc1.12.2)`.

2. `.slim/deepwork/real-client-e2e-plan.md` (was untracked; added to the repo here) — Phasing status markers: Slice 1 DONE (#451/#474), Slice 2 DONE (mc1.12.2 #449/#460 + 1.7.10/1.8.9/1.10.2 #438; gh-api-bump promotion remains), Slice 3 DONE (#440), Slice 4 PARTIAL (boot-smoke live; full driver + batch-promote pending).