### PR TITLE
release: bump all lanes to v2.1.0-rc2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,7 +189,7 @@ Never decompile raw obf jars for reading — use the deobf jars' decompiled outp
    `mc26.2-v*` (colloquial '26.2', matching the Forge 65.x line naming).
    forge-26.1 follows the same 26.x line pattern — own tag prefix
    `mc26.1-v*` (matching the Forge 62.x line naming), mod_version
-   2.1.0-beta.1.
+   2.1.0-rc2.
 6. **`:common` consumed unconditionally:** every forge-* subproject depends
    on `:common` via `implementation(project(":common"))` in
    buildSrc `everlastingskins.forge-module.gradle.kts`; there is no opt-out.

--- a/forge-1.10.2/gradle.properties
+++ b/forge-1.10.2/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx3G
 group=levosilimo.everlastingskins
 
 mod_id=everlastingskins
-mod_version=2.1.0-beta.1
+mod_version=2.1.0-rc2
 mod_name=EverlastingSkins
 mod_vendor=Levosilimo
 mod_license=MIT

--- a/forge-1.16.5/gradle.properties
+++ b/forge-1.16.5/gradle.properties
@@ -13,4 +13,4 @@ loader_version_range=[36,)
 curse_versions=1.16.5
 
 # Mod version (JAR filename + mods.toml impl version; keep in sync with root)
-mod_version=2.1.0
+mod_version=2.1.0-rc2

--- a/forge-1.16.5/src/main/resources/META-INF/mods.toml
+++ b/forge-1.16.5/src/main/resources/META-INF/mods.toml
@@ -4,7 +4,7 @@ license = "MIT License"
 
 [[mods]]
 modId = "everlastingskins"
-version = "2.1.0"
+version = "2.1.0-rc2"
 displayName = "Everlasting Skins"
 authors = "Levosilimo"
 description = '''

--- a/forge-1.18.2/gradle.properties
+++ b/forge-1.18.2/gradle.properties
@@ -13,4 +13,4 @@ mc.runDir=run
 mc.runDir2=run2
 
 # Mod version (JAR filename + mods.toml impl version; keep in sync with root)
-mod_version=2.1.0
+mod_version=2.1.0-rc2

--- a/forge-1.18.2/src/main/resources/META-INF/mods.toml
+++ b/forge-1.18.2/src/main/resources/META-INF/mods.toml
@@ -4,7 +4,7 @@ license = "MIT License"
 
 [[mods]]
 modId = "everlastingskins"
-version = "2.1.0"
+version = "2.1.0-rc2"
 displayName = "Everlasting Skins"
 authors = "Levosilimo"
 description = '''

--- a/forge-1.20.1/gradle.properties
+++ b/forge-1.20.1/gradle.properties
@@ -13,4 +13,4 @@ mc.runDir=run
 mc.runDir2=run2
 
 # Mod version (JAR filename + mods.toml impl version; keep in sync with root)
-mod_version=2.1.0
+mod_version=2.1.0-rc2

--- a/forge-1.20.1/src/main/resources/META-INF/mods.toml
+++ b/forge-1.20.1/src/main/resources/META-INF/mods.toml
@@ -4,7 +4,7 @@ license = "MIT License"
 
 [[mods]]
 modId = "everlastingskins"
-version = "2.1.0"
+version = "2.1.0-rc2"
 displayName = "Everlasting Skins"
 authors = "Levosilimo"
 description = '''

--- a/forge-1.21.1/gradle.properties
+++ b/forge-1.21.1/gradle.properties
@@ -1,6 +1,6 @@
 # MC / Forge versions for the 1.21.1 lane
 minecraft_version=1.21.1
-mod_version=2.1.0-rc1
+mod_version=2.1.0-rc2
 minecraft_version_range=[1.21.1,1.21.2)
 forge_version=52.1.16
 forge_version_range=[52.1.16,53)

--- a/forge-1.21.1/src/gametest/resources/META-INF/mods.toml
+++ b/forge-1.21.1/src/gametest/resources/META-INF/mods.toml
@@ -12,6 +12,6 @@ Development-only mod carrying the EverlastingSkins game test classes and structu
 [[dependencies.everlastingskins_gametest]]
 modId = "everlastingskins"
 mandatory = true
-versionRange = "[2.1.0-rc1,)"
+versionRange = "[2.1.0-rc2,)"
 ordering = "AFTER"
 side = "SERVER"

--- a/forge-1.21.1/src/main/resources/META-INF/mods.toml
+++ b/forge-1.21.1/src/main/resources/META-INF/mods.toml
@@ -4,7 +4,7 @@ license = "MIT License"
 
 [[mods]]
 modId = "everlastingskins"
-version = "2.1.0-rc1"
+version = "2.1.0-rc2"
 displayName = "Everlasting Skins"
 authors = "Levosilimo"
 description = '''

--- a/forge-1.21.4/gradle.properties
+++ b/forge-1.21.4/gradle.properties
@@ -1,6 +1,6 @@
 # MC / Forge versions for the 1.21.4 lane
 minecraft_version=1.21.4
-mod_version=2.1.0-rc1
+mod_version=2.1.0-rc2
 minecraft_version_range=[1.21.4,1.21.5)
 forge_version=54.1.18
 forge_version_range=[54.1.18,55)

--- a/forge-1.21.4/src/gametest/resources/META-INF/mods.toml
+++ b/forge-1.21.4/src/gametest/resources/META-INF/mods.toml
@@ -12,6 +12,6 @@ Development-only mod carrying the EverlastingSkins game test classes and structu
 [[dependencies.everlastingskins_gametest]]
 modId = "everlastingskins"
 mandatory = true
-versionRange = "[2.1.0-rc1,)"
+versionRange = "[2.1.0-rc2,)"
 ordering = "AFTER"
 side = "SERVER"

--- a/forge-1.21.4/src/main/resources/META-INF/mods.toml
+++ b/forge-1.21.4/src/main/resources/META-INF/mods.toml
@@ -4,7 +4,7 @@ license = "MIT License"
 
 [[mods]]
 modId = "everlastingskins"
-version = "2.1.0-rc1"
+version = "2.1.0-rc2"
 displayName = "Everlasting Skins"
 authors = "Levosilimo"
 description = '''

--- a/forge-1.21.8/gradle.properties
+++ b/forge-1.21.8/gradle.properties
@@ -1,6 +1,6 @@
 # MC / Forge versions for the 1.21.8 lane
 minecraft_version=1.21.8
-mod_version=2.1.0-rc1
+mod_version=2.1.0-rc2
 minecraft_version_range=[1.21.8,1.21.9)
 forge_version=58.1.21
 forge_version_range=[58.1.21,59)

--- a/forge-1.21.8/src/gametest/resources/META-INF/mods.toml
+++ b/forge-1.21.8/src/gametest/resources/META-INF/mods.toml
@@ -12,6 +12,6 @@ Development-only mod carrying the EverlastingSkins game test classes and structu
 [[dependencies.everlastingskins_gametest]]
 modId = "everlastingskins"
 mandatory = true
-versionRange = "[2.1.0-rc1,)"
+versionRange = "[2.1.0-rc2,)"
 ordering = "AFTER"
 side = "SERVER"

--- a/forge-1.21.8/src/main/resources/META-INF/mods.toml
+++ b/forge-1.21.8/src/main/resources/META-INF/mods.toml
@@ -4,7 +4,7 @@ license = "MIT License"
 
 [[mods]]
 modId = "everlastingskins"
-version = "2.1.0-rc1"
+version = "2.1.0-rc2"
 displayName = "Everlasting Skins"
 authors = "Levosilimo"
 description = '''

--- a/forge-1.21/gradle.properties
+++ b/forge-1.21/gradle.properties
@@ -1,6 +1,6 @@
 # MC / Forge versions for the 1.21 lane
 minecraft_version=1.21
-mod_version=2.1.0-rc1
+mod_version=2.1.0-rc2
 minecraft_version_range=[1.21,1.22)
 forge_version=51.0.8
 forge_version_range=[51.0.8,52)

--- a/forge-1.21/src/gametest/resources/META-INF/mods.toml
+++ b/forge-1.21/src/gametest/resources/META-INF/mods.toml
@@ -12,6 +12,6 @@ Development-only mod carrying the EverlastingSkins game test classes and structu
 [[dependencies.everlastingskins_gametest]]
 modId = "everlastingskins"
 mandatory = true
-versionRange = "[2.1.0-rc1,)"
+versionRange = "[2.1.0-rc2,)"
 ordering = "AFTER"
 side = "SERVER"

--- a/forge-1.21/src/main/resources/META-INF/mods.toml
+++ b/forge-1.21/src/main/resources/META-INF/mods.toml
@@ -4,7 +4,7 @@ license = "MIT License"
 
 [[mods]]
 modId = "everlastingskins"
-version = "2.1.0-rc1"
+version = "2.1.0-rc2"
 displayName = "Everlasting Skins"
 authors = "Levosilimo"
 description = '''

--- a/forge-1.4.7/gradle.properties
+++ b/forge-1.4.7/gradle.properties
@@ -13,7 +13,7 @@ mod_id=everlastingskins
 mod_name=EverlastingSkins
 mod_license=MIT
 mod_authors=Levosilimo
-mod_version=2.1.0-beta.1
+mod_version=2.1.0-rc2
 mod_vendor=Levosilimo
 
 # Maven-ish coordinates (unused by out-of-band lane publishing, kept for parity)

--- a/forge-1.5.2/gradle.properties
+++ b/forge-1.5.2/gradle.properties
@@ -13,7 +13,7 @@ mod_id=everlastingskins
 mod_name=EverlastingSkins
 mod_license=MIT
 mod_authors=Levosilimo
-mod_version=2.1.0-beta.1
+mod_version=2.1.0-rc2
 mod_vendor=Levosilimo
 
 # Maven-ish coordinates (unused by out-of-band lane publishing, kept for parity)

--- a/forge-1.6.4/gradle.properties
+++ b/forge-1.6.4/gradle.properties
@@ -12,7 +12,7 @@ mod_id=everlastingskins
 mod_name=EverlastingSkins
 mod_license=MIT
 mod_authors=Levosilimo
-mod_version=2.1.0-beta.1
+mod_version=2.1.0-rc2
 mod_vendor=Levosilimo
 
 # Maven-ish coordinates (unused by out-of-band lane publishing, kept for parity)

--- a/forge-1.7.10/gradle.properties
+++ b/forge-1.7.10/gradle.properties
@@ -10,7 +10,7 @@ mod_id=everlastingskins
 mod_name=EverlastingSkins
 mod_license=MIT
 mod_authors=Levosilimo
-mod_version=2.1.0-beta.1
+mod_version=2.1.0-rc2
 mod_vendor=Levosilimo
 
 # Maven-ish coordinates (unused by out-of-band lane publishing, kept for parity)

--- a/forge-1.8.9/gradle.properties
+++ b/forge-1.8.9/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx3G
 group=levosilimo.everlastingskins
 
 mod_id=everlastingskins
-mod_version=2.1.0-beta.1
+mod_version=2.1.0-rc2
 mod_name=EverlastingSkins
 mod_vendor=Levosilimo
 mod_license=MIT

--- a/forge-26.1/gradle.properties
+++ b/forge-26.1/gradle.properties
@@ -32,6 +32,6 @@ mod_name=EverlastingSkins
 mod_vendor=Levosilimo
 mod_license=MIT License
 mod_authors=Levosilimo
-mod_version=2.1.0-beta.1
+mod_version=2.1.0-rc2
 mixin_id=everlastingskins
 depAnalysis.graduateDuplicateClass=true

--- a/forge-26.1/src/gametest/resources/META-INF/mods.toml
+++ b/forge-26.1/src/gametest/resources/META-INF/mods.toml
@@ -12,6 +12,6 @@ Development-only mod carrying the EverlastingSkins game test classes and structu
 [[dependencies.everlastingskins_gametest]]
 modId = "everlastingskins"
 mandatory = true
-versionRange = "[2.1.0-beta.1,)"
+versionRange = "[2.1.0-rc2,)"
 ordering = "AFTER"
 side = "SERVER"

--- a/forge-26.1/src/main/resources/META-INF/mods.toml
+++ b/forge-26.1/src/main/resources/META-INF/mods.toml
@@ -6,7 +6,7 @@ license = "MIT License"
 
 [[mods]]
 modId = "everlastingskins"
-version = "2.1.0-beta.1"
+version = "2.1.0-rc2"
 displayName = "Everlasting Skins"
 authors = "Levosilimo"
 description = '''

--- a/forge-26.2/gradle.properties
+++ b/forge-26.2/gradle.properties
@@ -32,6 +32,6 @@ mod_name=EverlastingSkins
 mod_vendor=Levosilimo
 mod_license=MIT License
 mod_authors=Levosilimo
-mod_version=2.1.0-beta.1
+mod_version=2.1.0-rc2
 mixin_id=everlastingskins
 depAnalysis.graduateDuplicateClass=true

--- a/forge-26.2/src/gametest/resources/META-INF/mods.toml
+++ b/forge-26.2/src/gametest/resources/META-INF/mods.toml
@@ -12,6 +12,6 @@ Development-only mod carrying the EverlastingSkins game test classes and structu
 [[dependencies.everlastingskins_gametest]]
 modId = "everlastingskins"
 mandatory = true
-versionRange = "[2.1.0-beta.1,)"
+versionRange = "[2.1.0-rc2,)"
 ordering = "AFTER"
 side = "SERVER"

--- a/forge-26.2/src/main/resources/META-INF/mods.toml
+++ b/forge-26.2/src/main/resources/META-INF/mods.toml
@@ -6,7 +6,7 @@ license = "MIT License"
 
 [[mods]]
 modId = "everlastingskins"
-version = "2.1.0-beta.1"
+version = "2.1.0-rc2"
 displayName = "Everlasting Skins"
 authors = "Levosilimo"
 description = '''

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ org.gradle.configuration-cache.problems=warn
 # Maven coordinates + mod identity (shared by every module)
 group=levosilimo.everlastingskins
 mod_id=everlastingskins
-mod_version=2.1.0
+mod_version=2.1.0-rc2
 mod_name=EverlastingSkins
 mod_vendor=Levosilimo
 mod_license=MIT

--- a/mc1.12.2/gradle.properties
+++ b/mc1.12.2/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx3G
 group=levosilimo.everlastingskins
 
 mod_id=everlastingskins
-mod_version=2.1.0
+mod_version=2.1.0-rc2
 mod_name=EverlastingSkins
 mod_vendor=Levosilimo
 mod_license=MIT


### PR DESCRIPTION
Version bump for the rc2 release across all 16 lanes (2.1.0-rc1 / 2.1.0-beta.1 / 2.1.0 → 2.1.0-rc2). Version-string changes only: gradle.properties mod_version, literal mods.toml versions (in-root lanes + 1.16.5/1.18.2/1.20.1), gametest toml versionRange, root gradle.properties, AGENTS.md 26.1 reference. Tags are pushed out-of-band after merge.